### PR TITLE
Web Cloud Databases - Removing the deprecated tmpdir option

### DIFF
--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.de-de.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: 'Konfigurieren Ihres Datenbankservers'
 excerpt: 'Erfahren Sie hier, wie Sie Ihren Datenbankserver konfigurieren und optimieren können'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Ziel
@@ -103,7 +103,6 @@ Im Kasten **Allgemeine Konfiguration von MySQL** finden Sie die derzeit für Ihr
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- **Tmpdir**: Verzeichnis temporärer Dateien. **/dev/shm** entspricht dem RAM Speicher der Instanz. **/tmp** entspricht der Festplatte der Instanz.
 - **MaxAllowedPacket**: Maximale Paketgröße.
 - **max_user_connections**: Anzahl der erlaubten Simultanverbindungen je Benutzer.
 - **AutoCommit**: Legt fest, ob die SQL-Transaktionen automatisch bestätigt werden oder nicht.
@@ -117,15 +116,6 @@ Im Kasten **Allgemeine Konfiguration von MySQL** finden Sie die derzeit für Ihr
 > [!primary]
 > Wenn Sie auf Ihrer Webseite einen Fehler feststellen, der **"Too many connections"** anzeigt, ist dies auf die Überschreitung der Anzahl der gleichzeitigen Verbindungen auf Ihrer Datenbank zurückzuführen.
 > Dann können Sie die **MaxConnections**-Variable erhöhen, wenn sie nicht bereits am Limit ist.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: Der Datenbankserver wird die Hälfte seines RAM-Speichers diesem Verzeichnis für mehr Leistung zuweisen.
->
-> - /tmp: Der Server wird auf seiner Festplatte unbegrenzten Speicherplatz für dieses Verzeichnis freigeben, aber deutlich zu Lasten der Performance. Wir empfehlen Ihnen, dieses Verzeichnis nur gelegentlich für größere Operationen zu verwenden.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-asia.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objective
@@ -103,7 +103,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- <b>Tmpdir</b>: Directory of temporary files. <b>"/dev/shm"</b> is the instance’s RAM. <b>"/tmp"</b> is the instance’s hard drive.
 - <b>MaxAllowedPacket</b>: The maximum packet size.
 - <b>Max_user_connections</b>: The number of concurrent connections authorised per user.
 - <b>AutoCommit</b>: Sets whether requests are automatically committed or not.
@@ -117,15 +116,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 > [!primary]
 > When you encounter an error on your website stating "**Too many connections**", this is due to the number of simultaneous connections on your database server being exceeded.
 > You can then increase the **MaxConnections variable** if it is not at its maximum.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: The database server will allocate half of its RAM to this directory for higher performance.
->
-> - /tmp: The server will allocate unlimited space on its hard disk for this directory, but this will be much less efficient. We recommend using this directory only for occasional heavy operations.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-au.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objective
@@ -103,7 +103,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- <b>Tmpdir</b>: Directory of temporary files. <b>"/dev/shm"</b> is the instance’s RAM. <b>"/tmp"</b> is the instance’s hard drive.
 - <b>MaxAllowedPacket</b>: The maximum packet size.
 - <b>Max_user_connections</b>: The number of concurrent connections authorised per user.
 - <b>AutoCommit</b>: Sets whether requests are automatically committed or not.
@@ -117,15 +116,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 > [!primary]
 > When you encounter an error on your website stating "**Too many connections**", this is due to the number of simultaneous connections on your database server being exceeded.
 > You can then increase the **MaxConnections variable** if it is not at its maximum.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: The database server will allocate half of its RAM to this directory for higher performance.
->
-> - /tmp: The server will allocate unlimited space on its hard disk for this directory, but this will be much less efficient. We recommend using this directory only for occasional heavy operations.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-ca.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objective
@@ -103,7 +103,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- <b>Tmpdir</b>: Directory of temporary files. <b>"/dev/shm"</b> is the instance’s RAM. <b>"/tmp"</b> is the instance’s hard drive.
 - <b>MaxAllowedPacket</b>: The maximum packet size.
 - <b>Max_user_connections</b>: The number of concurrent connections authorised per user.
 - <b>AutoCommit</b>: Sets whether requests are automatically committed or not.
@@ -117,15 +116,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 > [!primary]
 > When you encounter an error on your website stating "**Too many connections**", this is due to the number of simultaneous connections on your database server being exceeded.
 > You can then increase the **MaxConnections variable** if it is not at its maximum.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: The database server will allocate half of its RAM to this directory for higher performance.
->
-> - /tmp: The server will allocate unlimited space on its hard disk for this directory, but this will be much less efficient. We recommend using this directory only for occasional heavy operations.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-gb.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objective
@@ -103,7 +103,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- <b>Tmpdir</b>: Directory of temporary files. <b>"/dev/shm"</b> is the instance’s RAM. <b>"/tmp"</b> is the instance’s hard drive.
 - <b>MaxAllowedPacket</b>: The maximum packet size.
 - <b>Max_user_connections</b>: The number of concurrent connections authorised per user.
 - <b>AutoCommit</b>: Sets whether requests are automatically committed or not.
@@ -117,15 +116,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 > [!primary]
 > When you encounter an error on your website stating "**Too many connections**", this is due to the number of simultaneous connections on your database server being exceeded.
 > You can then increase the **MaxConnections variable** if it is not at its maximum.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: The database server will allocate half of its RAM to this directory for higher performance.
->
-> - /tmp: The server will allocate unlimited space on its hard disk for this directory, but this will be much less efficient. We recommend using this directory only for occasional heavy operations.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-ie.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objective
@@ -103,7 +103,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- <b>Tmpdir</b>: Directory of temporary files. <b>"/dev/shm"</b> is the instance’s RAM. <b>"/tmp"</b> is the instance’s hard drive.
 - <b>MaxAllowedPacket</b>: The maximum packet size.
 - <b>Max_user_connections</b>: The number of concurrent connections authorised per user.
 - <b>AutoCommit</b>: Sets whether requests are automatically committed or not.
@@ -117,15 +116,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 > [!primary]
 > When you encounter an error on your website stating "**Too many connections**", this is due to the number of simultaneous connections on your database server being exceeded.
 > You can then increase the **MaxConnections variable** if it is not at its maximum.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: The database server will allocate half of its RAM to this directory for higher performance.
->
-> - /tmp: The server will allocate unlimited space on its hard disk for this directory, but this will be much less efficient. We recommend using this directory only for occasional heavy operations.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-sg.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objective
@@ -103,7 +103,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- <b>Tmpdir</b>: Directory of temporary files. <b>"/dev/shm"</b> is the instance’s RAM. <b>"/tmp"</b> is the instance’s hard drive.
 - <b>MaxAllowedPacket</b>: The maximum packet size.
 - <b>Max_user_connections</b>: The number of concurrent connections authorised per user.
 - <b>AutoCommit</b>: Sets whether requests are automatically committed or not.
@@ -117,15 +116,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 > [!primary]
 > When you encounter an error on your website stating "**Too many connections**", this is due to the number of simultaneous connections on your database server being exceeded.
 > You can then increase the **MaxConnections variable** if it is not at its maximum.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: The database server will allocate half of its RAM to this directory for higher performance.
->
-> - /tmp: The server will allocate unlimited space on its hard disk for this directory, but this will be much less efficient. We recommend using this directory only for occasional heavy operations.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-us.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configuring your database server'
 excerpt: 'Find out how to configure and optimise your database server'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objective
@@ -103,7 +103,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- <b>Tmpdir</b>: Directory of temporary files. <b>"/dev/shm"</b> is the instance’s RAM. <b>"/tmp"</b> is the instance’s hard drive.
 - <b>MaxAllowedPacket</b>: The maximum packet size.
 - <b>Max_user_connections</b>: The number of concurrent connections authorised per user.
 - <b>AutoCommit</b>: Sets whether requests are automatically committed or not.
@@ -117,15 +116,6 @@ In the **General configuration of MySQL** box, you will see the configuration cu
 > [!primary]
 > When you encounter an error on your website stating "**Too many connections**", this is due to the number of simultaneous connections on your database server being exceeded.
 > You can then increase the **MaxConnections variable** if it is not at its maximum.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: The database server will allocate half of its RAM to this directory for higher performance.
->
-> - /tmp: The server will allocate unlimited space on its hard disk for this directory, but this will be much less efficient. We recommend using this directory only for occasional heavy operations.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-es.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configurar el servidor de bases de datos'
 excerpt: 'Cómo configurar y optimizar el servidor de bases de datos'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objetivo
@@ -103,7 +103,6 @@ En el cuadro **"Configuración general de MySql"** encontrará la configuración
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- **Tmpdir**: Directorio de archivos temporales. **/dev/shm** corresponde a la memoria RAM de la instancia. **/tmp** es el disco duro de la instancia.
 - **MaxAllowedPacket**: Tamaño máximo de los envíos
 - **max_user_connections**: Número de conexiones simultáneas autorizadas por usuario.
 - **AutoCommit**: Define si las peticiones se validan automáticamente (committed) o no.
@@ -117,15 +116,6 @@ En el cuadro **"Configuración general de MySql"** encontrará la configuración
 > [!primary]
 > Cuando se produce un error en el sitio web que indica **"Too many connections"**, se debe a que se han superado las conexiones simultáneas a su base de datos.
 > Puede aumentar la variable **"MaxConnections"** si no está al máximo.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: El servidor de bases de datos asignará la mitad de su memoria RAM a este directorio para un mayor rendimiento.
->
-> - /tmp: El servidor asignará a su disco duro un espacio ilimitado para este repertorio, pero será mucho menos potente. Le recomendamos que utilice este directorio únicamente para operaciones ocasionales pesadas.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-us.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configurar el servidor de bases de datos'
 excerpt: 'Cómo configurar y optimizar el servidor de bases de datos'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objetivo
@@ -103,7 +103,6 @@ En el cuadro **"Configuración general de MySql"** encontrará la configuración
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- **Tmpdir**: Directorio de archivos temporales. **/dev/shm** corresponde a la memoria RAM de la instancia. **/tmp** es el disco duro de la instancia.
 - **MaxAllowedPacket**: Tamaño máximo de los envíos
 - **max_user_connections**: Número de conexiones simultáneas autorizadas por usuario.
 - **AutoCommit**: Define si las peticiones se validan automáticamente (committed) o no.
@@ -117,15 +116,6 @@ En el cuadro **"Configuración general de MySql"** encontrará la configuración
 > [!primary]
 > Cuando se produce un error en el sitio web que indica **"Too many connections"**, se debe a que se han superado las conexiones simultáneas a su base de datos.
 > Puede aumentar la variable **"MaxConnections"** si no está al máximo.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: El servidor de bases de datos asignará la mitad de su memoria RAM a este directorio para un mayor rendimiento.
->
-> - /tmp: El servidor asignará a su disco duro un espacio ilimitado para este repertorio, pero será mucho menos potente. Le recomendamos que utilice este directorio únicamente para operaciones ocasionales pesadas.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-ca.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configurer votre serveur de bases de données'
 excerpt: 'Découvrez comment configurer et optimiser votre serveur de base de données'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objectif
@@ -103,7 +103,6 @@ Vous trouverez dans le cadre **« Configuration générale de MySql »** la conf
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- **Tmpdir** : Répertoire des fichiers temporaires. **/dev/shm** correspond à la mémoire RAM de l'instance. **/tmp** correspond au disque dur de l'instance.
 - **MaxAllowedPacket** : Taille maximum des paquets.
 - **Max_user_connections** : Nombre de connexions simultanées autorisées par utilisateur.
 - **AutoCommit** : Définit si les requêtes sont automatiquement validées (committed) ou non.
@@ -116,15 +115,6 @@ Vous trouverez dans le cadre **« Configuration générale de MySql »** la conf
 
 > [!primary]
 > Lorsque vous rencontrez une erreur sur votre site indiquant **« Too many connections»**, cela est dû au dépassement du nombre de connexions simultanées sur votre de bases de données.Vous pouvez alors augmenter la variable **« MaxConnections »** si elle n'est pas à son maximum.
->
-
-> [!primary]
->
-> <b>Tmpdir</b> :
->
-> - /dev/shm : Le serveur de bases de données allouera la moitié de sa mémoire RAM à ce répertoire pour plus de performances.
->
-> - /tmp : Le serveur allouera sur son disque dur un espace illimité pour ce répertoire, mais cela sera beaucoup moins performant. Nous vous conseillons d'utiliser ce répertoire uniquement pour les opérations occasionnelles lourdes.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-fr.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Configurer votre serveur de bases de données"
 excerpt: "Découvrez comment configurer et optimiser votre serveur de base de données"
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objectif
@@ -103,7 +103,6 @@ Vous trouverez dans le cadre **« Configuration générale de MySql »** la conf
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- **Tmpdir** : Répertoire des fichiers temporaires. **/dev/shm** correspond à la mémoire RAM de l'instance. **/tmp** correspond au disque dur de l'instance.
 - **MaxAllowedPacket** : Taille maximum des paquets.
 - **Max_user_connections** : Nombre de connexions simultanées autorisées par utilisateur.
 - **AutoCommit** : Définit si les requêtes sont automatiquement validées (committed) ou non.
@@ -116,15 +115,6 @@ Vous trouverez dans le cadre **« Configuration générale de MySql »** la conf
 
 > [!primary]
 > Lorsque vous rencontrez une erreur sur votre site indiquant **« Too many connections»**, cela est dû au dépassement du nombre de connexions simultanées sur votre de bases de données.Vous pouvez alors augmenter la variable **« MaxConnections »** si elle n'est pas à son maximum.
->
-
-> [!primary]
->
-> <b>Tmpdir</b> :
->
-> - /dev/shm : Le serveur de bases de données allouera la moitié de sa mémoire RAM à ce répertoire pour plus de performances.
->
-> - /tmp : Le serveur allouera sur son disque dur un espace illimité pour ce répertoire, mais cela sera beaucoup moins performant. Nous vous conseillons d'utiliser ce répertoire uniquement pour les opérations occasionnelles lourdes.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Configura il tuo database server 
 excerpt: Come configurare e ottimizzare il tuo database server
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Obiettivo
@@ -102,7 +102,6 @@ Nel riquadro **"Configurazione generale di MySql"** troverai la configurazione a
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- **Temp**: Directory dei file temporanei. **/dev/shm** corrisponde alla memoria RAM dell'istanza. **/tmp** corrisponde all'hard disk dell'istanza.
 - **MaxAllowedPacket**: Dimensione massima dei pacchetti
 - **Max_user_connections**: Numero di connessioni simultanee autorizzate per utente.
 - **AutoCommit**: Definisce se le richieste sono automaticamente confermate (committed) o no.
@@ -116,15 +115,6 @@ Nel riquadro **"Configurazione generale di MySql"** troverai la configurazione a
 > [!primary]
 > Quando si verifica un errore sul tuo sito indicando **"Too many connections"**, è dovuto al superamento del numero di connessioni simultanee sul tuo database.
 > In questo caso, puoi aumentare la variabile **"MaxConnections"** se non è al massimo.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: Il database server assegnerà metà della memoria RAM a questa directory per ottenere migliori performance.
->
-> - /tmp: Il server assegnerà sul suo hard disk uno spazio illimitato per questa directory, ma sarà molto meno performante. Ti consigliamo di utilizzare questa directory solo per operazioni occasionali di grande impatto.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pl-pl.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: 'Konfiguracja serwera baz danych'
 excerpt: 'Dowiedz się, jak skonfigurować i zoptymalizować serwer bazy danych'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Wprowadzenie
@@ -102,7 +102,6 @@ W polu **"Ogólna konfiguracja MySQL"** znajdziesz konfigurację aktualnie zdefi
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- **Rozmiar**: Katalog plików tymczasowych. **/dev/shm** odpowiada instancji pamięci RAM. **/tmp** odpowiada instancji dysku twardego.
 - **MaxAllowedPacket**: Maksymalny rozmiar pakietów
 - **Max_user_connections**: Liczba autoryzowanych jednoczesnych połączeń na użytkownika.
 - **Automatycznie**: Definiuje, czy zapytania są automatycznie zatwierdzane (committed) czy nie.
@@ -116,15 +115,6 @@ W polu **"Ogólna konfiguracja MySQL"** znajdziesz konfigurację aktualnie zdefi
 > [!primary]
 > Jeśli na Twojej stronie pojawi się błąd wskazujący **"Too many connections"**, jest to spowodowane przekroczeniem liczby jednoczesnych połączeń do Twojej bazy danych.
 > Możesz następnie zwiększyć zmienną **"MaxConnections"**, jeśli nie ma już maksymalnej wartości.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: Serwer baz danych przypisze połowę pamięci RAM do tego katalogu, aby uzyskać większą wydajność.
->
-> - /tmp: Serwer przydzieli nielimitowaną przestrzeń dla tego katalogu na dysku twardym. Zalecamy korzystanie z tego katalogu tylko w przypadku sporadycznych, ciężkich operacji.
 >
 
 > [!primary]

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pt-pt.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: 'Configurar o servidor de bases de dados'
 excerpt: 'Descubra como configurar e otimizar o servidor de bases de dados'
-updated: 2025-02-20
+updated: 2026-02-06
 ---
 
 ## Objetivo
@@ -102,7 +102,6 @@ No quadro **Configuração geral do MySql**, vai encontrar a configuração defi
 
 ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 
-- **Tmpdir**: Diretório de ficheiros temporários. **/dev/shm** corresponde à memória RAM da instância. **/tmp** corresponde ao disco rígido da instância.
 - **MaxAllowedPacket**: Tamanho máximo dos pacotes.
 - **Max_user_connections**: Número de conexões simultâneas autorizadas por utlizador.
 - **AutoCommit**: Define se os pedidos são validados (committed) automaticamente.
@@ -116,15 +115,6 @@ No quadro **Configuração geral do MySql**, vai encontrar a configuração defi
 > [!primary]
 > Quando encontra um erro no seu site a indicar **"Too many connections"**, isso deve-se à ultrapassagem do número máximo de conexões simultâneas na base de dados.
 > Assim, se a variável **"MaxConnections"** não estiver no máximo, pode aumentá-la.
->
-
-> [!primary]
->
-> <b>Tmpdir</b>:
->
-> - /dev/shm: O servidor de bases de dados vai alocar para este diretório metade da sua memória RAM, tendo em vista um melhor desempenho.
->
-> - /tmp: O servidor vai alocar no disco rígido um espaço ilimitado para este diretório, mas o desempenho será muito inferior. Recomendamos que utilize este diretório apenas para operações pontuais pesadas.
 >
 
 > [!primary]


### PR DESCRIPTION
from dev/mikael.davranche/tmpdir to develop-stash

## What type of Pull Request is this?

- Update of existing guide(s)

## Description

The tmpdir option is now deprecated