### PR TITLE
Add LUKS encrypted persistent volumes documentation for MKS

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.de-de.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-asia.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-au.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-ca.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-gb.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-ie.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-sg.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.en-us.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.es-es.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.es-us.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.fr-ca.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.fr-fr.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.it-it.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.pl-pl.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: OVHcloud Managed Kubernetes - Features and roadmap
 excerpt: Find out how to review the latest product and feature updates for OVHcloud Managed Kubernetes and other Cloud services
-updated: 2023-10-11
+updated: 2026-01-30
 ---
 
 ## Cloud roadmap and changelog on our public GitHub repository
@@ -11,6 +11,17 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 [Managed Kubernetes Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/views/1?sliceBy%5Bvalue%5D=Managed+Kubernetes+Service)
 
 [Cloud Roadmap & Changelog](https://github.com/orgs/ovh/projects/16/)
+
+## Recent Features
+
+### LUKS Encrypted Persistent Volumes (Available)
+
+OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
+
+For more information, see:
+- [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
+- [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
+- [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)
 
 
 ## Go further

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/available-upcoming-features/guide.pt-pt.md
@@ -19,6 +19,7 @@ The roadmap and changelog of OVHcloud Managed Kubernetes and all our Public Clou
 OVHcloud Managed Kubernetes now supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). This feature is available in specific regions.
 
 For more information, see:
+
 - [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes)
 - [LUKS encrypted volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits#luks-encrypted-persistent-volumes)
 - [Complete tutorial on creating encrypted Persistent Volumes](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -138,6 +138,9 @@ And then connect to it and view your access logs:
 ```bash
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
+
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
 
 You should have a result like this:
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/backup-restore-pv-volume-snapshot/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Backing up and restoring your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
 excerpt: Find out how to back up and restore your Persistent Volume with Volume Snapshots on OVHcloud Managed Kubernetes
-updated: 2023-01-11
+updated: 2026-01-30
 ---
 
 In this tutorial, we are using [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) to back up and restore persistent volumes on an OVHcloud Managed Kubernetes cluster.
@@ -139,10 +139,13 @@ And then connect to it and view your access logs:
 kubectl -n nginx-example exec $POD_NAME -c nginx -- cat /var/log/nginx/access.log
 ```
 
+> [!primary]
+> Volume snapshots work with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during snapshot and restore operations.
+
 You should have a result like this:
 
 ```console
-$ kubectl apply -f nginx-example-with-pv.yml
+ apply -f nginx-example-with-pv.yml
 namespace/nginx-example created
 persistentvolumeclaim/nginx-logs created
 deployment.apps/nginx-deployment created

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.de-de.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -62,5 +62,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-asia.md
@@ -75,6 +75,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -86,7 +87,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-au.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-ca.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-gb.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-ie.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-sg.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-us.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.es-es.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.es-us.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.fr-ca.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.fr-fr.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.it-it.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -62,5 +62,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.pl-pl.md
@@ -75,6 +75,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -86,7 +87,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.pt-pt.md
@@ -76,6 +76,7 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > **Regional availability**
 >
 > LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+>
 > - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
 > - **Germany**: DE1
 > - **Italy**: EU-SOUTH-MIL
@@ -87,7 +88,8 @@ OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes u
 > If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Available datacenters, worker nodes and persistent storage flavors
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Available datacenters, worker nodes and persistent storage flavors
@@ -63,5 +63,31 @@ All these `Storage Classes` are based on Cinder, the OpenStack block storage ser
 
 High Speed performance is theoretically best for volumes up to 100GB. Above 100GB per volume, you will get enhanced performance with a High Speed Gen2 volume.
 This is detailed in the [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume) guide.
+
+#### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes also supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available in supported regions:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance, SSD NVMe)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks, 200 IOPS)
+
+> [!primary]
+> **Regional availability**
+>
+> LUKS encrypted storage is currently available in the following OVHcloud Public Cloud regions:
+> - **France**: RBX, SBG, GRA (GRA5, GRA7, GRA9, GRA11), EU-WEST-PAR
+> - **Germany**: DE1
+> - **Italy**: EU-SOUTH-MIL
+> - **Canada**: BHS5
+> - **United States**: US-WEST-OR-1, US-EAST-VA-1
+>
+> Additional regions will be supported in the coming months.
+>
+> If your cluster is deployed in a supported region but the encrypted storage classes are not yet visible, they will be automatically deployed when you update your cluster.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 We will support future classes as soon they are made available in OVHcloud Public Cloud.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -54,7 +54,13 @@ NAME                              PROVISIONER                RECLAIMPOLICY   VOL
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/fix-persistent-volumes-permissions/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting permission errors when enabling persistence
 excerpt: ''
-updated: 2024-08-14
+updated: 2026-01-30
 ---
 
 ## Objective
@@ -49,12 +49,18 @@ If you are in this case, please follow these instructions at your own risk:
 - Verify what is the `StorageClass` that you are using by default (generally the `csi-cinder-high-speed`):
 
 ```bash
-$ kubectl get storageclasses.storage.k8s.io 
+ get storageclasses.storage.k8s.io 
 NAME                              PROVISIONER                RECLAIMPOLICY   VOLUMEBINDINGMODE   ALLOWVOLUMEEXPANSION   AGE
 csi-cinder-classic                cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed (default)   cinder.csi.openstack.org   Delete          Immediate           true                   12d
 csi-cinder-high-speed-gen2        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-luks        cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-classic-luks           cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
+csi-cinder-high-speed-gen2-luks   cinder.csi.openstack.org   Delete          Immediate           true                   5h11m
 ```
+
+> [!primary]
+> If your cluster is deployed in a region that supports LUKS encrypted storage, you will also see the `-luks` variants of the storage classes listed above.
 
 - Delete the concerned `StorageClass` that you are using by default 
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.de-de.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-asia.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-au.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ca.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-gb.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-sg.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-us.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-es.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-us.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-ca.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Limites connues
 excerpt: 'Exigences et limites à respecter'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 Pour plus de détails, veuillez consulter la [documentation sur le redimensionnement des volumes persistants](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-fr.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Limites connues
 excerpt: 'Exigences et limites à respecter'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 Pour plus de détails, veuillez consulter la [documentation sur le redimensionnement des volumes persistants](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.it-it.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pl-pl.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pt-pt.md
@@ -96,12 +96,14 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
 
 The following encrypted storage classes are available:
+
 - `csi-cinder-high-speed-luks`
 - `csi-cinder-classic-luks`
 - `csi-cinder-high-speed-gen2-luks`
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Known limits
 excerpt: 'Requirements and limits to respect'
-updated: 2025-12-02
+updated: 2026-01-30
 ---
 
 <style>
@@ -87,6 +87,22 @@ The PersistentVolumeClaim "mysql-pv-claim" is invalid: spec.resources.requests.s
 ```
 
 For more details, please refer to the [Resizing Persistent Volumes documentation](/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes).
+
+### LUKS Encrypted Persistent Volumes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK).
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+The following encrypted storage classes are available:
+- `csi-cinder-high-speed-luks`
+- `csi-cinder-classic-luks`
+- `csi-cinder-high-speed-gen2-luks`
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ## LoadBalancer
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resizing-persistent-volumes/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Resizing Persistent Volumes
 excerpt: 'Find out how to resize Persistent Volumes on OVHcloud Managed Kubernetes'
-updated: 2021-10-19
+updated: 2026-01-30
 ---
 
 In this tutorial we are going to guide you with the resize of [Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (PVs) on your OVHcloud Managed Kubernetes Service.
@@ -12,6 +12,9 @@ Since Kubernetes 1.11, support for expanding PersistentVolumeClaims (PVCs) is en
 
 > [!warning]
 > Kubernetes PVCs resizing only allows to expand volumes, not to decrease them.
+
+> [!primary]
+> Volume resizing works with all storage classes, including LUKS encrypted volumes (`csi-cinder-high-speed-luks`, `csi-cinder-classic-luks`, `csi-cinder-high-speed-gen2-luks`). The encryption is transparently maintained during the resize operation.
 
 ## Before you begin
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.de-de.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-asia.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-au.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-ca.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-gb.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-ie.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-sg.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.en-us.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.es-es.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.es-us.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.fr-ca.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.fr-fr.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.it-it.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.pl-pl.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Persistent Volumes on OVHcloud Managed Kubernetes Service
 excerpt: 'Learn how to create Persistent Volume Claims (PVCs) and Persistent Volumes (PVs), attach a Pod to a PVC, modify the PV reclaim policy, and delete the created objects.'
-updated: 2025-12-08
+updated: 2026-01-30
 ---
 
 This tutorial goes through the setup of a [Persistent Volume (PV)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) on an OVHcloud Managed Kubernetes Service.
@@ -174,18 +174,30 @@ The following storage classes are currently supported on OVHcloud Managed Kubern
 * `csi-cinder-high-speed-gen2` storage class is based on hardware that includes SSD disks with NVMe interfaces. The performance allocation is progressive and linear (30 IOPS allocated per GB and 0.5MB/s allocated per GB) with a maximum of 20k IOPS and 1GB/s per volume. The IOPS and bandwidth performance will increase as  scale up the storage space.
 * `csi-cinder-high-speed` performance is fixed. You will get up to 3,000 IOPS per volume, regardless of the volume size.
 * `csi-cinder-classic` uses traditional spinning disks (200 IOPS guaranteed, Up to 64 MB/s per volume). (Not yet supported on the MKS Standard plan. Please refer to the limitations described in the `Multi availability zones deployments` section of our [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans) guide).
-* `*-luks` storage classes add a layer of encryption on top of the storage class. It is only available in specific regions: see the [related GitHub issue](https://github.com/ovh/public-cloud-roadmap/issues/307) for more information.
-
 All these `Storage Classes` are based on Cinder, the OpenStack block storage service. The difference between them is the associated physical storage device. They are distributed transparently, on three physical local replicas.
 
 `csi-cinder-high-speed` is recommended for volumes up to 100GB. Above 100GB per volume, enhanced performance is achieved with `csi-cinder-high-speed-gen2` volumes.
 
->> > [!warning]
->> >
->> > Creating a **-luks** volume automatically generates a dedicated key.
->> >
->> > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
->> >
+### LUKS Encrypted Storage Classes
+
+OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using OVHcloud Managed Keys (OMK). The following encrypted storage classes are available:
+
+* `csi-cinder-high-speed-gen2-luks` - Encrypted version of High Speed Gen2 (progressive performance)
+* `csi-cinder-high-speed-luks` - Encrypted version of High Speed (fixed 3,000 IOPS)
+* `csi-cinder-classic-luks` - Encrypted version of Classic (spinning disks)
+
+> [!primary]
+> This feature is available in specific regions. For detailed regional availability and storage class specifications, see [Datacenters, nodes and storage flavors - LUKS Encrypted Storage Classes](/pages/public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors#luks-encrypted-storage-classes).
+
+> [!warning]
+>
+> Creating a LUKS encrypted volume automatically generates a dedicated OVHcloud Managed Key (OMK).
+>
+> Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
+
+For more information:
+- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+- [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console
 $ kubectl get storageclass

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume/guide.pt-pt.md
@@ -196,7 +196,8 @@ OVHcloud Managed Kubernetes supports LUKS encrypted block storage volumes using 
 > Do not modify or delete this key if it is linked to a Block Storage volume. Doing so would make the data on that volume and all its snapshots permanently unrecoverable.
 
 For more information:
-- [Choosing the right Block Storage class](https://help.ovhcloud.com/csm/en-gb-public-cloud-block-storage-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0074119)
+
+- [Choosing the right Block Storage class](/pages/storage_and_backup/block_storage/block_storage_the_right_storage_class)
 - [Create encrypted Persistent Volumes on OVHcloud Managed Kubernetes clusters with LUKS](https://blog.ovhcloud.com/create-encrypted-persistent-volumes-on-ovhcloud-managed-kubernetes-clusters-with-luks/) (Complete tutorial)
 
 ```console


### PR DESCRIPTION

Hello the Team 👋


## What type of Pull Request is this?
- Update of existing guide(s)

## Description
Add LUKS encrypted persistent volumes documentation for MKS

- Add comprehensive LUKS/OMK documentation across 7 guides (105 files)
- Add regional availability information for LUKS encrypted storage
- Include storage class examples in fix-persistent-volumes-permissions

Guides updated:
- available-upcoming-features
- backup-restore-pv-volume-snapshot
- datacenters-nodes-storage-flavors
- fix-persistent-volumes-permissions
- known-limits
- resizing-persistent-volumes
- setting-up-a-persistent-volume

## Mandatory information

The translations in this Pull Request have been done using:
- [ ] OVHcloud integrated translation LLM <!-- If you're interested in this new option, contact the Guides team -->
- [ ] Systran
- [ ] Other tool (specify which tool was used)
- [x] This Pull Request didn't require any translation.

- This Pull Request can be merged as soon as possible.
- This Pull Request content should be replicated for the US OVHcloud documentation : YES