### PR TITLE
Virtual MAC: fix typos and redundancy in EN/FR guides

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.de-de.md
@@ -12,10 +12,9 @@ Bei OVHcloud können Sie eine virtuelle MAC-Adresse mit einer IP-Adresse verbind
 
 ## Voraussetzungen
 
-- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal) in Ihrem Kunden-Account, der [virtuelle MACs unterstützt](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
+- Sie haben einen [Dedicated Server](/links/bare-metal/bare-metal) in Ihrem Kunden-Account. Ihr Server muss virtuelle MAC-Adressen unterstützen. Überprüfen Sie dies mithilfe [unserer Anleitung](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 - Sie verfügen über eine [Additional IP](/links/network/additional-ip).
 - Sie haben Zugriff auf Ihr [OVHcloud Kundencenter](/links/manager) oder die [OVHcloud API](/links/api).
-- Ihr Server muss virtuelle MAC-Adressen unterstützen. Überprüfen Sie dies mithilfe [unserer Anleitung](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 
 > [!warning]
 > - Diese Funktion kann nur eingeschränkt oder nicht verfügbar sein, falls ein Dedicated Server der [**Eco** Produktlinie](/links/bare-metal/eco-about) eingesetzt wird. Weitere Informationen finden Sie auf der [Vergleichsseite](/links/bare-metal/eco-compare).

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-asia.md
@@ -12,10 +12,9 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) that supports [virtual MACs](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
+- A [dedicated server](/links/bare-metal/bare-metal) that supports virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 - An [Additional IP address](/links/network/additional-ip) or an Additional IP block (RIPE).
 - Access to your [OVHcloud Control Panel](/links/manager) or to the [OVHcloud API](/links/api).
-- Your server must support virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 
 > [!warning]
 > - This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about). Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
@@ -29,6 +28,8 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [First steps with the OVHcloud APIs](/pages/manage_and_operate/api/first-steps).
 
 ## Instructions
+
+### Assign a MAC address
 
 > [!warning]
 >
@@ -51,7 +52,7 @@ When the 'Add a virtual MAC' box appears, select a type from the dropdown list, 
 
 > [!primary]
 >
-> **Type:** Refers to the virtual MAC address type ('VmWare' will be a MAC address made for the VmWare ESXi system, while 'ovh' will be for any other type of virtualisation system).
+> **Type:** Refers to the virtual MAC address type ('VMware' will be a MAC address made for the VMware ESXi system, while 'ovh' will be for any other type of virtualisation system).
 >
 > **Name of virtual machine:** Refers to the desired name for the virtual MAC address, in order to make it easy to identify this IP/MAC pair in the future.
 >

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-au.md
@@ -12,10 +12,9 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) that supports [virtual MACs](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
+- A [dedicated server](/links/bare-metal/bare-metal) that supports virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 - An [Additional IP address](/links/network/additional-ip) or an Additional IP block (RIPE).
 - Access to your [OVHcloud Control Panel](/links/manager) or to the [OVHcloud API](/links/api).
-- Your server must support virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 
 > [!warning]
 > - This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about). Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
@@ -29,6 +28,8 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [First steps with the OVHcloud APIs](/pages/manage_and_operate/api/first-steps).
 
 ## Instructions
+
+### Assign a MAC address
 
 > [!warning]
 >
@@ -51,7 +52,7 @@ When the 'Add a virtual MAC' box appears, select a type from the dropdown list, 
 
 > [!primary]
 >
-> **Type:** Refers to the virtual MAC address type ('VmWare' will be a MAC address made for the VmWare ESXi system, while 'ovh' will be for any other type of virtualisation system).
+> **Type:** Refers to the virtual MAC address type ('VMware' will be a MAC address made for the VMware ESXi system, while 'ovh' will be for any other type of virtualisation system).
 >
 > **Name of virtual machine:** Refers to the desired name for the virtual MAC address, in order to make it easy to identify this IP/MAC pair in the future.
 >

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-ca.md
@@ -12,10 +12,9 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) that supports [virtual MACs](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
+- A [dedicated server](/links/bare-metal/bare-metal) that supports virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 - An [Additional IP address](/links/network/additional-ip) or an Additional IP block (RIPE).
 - Access to your [OVHcloud Control Panel](/links/manager) or to the [OVHcloud API](/links/api).
-- Your server must support virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 
 > [!warning]
 > - This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about). Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
@@ -29,6 +28,8 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [First steps with the OVHcloud APIs](/pages/manage_and_operate/api/first-steps).
 
 ## Instructions
+
+### Assign a MAC address
 
 > [!warning]
 >
@@ -51,7 +52,7 @@ When the 'Add a virtual MAC' box appears, select a type from the dropdown list, 
 
 > [!primary]
 >
-> **Type:** Refers to the virtual MAC address type ('VmWare' will be a MAC address made for the VmWare ESXi system, while 'ovh' will be for any other type of virtualisation system).
+> **Type:** Refers to the virtual MAC address type ('VMware' will be a MAC address made for the VMware ESXi system, while 'ovh' will be for any other type of virtualisation system).
 >
 > **Name of virtual machine:** Refers to the desired name for the virtual MAC address, in order to make it easy to identify this IP/MAC pair in the future.
 >

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-gb.md
@@ -15,7 +15,6 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 - A [dedicated server](/links/bare-metal/bare-metal) that supports [virtual MACs](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 - An [Additional IP address](/links/network/additional-ip) or an Additional IP block (RIPE).
 - Access to your [OVHcloud Control Panel](/links/manager) or to the [OVHcloud API](/links/api).
-- Your server must support virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 
 > [!warning]
 > - This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about). Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
@@ -29,6 +28,8 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [First steps with the OVHcloud APIs](/pages/manage_and_operate/api/first-steps).
 
 ## Instructions
+
+### Assign a MAC address
 
 > [!warning]
 >
@@ -51,7 +52,7 @@ When the 'Add a virtual MAC' box appears, select a type from the dropdown list, 
 
 > [!primary]
 >
-> **Type:** Refers to the virtual MAC address type ('VmWare' will be a MAC address made for the VmWare ESXi system, while 'ovh' will be for any other type of virtualisation system).
+> **Type:** Refers to the virtual MAC address type ('VMware' will be a MAC address made for the VMware ESXi system, while 'ovh' will be for any other type of virtualisation system).
 >
 > **Name of virtual machine:** Refers to the desired name for the virtual MAC address, in order to make it easy to identify this IP/MAC pair in the future.
 >

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-gb.md
@@ -12,7 +12,7 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) that supports [virtual MACs](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
+- A [dedicated server](/links/bare-metal/bare-metal) that supports virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 - An [Additional IP address](/links/network/additional-ip) or an Additional IP block (RIPE).
 - Access to your [OVHcloud Control Panel](/links/manager) or to the [OVHcloud API](/links/api).
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-ie.md
@@ -12,10 +12,9 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) that supports [virtual MACs](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
+- A [dedicated server](/links/bare-metal/bare-metal) that supports virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 - An [Additional IP address](/links/network/additional-ip) or an Additional IP block (RIPE).
 - Access to your [OVHcloud Control Panel](/links/manager) or to the [OVHcloud API](/links/api).
-- Your server must support virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 
 > [!warning]
 > - This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about). Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
@@ -29,6 +28,8 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [First steps with the OVHcloud APIs](/pages/manage_and_operate/api/first-steps).
 
 ## Instructions
+
+### Assign a MAC address
 
 > [!warning]
 >
@@ -51,7 +52,7 @@ When the 'Add a virtual MAC' box appears, select a type from the dropdown list, 
 
 > [!primary]
 >
-> **Type:** Refers to the virtual MAC address type ('VmWare' will be a MAC address made for the VmWare ESXi system, while 'ovh' will be for any other type of virtualisation system).
+> **Type:** Refers to the virtual MAC address type ('VMware' will be a MAC address made for the VMware ESXi system, while 'ovh' will be for any other type of virtualisation system).
 >
 > **Name of virtual machine:** Refers to the desired name for the virtual MAC address, in order to make it easy to identify this IP/MAC pair in the future.
 >

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-sg.md
@@ -12,10 +12,9 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) that supports [virtual MACs](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
+- A [dedicated server](/links/bare-metal/bare-metal) that supports virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 - An [Additional IP address](/links/network/additional-ip) or an Additional IP block (RIPE).
 - Access to your [OVHcloud Control Panel](/links/manager) or to the [OVHcloud API](/links/api).
-- Your server must support virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 
 > [!warning]
 > - This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about). Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
@@ -29,6 +28,8 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [First steps with the OVHcloud APIs](/pages/manage_and_operate/api/first-steps).
 
 ## Instructions
+
+### Assign a MAC address
 
 > [!warning]
 >
@@ -51,7 +52,7 @@ When the 'Add a virtual MAC' box appears, select a type from the dropdown list, 
 
 > [!primary]
 >
-> **Type:** Refers to the virtual MAC address type ('VmWare' will be a MAC address made for the VmWare ESXi system, while 'ovh' will be for any other type of virtualisation system).
+> **Type:** Refers to the virtual MAC address type ('VMware' will be a MAC address made for the VMware ESXi system, while 'ovh' will be for any other type of virtualisation system).
 >
 > **Name of virtual machine:** Refers to the desired name for the virtual MAC address, in order to make it easy to identify this IP/MAC pair in the future.
 >

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.en-us.md
@@ -12,10 +12,9 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 
 ## Requirements
 
-- A [dedicated server](/links/bare-metal/bare-metal) that supports [virtual MACs](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
+- A [dedicated server](/links/bare-metal/bare-metal) that supports virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 - An [Additional IP address](/links/network/additional-ip) or an Additional IP block (RIPE).
 - Access to your [OVHcloud Control Panel](/links/manager) or to the [OVHcloud API](/links/api).
-- Your server must support virtual MACs. To determine this, consult [this guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 
 > [!warning]
 > - This feature might be unavailable or limited on servers of the [**Eco** product line](/links/bare-metal/eco-about). Please visit our [comparison page](/links/bare-metal/eco-compare) for more information.
@@ -29,6 +28,8 @@ OVHcloud allows you to associate a virtual MAC address with an IP address, so th
 > If you are not familiar with using the OVHcloud API, please refer to our guide on [First steps with the OVHcloud APIs](/pages/manage_and_operate/api/first-steps).
 
 ## Instructions
+
+### Assign a MAC address
 
 > [!warning]
 >
@@ -51,7 +52,7 @@ When the 'Add a virtual MAC' box appears, select a type from the dropdown list, 
 
 > [!primary]
 >
-> **Type:** Refers to the virtual MAC address type ('VmWare' will be a MAC address made for the VmWare ESXi system, while 'ovh' will be for any other type of virtualisation system).
+> **Type:** Refers to the virtual MAC address type ('VMware' will be a MAC address made for the VMware ESXi system, while 'ovh' will be for any other type of virtualisation system).
 >
 > **Name of virtual machine:** Refers to the desired name for the virtual MAC address, in order to make it easy to identify this IP/MAC pair in the future.
 >

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.es-es.md
@@ -12,10 +12,9 @@ OVHcloud permite asociar una dirección MAC virtual a una dirección IP para pod
 
 ## Requisitos
 
-- Tener un [servidor dedicado](/links/bare-metal/bare-metal).
+- Tener [un servidor dedicado](/links/bare-metal/bare-metal) que soporte las MAC virtuales. Consulte [esta guía](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac) para averiguarlo.
 - Tener una [dirección Additional IP](/links/network/additional-ip) o un bloque de Additional IP (RIPE).
 - Estar conectado al [área de cliente de OVHcloud](/links/manager) o a [la API de OVHcloud](/links/api).
-- Su servidor debe soportar las MAC virtuales. Para ello, consulte [esta guía](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 
 > [!warning]
 > - Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about). Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.es-us.md
@@ -12,10 +12,9 @@ OVHcloud permite asociar una dirección MAC virtual a una dirección IP para pod
 
 ## Requisitos
 
-- Tener un [servidor dedicado](/links/bare-metal/bare-metal).
+- Tener [un servidor dedicado](/links/bare-metal/bare-metal) que soporte las MAC virtuales. Consulte [esta guía](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac) para averiguarlo.
 - Tener una [dirección Additional IP](/links/network/additional-ip) o un bloque de Additional IP (RIPE).
 - Estar conectado al [área de cliente de OVHcloud](/links/manager) o a [la API de OVHcloud](/links/api).
-- Su servidor debe soportar las MAC virtuales. Para ello, consulte [esta guía](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 
 > [!warning]
 > - Esta funcionalidad puede no estar disponible o estar limitada en los [servidores dedicados **Eco**](/links/bare-metal/eco-about). Para más información, consulte nuestra [comparativa](/links/bare-metal/eco-compare).

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.fr-ca.md
@@ -12,10 +12,9 @@ OVHcloud vous permet d’associer une adresse MAC virtuelle à une adresse IP, a
 
 ## Prérequis
 
-- Posséder [un serveur dédié](/links/bare-metal/bare-metal).
+- Posséder [un serveur dédié](/links/bare-metal/bare-metal) qui supporte les MAC virtuelles. Consultez [ce guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac) afin de le déterminer.
 - Disposer d'une [adresse Additional IP](/links/network/additional-ip) ou un bloc d’Additional IP (RIPE).
 - Être connecté à l'[espace client OVHcloud](/links/manager) ou à [l'API OVHcloud](/links/api).
-- Votre serveur doit supporter les MAC virtuelles. Consultez [ce guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac) afin de le déterminer.
 
 > [!warning]
 > - Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about). Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.
@@ -100,7 +99,7 @@ Utilisez l'appel API suivant :
 
 Le bloc ne sera pas déplacé.
 
-Exemple : si vous tentez de déplacer un bloc de 4 IPs avec des vMACs différentes attachées sur un serveur ayant déjà 30 vMACs le bloc ne sera pas déplacé car le total de vMACs serait supérieur aux 32 vMACs autorisées.
+Exemple : si vous tentez de déplacer un bloc de 4 IP avec des vMACs différentes attachées sur un serveur ayant déjà 30 vMACs le bloc ne sera pas déplacé car le total de vMACs serait supérieur aux 32 vMACs autorisées.
 
 ## Aller plus loin
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.fr-fr.md
@@ -12,10 +12,9 @@ OVHcloud vous permet d’associer une adresse MAC virtuelle à une adresse IP, a
 
 ## Prérequis
 
-- Posséder [un serveur dédié](/links/bare-metal/bare-metal).
+- Posséder [un serveur dédié](/links/bare-metal/bare-metal) qui supporte les MAC virtuelles. Consultez [ce guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac) afin de le déterminer.
 - Disposer d'une [adresse Additional IP](/links/network/additional-ip) ou un bloc d’Additional IP (RIPE).
 - Être connecté à l'[espace client OVHcloud](/links/manager) ou à [l'API OVHcloud](/links/api).
-- Votre serveur doit supporter les MAC virtuelles. Consultez [ce guide](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac) afin de le déterminer.
 
 > [!warning]
 > - Cette fonctionnalité peut être indisponible ou limitée sur les [serveurs dédiés **Eco**](/links/bare-metal/eco-about). Consultez notre [comparatif](/links/bare-metal/eco-compare) pour plus d’informations.

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.fr-fr.md
@@ -100,7 +100,7 @@ Utilisez l'appel API suivant :
 
 Le bloc ne sera pas déplacé.
 
-Exemple : si vous tentez de déplacer un bloc de 4 IPs avec des vMACs différentes attachées sur un serveur ayant déjà 30 vMACs le bloc ne sera pas déplacé car le total de vMACs serait supérieur aux 32 vMACs autorisées.
+Exemple : si vous tentez de déplacer un bloc de 4 IP avec des vMACs différentes attachées sur un serveur ayant déjà 30 vMACs le bloc ne sera pas déplacé car le total de vMACs serait supérieur aux 32 vMACs autorisées.
 
 ## Aller plus loin
 

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.it-it.md
@@ -12,10 +12,9 @@ OVHcloud ti permette di associare un indirizzo MAC virtuale a un indirizzo IP al
 
 ## Prerequisiti
 
-- Possedere un [server dedicato](/links/bare-metal/bare-metal)
+- Disporre di [un server dedicato](/links/bare-metal/bare-metal) che supporta i MAC virtuali. Per determinarlo, consulta [questa guida](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 - Disporre di un [indirizzo Additional IP](/links/network/additional-ip) o di un blocco Additional IP (RIPE)
 - Essere connesso allo [Spazio Cliente OVHcloud](/links/manager) o all'[API OVHcloud](/links/api)
-- Il tuo server deve supportare i MAC virtuali. Consulta [questa guida](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac) per determinarlo
 
 > [!warning]
 > - Questa funzionalità può non essere disponibile o limitata sui [server dedicati **Eco**](/links/bare-metal/eco-about). Per maggiori informazioni, consulta la nostra [a confronto](/links/bare-metal/eco-compare).

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.pl-pl.md
@@ -12,10 +12,9 @@ OVHcloud umożliwia Ci powiązanie wirtualnego adresu MAC z adresem IP, abyś m�
 
 ## Wymagania początkowe
 
-- Posiadanie [serwera dedykowanego](/links/bare-metal/bare-metal)
+- Posiadanie [serwera dedykowanego](/links/bare-metal/bare-metal). Twój serwer musi obsługiwać wirtualne adresy MAC. Zapoznaj się [z tym przewodnikiem](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 - Posiadanie [adresu Additional IP](/links/network/additional-ip) lub bloku Additional IP (RIPE)
 - Dostęp do [Panelu klienta](/links/manager) lub do [API OVHcloud](/links/api)
-- Twój serwer musi obsługiwać wirtualne adresy MAC. Zapoznaj się [z tym przewodnikiem](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac).
 
 > [!warning]
 > - Funkcja ta może być niedostępna lub ograniczona na [serwerach dedykowanych **Eco**](/links/bare-metal/eco-about). Aby uzyskać więcej informacji, zapoznaj się z naszym [porównaniem](/links/bare-metal/eco-compare).

--- a/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/network_virtual_mac/guide.pt-pt.md
@@ -12,10 +12,9 @@ A OVHcloud permite-lhe associar um endereço MAC virtual a um endereço de IP, d
 
 ## Requisitos
 
-- Dispor de um [servidor dedicado](/links/bare-metal/bare-metal).
+- Dispor de [um servidor dedicado](/links/bare-metal/bare-metal) que suporte os MAC virtuais. Consulte [este guia](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac) para o determinar.
 - Dispor de um [endereço de Additional IP](/links/network/additional-ip) ou de um bloco de Additional IP (RIPE).
 - Ter acesso à [Área de Cliente OVHcloud](/links/manager)  ou à [API OVHcloud](/links/api).
-- O seu servidor deve suportar os MAC virtuais. Consulte [este guia](/pages/bare_metal_cloud/dedicated_servers/network_support_virtual_mac) para saber mais.
 
 > [!warning]
 > - Esta funcionalidade pode estar indisponível ou limitada nos [servidores dedicados **Eco**](/links/bare-metal/eco-about). Para mais informações, consulte o nosso [comparativo](/links/bare-metal/eco-compare).


### PR DESCRIPTION
## What type of Pull Request is this?                                                          
                                                                                               
- Fix                                                                                          
                                                                                               
## Description                                                                                 
                                                                                               
EN:                                                                                            
- Remove redundant requirement (vMAC support already linked in first item)                     
- Add missing "Assign a MAC address" section header                                            
- Fix "VmWare" → "VMware"                                                                      
                                                                                               
FR:                                                                                            
- Fix "4 IPs" → "4 IP" (abbreviations are invariable in French)                                
                                                                                               
## Mandatory information                                                                       
                                                                                               
The translations in this Pull Request have been done using:                                    
- [x] This Pull Request didn't require any translation.                                        
                                                                                               
- This Pull Request can be merged as soon as possible.                                         
