### PR TITLE
Fix typos, technical errors, and improve consistency in the Software RAID guides

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/raid_soft/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/raid_soft/guide.en-gb.md
@@ -142,7 +142,7 @@ I/O size (minimum/optimal): 512 bytes / 512 bytes
 
 The `fdisk -l` command also allows you to identify your partition type. This is an important information when it comes to rebuilding your RAID in case of a disk failure.
 
-For **GPT** partitions, line 6 will display: `Disklabel type: gpt`. This information can only been seen when the server is in normal mode.
+For **GPT** partitions, line 6 will display: `Disklabel type: gpt`. This information can only be seen when the server is in normal mode.
 
 Still going by the results of `fdisk -l`, we can see that `/dev/md2` consists of 888.8GB and `/dev/md4` contains 973.5GB.
 
@@ -169,16 +169,22 @@ sdb       8:16   0   1.8T  0 disk
   └─md4   9:4    0 973.5G  0 raid1 /home
 ```
 
-We take note of the devices, partitions and their mount points. From the above commands and results, we have:
+Note the devices, partitions, and mount points, as this is important, especially after replacing a disk. This will allow you to verify that the partitions are correctly mounted on their respective mount points on the new disk.
 
-- Two RAID arrays: `/dev/md2` and `/dev/md4`.
-- Four partitions are part of the RAID with the mount points: `/` and `/home`.
+In our example, we have:
+
+- Partitions part of md2 (`/`): **sda2** and **sdb2**.
+- Partitions part of md4 (`/home`): **sda4** and **sdb4**.
+- Swap partitions: **sda3** and **sdb3**.
+- BIOS boot partitions: **sda1** and **sdb1**.
+
+The `sda5` partition is a [config drive](https://cloudinit.readthedocs.io/en/latest/reference/datasources/configdrive.html), i.e. a read-only volume that provides the server with its initial configuration data. It is only read once during initial boot and can be removed afterwards.
 
 <a name="diskfailure"></a>
 
 ### Simulating a disk failure
 
-Now that we have all the necessary information, we can now simulate a disk. In this example, we will fail the disk `sda`.
+Now that we have all the necessary information, we can now simulate a disk failure. In this example, we will fail the disk `sda`.
 
 The preferred way to do this is via the OVHcloud rescue mode environment.
 
@@ -385,7 +391,7 @@ Once the replacement is done, the next step is to copy the partition table from 
 >> The command should be in this format: `sfdisk -d /dev/healthydisk | sfdisk /dev/newdisk`.
 >>
 
-Once this is done, the next step is to randomize the GUID of the new disk to prevent GUID conflicts with other disks:
+Once this is done, the next step is to randomise the GUID of the new disk to prevent GUID conflicts with other disks:
 
 ```sh
 sudo sgdisk -G /dev/sdX
@@ -431,7 +437,7 @@ unused devices: <none>
 
 Lastly, we add a label and mount the [SWAP] partition (if applicable).
 
-To add a label the SWAP partition:
+To add a label to the SWAP partition:
 
 ```sh
 [user@server_ip ~]# sudo mkswap /dev/sda4 -L swap-sda4
@@ -442,7 +448,7 @@ Next, retrieve the UUIDs of both SWAP partitions:
 ```sh
 [user@server_ip ~]# sudo blkid -s UUID /dev/sda4
 /dev/sda4: UUID="b3c9e03a-52f5-4683-81b6-cc10091fcd15"
-[user@server_ip ~]# sudo blkid -S UUID /dev/sdb4
+[user@server_ip ~]# sudo blkid -s UUID /dev/sdb4
 /dev/sdb4: UUID="d6af33cf-fc15-4060-a43c-cb3b5537f58a"
 ```
 
@@ -451,7 +457,7 @@ We replace the old UUID of the SWAP partition (**sda4**) with the new one in the
 Example:
 
 ```sh
-[user@server_ip ~]# sudo nano etc/fstab
+[user@server_ip ~]# sudo nano /etc/fstab
 
 UUID=6abfaa3b-e630-457a-bbe0-e00e5b4b59e5       /       ext4    defaults       0       1
 UUID=f925a033-0087-40ec-817e-44efab0351ac       /boot   ext4    defaults       0       0
@@ -492,7 +498,7 @@ We have now successfully completed the RAID rebuild.
 
 /// details | **Rebuilding the RAID in rescue mode**
 
-If you server is unable to reboot in normal mode after a disk replacement, it will be rebooted in rescue mode by our datacentre team.
+If your server is unable to reboot in normal mode after a disk replacement, it will be rebooted in rescue mode by our datacentre team.
 
 In this example, we have replaced the disk `sdb`.
 
@@ -527,13 +533,13 @@ Once the disk has been replaced, we need to copy the partition table from the he
 >> sudo sfdisk -d /dev/sda /dev/sdb
 >> ```
 
-Once this is done, the next step is to randomize the GUID of the new disk to prevent GUID conflicts with other disks:
+Once this is done, the next step is to randomise the GUID of the new disk to prevent GUID conflicts with other disks:
 
 ```sh
 sudo sgdisk -G /dev/sdb
 ```
 
-If you the following message:
+If you receive the following message:
  
 ```console
 Warning: The kernel is still using the old partition table.
@@ -573,10 +579,10 @@ unused devices: <none>
 
 Lastly, we add a label and mount the [SWAP] partition (if applicable).
 
-Once the RAID rebuild is complete, we mount the partition containing the root of our operating system on `/mnt`. In our example, that partition is `md4`.
+Once the RAID rebuild is complete, we mount the partition containing the root of our operating system on `/mnt`. In our example, that partition is `md2`.
 
 ```sh
-root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # mount /dev/md4 /mnt
+root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # mount /dev/md2 /mnt
 ```
 
 We add the label to our SWAP partition with the command:
@@ -626,7 +632,7 @@ blkid /dev/sdb4
 Next, we replace the old UUID of the swap partition (**sdb4**) with the new one in `/etc/fstab`:
 
 ```sh
-root@rescue12-customer-eu:/# nano etc/fstab
+root@rescue12-customer-eu:/# nano /etc/fstab
 ```
 
 Example:
@@ -652,7 +658,7 @@ swap                     : ignored
 swap                     : ignored
 ```
 
-Enable the SWAP partition the following command:
+Enable the SWAP partition with the following command:
 
 ```sh
 root@rescue12-customer-eu:/# swapon -av
@@ -671,7 +677,7 @@ We exit the `chroot` environment with exit and reload the system:
 root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # systemctl daemon-reload
 ```
 
-We umount all the disks:
+We unmount all the disks:
 
 ```sh
 root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # umount -R /mnt

--- a/pages/bare_metal_cloud/dedicated_servers/raid_soft/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/raid_soft/guide.fr-fr.md
@@ -169,10 +169,16 @@ sdb       8:16   0   1.8T  0 disk
   └─md4   9:4    0 973.5G  0 raid1 /home
 ```
 
-Nous prenons en compte les périphériques, les partitions et leurs points de montage. À partir des commandes et des résultats ci-dessus, nous avons :
+Notez les périphériques, les partitions et les points de montage, car cela est important, en particulier après le remplacement d'un disque. Cela vous permettra de vérifier que les partitions sont correctement montées sur leurs points de montage respectifs sur le nouveau disque.
 
-- Deux baies RAID : `/dev/md2` et `/dev/md4`.
-- Quatre partitions font partie du RAID avec les points de montage : `/` et `/home`.
+Dans notre exemple, nous avons :
+
+- Partitions faisant partie de md2 (`/`) : **sda2** et **sdb2**.
+- Partitions faisant partie de md4 (`/home`) : **sda4** et **sdb4**.
+- Partitions swap : **sda3** et **sdb3**.
+- Partitions BIOS boot : **sda1** et **sdb1**.
+
+La partition `sda5` est un [config drive](https://cloudinit.readthedocs.io/en/latest/reference/datasources/configdrive.html), c'est-à-dire un volume en lecture seule qui fournit au serveur ses données de configuration initiale. Elle n'est lue qu'une seule fois lors du premier démarrage et peut être supprimée ensuite.
 
 <a name="diskfailure"></a>
 
@@ -442,7 +448,7 @@ Ensuite, récupérez les UUID des deux partitions SWAP :
 ```sh
 [user@server_ip ~]# sudo blkid -s UUID /dev/sda4
 /dev/sda4: UUID="b3c9e03a-52f5-4683-81b6-cc10091fcd15"
-[user@server_ip ~]# sudo blkid -S UUID /dev/sdb4
+[user@server_ip ~]# sudo blkid -s UUID /dev/sdb4
 /dev/sdb4: UUID="d6af33cf-fc15-4060-a43c-cb3b5537f58a"
 ```
 
@@ -451,7 +457,7 @@ Nous remplaçons l'ancien UUID de la partition SWAP (**sda4**) par le nouveau da
 Exemple :
 
 ```sh
-[user@server_ip ~]# sudo nano etc/fstab
+[user@server_ip ~]# sudo nano /etc/fstab
 
 UUID=6abfaa3b-e630-457a-bbe0-e00e5b4b59e5       /       ext4    defaults       0       1
 UUID=f925a033-0087-40ec-817e-44efab0351ac       /boot   ext4    defaults       0       0
@@ -573,19 +579,19 @@ unused devices: <none>
 
 Enfin, nous ajoutons une étiquette et montons la partition [SWAP] (le cas échéant).
 
-Une fois la reconstruction du RAID terminée, nous montons la partition contenant la racine de notre système d'exploitation sur `/mnt`. Dans notre exemple, cette partition est `md4`.
+Une fois la reconstruction du RAID terminée, nous montons la partition contenant la racine de notre système d'exploitation sur `/mnt`. Dans notre exemple, cette partition est `md2`.
 
 ```sh
-root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # mount /dev/md4 /mnt
+root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # mount /dev/md2 /mnt
 ```
 
 Nous ajoutons le label à notre partition swap avec la commande :
 
 ```sh
-root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # mkswap /dev/sda4 -L swap-sda4
-mkswap: /dev/sda4: warning: wiping old swap signature.
+root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # mkswap /dev/sdb4 -L swap-sdb4
+mkswap: /dev/sdb4: warning: wiping old swap signature.
 Setting up swapspace version 1, size = 512 MiB (536866816 bytes)
-LABEL=swap-nvme0n1p4, UUID=b3c9e03a-52f5-4683-81b6-cc10091fcd
+LABEL=swap-sdb4, UUID=b3c9e03a-52f5-4683-81b6-cc10091fcd
 ```
 
 Ensuite, nous montons les répertoires suivants pour nous assurer que toute manipulation que nous faisons dans l'environnement chroot fonctionne correctement :
@@ -626,7 +632,7 @@ blkid /dev/sdb4
 Ensuite, nous remplaçons l'ancien UUID de la partition SWAP (**sdb4**) par le nouveau dans `/etc/fstab` :
 
 ```sh
-root@rescue12-customer-eu:/# nano etc/fstab
+root@rescue12-customer-eu:/# nano /etc/fstab
 ```
 
 Exemple:

--- a/pages/bare_metal_cloud/dedicated_servers/raid_soft_uefi/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/raid_soft_uefi/guide.en-gb.md
@@ -54,7 +54,7 @@ When you purchase a new server, you may feel the need to perform a series of tes
 ### Content overview
 
 - [Basic Information](#basicinformation)
-- [Understanding the EFI System Partition (ESP)](#efisystemparition)
+- [Understanding the EFI System Partition (ESP)](#efisystempartition)
 - [Simulating a disk failure](#diskfailure)
     - [Removing the failed disk](#diskremove)
 - [Rebuilding the RAID (with non mirrored ESP)](#raidrebuildnonmirrored)
@@ -175,7 +175,7 @@ I/O size (minimum/optimal): 512 bytes / 512 bytes
 This command can also be used to identify the partition type.
 
 For **GPT** partitions, line 6 shows: `Disklabel type: gpt`.
-This information can only been seen when the server is in normal mode.
+This information can only be seen when the server is in normal mode.
 
 Still going by the results, we see that `/dev/md2` consists of 1022 MiB and `/dev/md3` contains 474.81 GiB. If we were to run the `mount` command we can also find out the layout of the disk.
 ///
@@ -228,12 +228,13 @@ Note the devices, partitions, and mount points, as this is important, especially
 
 In our example, we have:
 
-- Two RAID arrays: `/dev/md2` and `/dev/md3`.
-- Partitions part of the RAID: **nvme0n1p2**, **nvme0n1p3**, **nvme1n1p2** and **nvme0n1p3** with the mount points `/boot` and `/`.
-- Partitions not part of the RAID: **nvem0n1p1**, **nvme0n1p4** and **nvme1n1p4** with mount points `/boot/efi` and [SWAP].
-- One partition does not have a mount point: **nvme1n1p1**.
+- Partitions part of md2 (`/boot`): **nvme0n1p2** and **nvme1n1p2**.
+- Partitions part of md3 (`/`): **nvme0n1p3** and **nvme1n1p3**.
+- Swap partitions: **nvme0n1p4** and **nvme1n1p4**.
+- Mounted ESP (`/boot/efi`): **nvme0n1p1**.
+- Unmounted ESP: **nvme1n1p1**.
 
-The `nvme0n1p5` partition is a configuration partition, i.e. a read-only volume connected to the server that provides it with the initial configuration data.
+The `nvme0n1p5` partition is a [config drive](https://cloudinit.readthedocs.io/en/latest/reference/datasources/configdrive.html), i.e. a read-only volume that provides the server with its initial configuration data. It is only read once during initial boot and can be removed afterwards.
 
 <a name="efisystempartition"></a>
 
@@ -330,12 +331,12 @@ If your ESP is not mirrored, you may experience the following:
 - The server is able to boot in normal mode and you can proceed with the RAID rebuild.
 - The server is unable to boot in normal mode, use the rescue mode environment to rebuild the RAID and recreate the EFI partition on the new disk.
 
-**Case Study 2** – There have been major system updates (e.g., GRUB), and the ESPs are synchronized.
+**Case Study 2** – There have been major system updates (e.g., GRUB), and the ESPs are synchronised.
 
 - The server is able to boot in normal mode because all ESPs are up-to-date, and the RAID rebuild can be performed in normal mode.
 - The server is unable to boot in normal mode, use the rescue mode environment to rebuild the RAID and recreate the EFI partition on the new disk.
 
-**Case Study 3** – There have been major system updates (e.g GRUB) to the OS and the ESPs partitions have not been synchronised.
+**Case Study 3** – There have been major system updates (e.g. GRUB) to the OS and the ESP partitions have not been synchronised.
 
 - The server is unable to boot in normal mode, use the rescue mode environment to rebuild the RAID, recreate the EFI System Partition on the new disk, and reinstall the bootloader (e.g., GRUB).
 - The server can boot in normal mode (for example, when the OS is upgraded but the GRUB version remains unchanged), allowing you to proceed with the RAID rebuild.
@@ -347,13 +348,13 @@ In some cases, booting from an out-of-date ESP may fail; for example, a major GR
 If your ESP is not mirrored, consider the following:
 
 > [!primary]
-> Please note that depending on your operating system, the process might differ. For example, Ubuntu can keep multiple EFI System Partitions synchronized with every GRUB update, but it is the only OS that does so. We recommend consulting the official documentation of your OS to understand how to manage ESPs.
+> Please note that depending on your operating system, the process might differ. For example, Ubuntu can keep multiple EFI System Partitions synchronised with every GRUB update, but it is the only OS that does so. We recommend consulting the official documentation of your OS to understand how to manage ESPs.
 >
 > In this guide, the operating system used is Debian.
 
-We recommend synchronizing your ESPs regularly or after each major system update. By default, all EFI System partitions contain the same files after installation. However, after a major system update, synchronizing the ESPs is necessary to ensure the content remains up-to-date.
+We recommend synchronising your ESPs regularly or after each major system update. By default, all EFI System partitions contain the same files after installation. However, after a major system update, synchronising the ESPs is necessary to ensure the content remains up-to-date.
 
-Running a script is an effective way to keep your partitions regularly synchronized. Below is a script you can use to manually sync your ESPs. Alternatively, you can set up an automated script to sync them daily or whenever the system boots.
+Running a script is an effective way to keep your partitions regularly synchronised. Below is a script you can use to manually sync your ESPs. Alternatively, you can set up an automated script to sync them daily or whenever the system boots.
 
 Before executing the script, ensure that `rsync` is installed on your system:
 
@@ -369,7 +370,7 @@ sudo apt install rsync
 sudo yum install rsync
 ```
 
-To execute a script in linux, you need an executable file:
+To execute a script in Linux, you need an executable file:
 
 - Start by creating a .sh file in the directory of your choice, replacing `script-name` with the name of your choice:
 
@@ -647,7 +648,7 @@ nvme0n1     259:5    0 476.9G  0 disk
 └─nvme0n1p4 259:13   0   512M  0 part
 ```
 
-Next, randomize the GUID of the new disk to prevent GUID conflicts with other disks:
+Next, randomise the GUID of the new disk to prevent GUID conflicts with other disks:
 
 ```sh
 root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # sgdisk -G /dev/nvme0n1
@@ -799,7 +800,7 @@ mount --bind /run /mnt/run
 mount --make-slave /mnt/run
 ```
 
-Next, use the `chroot` command to access the mount point and verify that the new ESP has been properly created and that the system recognizes both ESPs:
+Next, use the `chroot` command to access the mount point and verify that the new ESP has been properly created and that the system recognises both ESPs:
 
 ```sh
 root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # chroot /mnt
@@ -835,7 +836,7 @@ If the primary disk is replaced while it contains EFI system partitions that hav
 
 In this case, along with rebuilding the RAID and recreating the EFI system partition in rescue mode, you must also reinstall GRUB on it.
 
-Once the ESP has been created (as explained above) and the system recognises both partitions, still in the `choot` environment, create the `/boot/efi` folder to mount the new EFI system partition **nvme0n1p1**:
+Once the ESP has been created (as explained above) and the system recognises both partitions, still in the `chroot` environment, create the `/boot/efi` folder to mount the new EFI system partition **nvme0n1p1**:
 
 ```sh
 root@rescue12-customer-eu:/# mount /boot
@@ -882,7 +883,7 @@ sudo sgdisk -R /dev/nvme0n1 /dev/nvme1n1
 
 The command should be in this format: `sgdisk -R /dev/new disk /dev/healthy disk`.
 
-Next, randomize the GUID of the new disk to prevent GUID conflicts with other disks:
+Next, randomise the GUID of the new disk to prevent GUID conflicts with other disks:
 
 ```sh
 sudo sgdisk -G /dev/nvme0n1
@@ -945,9 +946,9 @@ Once the rebuild is done, recreate the EFI System Partition on the new disk.
 [user@server_ip ~]# sudo fatlabel /dev/nvme0n1p1 EFI_SYSPART
 ```
 
-Once done, synchronize both partitions using the script provided in this guide.
+Once done, synchronise both partitions using the script provided in this guide.
 
-- Verify that the new EFI System Partition has been properly created and the system recongnises it:
+- Verify that the new EFI System Partition has been properly created and the system recognises it:
 
 ```sh
 [user@server_ip ~]# sudo blkid -t LABEL=EFI_SYSPART
@@ -1020,7 +1021,7 @@ Next, consult [this section](#swap-partition) to recreate the SWAP partition (if
 >> └─nvme0n1p4 259:13   0   512M  0 part
 >> ```
 >>
->> Next, randomize the GUID of the new disk to prevent GUID conflicts with other disks:
+>> Next, randomise the GUID of the new disk to prevent GUID conflicts with other disks:
 >>
 >> ```sh
 >> root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # sgdisk -G /dev/nvme0n1
@@ -1091,7 +1092,7 @@ Next, consult [this section](#swap-partition) to recreate the SWAP partition (if
 >> └─nvme0n1p5 iso9660           Joliet Extension config-2       2025-12-16-15-40-00-00
 >> ```
 >>
->> Once done, consult [this section](#swap-partition) to reacreate the SWAP partition (if applicable).
+>> Once done, consult [this section](#swap-partition) to recreate the SWAP partition (if applicable).
 >>
 > **In normal mode**
 >>
@@ -1120,7 +1121,7 @@ Next, consult [this section](#swap-partition) to recreate the SWAP partition (if
 >>
 >> The command should be in this format: `sgdisk -R /dev/new disk /dev/healthy disk`.
 >>
->> Next, randomize the GUID of the new disk to prevent GUID conflicts with other disks:
+>> Next, randomise the GUID of the new disk to prevent GUID conflicts with other disks:
 >>
 >> ```sh
 >> sudo sgdisk -G /dev/nvme0n1
@@ -1261,7 +1262,7 @@ Next, consult [this section](#swap-partition) to recreate the SWAP partition (if
 >> root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # systemctl daemon-reload
 >> ```
 >>
->> Umount all the disks:
+>> Unmount all the disks:
 >>
 >> ```sh
 >> root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # umount -Rl /mnt

--- a/pages/bare_metal_cloud/dedicated_servers/raid_soft_uefi/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/raid_soft_uefi/guide.fr-fr.md
@@ -54,10 +54,10 @@ Lorsque vous achetez un nouveau serveur, vous pouvez ressentir le besoin d'effec
 ### Aperçu du contenu
 
 - [Informations de base](#basicinformation)
-- [Compréhension de la partition système EFI (ESP)](#efisystemparition)
+- [Compréhension de la partition système EFI (ESP)](#efisystempartition)
 - [Simulation d'une panne de disque](#diskfailure)
     - [Retirer le disque défectueux](#diskremove)
-- [Reconstruction du RAID (avec des ESP non-mirrorrées)](#raidrebuildnonmirrored)
+- [Reconstruction du RAID (avec des ESP non mises en miroir)](#raidrebuildnonmirrored)
     - [Reconstruction du RAID après le remplacement du disque principal (mode rescue)](#nonmirroredrescuemode)
     - [Recréation de la partition système EFI](#recreateesp)
     - [Reconstruction du RAID avec des ESP non synchronisés après des mises à jour majeures du système (GRUB)](#efiraidgrub)
@@ -105,7 +105,7 @@ md2 : active raid1 nvme1n1p2[0] nvme0n1p2[1]
 unused devices: <none>
 ```
 
-D'après les résultats, nous avons actuellement trois périphériques RAID logiciels configurés, **md1**, **md2** et **md3**, avec **md3** étant le plus grand des deux. **md3** est composé de deux partitions, appelées **nvme0n1p3** et **nvme1n1p3**.
+D'après les résultats, nous avons actuellement trois périphériques RAID logiciels configurés, **md1**, **md2** et **md3**, avec **md3** étant le plus grand des trois. **md3** est composé de deux partitions, appelées **nvme0n1p3** et **nvme1n1p3**.
 
 Si vous avez un serveur avec des disques SATA, vous obtiendrez les résultats suivants :
 
@@ -227,20 +227,21 @@ nvme0n1
 
 Notez les périphériques, les partitions et les points de montage, car cela est important, en particulier après le remplacement d'un disque. Cela vous permettra de vérifier que les partitions sont correctement montées sur leurs points de montage respectifs sur le nouveau disque.
 
-Dans note exemple, nous avons :
+Dans notre exemple, nous avons :
 
-- Deux matrices RAID : `/dev/md2` et `/dev/md3`.
-- Partitions faisant partie du RAID : **nvme0n1p2**, **nvme0n1p3**, **nvme1n1p2** et **nvme0n1p3** avec les points de montage `/boot` et `/`.
-- Partitions ne faisant pas partie du RAID : **nvem0n1p1**, **nvme0n1p4** et **nvme1n1p4** avec les points de montage `/boot/efi` et [SWAP].
-- Une partition n'a pas de point de montage : **nvme1n1p1**.
+- Partitions faisant partie de md2 (`/boot`) : **nvme0n1p2** et **nvme1n1p2**.
+- Partitions faisant partie de md3 (`/`) : **nvme0n1p3** et **nvme1n1p3**.
+- Partitions swap : **nvme0n1p4** et **nvme1n1p4**.
+- ESP montée (`/boot/efi`) : **nvme0n1p1**.
+- ESP non montée : **nvme1n1p1**.
 
-La partition `nvme0n1p5` est une partition de configuration, c'est-à-dire un volume en lecture seule connecté au serveur qui lui fournit les données de configuration initiale.
+La partition `nvme0n1p5` est un [config drive](https://cloudinit.readthedocs.io/en/latest/reference/datasources/configdrive.html), c'est-à-dire un volume en lecture seule qui fournit au serveur ses données de configuration initiale. Elle n'est lue qu'une seule fois lors du premier démarrage et peut être supprimée ensuite.
 
 <a name="efisystempartition"></a>
 
 ### Comprendre la partition système EFI (ESP)
 
-/// details | **Déplier cette section**
+/// details | **Dépliez cette section**
 
 ***Qu'est-ce qu'une partition système EFI ?***
 
@@ -253,10 +254,10 @@ Une partition système EFI est une partition qui peut contenir les chargeurs de 
 * Debian 13
 * Proxmox 9
 * Ubuntu 25.10
-* AlmaLinux and Rocky Linux 10
+* AlmaLinux et Rocky Linux 10
 * Fedora 43
 
-Pour les versions antérieures de ces systèmes d'exploitation, la partition EFI n'est pas mise en miroir dans RAID ; plusieurs ESP sont créés, un par disque. Cependant, une seule ESP est montée à la fois, et toutes les ESP contiennent les mêmes fichiers. La partition système EFI est montée dans `/boot/efi`, et le disque sur lequel elle est montée est sélectionné par Linux au démarrage.
+Pour les versions antérieures de ces systèmes d'exploitation, la partition EFI n'est pas mise en miroir dans RAID ; plusieurs ESP sont créés, un par disque. Cependant, une seule ESP est montée à la fois. La partition système EFI est montée dans `/boot/efi`, et le disque sur lequel elle est montée est sélectionné par Linux au démarrage.
 
 Vous pouvez utiliser la commande `lsblk` pour vérifier si votre partition fait partie d'une configuration RAID.
 
@@ -605,7 +606,7 @@ Nous pouvons maintenant procéder au remplacement du disque et à la reconstruct
 
 <a name="raidrebuildnonmirrored"></a>
 
-### Reconstruction du RAID (avec des ESP non-mirrorrées)
+### Reconstruction du RAID (avec des ESP non mises en miroir)
 
 > [!primary]
 > Ce processus peut varier selon le système d'exploitation installé sur votre serveur. Nous vous recommandons de consulter la documentation officielle de votre système d'exploitation pour obtenir les commandes appropriées.
@@ -825,7 +826,7 @@ Ensuite, consultez [cette section](#swap-partition) pour recréer la partition S
 
 #### Reconstruction du RAID avec des ESP non synchronisés après des mises à jour majeures du système (GRUB) <a name="efiraidgrub"></a>
 
-/// details | **Développez cette section**
+/// details | **Dépliez cette section**
 
 > [!warning]
 > Veuillez suivre les étapes de cette section uniquement si cela s'applique à votre cas.
@@ -835,7 +836,7 @@ Si le disque principal est remplacé alors qu'il contient des partitions systèm
 
 Dans ce cas, en plus de reconstruire le RAID et de recréer la partition système EFI en mode rescue, vous devez également réinstaller le GRUB sur celle-ci.
 
-Une fois l'ESP créé (comme expliqué ci-dessus) et reconnu par le système, toujours dans l'environnement `choot`, créez le dossier /boot/efi pour monter la nouvelle partition système EFI **nvme0n1p1**.
+Une fois l'ESP créé (comme expliqué ci-dessus) et reconnu par le système, toujours dans l'environnement `chroot`, créez le dossier /boot/efi pour monter la nouvelle partition système EFI **nvme0n1p1**.
 
 ```sh
 root@rescue12-customer-eu:/# mount /boot
@@ -868,7 +869,7 @@ Ensuite, consultez [cette section](#swap-partition) pour recréer la partition S
 
 #### Reconstruction du RAID après le remplacement du disque principal (mode normal)
 
-/// details | **Développez cette section**
+/// details | **Dépliez cette section**
 
 Si votre serveur est capable de démarrer en mode normal après un remplacement de disque, vous pouvez suivre les étapes ci-dessous pour reconstruire le RAID.
 
@@ -1032,7 +1033,7 @@ Ensuite, consultez [cette section](#swap-partition) pour recréer la partition S
 >>
 >> Exécutez la commande `partprobe`.
 >>
->> Nous pouvons maintenant reconstruire la matrice RAID. L'extrait de code suivant montre comment ajouter à nouveau les nouvelles partitions (nvme0n1p2 et nvme0n1p3) à la matrice RAID.
+>> Nous pouvons maintenant reconstruire la matrice RAID. L'extrait de code suivant montre comment ajouter à nouveau les nouvelles partitions (nvme0n1p1, nvme0n1p2 et nvme0n1p3) à la matrice RAID.
 >>
 >> ```sh
 >> root@rescue12-customer-eu (nsxxxxx.ip-xx-xx-xx.eu) ~ # mdadm --add /dev/md1 /dev/nvme0n1p1
@@ -1157,7 +1158,7 @@ Ensuite, consultez [cette section](#swap-partition) pour recréer la partition S
 
 ///
 
-#### Ajout de l'étiquette à la partition SWAP (si applicable) <a name="swap-partition"></a>
+### Ajout de l'étiquette à la partition SWAP (si applicable) <a name="swap-partition"></a>
 
 /// details | **Dépliez cette section**
 


### PR DESCRIPTION
## What type of Pull Request is this?                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                        
- Update of existing guide(s)                                                                                                                                                                                                                                                           
- Fix                                                                                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                        
## Description                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                        
Fix typos, technical errors, and improve consistency in the Software RAID guides (both UEFI and BIOS/Legacy modes).                                                                                                                                                                     
                                                                                                                                                                                                                                                                                        
**UEFI guides (raid_soft_uefi):**                                                                                                                                                                                                                                                       
- Fix `choot` → `chroot` typo                                                                                                                                                                                                                                                           
- Use British spelling: `synchronising`, `randomise`                                                                                                                                                                                                                                    
- Fix "Linux" capitalisation                                                                                                                                                                                                                                                            
- Improve "In our example" section to list partitions by RAID array                                                                                                                                                                                                                     
- Fix heading levels for consistency                                                                                                                                                                                                                                                    
- Remove misleading phrase about ESP files                                                                                                                                                                                                                                              
- Standardise collapsible section labels                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                        
**BIOS guides (raid_soft):**                                                                                                                                                                                                                                                            
- Fix `can only been seen` → `can only be seen`                                                                                                                                                                                                                                         
- Fix `simulate a disk.` → `simulate a disk failure.`                                                                                                                                                                                                                                   
- Fix `To add a label the SWAP` → `To add a label to the SWAP`                                                                                                                                                                                                                          
- Fix `blkid -S UUID` → `blkid -s UUID` (lowercase flag)                                                                                                                                                                                                                                
- Fix missing leading slash in `/etc/fstab` paths                                                                                                                                                                                                                                       
- Fix `If you server` → `If your server`                                                                                                                                                                                                                                                
- Fix wrong partition `md4` → `md2` for root in rescue mode section                                                                                                                                                                                                                     
- Fix `partition the following` → `partition with the following`                                                                                                                                                                                                                        
- Fix `umount` → `unmount`                                                                                                                                                                                                                                                              
- Fix mkswap command in rescue mode: `sda4` → `sdb4` (sdb was the replaced disk)                                                                                                                                                                                                        
- Use British spelling: `randomise`                                                                                                                                                                                                                                                     
- Fix `If you the following` → `If you receive the following`                                                                                                                                                                                                                           
- Improve "In our example" section to list partitions by RAID array                                                                                                                                                                                                                     
- Add explanation for config drive partition                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                        
## Mandatory information                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                        
The translations in this Pull Request have been done using:                                                                                                                                                                                                                             
- [x] This Pull Request didn't require any translation.                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                        
- This Pull Request can be merged as soon as possible.                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                                                                        
- This Pull Request content should be replicated for the US OVHcloud documentation: yes                                                                                                                                                                                               
