### PR TITLE
Fix logs data platform quickstart rfc 5424 example

### DIFF
--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.de-de.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.de-de.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-asia.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-asia.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-au.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-au.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-ca.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-gb.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-gb.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-ie.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-ie.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-sg.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-sg.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.en-us.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.es-es.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.es-es.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.es-us.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.es-us.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.fr-ca.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.fr-ca.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.fr-fr.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.fr-fr.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.it-it.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.it-it.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.pl-pl.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.pl-pl.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 

--- a/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.pt-pt.md
+++ b/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start/guide.pt-pt.md
@@ -118,7 +118,7 @@ For this format the time is in the RFC 3339 format.
 *RFC 5424*:
 
 ```shell-session
-$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
+$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
 openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
 ```
 


### PR DESCRIPTION
<!--
Hello 👋
Thank you for submitting a Pull Request.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details. As long as your Pull Request is a draft, the OVHcloud Guides Team will not start proofreading it.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

DO NOT USE a fork if you are an OVHcloud employee. Instead, please contact the OVHcloud Guides Team so to be granted /write access to this repository.

Feel free to apply labels on your Pull Request, selecting them from the list to your right.

Before submitting a Pull Request, please ensure you have:

- 📖 Read the OVHcloud Documentation readme: https://github.com/ovh/docs/blob/develop/readme.md
- 🇬🇧 Edited (at least) the en-gb version of a guide.
- 🇫🇷 Edited also the fr-fr version if you are a French speaker.
- 🌐 Edited all the files if you're doing a fix or a minor update (this is not mandatory but recommended).
- 👷‍♀️ Created a small PR, if applicable.
- ✅ Tested every step you're documenting.
- 📝 Used descriptive commit messages.
- 📐 Resized images which width exceeds 1400px.
- 📝 Edited or blurred any sensitive/private information from your text and images (IPs, user IDs, private URLs, etc.).
-->

## What type of Pull Request is this?

<!-- Delete the lines which don't apply: -->
- Fix

## Description

In the logs data platform guide, the RFC 5424 example using openssl didn't work as it lacked the MSGID field :

```sh
$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
``` 

I add a `-` for this field in the guides :

```
$ ubuntu@server:~$ echo -e '<6>1 2016-03-08T14:44:01+01:00 149.202.165.20 example.org - - - [exampleSDID@8485 X-OVH-TOKEN="d93eee2a-697f-4bac-a452-705416b98a04" user_id="9001"  some_info="foo" some_metric_num="42.0" ] A short message that helps you identify what is going on\n' | \
openssl s_client -quiet -no_ign_eof -connect <your_cluster>.logs.ovh.com:6514
```

## Mandatory information

The translations in this Pull Request have been done using:
- [ ] OVHcloud integrated translation LLM <!-- If you're interested in this new option, contact the Guides team -->
- [ ] Systran
- [ ] Other tool (specify which tool was used)
- [x] This Pull Request didn't require any translation.

<!-- Delete the line which doesn't apply: -->
- This Pull Request can be merged as soon as possible.

<!-- If you know about the following, please mention it. If you don't know, delete the line.-->
- This Pull Request content should be replicated for the US OVHcloud documentation : YES<!-- https://support.us.ovhcloud.com/hc/en-us -->
