### PR TITLE
docs(opcp): add trunk port configuration guide (EN/FR)

### DIFF
--- a/pages/hosted_private_cloud/opcp/how-to-setup-trunk-on-node/guide.en-gb.md
+++ b/pages/hosted_private_cloud/opcp/how-to-setup-trunk-on-node/guide.en-gb.md
@@ -1,0 +1,355 @@
+---
+title: "OPCP - How to setup Trunk ports on a Node"
+excerpt: Learn how to configure Neutron Trunk ports in OPCP for multi-network vlan connectivity on baremetal or virtual machine instances
+updated: 2026-02-18
+---
+
+## Objective
+
+Trunk ports allow a single instance (baremetal or virtual machine) to send and receive traffic on multiple Neutron networks using vlan tagging, through a single physical interface or an [LACP bond](/pages/hosted_private_cloud/opcp/how-to-setup-lacp-on-node).
+
+**This guide explains how to configure Neutron Trunk ports in OPCP to enable multi-network (vlan) connectivity on a baremetal node or a virtual machine.**
+
+We will also see how to configure **vlan sub-interfaces** within your instance to access each network attached to the trunk.
+
+> [!warning]
+> Trunk creation requires the **admin** role. A project user cannot create trunks.
+> Adding sub-ports to a trunk also requires admin rights by default, but this can be delegated by your administrator.
+>
+> It is recommended to configure the trunk **before** deploying an instance.
+> This guide **does not cover** configuring a trunk on an instance that is already in production.
+
+## Why Use Trunk Ports?
+
+Trunk ports can be used in two specific use cases:
+
+- **Multi-network access from a single instance:** Trunk ports allow a baremetal server or a virtual machine to communicate on multiple isolated Neutron networks using vlan tagging, without needing separate ports for each network.
+- **Simplified network management:** Instead of provisioning multiple ports and attaching them individually, you create a single trunk with sub-ports, each tagged with a specific vlan ID. This keeps the network topology clean and manageable.
+
+## Requirements
+
+Before starting, make sure you have the following:
+
+- An active [OPCP service](/links/hosted-private-cloud/onprem-cloud-platform).
+- **[Configured OpenStack CLI access](/pages/hosted_private_cloud/opcp/how-to-use-api-and-get-credentials)** with the necessary permissions (`clouds.yaml` or environment variables).
+- The **admin** role (required for trunk creation and sub-port management).
+- At least **two Neutron networks** already created in your project (one for the parent port and one or more for sub-ports).
+- An available baremetal node or virtual machine project.
+
+Trunk port configuration is an advanced networking feature requiring familiarity with OpenStack Neutron networking concepts, vlan tagging, and the OpenStack CLI.
+
+## Instructions
+
+### Network and Trunk Configuration
+
+#### 1. Identify Your Networks
+
+Before creating the trunk, identify the networks your instance needs access to. List the available networks in your project:
+
+```bash
+openstack network list
+```
+
+**Example output:**
+
+```bash
++--------------------------------------+--------------------+--------------------------------------+
+| ID                                   | Name               | Subnets                              |
++--------------------------------------+--------------------+--------------------------------------+
+| 3fa85f64-5717-4562-b3fc-2c963f66afa6 | primary-network    | a1b2c3d4-e5f6-7890-abcd-ef1234567890 |
+| 7c9e6679-7425-40de-944b-e07fc1f90ae7 | network-1          | b2c3d4e5-f6a7-8901-bcde-f12345678901 |
+| 9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d | network-2          | c3d4e5f6-a7b8-9012-cdef-123456789012 |
++--------------------------------------+--------------------+--------------------------------------+
+```
+
+#### 2. Create the Parent Port
+
+Create a Neutron port that will serve as the **parent port** of the trunk. This port is required by the Neutron trunk model to anchor the trunk to the instance.
+
+```bash
+openstack port create --network <network-name> <parent-port-name>
+```
+
+**Example:**
+
+```bash
+openstack port create --network primary-network primary-port
+```
+
+**Example output:**
+
+```bash
++-------------------------+--------------------------------------+
+| Field                   | Value                                |
++-------------------------+--------------------------------------+
+| id                      | f47ac10b-58cc-4372-a567-0e02b2c3d479 |
+| mac_address             | fa:16:3e:aa:bb:cc                    |
+| name                    | primary-port                         |
+| network_id              | 3fa85f64-5717-4562-b3fc-2c963f66afa6 |
+| status                  | DOWN                                 |
++-------------------------+--------------------------------------+
+```
+
+> [!warning]
+> On **baremetal instances**, the parent port is a **dummy port**. It exists in the Neutron database but has **no effect on the network fabric**. The network assigned to the parent port will **not** carry any traffic to the instance. All actual network connectivity must be configured through **sub-ports** (see steps 4 and 5).
+>
+> On **virtual machines**, the parent port carries the parent network as **untagged** traffic on the base interface. Sub-port networks are delivered as tagged vlan traffic.
+
+#### 3. Create the Trunk
+
+Create a Neutron trunk using the parent port created in the previous step:
+
+```bash
+openstack network trunk create --parent-port <parent-port-name> <trunk-name>
+```
+
+**Example:**
+
+```bash
+openstack network trunk create --parent-port primary-port my-trunk
+```
+
+**Example output:**
+
+```bash
++----------------+--------------------------------------+
+| Field          | Value                                |
++----------------+--------------------------------------+
+| id             | 550e8400-e29b-41d4-a716-446655440000 |
+| name           | my-trunk                             |
+| parent_port_id | f47ac10b-58cc-4372-a567-0e02b2c3d479 |
+| status         | DOWN                                 |
+| sub_ports      |                                      |
++----------------+--------------------------------------+
+```
+
+> [!primary]
+> At this point, the trunk exists but is not attached to any server. The parent port is a standard Neutron port that will be referenced when creating the instance.
+
+#### 4. Create a Sub-Port
+
+Create a Neutron port on each network you want to make accessible through the trunk:
+
+```bash
+openstack port create --network <network-name> <sub-port-name>
+```
+
+**Example:**
+
+```bash
+openstack port create --network network-1 sub-port-1
+```
+
+#### 5. Add Sub-Port to the Trunk
+
+Attach the sub-port to the trunk, specifying the segmentation type (`vlan`) and the segmentation ID matching the network's vlan tag:
+
+```bash
+openstack network trunk set \
+  --subport port=<sub-port-name>,segmentation-type=vlan,segmentation-id=<vlan-id> \
+  <trunk-name>
+```
+
+**Example:**
+
+```bash
+openstack network trunk set \
+  --subport port=sub-port-1,segmentation-type=vlan,segmentation-id=100 \
+  my-trunk
+```
+
+> [!warning]
+> The `segmentation-id` **must match** the segmentation ID of the network assigned to the sub-port. Neutron does not verify this value, but if it does not match the network's actual segmentation ID, the sub-port traffic will be ignored.
+>
+> Make sure the `segmentation-id` you specify is identical to the one configured on the target network.
+
+> [!primary]
+> To add more networks, repeat steps 4 and 5 for each additional network, using the matching `segmentation-id` of each network.
+
+#### 6. Verify the Trunk Configuration
+
+Confirm the trunk is properly configured with all expected sub-ports:
+
+```bash
+openstack network trunk show <trunk-name>
+```
+
+**Example:**
+
+```bash
+openstack network trunk show my-trunk
+```
+
+**Example output:**
+
+```bash
++----------------+------------------------------------------------------------------------------------------------+
+| Field          | Value                                                                                          |
++----------------+------------------------------------------------------------------------------------------------+
+| id             | 550e8400-e29b-41d4-a716-446655440000                                                           |
+| name           | my-trunk                                                                                       |
+| parent_port_id | f47ac10b-58cc-4372-a567-0e02b2c3d479                                                           |
+| status         | DOWN                                                                                           |
+| sub_ports      | [{"port_id": "...", "segmentation_id": 100, "segmentation_type": "vlan"}]                      |
++----------------+------------------------------------------------------------------------------------------------+
+```
+
+#### 7. Deploy an Instance Using the Trunk
+
+Create the instance referencing the **parent port**. OpenStack will configure the trunk during provisioning.
+
+```bash
+openstack server create \
+  --image <image-name> \
+  --flavor <flavor> \
+  --port <parent-port-name> \
+  --key-name <keypair-name> \
+  <instance-name>
+```
+
+**Baremetal example:**
+
+```bash
+openstack server create \
+  --image ubuntu-22.04 \
+  --flavor baremetal \
+  --port primary-port \
+  --key-name my-keypair \
+  --availability-zone "nova::88830859-5b16-4935-8f41-d381b754cbe5" \
+  my-trunk-instance
+```
+
+**Virtual machine example:**
+
+```bash
+openstack server create \
+  --image ubuntu-22.04 \
+  --flavor m1.large \
+  --port primary-port \
+  --key-name my-keypair \
+  my-trunk-instance
+```
+
+> [!warning]
+> You **must** use `--port` (referencing the parent port) rather than `--nic net-id=...`. Using `--nic` would create a new port and bypass the trunk configuration entirely.
+
+#### Summary of Steps
+
+| Step | Action | Command |
+|------|--------|---------|
+| 1 | List networks | `openstack network list` |
+| 2 | Create parent port | `openstack port create --network <network-name> <parent-port-name>` |
+| 3 | Create trunk | `openstack network trunk create --parent-port <parent-port-name> <trunk-name>` |
+| 4 | Create sub-port | `openstack port create --network <network-name> <sub-port-name>` |
+| 5 | Add sub-port to trunk | `openstack network trunk set --subport port=<sub-port-name>,segmentation-type=vlan,segmentation-id=<vlan-id> <trunk-name>` |
+| 6 | Verify trunk | `openstack network trunk show <trunk-name>` |
+| 7 | Deploy instance | `openstack server create --port <parent-port-name> --flavor <flavor> ...` |
+
+### Instance Operating System Configuration
+
+After deploying your instance, you need to configure **vlan sub-interfaces** inside the guest OS to access each network attached through the trunk sub-ports.
+
+> [!warning]
+> On **baremetal instances**, since the parent port is a dummy port with no effect on the network fabric, the base network interface will **not** have any network connectivity by default. All networks must be accessed through vlan sub-interfaces matching the `segmentation-id` assigned to each sub-port.
+>
+> On **virtual machines**, the base interface carries the parent network as untagged traffic. Only sub-port networks require vlan sub-interfaces.
+
+#### 1. Identify the Main Network Interface
+
+Connect to your instance and identify the primary network interface:
+
+```bash
+ip link show
+```
+
+Look for the main interface (e.g., `ens3`, `ens21f0np0`, or `bond0` if LACP is configured). This is the physical interface carrying the trunk.
+
+#### 2. Create vlan Sub-Interfaces (Temporary)
+
+For each sub-port, create a vlan sub-interface matching the `segmentation-id` you assigned. This is a non-persistent method for testing:
+
+```bash
+sudo ip link add link <main-interface> name <main-interface>.<vlan-id> type vlan id <vlan-id>
+sudo ip link set <main-interface>.<vlan-id> up
+sudo ip addr add <ip-address>/<cidr> dev <main-interface>.<vlan-id>
+```
+
+**Example:**
+
+```bash
+sudo ip link add link ens3 name ens3.100 type vlan id 100
+sudo ip link set ens3.100 up
+sudo ip addr add 192.168.1.10/24 dev ens3.100
+```
+
+> [!warning]
+> This configuration will not survive a reboot. See the next step for a persistent configuration.
+
+#### 3. Persistent Configuration (Netplan Example)
+
+For a persistent vlan sub-interface configuration using Netplan (Ubuntu/Debian with cloud-init), create a configuration file (e.g., `/etc/netplan/60-vlans.yaml`):
+
+```yaml
+network:
+  version: 2
+  vlans:
+    ens3.100:
+      id: 100
+      link: ens3
+      addresses:
+        - 192.168.1.10/24
+    ens3.200:
+      id: 200
+      link: ens3
+      addresses:
+        - 10.0.0.10/24
+```
+
+Then apply the configuration:
+
+```bash
+sudo netplan apply
+```
+
+> [!primary]
+> If your instance uses LACP bonding (see [LACP guide](/pages/hosted_private_cloud/opcp/how-to-setup-lacp-on-node)), replace `ens3` with your bond interface name (e.g., `bond0`). The vlan sub-interfaces then become `bond0.100`, `bond0.200`, etc.
+
+#### 4. Verify Connectivity
+
+Check that your vlan sub-interfaces are up and have the correct IP addresses:
+
+```bash
+ip addr show <main-interface>.<vlan-id>
+```
+
+Then test connectivity:
+
+```bash
+ping <gateway-or-peer-on-vlan>
+```
+
+**Example:**
+
+```bash
+ip addr show ens3.100
+ping 192.168.1.1
+```
+
+> [!success]
+> If the ping succeeds, your vlan sub-interface is correctly configured and the trunk is carrying traffic for the corresponding network.
+
+## Conclusion
+
+You have successfully configured:
+
+- **Neutron Trunk ports** at the OpenStack level, connecting an instance to multiple networks via vlan tagging;
+- **vlan sub-interfaces** within the guest OS to access each network attached through trunk sub-ports;
+- And verified **network connectivity** on each vlan.
+
+Your instance can now communicate on multiple isolated networks through a single trunk configuration.
+
+## Go further
+
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
+
+Join our [community of users](/links/community).

--- a/pages/hosted_private_cloud/opcp/how-to-setup-trunk-on-node/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/opcp/how-to-setup-trunk-on-node/guide.fr-fr.md
@@ -1,0 +1,353 @@
+---
+title: "OPCP - Comment configurer les ports Trunk sur un nœud"
+excerpt: "Apprenez à configurer les ports Trunk Neutron dans OPCP pour une connectivité multi-réseau vlan sur des instances baremetal ou machines virtuelles"
+updated: 2026-02-18
+---
+
+## Objectif
+
+Les ports Trunk permettent à une seule instance (baremetal ou machine virtuelle) d'envoyer et de recevoir du trafic sur plusieurs réseaux Neutron via du vlan tagging, à travers une seule interface physique ou un [bond LACP](/pages/hosted_private_cloud/opcp/how-to-setup-lacp-on-node).
+
+**Ce guide explique comment configurer les ports Trunk Neutron dans OPCP pour activer la connectivité multi-réseau (vlan) sur un nœud baremetal ou une machine virtuelle.**
+
+Nous verrons également comment configurer des **sous-interfaces vlan** au sein de votre instance pour accéder à chaque réseau rattaché au trunk.
+
+> [!warning]
+> La création de trunk nécessite le rôle **admin**. Un utilisateur projet ne peut pas créer de trunks.
+> L'ajout de sous-ports à un trunk nécessite également les droits admin par défaut, mais cela peut être délégué par votre administrateur.
+>
+> Il est recommandé de configurer le trunk **avant** le déploiement d'une instance.
+> Ce guide **ne couvre pas** la configuration d'un trunk sur une instance déjà en production.
+
+## Pourquoi utiliser les ports Trunk ?
+
+Les ports Trunk peuvent être utilisés dans deux cas d'usage précis :
+
+- **Accès multi-réseau depuis une seule instance :** Les ports Trunk permettent à un serveur baremetal ou une machine virtuelle de communiquer sur plusieurs réseaux Neutron isolés via du vlan tagging, sans nécessiter de ports séparés pour chaque réseau.
+- **Gestion réseau simplifiée :** Au lieu de provisionner plusieurs ports et de les attacher individuellement, vous créez un seul trunk avec des sous-ports, chacun taggé avec un vlan ID spécifique. Cela permet de garder la topologie réseau claire et maintenable.
+
+## Prérequis
+
+Avant de commencer, assurez-vous de disposer des éléments suivants :
+
+- Disposer d'un service [OPCP](/links/hosted-private-cloud/onprem-cloud-platform) actif.
+- Un accès **[OpenStack CLI configuré](/pages/hosted_private_cloud/opcp/how-to-use-api-and-get-credentials)** avec les droits nécessaires (`clouds.yaml` ou variables d'environnement).
+- Le rôle **admin** (nécessaire pour la création de trunks et la gestion des sous-ports).
+- Au moins **deux réseaux Neutron** déjà créés dans votre projet (un pour le port parent et un ou plusieurs pour les sous-ports).
+- Un nœud baremetal ou un projet de machine virtuelle disponible.
+
+La configuration des ports Trunk est une fonctionnalité réseau avancée nécessitant une bonne connaissance des concepts réseau OpenStack Neutron, du vlan tagging et de la CLI OpenStack.
+
+## En pratique
+
+### Configuration réseau et Trunk
+
+#### 1. Identifier vos réseaux
+
+Avant de créer le trunk, identifiez les réseaux auxquels votre instance doit accéder. Listez les réseaux disponibles dans votre projet :
+
+```bash
+openstack network list
+```
+
+**Exemple de sortie :**
+
+```bash
++--------------------------------------+--------------------+--------------------------------------+
+| ID                                   | Name               | Subnets                              |
++--------------------------------------+--------------------+--------------------------------------+
+| 3fa85f64-5717-4562-b3fc-2c963f66afa6 | primary-network    | a1b2c3d4-e5f6-7890-abcd-ef1234567890 |
+| 7c9e6679-7425-40de-944b-e07fc1f90ae7 | network-1          | b2c3d4e5-f6a7-8901-bcde-f12345678901 |
+| 9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d | network-2          | c3d4e5f6-a7b8-9012-cdef-123456789012 |
++--------------------------------------+--------------------+--------------------------------------+
+```
+
+#### 2. Créer le port parent
+
+Créez un port Neutron qui servira de **port parent** du trunk. Ce port est requis par le modèle trunk de Neutron pour ancrer le trunk à l'instance.
+
+```bash
+openstack port create --network <nom-reseau> <nom-port-parent>
+```
+
+**Exemple :**
+
+```bash
+openstack port create --network primary-network primary-port
+```
+
+**Exemple de sortie :**
+
+```bash
++-------------------------+--------------------------------------+
+| Field                   | Value                                |
++-------------------------+--------------------------------------+
+| id                      | f47ac10b-58cc-4372-a567-0e02b2c3d479 |
+| mac_address             | fa:16:3e:aa:bb:cc                    |
+| name                    | primary-port                         |
+| network_id              | 3fa85f64-5717-4562-b3fc-2c963f66afa6 |
+| status                  | DOWN                                 |
++-------------------------+--------------------------------------+
+```
+
+> [!warning]
+> Sur les **instances baremetal**, le port parent est un **port factice**. Il existe dans la base de données Neutron mais n'a **aucun effet sur le fabric réseau**. Le réseau assigné au port parent ne transportera **aucun** trafic vers l'instance. Toute la connectivité réseau réelle doit être configurée via les **sous-ports** (voir étapes 4 et 5).
+>
+> Sur les **machines virtuelles**, le port parent transporte le réseau parent en trafic **non taggé** sur l'interface de base. Les réseaux des sous-ports sont délivrés en trafic vlan taggé.
+
+#### 3. Créer le Trunk
+
+Créez un trunk Neutron en utilisant le port parent créé à l'étape précédente :
+
+```bash
+openstack network trunk create --parent-port <nom-port-parent> <nom-trunk>
+```
+
+**Exemple :**
+
+```bash
+openstack network trunk create --parent-port primary-port my-trunk
+```
+
+**Exemple de sortie :**
+
+```bash
++----------------+--------------------------------------+
+| Field          | Value                                |
++----------------+--------------------------------------+
+| id             | 550e8400-e29b-41d4-a716-446655440000 |
+| name           | my-trunk                             |
+| parent_port_id | f47ac10b-58cc-4372-a567-0e02b2c3d479 |
+| status         | DOWN                                 |
+| sub_ports      |                                      |
++----------------+--------------------------------------+
+```
+
+> [!primary]
+> À ce stade, le trunk existe mais n'est attaché à aucun serveur. Le port parent est un port Neutron standard qui sera référencé lors de la création de l'instance.
+
+#### 4. Créer un sous-port
+
+Créez un port Neutron sur chaque réseau que vous souhaitez rendre accessible via le trunk :
+
+```bash
+openstack port create --network <nom-reseau> <nom-sous-port>
+```
+
+**Exemple :**
+
+```bash
+openstack port create --network network-1 sub-port-1
+```
+
+#### 5. Ajouter le sous-port au Trunk
+
+Attachez le sous-port au trunk en spécifiant le type de segmentation (`vlan`) et l'identifiant de segmentation correspondant au tag vlan du réseau :
+
+```bash
+openstack network trunk set \
+  --subport port=<nom-sous-port>,segmentation-type=vlan,segmentation-id=<vlan-id> \
+  <nom-trunk>
+```
+
+**Exemple :**
+
+```bash
+openstack network trunk set \
+  --subport port=sub-port-1,segmentation-type=vlan,segmentation-id=100 \
+  my-trunk
+```
+
+> [!warning]
+> Le `segmentation-id` **doit correspondre** à l'identifiant de segmentation du réseau assigné au sous-port. Neutron ne vérifie pas cette valeur, mais si elle ne correspond pas au segmentation ID réel du réseau, le trafic du sous-port sera ignoré.
+>
+> Assurez-vous que le `segmentation-id` que vous spécifiez est identique à celui configuré sur le réseau cible.
+
+> [!primary]
+> Pour ajouter d'autres réseaux, répétez les étapes 4 et 5 pour chaque réseau supplémentaire, en utilisant le `segmentation-id` correspondant à chaque réseau.
+
+#### 6. Vérifier la configuration du Trunk
+
+Confirmez que le trunk est correctement configuré avec tous les sous-ports attendus :
+
+```bash
+openstack network trunk show <nom-trunk>
+```
+
+**Exemple :**
+
+```bash
+openstack network trunk show my-trunk
+```
+
+**Exemple de sortie :**
+
+```bash
++----------------+------------------------------------------------------------------------------------------------+
+| Field          | Value                                                                                          |
++----------------+------------------------------------------------------------------------------------------------+
+| id             | 550e8400-e29b-41d4-a716-446655440000                                                           |
+| name           | my-trunk                                                                                       |
+| parent_port_id | f47ac10b-58cc-4372-a567-0e02b2c3d479                                                           |
+| status         | DOWN                                                                                           |
+| sub_ports      | [{"port_id": "...", "segmentation_id": 100, "segmentation_type": "vlan"}]                      |
++----------------+------------------------------------------------------------------------------------------------+
+```
+
+#### 7. Déployer une instance avec le Trunk
+
+Créez l'instance en référençant le **port parent**. OpenStack configurera le trunk lors du provisionnement.
+
+```bash
+openstack server create \
+  --image <nom-image> \
+  --flavor <flavor> \
+  --port <nom-port-parent> \
+  --key-name <nom-keypair> \
+  <nom-instance>
+```
+
+**Exemple baremetal :**
+
+```bash
+openstack server create \
+  --image ubuntu-22.04 \
+  --flavor baremetal \
+  --port primary-port \
+  --key-name my-keypair \
+  --availability-zone "nova::88830859-5b16-4935-8f41-d381b754cbe5" \
+  my-trunk-instance
+```
+
+**Exemple machine virtuelle :**
+
+```bash
+openstack server create \
+  --image ubuntu-22.04 \
+  --flavor m1.large \
+  --port primary-port \
+  --key-name my-keypair \
+  my-trunk-instance
+```
+
+> [!warning]
+> Vous **devez** utiliser `--port` (en référençant le port parent) plutôt que `--nic net-id=...`. Utiliser `--nic` créerait un nouveau port et contournerait entièrement la configuration trunk.
+
+#### Résumé des étapes
+
+| Étape | Action | Commande |
+|-------|--------|----------|
+| 1 | Lister les réseaux | `openstack network list` |
+| 2 | Créer le port parent | `openstack port create --network <nom-reseau> <nom-port-parent>` |
+| 3 | Créer le trunk | `openstack network trunk create --parent-port <nom-port-parent> <nom-trunk>` |
+| 4 | Créer un sous-port | `openstack port create --network <nom-reseau> <nom-sous-port>` |
+| 5 | Ajouter le sous-port au trunk | `openstack network trunk set --subport port=<nom-sous-port>,segmentation-type=vlan,segmentation-id=<vlan-id> <nom-trunk>` |
+| 6 | Vérifier le trunk | `openstack network trunk show <nom-trunk>` |
+| 7 | Déployer l'instance | `openstack server create --port <nom-port-parent> --flavor <flavor> ...` |
+
+### Configuration du système d'exploitation de l'instance
+
+Après le déploiement de votre instance, vous devez configurer des **sous-interfaces vlan** dans l'OS invité pour accéder à chaque réseau rattaché via les sous-ports du trunk.
+
+> [!warning]
+> Sur les **instances baremetal**, le port parent étant un port factice sans effet sur le fabric réseau, l'interface réseau de base n'aura **aucune** connectivité réseau par défaut. Tous les réseaux doivent être accessibles via des sous-interfaces vlan correspondant au `segmentation-id` assigné à chaque sous-port.
+>
+> Sur les **machines virtuelles**, l'interface de base transporte le réseau parent en trafic non taggé. Seuls les réseaux des sous-ports nécessitent des sous-interfaces vlan.
+
+#### 1. Identifier l'interface réseau principale
+
+Connectez-vous à votre instance et identifiez l'interface réseau principale :
+
+```bash
+ip link show
+```
+
+Repérez l'interface principale (par exemple `ens3`, `ens21f0np0`, ou `bond0` si LACP est configuré). C'est l'interface physique qui transporte le trunk.
+
+#### 2. Créer des sous-interfaces vlan (temporaire)
+
+Pour chaque sous-port, créez une sous-interface vlan correspondant au `segmentation-id` que vous avez assigné. Il s'agit d'une méthode non persistante pour les tests :
+
+```bash
+sudo ip link add link <interface-principale> name <interface-principale>.<vlan-id> type vlan id <vlan-id>
+sudo ip link set <interface-principale>.<vlan-id> up
+sudo ip addr add <adresse-ip>/<cidr> dev <interface-principale>.<vlan-id>
+```
+
+**Exemple :**
+
+```bash
+sudo ip link add link ens3 name ens3.100 type vlan id 100
+sudo ip link set ens3.100 up
+sudo ip addr add 192.168.1.10/24 dev ens3.100
+```
+
+> [!warning]
+> Cette configuration ne survivra pas à un redémarrage. Consultez l'étape suivante pour une configuration persistante.
+
+#### 3. Configuration persistante (exemple Netplan)
+
+Pour une configuration persistante des sous-interfaces vlan avec Netplan (Ubuntu/Debian avec cloud-init), créez un fichier de configuration (par exemple `/etc/netplan/60-vlans.yaml`) :
+
+```yaml
+network:
+  version: 2
+  vlans:
+    ens3.100:
+      id: 100
+      link: ens3
+      addresses:
+        - 192.168.1.10/24
+    ens3.200:
+      id: 200
+      link: ens3
+      addresses:
+        - 10.0.0.10/24
+```
+
+Puis appliquez la configuration :
+
+```bash
+sudo netplan apply
+```
+
+> [!primary]
+> Si votre instance utilise le bonding LACP (voir le [guide LACP](/pages/hosted_private_cloud/opcp/how-to-setup-lacp-on-node)), remplacez `ens3` par le nom de votre interface bond (par exemple `bond0`). Les sous-interfaces vlan deviennent alors `bond0.100`, `bond0.200`, etc.
+
+#### 4. Vérifier la connectivité
+
+Vérifiez que vos sous-interfaces vlan sont actives et possèdent les bonnes adresses IP :
+
+```bash
+ip addr show <interface-principale>.<vlan-id>
+```
+
+Puis testez la connectivité :
+
+```bash
+ping <passerelle-ou-pair-sur-vlan>
+```
+
+**Exemple :**
+
+```bash
+ip addr show ens3.100
+ping 192.168.1.1
+```
+
+> [!success]
+> Si le ping réussit, votre sous-interface vlan est correctement configurée et le trunk transporte le trafic du réseau correspondant.
+
+## Conclusion
+
+Vous avez configuré avec succès :
+
+- Les **ports Trunk Neutron** au niveau OpenStack, connectant une instance à plusieurs réseaux via du vlan tagging ;
+- Les **sous-interfaces vlan** dans l'OS invité pour accéder à chaque réseau rattaché via les sous-ports du trunk ;
+- Et vérifié la **connectivité réseau** sur chaque vlan.
+
+Votre instance peut désormais communiquer sur plusieurs réseaux isolés grâce à une seule configuration trunk.
+
+## Aller plus loin
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/opcp/how-to-setup-trunk-on-node/meta.yaml
+++ b/pages/hosted_private_cloud/opcp/how-to-setup-trunk-on-node/meta.yaml
@@ -1,0 +1,2 @@
+id: 830f45ba-5292-43ce-a26e-44c56f128d22
+full_slug: how-to-setup-trunk-on-node


### PR DESCRIPTION
## What type of Pull Request is this?

- New guide(s)

## Description

Add documentation for setting up Neutron Trunk ports on OPCP, covering both baremetal and virtual machine instances with vlan tagging, sub-port management, and OS-level vlan sub-interface configuration.

The guide covers:
- Creating a parent port and trunk in Neutron
- Adding sub-ports with segmentation IDs matching network configuration
- Deploying baremetal and VM instances using the trunk
- Configuring vlan sub-interfaces in the guest OS (temporary and persistent via Netplan)
- Key differences between baremetal (dummy parent port) and VM (untagged parent network) behavior

## Mandatory information

The translations in this Pull Request have been done using:
- [x] Other tool (me)

- This Pull Request can be merged as soon as possible.
- This Pull Request content should be replicated for the US OVHcloud documentation : NO