### PR TITLE
MKS - New Architecture guide + Fixing obsolete versions

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -959,6 +959,7 @@
     + [Containers & Orchestration](products/public-cloud-containers-orchestration)
         + [Managed Kubernetes Service (MKS)](products/public-cloud-containers-orchestration-managed-kubernetes-k8s)
             + [Key concepts](public-cloud-containers-orchestration-managed-kubernetes-k8s-key-concepts)
+                + [Understanding OVHcloud Managed Kubernetes architecture](public_cloud/containers_orchestration/managed_kubernetes/understanding-mks-architecture)
                 + [Known limits](public_cloud/containers_orchestration/managed_kubernetes/known-limits)
                 + [Choosing the right OVHcloud Managed Kubernetes Plan, Free or Standard](public_cloud/containers_orchestration/managed_kubernetes/mks_plans)
                 + [Available datacenters, worker nodes and persistent storage flavors](public_cloud/containers_orchestration/managed_kubernetes/datacenters-nodes-storage-flavors)

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-gb.md
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/automatically-label-taint-node-pool/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Adding Labels & Taint on Node Pool (Node Pool template)
 excerpt: 'Find out how to add labels, annotations and taints on Nodes thanks to Node Pools template on OVHcloud Managed Kubernetes'
-updated: 2023-06-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -447,7 +447,7 @@ Let's display our node. We should have 1 node running:
 ```bash
 $ kubectl get nodes
 NAME                       STATUS   ROLES    AGE     VERSION
-my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.22.9
+my-node-pool-node-5781fa   Ready    <none>   7m55s   v1.34.0
 ```
 
 Check that the label, annotation and taint you defined are well propageted to the node:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-gb.md
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/creating-a-cluster/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Creating a cluster
 excerpt: 'Find out how to create a Kubernetes cluster managed by OVHcloud using the OVHcloud Control Panel, Terraform, Pulumi or CDK'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 <style>
@@ -279,7 +279,7 @@ resource "ovh_cloud_project_kube" "my_kube_cluster" {
    service_name = "${var.service_name}"
    name         = "my_kube_cluster"
    region       = "GRA7"
-   version      = "1.22"
+   version      = "1.34"
 }
 
 resource "ovh_cloud_project_kube_nodepool" "node_pool" {
@@ -293,7 +293,7 @@ resource "ovh_cloud_project_kube_nodepool" "node_pool" {
 }
 ```
 
-In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using the Kubernetes version 1.22 (the last and recommended version at the time we wrote this tutorial).
+In this resources configuration, we ask Terraform to create a Kubernetes cluster, in the GRA7 region, using Kubernetes version 1.34.
 
 And we tell Terraform to create a Node Pool with 3 Nodes with B2-7 machine type.
 
@@ -393,7 +393,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -457,7 +457,7 @@ Terraform will perform the following actions:
       + status                      = (known after apply)
       + update_policy               = (known after apply)
       + url                         = (known after apply)
-      + version                     = "1.22"
+      + version                     = "1.34"
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be created
@@ -994,11 +994,11 @@ ovhcloud
           
           Outputs:
 
-          cluster_version = "1.28"
+          cluster_version = "1.34"
           nodePoolID = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx"
 
   ovhcloud
-  cluster_version = 1.28
+  cluster_version = 1.34
   nodePoolID = xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx
 ```
 
@@ -1330,9 +1330,9 @@ Display the list of Nodes:
 ```
 $ kubectl --kubeconfig=/Users/<your-user>/.kube/my_kube_cluster.yml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-1bb290   Ready    <none>   1d   v1.22.2
-my-pool-node-8280a6   Ready    <none>   1d   v1.22.2
-my-pool-node-8a1bfe   Ready    <none>   1d   v1.22.2
+my-pool-node-1bb290   Ready    <none>   1d   v1.34.0
+my-pool-node-8280a6   Ready    <none>   1d   v1.34.0
+my-pool-node-8a1bfe   Ready    <none>   1d   v1.34.0
 ```
 
 Awesome!
@@ -1362,7 +1362,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                  STATUS   ROLES    AGE   VERSION
-my-pool-node-0784ed   Ready    <none>   76m   v1.28.3
+my-pool-node-0784ed   Ready    <none>   76m   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Terraform.
@@ -1394,7 +1394,7 @@ Display the list of Nodes:
 ```bash
 $ kubectl --kubeconfig=kubeconfig.yaml get node
 NAME                          STATUS   ROLES    AGE    VERSION
-my-desired-pool-node-a90c09   Ready    <none>   115s   v1.27.4
+my-desired-pool-node-a90c09   Ready    <none>   115s   v1.34.0
 ```
 
 You can now deploy your applications and/or create new clusters through Pulumi.
@@ -1602,7 +1602,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra7.k8s.ovh.net" -> null
-      - version                     = "1.22" -> null
+      - version                     = "1.34" -> null
     }
 
   # ovh_cloud_project_kube_nodepool.node_pool will be destroyed
@@ -1711,7 +1711,7 @@ ovhcloud    # local_file.kubeconfig (kubeconfig) will be destroyed
                 - status                      = "READY" -> null
                 - update_policy               = "ALWAYS_UPDATE" -> null
                 - url                         = "xxxxxx.c2.gra.k8s.ovh.net" -> null
-                - version                     = "1.28" -> null
+                - version                     = "1.34" -> null
 
                 - customization_apiserver {
                     - admissionplugins {
@@ -1754,7 +1754,7 @@ ovhcloud  - created_at                                   = "2024-03-14T10:56:35Z
           Plan: 0 to add, 0 to change, 3 to destroy.
           
           Changes to Outputs:
-            - cluster_version = "1.28" -> null
+            - cluster_version = "1.34" -> null
             - nodePoolID      = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxx" -> null
           
           Do you really want to destroy all resources?

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-gb.md
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/customizing-kubeproxy/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Customizing Kube-proxy on an OVHcloud Managed Kubernetes cluster
 excerpt: 'Find out how to customize the Kube-proxy configuration on an OVHcloud Managed Kubernetes cluster'
-updated: 2023-03-14
+updated: 2026-02-25
 ---
 
 <style>
@@ -595,7 +595,7 @@ Terraform will perform the following actions:
       - status                      = "READY" -> null
       - update_policy               = "ALWAYS_UPDATE" -> null
       - url                         = "xxxxxx.c1.gra.k8s.ovh.net" -> null
-      - version                     = "1.25" -> null
+      - version                     = "1.34" -> null
 
       - customization_apiserver {
           - admissionplugins {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-gb.md
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/deploying-hello-world/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Deploying a Hello World application
 excerpt: 'Find out how to deploy a Hello World application with the OVHcloud Control Panel and the OVHcloud API'
-updated: 2025-05-06
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -86,10 +86,8 @@ In this guide, we’ll walk you through deploying a Hello World application on y
 >>   "name": "my-tiny-cluster",
 >>   "url": "xxxxxx.c2.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c2.gra.k8s.ovh.net",
->>   "version": "1.24.8-1",
->>   "nextUpgradeVersions": [
->>     "1.25"
->>   ],
+>>   "version": "1.34.1",
+>>   "nextUpgradeVersions": [],
 >>   "customization": {
 >>     "apiServer": {
 >>       "admissionPlugins": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-gb.md
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/installing-keycloak/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Keycloak, an OIDC Provider, on OVHcloud Managed Kubernetes
 excerpt: Secure Your OVHcloud Managed Kubernetes Cluster with Keycloak, an OpenID Connect provider (OIDC) and RBAC.
-updated: 2022-11-24
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -713,9 +713,9 @@ For example:
 ```console
 $ kubectl --user=oidc get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.22.2
-nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.22.2
+nodepool-d18716fa-e910-4e77-a2-node-79add5   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-aa7701   Ready    <none>   2d    v1.34.0
+nodepool-d18716fa-e910-4e77-a2-node-f9f18e   Ready    <none>   2d    v1.34.0
 ```
 
 If you can see the nodes of your Managed Kubernetes Service, congratulations, your Keycloak instance is up and running!

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-gb.md
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/label-nodeaffinity-node-pools/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy applications to specific Nodes and Nodes Pools
 excerpt: 'Find out how to deploy applications to specific Nodes and Nodes Pools, with labels and NodeAffinity, on OVHcloud Managed Kubernetes'
-updated: 2021-12-15
+updated: 2026-02-25
 ---
 
 <style>
@@ -164,10 +164,10 @@ Let's display our nodes. You should have 3 nodes running in our first node pool 
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-hourly-node-8e4db2                           Ready    <none>   3m13s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.22.2
+hourly-node-8e4db2                           Ready    <none>   3m13s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   161m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   163m    v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   161m    v1.34.0
 ```
 
 If you don't do anything during several minutes, the AutoScaling in "hourly" node pool will terminate the node because of inactivity:
@@ -175,9 +175,9 @@ If you don't do anything during several minutes, the AutoScaling in "hourly" nod
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.22.2
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h18m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h20m   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h18m   v1.34.0
 ```
 
 ### Deploying our application
@@ -195,9 +195,9 @@ Let's show the labels of our running nodes:
 ```bash
 $ kubectl get node --show-labels
 NAME                                         STATUS   ROLES    AGE     VERSION   LABELS
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.22.2   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-23e81b,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   3h58m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-4bd23f,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   3h56m   v1.34.0   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=GRA7,failure-domain.beta.kubernetes.io/zone=nova,kubernetes.io/arch=amd64,kubernetes.io/hostname=nodepool-cc40f90c-effb-4945-b7-node-ef121e,kubernetes.io/os=linux,node.k8s.ovh/type=standard,node.kubernetes.io/instance-type=0da61e94-ce69-4971-b6df-c410fa3659ec,nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d,topology.cinder.csi.openstack.org/zone=nova,topology.kubernetes.io/region=GRA7,topology.kubernetes.io/zone=nova
 ```
 
 As you can maybe see, our running Nodes got the label `nodepool=nodepool-cc40f90c-effb-4945-b7b9-05073725d62d`.
@@ -279,10 +279,10 @@ You have to wait several minutes in order to have a new Node that matches your c
 ```bash
 $ kubectl get node
 NAME                                         STATUS   ROLES    AGE   VERSION
-hourly-node-d4f9d7                           Ready    <none>   18s   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.22.2
-nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.22.2
+hourly-node-d4f9d7                           Ready    <none>   18s   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-23e81b   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-4bd23f   Ready    <none>   21h   v1.34.0
+nodepool-cc40f90c-effb-4945-b7-node-ef121e   Ready    <none>   21h   v1.34.0
 ```
 
 And you can check in which node our application is running:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-gb.md
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-11-20
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/managing-nodes/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: How to manage nodes and node pools on an OVHcloud Managed Kubernetes cluster
 excerpt: Learn how to manage nodes and node pools using the OVHcloud Control Panel, the OVHcloud API, and the NodePools Custom Resource Definition (CRD)
-updated: 2025-12-02
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -339,7 +339,7 @@ We will walk you through each method to help you efficiently scale and manage yo
 >>   "name": "my_kube_cluster",
 >>   "url": "xxxxxx.c1.gra.k8s.ovh.net",
 >>   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
->>   "version": "1.25.4-1",
+>>   "version": "1.34.1",
 >>   "nextUpgradeVersions": [],
 >>   "kubeProxyMode": "iptables",
 >>   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-gb.md
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/resetting-a-cluster/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Resetting an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to reset an OVHcloud Managed Kubernetes cluster
-updated: 2023-03-23
+updated: 2026-02-25
 ---
 
 <style>
@@ -116,7 +116,7 @@ If you go to the [Kubernetes section](https://api.ovh.com/console/#/cloud/projec
 {
   "name": "my-test-cluster",
   "updatePolicy": "ALWAYS_UPDATE",
-  "version": "1.25"
+  "version": "1.34"
 }
 ```
 
@@ -146,7 +146,7 @@ By default, if you don't specify it, the `workerNodesPolicy` option will be equi
   "name": "my-test-cluster",
   "url": "xxxxxx.xx.gra.k8s.ovh.net",
   "nodesUrl": "xxxxxx.nodes.c1.gra.k8s.ovh.net",
-  "version": "1.25.4-2",
+  "version": "1.34.1",
   "nextUpgradeVersions": [],
   "kubeProxyMode": "iptables",
   "customization": {

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-gb.md
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/taint-drain-node-pools/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Taint, cordon and drain specific Nodes and Nodes Pools
 excerpt: 'Find out how to do some operations on specific Nodes and Nodes Pools, like taint, drain and cordon, on OVHcloud Managed Kubernetes'
-updated: 2021-12-23
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -106,12 +106,12 @@ Let's display our nodes. We should have 3 nodes running in our first node pool a
 ```bash
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   3m30s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   3m30s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   3m28s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   3m35s   v1.34.0
 ```
 
 ### Cordon a Node
@@ -143,12 +143,12 @@ node/second-node-pool-node-c355db cordoned
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   4m23s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   4m21s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   4m28s   v1.34.0
 ```
 
 All the nodes in `second-node-pool` are now marked as `Unschedulable`.
@@ -173,12 +173,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   4m53s   v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   4m53s   v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   4m51s   v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   4m58s   v1.34.0
 ```
 
 Nodes are in `Ready` state again.
@@ -214,12 +214,12 @@ error: cannot delete DaemonSet-managed Pods (use --ignore-daemonsets to ignore):
 
 $ kubectl get nodes
 NAME                                         STATUS                     ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.22.2
-second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.22.2
-second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready                      <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready                      <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready,SchedulingDisabled   <none>   5m37s   v1.34.0
+second-node-pool-node-5fda8f                 Ready,SchedulingDisabled   <none>   5m35s   v1.34.0
+second-node-pool-node-c355db                 Ready,SchedulingDisabled   <none>   5m42s   v1.34.0
 ```
 
 As you can see, Kubernetes can't remove `DaemonSet` objects, so in order to not have this error message, you can add the `--ignore-daemonsets` option:
@@ -245,12 +245,12 @@ node/second-node-pool-node-c355db uncordoned
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE     VERSION
-nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.22.2
-nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.22.2
-second-node-pool-node-519613                 Ready    <none>   6m8s    v1.22.2
-second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.22.2
-second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.22.2
+nodepool-9680a2e9-3e58-48c7-b4-node-874105   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-b5c9e2   Ready    <none>   2d      v1.34.0
+nodepool-9680a2e9-3e58-48c7-b4-node-c65648   Ready    <none>   2d      v1.34.0
+second-node-pool-node-519613                 Ready    <none>   6m8s    v1.34.0
+second-node-pool-node-5fda8f                 Ready    <none>   6m6s    v1.34.0
+second-node-pool-node-c355db                 Ready    <none>   6m13s   v1.34.0
 ```
 
 ### Taint a Node

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/understanding-mks-architecture/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/understanding-mks-architecture/guide.en-gb.md
@@ -1,0 +1,842 @@
+---
+title: Understanding OVHcloud Managed Kubernetes architecture
+excerpt: 'Learn how OVHcloud Managed Kubernetes Service works under the hood: control plane, worker nodes, networking, and storage'
+updated: 2026-01-22
+---
+
+## Objective
+
+This guide explains the architecture of OVHcloud Managed Kubernetes Service (MKS) to help you understand how your clusters are deployed, managed, and connected. Understanding this architecture will help you make informed decisions about cluster configuration, troubleshooting, and scaling.
+
+## Overview
+
+OVHcloud Managed Kubernetes Service is a CNCF-certified Kubernetes offering that abstracts away the complexity of managing the control plane while giving you full control over your worker nodes and workloads.
+
+```
++------------------------------------------------------------------+
+|                    OVHcloud Managed Kubernetes                    |
++------------------------------------------------------------------+
+|                                                                  |
+|  +------------------------+      +----------------------------+  |
+|  |     CONTROL PLANE      |      |       WORKER NODES         |  |
+|  |    (Managed by OVH)    |      |   (Your responsibility)    |  |
+|  +------------------------+      +----------------------------+  |
+|  |                        |      |                            |  |
+|  |  +------------------+  |      |  +---------+  +---------+  |  |
+|  |  |   API Server     |  |      |  | Node 1  |  | Node 2  |  |  |
+|  |  +------------------+  |      |  |+--+ +--+|  |+--+ +--+|  |  |
+|  |  +------------------+  |      |  ||P1| |P2||  ||P3| |P4||  |  |
+|  |  |   Controller     |  |<---->|  |+--+ +--+|  |+--+ +--+|  |  |
+|  |  |   Manager        |  |      |  +---------+  +---------+  |  |
+|  |  +------------------+  |      |                            |  |
+|  |  +------------------+  |      |  +---------+               |  |
+|  |  |   Scheduler      |  |      |  | Node 3  |               |  |
+|  |  +------------------+  |      |  |+--+ +--+|               |  |
+|  |  +------------------+  |      |  ||P5| |P6||               |  |
+|  |  |   etcd           |  |      |  |+--+ +--+|               |  |
+|  |  +------------------+  |      |  +---------+               |  |
+|  |                        |      |                            |  |
+|  +------------------------+      +----------------------------+  |
+|                                                                  |
++------------------------------------------------------------------+
+      P1, P2, ... = Your Pods running on each node
+```
+
+## Control Plane architecture
+
+The control plane is the brain of your Kubernetes cluster. OVHcloud fully manages this component, which includes:
+
+- **API Server**: The front-end for the Kubernetes control plane, handling all API requests
+- **etcd**: The distributed key-value store that holds all cluster state and configuration
+- **Controller Manager**: Runs controller processes (node controller, replication controller, etc.)
+- **Scheduler**: Assigns pods to nodes based on resource requirements and constraints
+
+### What OVHcloud manages for you
+
+OVHcloud handles all operational aspects of the control plane:
+
+| Component | OVHcloud responsibility |
+|-----------|------------------------|
+| API Server | Deployment, scaling, high availability, security patches |
+| etcd | Backups, encryption at rest, cluster health |
+| Controller Manager | Updates, configuration, monitoring |
+| Scheduler | Updates, configuration |
+| Kubernetes versions | New minor versions availability, security patches (defined by user through Security Policy parameter) |
+
+> [!primary]
+>
+> **About Kubernetes upgrades**: OVHcloud makes new Kubernetes minor versions available. You control when to trigger the upgrade. The only exception is when your cluster runs an End-of-Life version, in this case, OVHcloud will force an upgrade to the next supported version after prior notification.
+>
+
+### Free vs Standard plan: Control plane differences
+
+The control plane architecture differs significantly between plans:
+
+```
+FREE PLAN                                STANDARD PLAN
++--------------------+                   +------------------------------------------------+
+|   Single Zone      |                   |              Multi-AZ Deployment               |
+|                    |                   |                                                |
+|  +-------------+   |                   |   Zone A        Zone B        Zone C           |
+|  |Control Plane|   |                   |  +------+      +------+      +------+          |
+|  |  (shared)   |   |                   |  | CP   |      | CP   |      | CP   |          |
+|  +-------------+   |                   |  |Replica|     |Replica|     |Replica|         |
+|  +-------------+   |                   |  +------+      +------+      +------+          |
+|  |    etcd     |   |                   |  | etcd |      | etcd |      | etcd |          |
+|  |  (shared)   |   |                   |  |replica|     |replica|     |replica|         |
+|  | max 400MB   |   |                   |  +------+      +------+      +------+          |
+|  +-------------+   |                   |       \           |           /                |
+|                    |                   |        \          |          /                 |
+|  SLO: 99.5%        |                   |         +---------+---------+                  |
+|                    |                   |         | Dedicated etcd 8GB |                 |
+|                    |                   |         +--------------------+                 |
+|                    |                   |                                                |
+|                    |                   |  SLA: 99.99%                                   |
++--------------------+                   +------------------------------------------------+
+```
+
+| Feature | Free Plan | Standard Plan |
+|---------|-----------|---------------|
+| Control Plane | Managed, single-zone | Managed, cross-AZ resilient |
+| Availability | 99.5% SLO | 99.99% SLA (at GA) |
+| etcd storage | Shared, up to 400MB | Dedicated, up to 8GB, distributed across 3 AZs |
+| Max cluster size | 100 nodes | 500 nodes |
+| Regional availability | Single-zone | 3 Availability Zones |
+| CNI | Canal (Flannel + Calico) | Cilium |
+
+> [!primary]
+>
+> Based on SLA/SLO commitments, a Free plan cluster could experience up to ~43 minutes of downtime per month (worst case), while a Standard plan cluster limits this to approximately 4 minutes maximum.
+>
+
+## Worker Nodes architecture
+
+Worker nodes are the machines where your containerized applications run. Unlike the control plane, you have direct control over node configuration.
+
+### How nodes are provisioned
+
+Worker nodes are based on OVHcloud Public Cloud instances. When you create a node pool:
+
+1. OVHcloud provisions Public Cloud instances with your chosen flavor
+2. The instances are automatically configured with the required Kubernetes components
+3. Nodes register themselves with the control plane via Konnectivity
+
+The CNI differs depending on your plan:
+
+```
+FREE PLAN - Worker Node                     STANDARD PLAN - Worker Node
++------------------------------+            +------------------------------+
+|                              |            |                              |
+| +----------+ +-------------+ |            | +----------+ +-------------+ |
+| | kubelet  | | kube-proxy  | |            | | kubelet  | | kube-proxy  | |
+| +----------+ +-------------+ |            | +----------+ +-------------+ |
+|                              |            |                              |
+| +----------+ +-------------+ |            | +----------+ +-------------+ |
+| |containerd| | CNI: Canal  | |            | |containerd| | CNI: Cilium | |
+| |          | | (Flannel +  | |            | |          | | (eBPF-based)| |
+| |          | |  Calico)    | |            | |          | |             | |
+| +----------+ +-------------+ |            | +----------+ +-------------+ |
+|                              |            |                              |
+| +-------+ +-------+ +------+ |            | +-------+ +-------+ +------+ |
+| | Pod A | | Pod B | | ...  | |            | | Pod A | | Pod B | | ...  | |
+| +-------+ +-------+ +------+ |            | +-------+ +-------+ +------+ |
+|                              |            |                              |
+| OS: Ubuntu 22.04 LTS         |            | OS: Ubuntu 22.04 LTS         |
++------------------------------+            +------------------------------+
+```
+
+### Node pools concept
+
+Nodes are organized into node pools - groups of nodes sharing the same configuration:
+
+- **Flavor**: Instance type (b3-8, b3-16, t1-45 for GPU, etc.)
+- **Autoscaling settings**: Min/max nodes, scale-down thresholds
+- **Anti-affinity**: Distribute nodes across different hypervisors
+- **Billing**: Hourly or monthly (for gen2 flaovrs), Saving Plans for gen3 and above
+- **Labels and taints**: For workload scheduling
+
+```
++------------------------------------------------------------------+
+|                         KUBERNETES CLUSTER                        |
++------------------------------------------------------------------+
+|                                                                  |
+|  NODE POOL: "general"          NODE POOL: "gpu"                  |
+|  Flavor: b3-16                 Flavor: t1-45                     |
+|  Autoscale: true               Autoscale: false                  |
+|  Min: 2, Max: 10               Nodes: 2                          |
+|  +---------+ +---------+       +---------+ +---------+           |
+|  | Node 1  | | Node 2  |  ...  | GPU-1   | | GPU-2   |           |
+|  |+--+ +--+| |+--+ +--+|       |+--+ +--+| |+--+ +--+|           |
+|  ||P1| |P2|| ||P3| |P4||       ||P5| |P6|| ||P7| |P8||           |
+|  |+--+ +--+| |+--+ +--+|       |+--+ +--+| |+--+ +--+|           |
+|  +---------+ +---------+       +---------+ +---------+           |
+|                                                                  |
+|  NODE POOL: "high-memory"                                        |
+|  Flavor: r3-128                                                  |
+|  Anti-affinity: true (max 5 nodes)                               |
+|  +---------+ +---------+ +---------+                             |
+|  | Node 1  | | Node 2  | | Node 3  |                             |
+|  |+--+ +--+| |+--+ +--+| |+--+ +--+|                             |
+|  ||P9||P10|| ||P ||P  || ||P ||P  ||                             |
+|  |+--+ +--+| |+--+ +--+| |+--+ +--+|                             |
+|  +---------+ +---------+ +---------+                             |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+### Node lifecycle
+
+```
+                              NORMAL LIFECYCLE
+  +------------+      +----------+      +-----------+      +------------+
+  |            |      |          |      |           |      |            |
+  | Installing |----->|  Ready   |----->|  Draining |----->| Terminated |
+  |            |      |          |      |           |      |            |
+  +------------+      +-----+----+      +-----------+      +------------+
+                            |
+                            | (Node becomes unhealthy)
+                            v
+                      +----------+
+                      | NotReady |
+                      +-----+----+
+                            |
+                            | (After 10 min)
+                            v
+              +-------------------------------+
+              |         AUTO-HEALING          |
+              +-------------------------------+
+              |                               |
+              |  FREE PLAN     STANDARD PLAN  |
+              |                               |
+              | +----------+   +------------+ |
+              | | Node is  |   | Node is    | |
+              | | reinstall|   | deleted &  | |
+              | | in-place |   | new node   | |
+              | |          |   | created    | |
+              | +----+-----+   +-----+------+ |
+              |      |               |        |
+              |      v               v        |
+              | +----------+   +------------+ |
+              | |  Ready   |   | Installing | |
+              | +----------+   +-----+------+ |
+              |                      |        |
+              |                      v        |
+              |                +----------+   |
+              |                |  Ready   |   |
+              |                +----------+   |
+              |                               |
+              +-------------------------------+
+```
+
+- **Installing**: Node is being provisioned and configured
+- **Ready**: Node is healthy and can receive pods
+- **NotReady**: Node has issues (network, resources, etc.)
+- **Draining**: Node is being evacuated (graceful, respects PDBs for 10 min max)
+- **Terminated**: Node is deleted
+
+> [!warning]
+>
+> GPU worker nodes (t1 and t2 flavors) may take more than one hour to reach a ready state.
+>
+
+### Auto-healing
+
+OVHcloud monitors node health. If a node remains in `NotReady` state for more than 10 minutes, auto-healing is triggered:
+
+- **Free plan**: The node is reinstalled in-place
+- **Standard plan**: The node is deleted and a new one is created
+
+This ensures cluster stability but means:
+
+- Do not store important data directly on nodes
+- Always use Persistent Volumes for stateful workloads
+- Design applications to be resilient to node failures
+
+### Node upgrades
+
+When upgrading Kubernetes versions, MKS offers two strategies for updating worker nodes:
+
+```
++=============================================================================+
+|                          NODE UPGRADE STRATEGIES                            |
++=============================================================================+
+|                                                                             |
+|  IN-PLACE UPGRADE                         ROLLING UPGRADE                   |
+|  (Free & Standard)                        (Standard only for now)           |
+|                                                                             |
+|  Same instance,                           New instances replace             |
+|  components updated                       old ones                          |
+|                                                                             |
+|  +-------+  +-------+  +-------+          +-------+  +-------+  +-------+   |
+|  |Node 1 |  |Node 2 |  |Node 3 |          |Node 1 |  |Node 2 |  |Node 3 |   |
+|  | v1.33 |  | v1.33 |  | v1.33 |          | v1.33 |  | v1.33 |  | v1.33 |   |
+|  +---+---+  +-------+  +-------+          +-------+  +-------+  +---+---+   |
+|      |                                                              |       |
+|      | 1. Cordon & Drain                    1. Create new node +-------+    |
+|      v                                                         |Node 4 |    |
+|  +-------+                                                     | v1.34 |    |
+|  |Node 1 |  Pods moved to                                      +---+---+    |
+|  |UPGRADE|  other nodes                     2. Cordon & Drain      |        |
+|  +---+---+                                     old node       <----+        |
+|      |                                                                      |
+|      | 2. Upgrade                             +-------+                     |
+|      v    components                          |Node 3 |  3. Migrate pods    |
+|  +-------+  +-------+  +-------+              |DRAIN  |     to new node     |
+|  |Node 1 |  |Node 2 |  |Node 3 |              +---+---+                     |
+|  | v1.34 |  | v1.33 |  | v1.33 |                  |                         |
+|  +-------+  +---+---+  +-------+                  | 4. Delete old node      |
+|                 |                                 v                         |
+|      3. Repeat for                            +-------+  +-------+  +-----+ |
+|         next node                             |Node 1 |  |Node 2 |  |Node | |
+|                 |                             | v1.33 |  | v1.33 |  |4    | |
+|                 v                             +-------+  +-------+  |v1.34| |
+|  +-------+  +-------+  +-------+                                    +-----+ |
+|  |Node 1 |  |Node 2 |  |Node 3 |                                            |
+|  | v1.34 |  | v1.34 |  | v1.34 |              5. Repeat until all upgraded  |
+|  +-------+  +-------+  +-------+                                            |
+|                                                                             |
++=============================================================================+
+```
+
+#### In-place upgrades
+
+With in-place upgrades, each worker node is updated directly on its existing Public Cloud instance:
+
+1. MKS **cordons** the node (marks it unschedulable)
+2. MKS **drains** the node (evicts all pods, respecting PodDisruptionBudgets)
+3. Kubernetes components are **upgraded** on the same instance
+4. Node becomes **Ready** again
+5. Process **repeats** for the next node (strictly one-by-one)
+
+**Characteristics:**
+
+- No extra instances required
+- Preserves instance identity (same IPs, same billing)
+- Slower process (sequential, one node at a time)
+- Temporary capacity reduction during each node upgrade
+
+> [!warning]
+>
+> In-place upgrades can lead to resource pressure if your cluster doesn't have enough spare capacity to accommodate pods evicted from the node being upgraded. Ensure your remaining nodes can handle the extra workload.
+>
+
+**Use cases:**
+
+- Monthly-billed instances (keep the same instance)
+- Need to preserve public IP addresses
+- Cost-sensitive environments (no extra instance costs)
+
+#### Rolling upgrades
+
+With rolling upgrades (currently available on Standard plan only), new worker nodes are created with the target Kubernetes version:
+
+1. MKS **creates** a new node running the target version
+2. MKS **cordons and drains** an old node
+3. Workloads **migrate** to the new node
+4. Old node is **deleted**
+5. Process **repeats** until all nodes are upgraded
+
+**Characteristics:**
+
+- Requires temporary extra capacity (new nodes created before old ones deleted)
+- Faster upgrades with higher availability
+- Clean node state (fresh instances)
+- Better handling of workload migration
+
+> [!primary]
+>
+> In the future roadmap, rolling upgrades will support Kubernetes-style `maxSurge` and `maxUnavailable` settings to control how many nodes can be added or taken offline simultaneously.
+>
+
+**Use cases:**
+
+- Production environments requiring high availability
+- Faster upgrade cycles
+- When clean node state is preferred
+
+#### Comparison
+
+| Aspect | In-place | Rolling |
+|--------|----------|---------|
+| Availability | Free & Standard | Standard only (for now) |
+| Extra instances | No | Yes (temporary) |
+| Speed | Slower (sequential) | Faster (parallel possible) |
+| Instance identity | Preserved | New instances |
+| Public IPs | Preserved | Changed |
+| Resource pressure | Higher (reduced capacity) | Lower (extra capacity) |
+| Best for | Cost optimization | High availability |
+
+### Reserved resources
+
+Each worker node reserves resources for Kubernetes system components:
+
+| Resource | Formula |
+|----------|---------|
+| CPU | 15% of 1 CPU + 0.5% of all CPU cores |
+| RAM | Fixed 1590 MB |
+| Storage | log10(total storage in GB) * 10 + 10% of total storage |
+
+Example for b3-16 flavor: 170ms CPU, 1.59GB RAM, 30GB storage reserved.
+
+## Networking architecture
+
+### Cluster network overview
+
+```
++====================================================================================+
+|                            NETWORKING ARCHITECTURE                                 |
++====================================================================================+
+|                                                                                    |
+|   INTERNET                                                                         |
+|   +------+                                                                         |
+|   |      |                                                                         |
+|   +--+---+                                                                         |
+|      |                                                                             |
+|      +------------------+------------------------+                                 |
+|      |                  ^                        ^                                 |
+|      | OPTION 1         | OPTION 2               | OPTION 3                        |
+|      | Load Balancer    | Node Floating IPs      | Gateway (SNAT)                  |
+|      | (recommended)    | (direct access)        | (outbound only)                 |
+|      |                  |                        |                                 |
+|      v                  |                        |                                 |
+|   +----------+          |                 +------------+                           |
+|   |Floating  |          |                 |  Gateway   |                           |
+|   |   IP     |          |                 | (Octavia)  |                           |
+|   +----+-----+          |                 +-----+------+                           |
+|        |                |                       ^                                  |
+|        v                |                       | SNAT                             |
+|   +----------+          |                       | (outbound)                       |
+|   |   Load   |          |                       |                                  |
+|   | Balancer |          |                       |                                  |
+|   | (Octavia)|          |                       |                                  |
+|   +----+-----+          |                       |                                  |
+|        |                |                       |                                  |
+|   +----|----------------|----------------------------------------------------+     |
+|   |    |    PRIVATE NETWORK (or vRack)          |                            |     |
+|   |    v                v                       |                            |     |
+|   | +--------------------------------------------------------------------+   |     |
+|   | |                      KUBERNETES CLUSTER                            |   |     |
+|   | |                                                                    |   |     |
+|   | |  +------------+     +------------+     +------------+              |   |     |
+|   | |  |   Node 1   |     |   Node 2   |     |   Node 3   |--------------+   |     |
+|   | |  | +--------+ |     | +--------+ |     | +--------+ |              |   |     |
+|   | |  | |Floating| |     | |Floating| |     | |Floating| |  (Option 2)  |   |     |
+|   | |  | |IP (opt)| |     | |IP (opt)| |     | |IP (opt)| |              |   |     | 
+|   | |  | +--------+ |     | +--------+ |     | +--------+ |              |   |     |
+|   | |  | +--+ +--+  |     | +--+ +--+  |     | +--+ +--+  |              |   |     |
+|   | |  | |P1| |P2|  |<--->| |P3| |P4|  |<--->| |P5| |P6|  |              |   |     |
+|   | |  | +--+ +--+  |     | +--+ +--+  |     | +--+ +--+  |              |   |     |
+|   | |  +------------+     +------------+     +------------+              |   |     |
+|   | |        ^                  ^                  ^                     |   |     |
+|   | |        +------------------+------------------+                     |   |     |
+|   | |                           |                                        |   |     |
+|   | |              CNI: Canal (Free) / Cilium (Standard)                 |   |     |
+|   | +--------------------------------------------------------------------+   |     |
+|   +--------------------------------------------------------------------------+     |
+|                                                                                    |
++====================================================================================+
+```
+
+### Internet access options
+
+MKS clusters support three networking patterns for Internet connectivity:
+
+| Option | Direction | Use case |
+|--------|-----------|----------|
+| **Load Balancer** | Inbound | Expose services (recommended for production) |
+| **Node Floating IPs** | Inbound & Outbound | Direct node access, preserve source IP |
+| **Gateway (SNAT)** | Outbound only | Default outbound, shared IP for all nodes |
+
+**Option 1 - Load Balancer (Octavia):**
+
+- Recommended for exposing services to the Internet
+- Provides health checking, load distribution
+- Single entry point with a Floating IP
+- Supports L4 (TCP/UDP) load balancing
+
+**Option 2 - Node Floating IPs:**
+
+- Each node can have its own Floating IP attached
+- Enables direct inbound access (e.g., via NodePort services)
+- Preserves source IP addresses for outbound traffic (no SNAT)
+- Useful when pods need to reach external services that whitelist IPs
+- IP is preserved during in-place upgrades, but changes with rolling upgrades
+
+> [!warning]
+>
+> To attach a Floating IP to a node, a Gateway (OpenStack router) must be configured on the private network subnet. Without a Gateway, Floating IPs cannot be associated with instances in that subnet.
+>
+
+**Option 3 - Gateway (SNAT):**
+
+- Default for outbound Internet access when no Floating IP is attached
+- All nodes share the same outbound IP (Gateway IP)
+- Does NOT expose services to the Internet
+- Source IP is translated (SNAT)
+
+### CNI: Container Network Interface
+
+The CNI plugin differs between plans:
+
+| Plan | CNI | Description |
+|------|-----|-------------|
+| **Free** | Canal (Flannel + Calico) | Flannel for overlay network, Calico for network policies |
+| **Standard** | Cilium | eBPF-based, high performance, advanced observability |
+
+Reserved subnets (do not use in your private network):
+
+**Free plan:**
+
+| Subnet | Purpose |
+|--------|---------|
+| 10.2.0.0/16 | Pod network |
+| 10.3.0.0/16 | Service network |
+| 172.17.0.0/16 | Docker daemon (legacy) |
+
+**Standard plan:**
+
+| Subnet | Purpose |
+|--------|---------|
+| 10.240.0.0/13 | Pod network |
+| 10.3.0.0/16 | Service network |
+
+### Service exposure options
+
+Kubernetes Services can be exposed in several ways:
+
+```
++------------------------------------------------------------------+
+|                    SERVICE EXPOSURE OPTIONS                       |
++------------------------------------------------------------------+
+|                                                                  |
+|  ClusterIP (Internal only)                                       |
+|  +------------------+                                            |
+|  |  10.3.x.x        |  Only accessible within the cluster        |
+|  +------------------+                                            |
+|                                                                  |
+|  NodePort (Direct node access)                                   |
+|  +------------------+                                            |
+|  |  <NodeIP>:30000- |  Accessible on all nodes                   |
+|  |           32767  |  (Port range 30000-32767)                  |
+|  +------------------+                                            |
+|                                                                  |
+|  LoadBalancer (Recommended for production)                       |
+|  +------------------+     +------------------+                   |
+|  |  Floating IP     |---->|  Octavia LB      |---> Nodes         |
+|  |  (Public)        |     |  (L4)            |                   |
+|  +------------------+     +------------------+                   |
+|                                                                  |
+|  Ingress (L7 routing)                                            |
+|  +------------------+     +------------------+                   |
+|  |  LoadBalancer    |---->|  Ingress         |---> Services      |
+|  |                  |     |  Controller      |                   |
+|  |                  |     |  (nginx, etc.)   |                   |
+|  +------------------+     +------------------+                   |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+### Load Balancer integration
+
+Creating a `Service` of type `LoadBalancer` automatically provisions an OVHcloud Public Cloud Load Balancer (based on OpenStack Octavia):
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  annotations:
+    # Required for Kubernetes < 1.31
+    loadbalancer.ovhcloud.com/class: octavia
+    # Optional: choose LB size (small, medium, large, xl)
+    loadbalancer.ovhcloud.com/flavor: small
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app: my-app
+```
+
+> [!primary]
+>
+> For Kubernetes versions >= 1.31, Octavia is the default Load Balancer and no annotation is required.
+>
+
+### Private networking options
+
+OVHcloud offers two ways to use private networks with MKS:
+
+#### 1. Public Cloud Private Network (without vRack)
+
+For connecting OVHcloud Public Cloud services within the same region:
+
+- MKS clusters
+- Public Cloud instances
+- Managed Databases (DBaaS)
+- Other Public Cloud services
+
+This is the simplest option when you only need private connectivity between Public Cloud resources.
+
+#### 2. vRack integration
+
+For broader interconnectivity across OVHcloud product universes and regions:
+
+```
++------------------------------------------------------------------+
+|                         vRack INTEGRATION                         |
++------------------------------------------------------------------+
+|                                                                  |
+|  +------------------------+    +------------------------+        |
+|  |  MKS Cluster           |    |  Dedicated Servers     |        |
+|  |  (Region: GRA)         |    |  (Bare Metal)          |        |
+|  +------------------------+    +------------------------+        |
+|           |                              |                       |
+|           v                              v                       |
+|  +----------------------------------------------------------+    |
+|  |                        vRack                              |   |
+|  |     (Private Layer 2 network across OVHcloud universe)    |   |
+|  +----------------------------------------------------------+    |
+|           |                              |                       |
+|           v                              v                       |
+|  +------------------------+    +------------------------+        |
+|  |  Hosted Private Cloud  |    |  MKS Cluster           |        |
+|  |  (VMware)              |    |  (Region: SBG)         |        |
+|  +------------------------+    +------------------------+        |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+vRack enables:
+- Cross-region private connectivity
+- Interconnection with Bare Metal servers
+- Interconnection with Hosted Private Cloud (VMware)
+- Interconnection with other OVHcloud dedicated products
+
+> [!warning]
+>
+> When using a private network (with or without vRack), you will still see a public IPv4 on worker nodes. This IP is not reachable from the Internet and is used exclusively for node administration and control plane communication.
+>
+
+## Storage architecture
+
+### Persistent Volumes with Cinder CSI
+
+MKS uses the OpenStack Cinder CSI driver for persistent storage:
+
+```
++------------------------------------------------------------------+
+|                    STORAGE ARCHITECTURE                           |
++------------------------------------------------------------------+
+|                                                                  |
+|  KUBERNETES                           OVHcloud BLOCK STORAGE     |
+|                                                                  |
+|  +------------------+                                            |
+|  |      Pod         |                                            |
+|  |  +------------+  |                                            |
+|  |  | Container  |  |                                            |
+|  |  |  /data     |  |    Mount                                   |
+|  |  +-----+------+  |       |                                    |
+|  +--------+---------+       |                                    |
+|           |                 |                                    |
+|           v                 v                                    |
+|  +------------------+     +------------------+                   |
+|  |       PVC        |<--->|       PV         |                   |
+|  | (Request)        |     | (Provisioned)    |                   |
+|  +------------------+     +--------+---------+                   |
+|                                    |                             |
+|                                    | Cinder CSI                  |
+|                                    v                             |
+|                           +------------------+                   |
+|                           |  Block Storage   |                   |
+|                           |  Volume          |                   |
+|                           |  (Cinder)        |                   |
+|                           +------------------+                   |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+### Storage classes
+
+| Storage Class | Description | IOPS | Recommended for |
+|--------------|-------------|------|-----------------|
+| `csi-cinder-high-speed` (default) | Fixed performance SSD | Up to 3,000 | Volumes up to 100GB |
+| `csi-cinder-high-speed-gen2` | Progressive performance NVMe | 30 IOPS/GB (max 20k) | Volumes > 100GB |
+| `csi-cinder-classic` | Traditional spinning disks | 200 guaranteed | Cost-sensitive workloads |
+| `*-luks` variants | Encrypted versions | Same as base | Sensitive data |
+
+### Access modes and limitations
+
+| Access Mode | Support | Description |
+|-------------|---------|-------------|
+| ReadWriteOnce (RWO) | Supported | Single node read-write |
+| ReadOnlyMany (ROX) | Not supported* | Multi-node read-only |
+| ReadWriteMany (RWX) | Not supported* | Multi-node read-write |
+
+*For multi-attach volumes (RWX), use one of these OVHcloud storage solutions:
+
+| Solution | Protocol | Documentation |
+|----------|----------|---------------|
+| **File Storage** (Public Cloud) | NFS | [File Storage documentation](/pages/storage_and_backup/file_storage/file_storage_service) |
+| **Enterprise File Storage** | NFS | [EFS with MKS](/pages/public_cloud/containers_orchestration/managed_kubernetes/configuring-multi-attach-persistent-volumes-with-ovh-efs) |
+| **NAS-HA** | NFS | [NAS-HA with MKS](/pages/public_cloud/containers_orchestration/managed_kubernetes/configuring-multi-attach-persistent-volumes-with-ovh-nas-ha) |
+| **Cloud Disk Array** | CephFS | [CDA with MKS](/pages/public_cloud/containers_orchestration/managed_kubernetes/configuring-multi-attach-persistent-volumes-with-ovh-cloud-disk-array) |
+
+> [!warning]
+>
+> A worker node can have a maximum of 100 Cinder persistent volumes attached to it.
+>
+
+## Security model
+
+### Shared responsibility
+
+```
++------------------------------------------------------------------+
+|                    SHARED RESPONSIBILITY MODEL                    |
++------------------------------------------------------------------+
+|                                                                  |
+|  OVHcloud RESPONSIBILITY              YOUR RESPONSIBILITY        |
+|  +---------------------------+       +------------------------+  |
+|  |                           |       |                        |  |
+|  | - Control plane security  |       | - Application security |  |
+|  | - Control plane updates   |       | - Container images     |  |
+|  | - Node OS patches         |       | - RBAC configuration   |  |
+|  | - etcd encryption         |       | - Network policies     |  |
+|  | - Infrastructure security |       | - Secrets management   |  |
+|  | - Physical security       |       | - Workload isolation   |  |
+|  | - Node provisioning       |       | - Data backup          |  |
+|  | - Auto-healing            |       | - Application updates  |  |
+|  | - K8s version availability|       | - K8s upgrade trigger  |  |
+|  | - Force upgrade EOL vers. |       | - Access management    |  |
+|  |                           |       |                        |  |
+|  +---------------------------+       +------------------------+  |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+> [!primary]
+>
+> **About Kubernetes version upgrades**: OVHcloud provides new minor versions. You decide when to upgrade. However, if your cluster runs an End-of-Life version, OVHcloud will force an upgrade to the next version after prior notification.
+>
+
+### Access control mechanisms
+
+1. **kubeconfig authentication**: Downloaded from OVHcloud Control Panel, provides admin access
+2. **OIDC integration**: Connect your identity provider for SSO
+3. **API server IP restrictions**: Limit access to specific IP ranges
+4. **RBAC**: Role-Based Access Control for fine-grained permissions
+
+### Security features
+
+- **Free plan**: Network policies via Calico
+- **Standard plan**: Network policies via Cilium (eBPF-based)
+- Secrets encryption in transit and at rest
+- Node isolation via security groups
+- Audit logs available in Control Panel
+
+## Component versions
+
+Current software versions (as of the latest Kubernetes releases):
+
+| Component | Free Plan | Standard Plan |
+|-----------|-----------|---------------|
+| OS | Ubuntu 22.04 LTS | Ubuntu 22.04 LTS |
+| Kernel | 5.15-generic | 5.15-generic |
+| Container runtime | containerd 2.1.4 | containerd 2.1.4 |
+| CNI | Canal (Calico v3.30.1 + Flannel v0.24.4) | Cilium |
+| CSI | Cinder CSI v1.29.0 | Cinder CSI v1.29.0 |
+| CoreDNS | v1.12.4 | v1.12.4 |
+| Metrics Server | v0.8.0 | v0.8.0 |
+
+For the complete version matrix, see [Kubernetes Plugins & Software versions](/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources).
+
+## Architecture diagram: Complete overview
+
+```
++=======================================================================================+
+|                        OVHCLOUD MANAGED KUBERNETES SERVICE                             |
++=======================================================================================+
+|                                                                                       |
+|   INTERNET                                                                            |
+|   +------+                                                                            |
+|   |      |                                                                            |
+|   +--+---+                                                                            |
+|      |                                                                                |
+|      +------------------+------------------------+                                    |
+|      |                  |                        |                                    |
+|      v                  |                        v                                    |
+|   +----------+          |                 +------------+                              |
+|   |Floating  |          |                 |  Gateway   | (SNAT for                    |
+|   |   IP     |          |                 | (Octavia)  |  outbound)                   |
+|   +----+-----+          |                 +-----+------+                              |
+|        |                |                       ^                                     |
+|        v                |                       |                                     |
+|   +----------+          |                       |                                     |
+|   |   Load   |          |                       |                                     |
+|   | Balancer |          |                       |                                     |
+|   | (Octavia)|          |                       |                                     |
+|   +----+-----+          |                       |                                     |
+|        |                |                       |                                     |
+|   +----|----------------|----------------------------------------------------+        |
+|   |    |    PRIVATE NETWORK (Public Cloud network or vRack)                  |       |
+|   |    v                |                       |                            |        |
+|   | +--------------------------------------------------------------------+   |        |
+|   | |                        MKS CLUSTER                                  |  |        |
+|   | |                                                                    |   |        |
+|   | |  CONTROL PLANE (OVHcloud Managed)                                  |   |        |
+|   | |  +--------------------------------------------------------------+  |   |        |
+|   | |  |                                                              |  |   |        |
+|   | |  |  FREE: Single zone          STANDARD: Multi-AZ               |  |   |        |
+|   | |  |  +------------------+       +-------+ +-------+ +-------+    |  |   |        |
+|   | |  |  | API | etcd | CM  |       |API|etcd| |API|etcd| |API|etcd| |  |   |        |
+|   | |  |  | Scheduler        |       | Zone A | | Zone B | | Zone C | |  |   |        |
+|   | |  |  +------------------+       +-------+ +-------+ +-------+    |  |   |        |
+|   | |  |                                                              |  |   |        |
+|   | |  +--------------------------------------------------------------+  |   |        |
+|   | |                             ^                                      |   |        |
+|   | |                             | Konnectivity                         |   |        |
+|   | |                             v                                      |   |        |
+|   | |  WORKER NODES                                                      |   |        |
+|   | |  +------------------+ +------------------+ +------------------+    |   |        |
+|   | |  |     Node 1       | |     Node 2       | |     Node 3       |----+   |        |
+|   | |  | +-----+ +-----+  | | +-----+ +-----+  | | +-----+ +-----+  |    |   |        |
+|   | |  | |Pod A| |Pod B|  | | |Pod C| |Pod D|  | | |Pod E| |Pod F|  |    |   |        |
+|   | |  | +-----+ +-----+  | | +-----+ +-----+  | | +-----+ +-----+  |    |   |        |
+|   | |  | kubelet|kube-prx | | kubelet|kube-prx | | kubelet|kube-prx |    |   |        |
+|   | |  | containerd      | | containerd       | | containerd       |    |   |        |
+|   | |  +--------+---------+ +--------+---------+ +--------+---------+    |   |        |
+|   | |           |                    |                    |              |   |        |
+|   | |           +--------------------+--------------------+              |   |        |
+|   | |                                |                                   |   |        |
+|   | |             FREE: Canal (Flannel + Calico)                         |   |        |
+|   | |             STANDARD: Cilium (eBPF)                                |   |        |
+|   | |                                                                    |   |        |
+|   | +--------------------------------------------------------------------+   |        |
+|   |                                                                          |        |
+|   +--------------------------------------------------------------------------+        |
+|                                                                                       |
+|   STORAGE                                                                             |
+|   +------------------+  +------------------+  +-------------------+                   |
+|   |  Block Storage   |  |  Block Storage   |  |  File Storage     |                  |
+|   |  (Cinder PV)     |  |  (Cinder PV)     |  |  (NFS - RWX)      |                   |
+|   |  RWO only        |  |  RWO only        |  |  Multi-attach     |                  |
+|   +------------------+  +------------------+  +-------------------+                   |
+|                                                                                       |
++=======================================================================================+
+```
+
+## Go further
+
+- [Known limits](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits)
+- [Choosing the right plan: Free vs Standard](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans)
+- [Responsibility model](/pages/public_cloud/containers_orchestration/managed_kubernetes/responsibility-model)
+- [Software versions and reserved resources](/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources)
+- [Using vRack Private Network](/pages/public_cloud/containers_orchestration/managed_kubernetes/using-vrack)
+- [Persistent Volumes](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume)
+- [Expose your applications using Load Balancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer)
+
+If you need training or technical assistance to implement our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and ask our Professional Services experts for a custom analysis of your project.
+
+Join our [community of users](/links/community).

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/understanding-mks-architecture/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/understanding-mks-architecture/guide.en-gb.md
@@ -1,25 +1,25 @@
 ---
 title: Understanding OVHcloud Managed Kubernetes architecture
 excerpt: 'Learn how OVHcloud Managed Kubernetes Service works under the hood: control plane, worker nodes, networking, and storage'
-updated: 2026-01-22
+updated: 2026-02-25
 ---
 
 ## Objective
 
-This guide explains the architecture of OVHcloud Managed Kubernetes Service (MKS) to help you understand how your clusters are deployed, managed, and connected. Understanding this architecture will help you make informed decisions about cluster configuration, troubleshooting, and scaling.
+**This guide explains the architecture of OVHcloud Managed Kubernetes Service (MKS) to help you understand how your clusters are deployed, managed, and connected. Understanding this architecture will help you make informed decisions about cluster configuration, troubleshooting, and scaling.**
 
 ## Overview
 
 OVHcloud Managed Kubernetes Service is a CNCF-certified Kubernetes offering that abstracts away the complexity of managing the control plane while giving you full control over your worker nodes and workloads.
 
-```
+```text
 +------------------------------------------------------------------+
 |                    OVHcloud Managed Kubernetes                    |
 +------------------------------------------------------------------+
 |                                                                  |
 |  +------------------------+      +----------------------------+  |
 |  |     CONTROL PLANE      |      |       WORKER NODES         |  |
-|  |    (Managed by OVH)    |      |   (Your responsibility)    |  |
+|  | (Managed by OVHcloud)  |      |   (Your responsibility)    |  |
 |  +------------------------+      +----------------------------+  |
 |  |                        |      |                            |  |
 |  |  +------------------+  |      |  +---------+  +---------+  |  |
@@ -65,14 +65,14 @@ OVHcloud handles all operational aspects of the control plane:
 
 > [!primary]
 >
-> **About Kubernetes upgrades**: OVHcloud makes new Kubernetes minor versions available. You control when to trigger the upgrade. The only exception is when your cluster runs an End-of-Life version, in this case, OVHcloud will force an upgrade to the next supported version after prior notification.
+> **About Kubernetes upgrades**: OVHcloud makes new Kubernetes minor versions available. You control when to trigger the upgrade. The only exception is when your cluster runs an End-of-Life version; in this case, OVHcloud will force an upgrade to the next supported version after prior notification.
 >
 
 ### Free vs Standard plan: Control plane differences
 
 The control plane architecture differs significantly between plans:
 
-```
+```text
 FREE PLAN                                STANDARD PLAN
 +--------------------+                   +------------------------------------------------+
 |   Single Zone      |                   |              Multi-AZ Deployment               |
@@ -123,7 +123,7 @@ Worker nodes are based on OVHcloud Public Cloud instances. When you create a nod
 
 The CNI differs depending on your plan:
 
-```
+```text
 FREE PLAN - Worker Node                     STANDARD PLAN - Worker Node
 +------------------------------+            +------------------------------+
 |                              |            |                              |
@@ -152,10 +152,10 @@ Nodes are organized into node pools - groups of nodes sharing the same configura
 - **Flavor**: Instance type (b3-8, b3-16, t1-45 for GPU, etc.)
 - **Autoscaling settings**: Min/max nodes, scale-down thresholds
 - **Anti-affinity**: Distribute nodes across different hypervisors
-- **Billing**: Hourly or monthly (for gen2 flaovrs), Saving Plans for gen3 and above
+- **Billing**: Hourly or monthly (for gen2 flavors), Saving Plans for gen3 and above
 - **Labels and taints**: For workload scheduling
 
-```
+```text
 +------------------------------------------------------------------+
 |                         KUBERNETES CLUSTER                        |
 +------------------------------------------------------------------+
@@ -186,7 +186,7 @@ Nodes are organized into node pools - groups of nodes sharing the same configura
 
 ### Node lifecycle
 
-```
+```text
                               NORMAL LIFECYCLE
   +------------+      +----------+      +-----------+      +------------+
   |            |      |          |      |           |      |            |
@@ -256,7 +256,7 @@ This ensures cluster stability but means:
 
 When upgrading Kubernetes versions, MKS offers two strategies for updating worker nodes:
 
-```
+```text
 +=============================================================================+
 |                          NODE UPGRADE STRATEGIES                            |
 +=============================================================================+
@@ -376,13 +376,13 @@ Each worker node reserves resources for Kubernetes system components:
 | RAM | Fixed 1590 MB |
 | Storage | log10(total storage in GB) * 10 + 10% of total storage |
 
-Example for b3-16 flavor: 170ms CPU, 1.59GB RAM, 30GB storage reserved.
+Example for b3-16 flavor: 170m CPU, 1.59GB RAM, 30GB storage reserved.
 
 ## Networking architecture
 
 ### Cluster network overview
 
-```
+```text
 +====================================================================================+
 |                            NETWORKING ARCHITECTURE                                 |
 +====================================================================================+
@@ -504,7 +504,7 @@ Reserved subnets (do not use in your private network):
 
 Kubernetes Services can be exposed in several ways:
 
-```
+```text
 +------------------------------------------------------------------+
 |                    SERVICE EXPOSURE OPTIONS                       |
 +------------------------------------------------------------------+
@@ -583,7 +583,7 @@ This is the simplest option when you only need private connectivity between Publ
 
 For broader interconnectivity across OVHcloud product universes and regions:
 
-```
+```text
 +------------------------------------------------------------------+
 |                         vRack INTEGRATION                         |
 +------------------------------------------------------------------+
@@ -609,6 +609,7 @@ For broader interconnectivity across OVHcloud product universes and regions:
 ```
 
 vRack enables:
+
 - Cross-region private connectivity
 - Interconnection with Bare Metal servers
 - Interconnection with Hosted Private Cloud (VMware)
@@ -625,7 +626,7 @@ vRack enables:
 
 MKS uses the OpenStack Cinder CSI driver for persistent storage:
 
-```
+```text
 +------------------------------------------------------------------+
 |                    STORAGE ARCHITECTURE                           |
 +------------------------------------------------------------------+
@@ -692,7 +693,7 @@ MKS uses the OpenStack Cinder CSI driver for persistent storage:
 
 ### Shared responsibility
 
-```
+```text
 +------------------------------------------------------------------+
 |                    SHARED RESPONSIBILITY MODEL                    |
 +------------------------------------------------------------------+
@@ -754,7 +755,7 @@ For the complete version matrix, see [Kubernetes Plugins & Software versions](/p
 
 ## Architecture diagram: Complete overview
 
-```
+```text
 +=======================================================================================+
 |                        OVHCLOUD MANAGED KUBERNETES SERVICE                             |
 +=======================================================================================+

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/understanding-mks-architecture/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/understanding-mks-architecture/guide.fr-fr.md
@@ -1,0 +1,844 @@
+---
+title: Comprendre l'architecture d'OVHcloud Managed Kubernetes
+excerpt: "Découvrez le fonctionnement d'OVHcloud Managed Kubernetes Service : control plane, worker nodes, réseau et stockage"
+updated: 2026-01-22
+---
+
+## Objectif
+
+Ce guide explique l'architecture d'OVHcloud Managed Kubernetes Service (MKS) pour vous aider à comprendre comment vos clusters sont déployés, gérés et connectés. Comprendre cette architecture vous aidera à prendre des décisions éclairées concernant la configuration, le dépannage et le dimensionnement de votre cluster.
+
+## Vue d'ensemble
+
+OVHcloud Managed Kubernetes Service est une offre Kubernetes certifiée CNCF qui abstrait la complexité de la gestion du control plane tout en vous donnant un contrôle total sur vos worker nodes et vos workloads.
+
+```
++------------------------------------------------------------------+
+|                    OVHcloud Managed Kubernetes                    |
++------------------------------------------------------------------+
+|                                                                  |
+|  +------------------------+      +----------------------------+  |
+|  |     CONTROL PLANE      |      |       WORKER NODES         |  |
+|  |    (Géré par OVH)      |      |  (Votre responsabilité)    |  |
+|  +------------------------+      +----------------------------+  |
+|  |                        |      |                            |  |
+|  |  +------------------+  |      |  +---------+  +---------+  |  |
+|  |  |   API Server     |  |      |  | Node 1  |  | Node 2  |  |  |
+|  |  +------------------+  |      |  |+--+ +--+|  |+--+ +--+|  |  |
+|  |  +------------------+  |      |  ||P1| |P2||  ||P3| |P4||  |  |
+|  |  |   Controller     |  |<---->|  |+--+ +--+|  |+--+ +--+|  |  |
+|  |  |   Manager        |  |      |  +---------+  +---------+  |  |
+|  |  +------------------+  |      |                            |  |
+|  |  +------------------+  |      |  +---------+               |  |
+|  |  |   Scheduler      |  |      |  | Node 3  |               |  |
+|  |  +------------------+  |      |  |+--+ +--+|               |  |
+|  |  +------------------+  |      |  ||P5| |P6||               |  |
+|  |  |   etcd           |  |      |  |+--+ +--+|               |  |
+|  |  +------------------+  |      |  +---------+               |  |
+|  |                        |      |                            |  |
+|  +------------------------+      +----------------------------+  |
+|                                                                  |
++------------------------------------------------------------------+
+      P1, P2, ... = Vos Pods s'exécutant sur chaque node
+```
+
+## Architecture du Control Plane
+
+Le control plane est le cerveau de votre cluster Kubernetes. OVHcloud gère entièrement ce composant, qui inclut :
+
+- **API Server** : L'interface principale du control plane Kubernetes, gérant toutes les requêtes API
+- **etcd** : Le magasin de données clé-valeur distribué qui contient l'état et la configuration du cluster
+- **Controller Manager** : Exécute les processus de contrôle (node controller, replication controller, etc.)
+- **Scheduler** : Assigne les pods aux nodes en fonction des besoins en ressources et des contraintes
+
+### Ce qu'OVHcloud gère pour vous
+
+OVHcloud gère tous les aspects opérationnels du control plane :
+
+| Composant | Responsabilité OVHcloud |
+|-----------|------------------------|
+| API Server | Déploiement, mise à l'échelle, haute disponibilité, correctifs de sécurité |
+| etcd | Sauvegardes, chiffrement au repos, santé du cluster |
+| Controller Manager | Mises à jour, configuration, supervision |
+| Scheduler | Mises à jour, configuration |
+| Versions Kubernetes | Disponibilité des nouvelles versions mineures, correctifs de sécurité |
+
+> [!primary]
+>
+> **À propos des mises à jour Kubernetes** : OVHcloud met à disposition les nouvelles versions mineures de Kubernetes. Vous décidez quand déclencher la mise à jour. La seule exception concerne les clusters exécutant une version End-of-Life - dans ce cas, OVHcloud forcera une mise à jour vers la version suivante après notification préalable.
+>
+
+### Plans Free vs Standard : différences du Control Plane
+
+L'architecture du control plane diffère significativement entre les plans :
+
+```
+PLAN FREE                                PLAN STANDARD
++--------------------+                   +------------------------------------------------+
+|   Zone unique      |                   |              Déploiement Multi-AZ              |
+|                    |                   |                                                |
+|  +-------------+   |                   |   Zone A        Zone B        Zone C           |
+|  |Control Plane|   |                   |  +------+      +------+      +------+          |
+|  |  (partagé)  |   |                   |  | CP   |      | CP   |      | CP   |          |
+|  +-------------+   |                   |  |Replica|     |Replica|     |Replica|         |
+|  +-------------+   |                   |  +------+      +------+      +------+          |
+|  |    etcd     |   |                   |  | etcd |      | etcd |      | etcd |          |
+|  |  (partagé)  |   |                   |  |replica|     |replica|     |replica|         |
+|  | max 400MB   |   |                   |  +------+      +------+      +------+          |
+|  +-------------+   |                   |       \           |           /                |
+|                    |                   |        \          |          /                 |
+|  SLO: 99.5%        |                   |         +---------+---------+                  |
+|                    |                   |         | etcd dédié 8GB    |                  |
+|                    |                   |         +--------------------+                 |
+|                    |                   |                                                |
+|                    |                   |  SLA: 99.99%                                   |
++--------------------+                   +------------------------------------------------+
+```
+
+| Fonctionnalité | Plan Free | Plan Standard |
+|----------------|-----------|---------------|
+| Control Plane | Géré, zone unique | Géré, résilient cross-AZ |
+| Disponibilité | 99.5% SLO | 99.99% SLA (en GA) |
+| Stockage etcd | Partagé, jusqu'à 400MB | Dédié, jusqu'à 8GB, distribué sur 3 AZs |
+| Taille max cluster | 100 nodes | 500 nodes |
+| Disponibilité régionale | Zone unique | 3 Zones de disponibilité |
+| CNI | Canal (Flannel + Calico) | Cilium |
+
+> [!primary]
+>
+> Selon les engagements SLA/SLO, un cluster Free peut connaître jusqu'à ~43 minutes d'indisponibilité par mois (pire cas), tandis qu'un cluster Standard limite cela à environ 4 minutes maximum.
+>
+
+## Architecture des Worker Nodes
+
+Les worker nodes sont les machines où vos applications conteneurisées s'exécutent. Contrairement au control plane, vous avez un contrôle direct sur la configuration des nodes.
+
+### Comment les nodes sont provisionnés
+
+Les worker nodes sont basés sur des instances OVHcloud Public Cloud. Quand vous créez un node pool :
+
+1. OVHcloud provisionne des instances Public Cloud avec la flavor choisie
+2. Les instances sont automatiquement configurées avec les composants Kubernetes requis
+3. Les nodes s'enregistrent auprès du control plane via Konnectivity
+
+Le CNI diffère selon votre plan :
+
+```
+PLAN FREE - Worker Node                     PLAN STANDARD - Worker Node
++------------------------------+            +------------------------------+
+|                              |            |                              |
+| +----------+ +-------------+ |            | +----------+ +-------------+ |
+| | kubelet  | | kube-proxy  | |            | | kubelet  | | kube-proxy  | |
+| +----------+ +-------------+ |            | +----------+ +-------------+ |
+|                              |            |                              |
+| +----------+ +-------------+ |            | +----------+ +-------------+ |
+| |containerd| | CNI: Canal  | |            | |containerd| | CNI: Cilium | |
+| |          | | (Flannel +  | |            | |          | | (basé eBPF) | |
+| |          | |  Calico)    | |            | |          | |             | |
+| +----------+ +-------------+ |            | +----------+ +-------------+ |
+|                              |            |                              |
+| +-------+ +-------+ +------+ |            | +-------+ +-------+ +------+ |
+| | Pod A | | Pod B | | ...  | |            | | Pod A | | Pod B | | ...  | |
+| +-------+ +-------+ +------+ |            | +-------+ +-------+ +------+ |
+|                              |            |                              |
+| OS: Ubuntu 22.04 LTS         |            | OS: Ubuntu 22.04 LTS         |
++------------------------------+            +------------------------------+
+```
+
+### Concept des Node Pools
+
+Les nodes sont organisés en node pools - des groupes de nodes partageant la même configuration :
+
+- **Flavor** : Type d'instance (b3-8, b3-16, t1-45 pour GPU, etc.)
+- **Paramètres d'autoscaling** : Min/max nodes, seuils de scale-down
+- **Anti-affinité** : Distribuer les nodes sur différents hyperviseurs
+- **Facturation** : Horaire ou mensuelle
+- **Labels et taints** : Pour le scheduling des workloads
+
+```
++------------------------------------------------------------------+
+|                         CLUSTER KUBERNETES                        |
++------------------------------------------------------------------+
+|                                                                  |
+|  NODE POOL: "general"          NODE POOL: "gpu"                  |
+|  Flavor: b3-16                 Flavor: t1-45                     |
+|  Autoscale: true               Autoscale: false                  |
+|  Min: 2, Max: 10               Nodes: 2                          |
+|  +---------+ +---------+       +---------+ +---------+           |
+|  | Node 1  | | Node 2  |  ...  | GPU-1   | | GPU-2   |           |
+|  |+--+ +--+| |+--+ +--+|       |+--+ +--+| |+--+ +--+|           |
+|  ||P1| |P2|| ||P3| |P4||       ||P5| |P6|| ||P7| |P8||           |
+|  |+--+ +--+| |+--+ +--+|       |+--+ +--+| |+--+ +--+|           |
+|  +---------+ +---------+       +---------+ +---------+           |
+|                                                                  |
+|  NODE POOL: "high-memory"                                        |
+|  Flavor: r3-128                                                  |
+|  Anti-affinité: true (max 5 nodes)                               |
+|  +---------+ +---------+ +---------+                             |
+|  | Node 1  | | Node 2  | | Node 3  |                             |
+|  |+--+ +--+| |+--+ +--+| |+--+ +--+|                             |
+|  ||P9||P10|| ||P ||P  || ||P ||P  ||                             |
+|  |+--+ +--+| |+--+ +--+| |+--+ +--+|                             |
+|  +---------+ +---------+ +---------+                             |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+### Cycle de vie des nodes
+
+```
+                              CYCLE DE VIE NORMAL
+  +------------+      +----------+      +-----------+      +------------+
+  |            |      |          |      |           |      |            |
+  | Installing |----->|  Ready   |----->|  Draining |----->| Terminated |
+  |            |      |          |      |           |      |            |
+  +------------+      +-----+----+      +-----------+      +------------+
+                            |
+                            | (Le node devient défaillant)
+                            v
+                      +----------+
+                      | NotReady |
+                      +-----+----+
+                            |
+                            | (Après 10 min)
+                            v
+              +-------------------------------+
+              |         AUTO-HEALING          |
+              +-------------------------------+
+              |                               |
+              |  PLAN FREE     PLAN STANDARD  |
+              |                               |
+              | +----------+   +------------+ |
+              | | Le node  |   | Le node    | |
+              | | est      |   | est        | |
+              | | réinstall|   | supprimé & | |
+              | | in-place |   | nouveau    | |
+              | |          |   | créé       | |
+              | +----+-----+   +-----+------+ |
+              |      |               |        |
+              |      v               v        |
+              | +----------+   +------------+ |
+              | |  Ready   |   | Installing | |
+              | +----------+   +-----+------+ |
+              |                      |        |
+              |                      v        |
+              |                +----------+   |
+              |                |  Ready   |   |
+              |                +----------+   |
+              |                               |
+              +-------------------------------+
+```
+
+- **Installing** : Le node est en cours de provisionnement et de configuration
+- **Ready** : Le node est sain et peut recevoir des pods
+- **NotReady** : Le node a des problèmes (réseau, ressources, etc.)
+- **Draining** : Le node est en cours d'évacuation (graceful, respecte les PDBs pendant 10 min max)
+- **Terminated** : Le node est supprimé
+
+> [!warning]
+>
+> Les worker nodes GPU (flavors t1 et t2) peuvent prendre plus d'une heure pour atteindre l'état ready.
+>
+
+### Auto-healing
+
+OVHcloud surveille la santé des nodes. Si un node reste en état `NotReady` pendant plus de 10 minutes, l'auto-healing est déclenché :
+
+- **Plan Free** : Le node est réinstallé in-place
+- **Plan Standard** : Le node est supprimé et un nouveau est créé
+
+Cela garantit la stabilité du cluster mais signifie :
+
+- Ne stockez pas de données importantes directement sur les nodes
+- Utilisez toujours des Persistent Volumes pour les workloads stateful
+- Concevez vos applications pour être résilientes aux pannes de nodes
+
+### Mises à jour des nodes
+
+Lors de la mise à jour des versions Kubernetes, MKS propose deux stratégies pour mettre à jour les worker nodes :
+
+```
++===============================================================================+
+|                     STRATÉGIES DE MISE À JOUR DES NODES                       |
++===============================================================================+
+|                                                                               |
+|  MISE À JOUR IN-PLACE                     ROLLING UPGRADE                     |
+|  (Free & Standard)                        (Standard uniquement pour l'instant)|
+|                                                                               |
+|  Même instance, composants                Nouvelles instances remplacent      |
+|  mis à jour                               les anciennes                       |
+|                                                                               |
+|  +-------+  +-------+  +-------+          +-------+  +-------+  +-------+     |
+|  |Node 1 |  |Node 2 |  |Node 3 |          |Node 1 |  |Node 2 |  |Node 3 |     |
+|  | v1.33 |  | v1.33 |  | v1.33 |          | v1.33 |  | v1.33 |  | v1.33 |     |
+|  +---+---+  +-------+  +-------+          +-------+  +-------+  +---+---+     |
+|      |                                                              |         |
+|      | 1. Cordon & Drain                    1. Créer nouveau   +-------+      |
+|      v                                         node            |Node 4 |      |
+|  +-------+                                                     | v1.34 |      |
+|  |Node 1 |  Pods déplacés                                      +---+---+      |
+|  |UPGRADE|  vers autres nodes               2. Cordon & Drain      |          |
+|  +---+---+                                     ancien node    <----+          |
+|      |                                                                        |
+|      | 2. Mise à jour                         +-------+                       |
+|      v    composants                          |Node 3 |  3. Migrer pods       |
+|  +-------+  +-------+  +-------+              |DRAIN  |     vers nouveaur node|
+|  |Node 1 |  |Node 2 |  |Node 3 |              +---+---+                       |
+|  | v1.34 |  | v1.33 |  | v1.33 |                  |                           |
+|  +-------+  +---+---+  +-------+                  | 4. Supprimer ancien node  |
+|                 |                                 v                           |
+|      3. Répéter pour                          +-------+  +-------+  +-----+   |
+|         node suivant                          |Node 1 |  |Node 2 |  |Node |   |
+|                 |                             | v1.33 |  | v1.33 |  |4    |   |
+|                 v                             +-------+  +-------+  |v1.34|   |
+|  +-------+  +-------+  +-------+                                    +-----+   |
+|  |Node 1 |  |Node 2 |  |Node 3 |                                              |
+|  | v1.34 |  | v1.34 |  | v1.34 |              5. Répéter jusqu'à la fin       |
+|  +-------+  +-------+  +-------+                                              |
+|                                                                               |
++===============================================================================+
+```
+
+#### Mises à jour in-place
+
+Avec les mises à jour in-place, chaque worker node est mis à jour directement sur son instance Public Cloud existante :
+
+1. MKS met le node en **cordon** (le marque comme non-schedulable)
+2. MKS **draine** le node (évacue tous les pods, en respectant les PodDisruptionBudgets)
+3. Les composants Kubernetes sont **mis à jour** sur la même instance
+4. Le node redevient **Ready**
+5. Le processus se **répète** pour le node suivant (strictement un par un)
+
+**Caractéristiques :**
+
+- Pas d'instances supplémentaires requises
+- Préserve l'identité de l'instance (mêmes IPs, même facturation)
+- Processus plus lent (séquentiel, un node à la fois)
+- Réduction temporaire de capacité pendant la mise à jour de chaque node
+
+> [!warning]
+>
+> Les mises à jour in-place peuvent créer une pression sur les ressources si votre cluster n'a pas assez de capacité disponible pour accueillir les pods évacués du node en cours de mise à jour. Assurez-vous que vos nodes restants peuvent gérer la charge supplémentaire.
+>
+
+**Cas d'usage :**
+
+- Instances facturées mensuellement (conserver la même instance)
+- Besoin de préserver les adresses IP publiques
+- Environnements sensibles aux coûts (pas de coûts d'instances supplémentaires)
+
+#### Rolling upgrades
+
+Avec les rolling upgrades (actuellement disponible uniquement sur le plan Standard), de nouveaux worker nodes sont créés avec la version Kubernetes cible :
+
+1. MKS **crée** un nouveau node avec la version cible
+2. MKS met en **cordon et draine** un ancien node
+3. Les workloads **migrent** vers le nouveau node
+4. L'ancien node est **supprimé**
+5. Le processus se **répète** jusqu'à ce que tous les nodes soient mis à jour
+
+**Caractéristiques :**
+
+- Nécessite une capacité supplémentaire temporaire (nouveaux nodes créés avant suppression des anciens)
+- Mises à jour plus rapides avec une meilleure disponibilité
+- État propre des nodes (instances fraîches)
+- Meilleure gestion de la migration des workloads
+
+> [!primary]
+>
+> Dans la roadmap future, les rolling upgrades supporteront les paramètres Kubernetes `maxSurge` et `maxUnavailable` pour contrôler combien de nodes peuvent être ajoutés ou mis hors ligne simultanément.
+>
+
+**Cas d'usage :**
+
+- Environnements de production nécessitant une haute disponibilité
+- Cycles de mise à jour plus rapides
+- Quand un état propre des nodes est préféré
+
+#### Comparaison
+
+| Aspect | In-place | Rolling |
+|--------|----------|---------|
+| Disponibilité | Free & Standard | Standard uniquement (pour l'instant) |
+| Instances supplémentaires | Non | Oui (temporaire) |
+| Vitesse | Plus lent (séquentiel) | Plus rapide (parallèle possible) |
+| Identité de l'instance | Préservée | Nouvelles instances |
+| IPs publiques | Préservées | Changées |
+| Pression sur les ressources | Plus élevée (capacité réduite) | Plus faible (capacité supplémentaire) |
+| Idéal pour | Optimisation des coûts | Haute disponibilité |
+
+### Ressources réservées
+
+Chaque worker node réserve des ressources pour les composants système Kubernetes :
+
+| Ressource | Formule |
+|----------|---------|
+| CPU | 15% de 1 CPU + 0.5% de tous les cœurs CPU |
+| RAM | Fixe 1590 MB |
+| Stockage | log10(stockage total en GB) * 10 + 10% du stockage total |
+
+Exemple pour la flavor b3-16 : 170ms CPU, 1.59GB RAM, 30GB stockage réservés.
+
+## Architecture réseau
+
+### Vue d'ensemble du réseau cluster
+
+```
++====================================================================================+
+|                             ARCHITECTURE RÉSEAU                                     |
++====================================================================================+
+|                                                                                    |
+|   INTERNET                                                                         |
+|   +------+                                                                         |
+|   |      |                                                                         |
+|   +--+---+                                                                         |
+|      |                                                                             |
+|      +------------------+------------------------+.                                |
+|      |                  ^                        ^                                 |
+|      | OPTION 1         | OPTION 2               | OPTION 3                        |
+|      | Load Balancer    | Floating IPs nodes     | Gateway (SNAT)                  |
+|      | (recommandé)     | (accès direct)         | (sortant uniq.)                 |
+|      |                  |                        |                                 |
+|      v                  |                        |                                 |
+|   +----------+          |                 +------------+                           |
+|   |Floating  |          |                 |  Gateway   |                           |
+|   |   IP     |          |                 | (Octavia)  |                           |
+|   +----+-----+          |                 +-----+------+                           |
+|        |                |                       ^                                  |
+|        v                |                       | SNAT                             |
+|   +----------+          |                       | (sortant)                        |
+|   |   Load   |          |                       |                                  |
+|   | Balancer |          |                       |                                  |
+|   | (Octavia)|          |                       |                                  |
+|   +----+-----+          |                       |                                  |
+|        |                |                       |                                  |
+|   +----|----------------|----------------------------------------------------+     |
+|   |    |    RÉSEAU PRIVÉ (ou vRack)             |                            |     |
+|   |    v                v                       |                            |     |
+|   | +--------------------------------------------------------------------+   |     |
+|   | |                      CLUSTER KUBERNETES                            |   |     |
+|   | |                                                                    |   |     |
+|   | |  +------------+     +------------+     +------------+              |   |     |
+|   | |  |   Node 1   |     |   Node 2   |     |   Node 3   |--------------+   |     |
+|   | |  | +--------+ |     | +--------+ |     | +--------+ |              |   |     |
+|   | |  | |Floating| |     | |Floating| |     | |Floating| |  (Option 2)  |   |     |
+|   | |  | |IP (opt)| |     | |IP (opt)| |     | |IP (opt)| |              |   |     |
+|   | |  | +--------+ |     | +--------+ |     | +--------+ |              |   |     |
+|   | |  | +--+ +--+  |     | +--+ +--+  |     | +--+ +--+  |              |   |     |
+|   | |  | |P1| |P2|  |<--->| |P3| |P4|  |<--->| |P5| |P6|  |              |   |     |
+|   | |  | +--+ +--+  |     | +--+ +--+  |     | +--+ +--+  |              |   |     |
+|   | |  +------------+     +------------+     +------------+              |   |     |
+|   | |        ^                  ^                  ^                     |   |     |
+|   | |        +------------------+------------------+                     |   |     |
+|   | |                           |                                        |   |     |
+|   | |              CNI: Canal (Free) / Cilium (Standard)                 |   |     |
+|   | +--------------------------------------------------------------------+   |     |
+|   +--------------------------------------------------------------------------+     |
+|                                                                                    |
++====================================================================================+
+```
+
+### Options d'accès Internet
+
+Les clusters MKS supportent trois schémas de connectivité Internet :
+
+| Option | Direction | Cas d'usage |
+|--------|-----------|-------------|
+| **Load Balancer** | Entrant | Exposer des services (recommandé en production) |
+| **Floating IPs sur les nodes** | Entrant & Sortant | Accès direct aux nodes, préserver l'IP source |
+| **Gateway (SNAT)** | Sortant uniquement | Sortie par défaut, IP partagée pour tous les nodes |
+
+**Option 1 - Load Balancer (Octavia) :**
+
+- Recommandé pour exposer des services sur Internet
+- Fournit health checking, distribution de charge
+- Point d'entrée unique avec une Floating IP
+- Supporte le load balancing L4 (TCP/UDP)
+
+**Option 2 - Floating IPs sur les nodes :**
+
+- Chaque node peut avoir sa propre Floating IP attachée
+- Permet un accès entrant direct (ex: via services NodePort)
+- Préserve les adresses IP source pour le trafic sortant (pas de SNAT)
+- Utile quand les pods doivent atteindre des services externes qui filtrent par IP
+- L'IP est préservée lors des mises à jour in-place, mais change avec les rolling upgrades
+
+> [!warning]
+>
+> Pour attacher une Floating IP à un node, une Gateway (routeur OpenStack) doit être configurée sur le subnet du réseau privé. Sans Gateway, les Floating IPs ne peuvent pas être associées aux instances de ce subnet.
+>
+
+**Option 3 - Gateway (SNAT) :**
+
+- Par défaut pour l'accès Internet sortant quand aucune Floating IP n'est attachée
+- Tous les nodes partagent la même IP sortante (IP de la Gateway)
+- N'EXPOSE PAS les services sur Internet
+- L'IP source est traduite (SNAT)
+
+### CNI : Container Network Interface
+
+Le plugin CNI diffère selon les plans :
+
+| Plan | CNI | Description |
+|------|-----|-------------|
+| **Free** | Canal (Flannel + Calico) | Flannel pour le réseau overlay, Calico pour les network policies |
+| **Standard** | Cilium | Basé sur eBPF, haute performance, observabilité avancée |
+
+Sous-réseaux réservés (ne pas utiliser dans votre réseau privé) :
+
+**Plan Free :**
+
+| Sous-réseau | Usage |
+|--------|---------|
+| 10.2.0.0/16 | Réseau des pods |
+| 10.3.0.0/16 | Réseau des services |
+| 172.17.0.0/16 | Docker daemon (legacy) |
+
+**Plan Standard :**
+
+| Sous-réseau | Usage |
+|--------|---------|
+| 10.240.0.0/13 | Réseau des pods |
+| 10.3.0.0/16 | Réseau des services |
+
+### Options d'exposition des services
+
+Les Services Kubernetes peuvent être exposés de plusieurs façons :
+
+```
++------------------------------------------------------------------+
+|                    OPTIONS D'EXPOSITION DES SERVICES              |
++------------------------------------------------------------------+
+|                                                                  |
+|  ClusterIP (Interne uniquement)                                  |
+|  +------------------+                                            |
+|  |  10.3.x.x        |  Accessible uniquement dans le cluster     |
+|  +------------------+                                            |
+|                                                                  |
+|  NodePort (Accès direct aux nodes)                               |
+|  +------------------+                                            |
+|  |  <NodeIP>:30000- |  Accessible sur tous les nodes             |
+|  |           32767  |  (Plage de ports 30000-32767)              |
+|  +------------------+                                            |
+|                                                                  |
+|  LoadBalancer (Recommandé pour la production)                    |
+|  +------------------+     +------------------+                   |
+|  |  Floating IP     |---->|  Octavia LB      |---> Nodes         |
+|  |  (Public)        |     |  (L4)            |                   |
+|  +------------------+     +------------------+                   |
+|                                                                  |
+|  Ingress (Routage L7)                                            |
+|  +------------------+     +------------------+                   |
+|  |  LoadBalancer    |---->|  Ingress         |---> Services      |
+|  |                  |     |  Controller      |                   |
+|  |                  |     |  (nginx, etc.)   |                   |
+|  +------------------+     +------------------+                   |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+### Intégration Load Balancer
+
+Créer un `Service` de type `LoadBalancer` provisionne automatiquement un OVHcloud Public Cloud Load Balancer (basé sur OpenStack Octavia) :
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  annotations:
+    # Requis pour Kubernetes < 1.31
+    loadbalancer.ovhcloud.com/class: octavia
+    # Optionnel : choisir la taille du LB (small, medium, large, xl)
+    loadbalancer.ovhcloud.com/flavor: small
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 80
+      targetPort: 8080
+  selector:
+    app: my-app
+```
+
+> [!primary]
+>
+> Pour les versions Kubernetes >= 1.31, Octavia est le Load Balancer par défaut et aucune annotation n'est requise.
+>
+
+### Options de réseau privé
+
+OVHcloud propose deux façons d'utiliser les réseaux privés avec MKS :
+
+#### 1. Réseau privé Public Cloud (sans vRack)
+
+Pour connecter les services OVHcloud Public Cloud dans la même région :
+
+- Clusters MKS
+- Instances Public Cloud
+- Bases de données managées (DBaaS)
+- Autres services Public Cloud
+
+C'est l'option la plus simple quand vous avez uniquement besoin de connectivité privée entre ressources Public Cloud.
+
+#### 2. Intégration vRack
+
+Pour une interconnectivité plus large entre les univers produits OVHcloud et entre régions :
+
+```
++------------------------------------------------------------------+
+|                      INTÉGRATION vRack                            |
++------------------------------------------------------------------+
+|                                                                  |
+|  +------------------------+    +------------------------+        |
+|  |  Cluster MKS           |    |  Serveurs dédiés       |        |
+|  |  (Région: GRA)         |    |  (Bare Metal)          |        |
+|  +------------------------+    +------------------------+        |
+|           |                              |                       |
+|           v                              v                       |
+|  +----------------------------------------------------------+    |
+|  |                        vRack                              |   |
+|  |   (Réseau privé Layer 2 à travers l'univers OVHcloud)     |   |
+|  +----------------------------------------------------------+    |
+|           |                              |                       |
+|           v                              v                       |
+|  +------------------------+    +------------------------+        |
+|  |  Hosted Private Cloud  |    |  Cluster MKS           |        |
+|  |  (VMware)              |    |  (Région: SBG)         |        |
+|  +------------------------+    +------------------------+        |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+Le vRack permet :
+- Connectivité privée inter-régions
+- Interconnexion avec les serveurs Bare Metal
+- Interconnexion avec Hosted Private Cloud (VMware)
+- Interconnexion avec d'autres produits dédiés OVHcloud
+
+> [!warning]
+>
+> Avec un réseau privé (avec ou sans vRack), vous verrez toujours une IPv4 publique sur les worker nodes. Cette IP n'est pas joignable depuis Internet et est utilisée exclusivement pour l'administration des nodes et la communication avec le control plane.
+>
+
+## Architecture de stockage
+
+### Volumes persistants avec Cinder CSI
+
+MKS utilise le driver OpenStack Cinder CSI pour le stockage persistant :
+
+```
++------------------------------------------------------------------+
+|                    ARCHITECTURE DE STOCKAGE                       |
++------------------------------------------------------------------+
+|                                                                  |
+|  KUBERNETES                           OVHcloud BLOCK STORAGE     |
+|                                                                  |
+|  +------------------+                                            |
+|  |      Pod         |                                            |
+|  |  +------------+  |                                            |
+|  |  | Container  |  |                                            |
+|  |  |  /data     |  |    Montage                                 |
+|  |  +-----+------+  |       |                                    |
+|  +--------+---------+       |                                    |
+|           |                 |                                    |
+|           v                 v                                    |
+|  +------------------+     +------------------+                   |
+|  |       PVC        |<--->|       PV         |                   |
+|  | (Demande)        |     | (Provisionné)    |                   |
+|  +------------------+     +--------+---------+                   |
+|                                    |                             |
+|                                    | Cinder CSI                  |
+|                                    v                             |
+|                           +------------------+                   |
+|                           |  Volume Block    |                   |
+|                           |  Storage         |                   |
+|                           |  (Cinder)        |                   |
+|                           +------------------+                   |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+### Classes de stockage
+
+| Classe de stockage | Description | IOPS | Recommandé pour |
+|--------------|-------------|------|-----------------|
+| `csi-cinder-high-speed` (défaut) | SSD performance fixe | Jusqu'à 3 000 | Volumes jusqu'à 100GB |
+| `csi-cinder-high-speed-gen2` | NVMe performance progressive | 30 IOPS/GB (max 20k) | Volumes > 100GB |
+| `csi-cinder-classic` | Disques rotatifs traditionnels | 200 garantis | Workloads sensibles au coût |
+| Variantes `*-luks` | Versions chiffrées | Identique à la base | Données sensibles |
+
+### Modes d'accès et limitations
+
+| Mode d'accès | Support | Description |
+|-------------|---------|-------------|
+| ReadWriteOnce (RWO) | Supporté | Lecture-écriture sur un seul node |
+| ReadOnlyMany (ROX) | Non supporté* | Lecture seule multi-nodes |
+| ReadWriteMany (RWX) | Non supporté* | Lecture-écriture multi-nodes |
+
+*Pour les volumes multi-attach (RWX), utilisez une de ces solutions de stockage OVHcloud :
+
+| Solution | Protocole | Documentation |
+|----------|----------|---------------|
+| **File Storage** (Public Cloud) | NFS | [Documentation File Storage](/pages/storage_and_backup/file_storage/file_storage_service) |
+| **Enterprise File Storage** | NFS | [EFS avec MKS](/pages/public_cloud/containers_orchestration/managed_kubernetes/configuring-multi-attach-persistent-volumes-with-ovh-efs) |
+| **NAS-HA** | NFS | [NAS-HA avec MKS](/pages/public_cloud/containers_orchestration/managed_kubernetes/configuring-multi-attach-persistent-volumes-with-ovh-nas-ha) |
+| **Cloud Disk Array** | CephFS | [CDA avec MKS](/pages/public_cloud/containers_orchestration/managed_kubernetes/configuring-multi-attach-persistent-volumes-with-ovh-cloud-disk-array) |
+
+> [!warning]
+>
+> Un worker node peut avoir un maximum de 100 volumes persistants Cinder attachés.
+>
+
+## Modèle de sécurité
+
+### Responsabilité partagée
+
+```
++------------------------------------------------------------------+
+|                    MODÈLE DE RESPONSABILITÉ PARTAGÉE              |
++------------------------------------------------------------------+
+|                                                                  |
+|  RESPONSABILITÉ OVHcloud           VOTRE RESPONSABILITÉ          |
+|  +---------------------------+    +---------------------------+  |
+|  |                           |    |                           |  |
+|  | - Sécurité control plane  |    | - Sécurité applications   |  |
+|  | - Mises à jour control    |    | - Images conteneurs       |  |
+|  |   plane                   |    | - Configuration RBAC      |  |
+|  | - Correctifs OS nodes     |    | - Network policies        |  |
+|  | - Chiffrement etcd        |    | - Gestion des secrets     |  |
+|  | - Sécurité infrastructure |    | - Isolation des workloads |  |
+|  | - Sécurité physique       |    | - Sauvegarde des données  |  |
+|  | - Provisionnement nodes   |    | - Mises à jour applis     |  |
+|  | - Auto-healing            |    | - Déclenchement upgrade   |  |
+|  | - Dispo. versions K8s     |    |   K8s                     |  |
+|  | - Force upgrade vers. EOL |    | - Gestion des accès       |  |
+|  |                           |    |                           |  |
+|  +---------------------------+    +---------------------------+  |
+|                                                                  |
++------------------------------------------------------------------+
+```
+
+> [!primary]
+>
+> **À propos des mises à jour de version Kubernetes** : OVHcloud fournit les nouvelles versions mineures. Vous décidez quand mettre à jour. Cependant, si votre cluster exécute une version End-of-Life, OVHcloud forcera une mise à jour vers la version suivante après notification préalable.
+>
+
+### Mécanismes de contrôle d'accès
+
+1. **Authentification kubeconfig** : Téléchargé depuis l'espace client OVHcloud, donne un accès admin
+2. **Intégration OIDC** : Connectez votre fournisseur d'identité pour le SSO
+3. **Restrictions IP API server** : Limitez l'accès à des plages IP spécifiques
+4. **RBAC** : Contrôle d'accès basé sur les rôles pour des permissions granulaires
+
+### Fonctionnalités de sécurité
+
+- **Plan Free** : Network policies via Calico
+- **Plan Standard** : Network policies via Cilium (basé eBPF)
+- Chiffrement des secrets en transit et au repos
+- Isolation des nodes via les security groups
+- Logs d'audit disponibles dans l'espace client
+
+## Versions des composants
+
+Versions logicielles actuelles (pour les dernières versions Kubernetes) :
+
+| Composant | Plan Free | Plan Standard |
+|-----------|-----------|---------------|
+| OS | Ubuntu 22.04 LTS | Ubuntu 22.04 LTS |
+| Kernel | 5.15-generic | 5.15-generic |
+| Runtime conteneur | containerd 2.1.4 | containerd 2.1.4 |
+| CNI | Canal (Calico v3.30.1 + Flannel v0.24.4) | Cilium |
+| CSI | Cinder CSI v1.29.0 | Cinder CSI v1.29.0 |
+| CoreDNS | v1.12.4 | v1.12.4 |
+| Metrics Server | v0.8.0 | v0.8.0 |
+
+Pour la matrice complète des versions, consultez [Plugins Kubernetes et versions logicielles](/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources).
+
+## Diagramme d'architecture : vue complète
+
+```
++=======================================================================================+
+|                        OVHCLOUD MANAGED KUBERNETES SERVICE                             |
++=======================================================================================+
+|                                                                                       |
+|   INTERNET                                                                            |
+|   +------+                                                                            |
+|   |      |                                                                            |
+|   +--+---+                                                                            |
+|      |                                                                                |
+|      +------------------+------------------------+                                    |
+|      |                  |                        |                                    |
+|      v                  |                        v                                    |
+|   +----------+          |                 +------------+                              |
+|   |Floating  |          |                 |  Gateway   | (SNAT pour                   |
+|   |   IP     |          |                 | (Octavia)  |  sortant)                    |
+|   +----+-----+          |                 +-----+------+                              |
+|        |                |                       ^                                     |
+|        v                |                       |                                     |
+|   +----------+          |                       |                                     |
+|   |   Load   |          |                       |                                     |
+|   | Balancer |          |                       |                                     |
+|   | (Octavia)|          |                       |                                     |
+|   +----+-----+          |                       |                                     |
+|        |                |                       |                                     |
+|   +----|----------------|----------------------------------------------------+        |
+|   |    |   RÉSEAU PRIVÉ (réseau Public Cloud ou vRack)                       |       |
+|   |    v                |                       |                            |        |
+|   | +--------------------------------------------------------------------+   |        |
+|   | |                        CLUSTER MKS                                  |  |        |
+|   | |                                                                    |   |        |
+|   | |  CONTROL PLANE (Géré par OVHcloud)                                 |   |        |
+|   | |  +--------------------------------------------------------------+  |   |        |
+|   | |  |                                                              |  |   |        |
+|   | |  |  FREE: Zone unique        STANDARD: Multi-AZ                 |  |   |        |
+|   | |  |  +------------------+     +-------+ +-------+ +-------+      |  |   |        |
+|   | |  |  | API | etcd | CM  |     |API|etcd| |API|etcd| |API|etcd|   |  |   |        |
+|   | |  |  | Scheduler        |     | Zone A | | Zone B | | Zone C |   |  |   |        |
+|   | |  |  +------------------+     +-------+ +-------+ +-------+      |  |   |        |
+|   | |  |                                                              |  |   |        |
+|   | |  +--------------------------------------------------------------+  |   |        |
+|   | |                             ^                                      |   |        |
+|   | |                             | Konnectivity                         |   |        |
+|   | |                             v                                      |   |        |
+|   | |  WORKER NODES                                                      |   |        |
+|   | |  +------------------+ +------------------+ +------------------+    |   |        |
+|   | |  |     Node 1       | |     Node 2       | |     Node 3       |----+   |        |
+|   | |  | +-----+ +-----+  | | +-----+ +-----+  | | +-----+ +-----+  |    |   |        |
+|   | |  | |Pod A| |Pod B|  | | |Pod C| |Pod D|  | | |Pod E| |Pod F|  |    |   |        |
+|   | |  | +-----+ +-----+  | | +-----+ +-----+  | | +-----+ +-----+  |    |   |        |
+|   | |  | kubelet|kube-prx | | kubelet|kube-prx | | kubelet|kube-prx |    |   |        |
+|   | |  | containerd      | | containerd       | | containerd       |    |   |        |
+|   | |  +--------+---------+ +--------+---------+ +--------+---------+    |   |        |
+|   | |           |                    |                    |              |   |        |
+|   | |           +--------------------+--------------------+              |   |        |
+|   | |                                |                                   |   |        |
+|   | |             FREE: Canal (Flannel + Calico)                         |   |        |
+|   | |             STANDARD: Cilium (eBPF)                                |   |        |
+|   | |                                                                    |   |        |
+|   | +--------------------------------------------------------------------+   |        |
+|   |                                                                          |        |
+|   +--------------------------------------------------------------------------+        |
+|                                                                                       |
+|   STOCKAGE                                                                            |
+|   +------------------+  +------------------+  +-------------------+                   |
+|   |  Block Storage   |  |  Block Storage   |  |  File Storage     |                  |
+|   |  (Cinder PV)     |  |  (Cinder PV)     |  |  (NFS - RWX)      |                   |
+|   |  RWO uniquement  |  |  RWO uniquement  |  |  Multi-attach     |                  |
+|   +------------------+  +------------------+  +-------------------+                   |
+|                                                                                       |
++=======================================================================================+
+```
+
+## Aller plus loin
+
+- [Limites connues](/pages/public_cloud/containers_orchestration/managed_kubernetes/known-limits)
+- [Choisir le bon plan : Free vs Standard](/pages/public_cloud/containers_orchestration/managed_kubernetes/mks_plans)
+- [Modèle de responsabilité](/pages/public_cloud/containers_orchestration/managed_kubernetes/responsibility-model)
+- [Versions logicielles et ressources réservées](/pages/public_cloud/containers_orchestration/managed_kubernetes/software-versions-reserved-resources)
+- [Utiliser le réseau privé vRack](/pages/public_cloud/containers_orchestration/managed_kubernetes/using-vrack)
+- [Volumes persistants](/pages/public_cloud/containers_orchestration/managed_kubernetes/setting-up-a-persistent-volume)
+- [Exposer vos applications avec le Load Balancer](/pages/public_cloud/containers_orchestration/managed_kubernetes/expose_your_applications_using_a_load_balancer)
+
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez votre Technical Account Manager ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l'équipe Professional Services.
+
+Rejoignez notre [communauté d'utilisateurs](/links/community).

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/understanding-mks-architecture/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/understanding-mks-architecture/guide.fr-fr.md
@@ -1,25 +1,25 @@
 ---
-title: Comprendre l'architecture d'OVHcloud Managed Kubernetes
+title: "Comprendre l'architecture d'OVHcloud Managed Kubernetes"
 excerpt: "Découvrez le fonctionnement d'OVHcloud Managed Kubernetes Service : control plane, worker nodes, réseau et stockage"
-updated: 2026-01-22
+updated: 2026-02-25
 ---
 
 ## Objectif
 
-Ce guide explique l'architecture d'OVHcloud Managed Kubernetes Service (MKS) pour vous aider à comprendre comment vos clusters sont déployés, gérés et connectés. Comprendre cette architecture vous aidera à prendre des décisions éclairées concernant la configuration, le dépannage et le dimensionnement de votre cluster.
+**Ce guide explique l'architecture d'OVHcloud Managed Kubernetes Service (MKS) pour vous aider à comprendre comment vos clusters sont déployés, gérés et connectés. Comprendre cette architecture vous aidera à prendre des décisions éclairées concernant la configuration, le dépannage et le dimensionnement de votre cluster.**
 
 ## Vue d'ensemble
 
 OVHcloud Managed Kubernetes Service est une offre Kubernetes certifiée CNCF qui abstrait la complexité de la gestion du control plane tout en vous donnant un contrôle total sur vos worker nodes et vos workloads.
 
-```
+```text
 +------------------------------------------------------------------+
 |                    OVHcloud Managed Kubernetes                    |
 +------------------------------------------------------------------+
 |                                                                  |
 |  +------------------------+      +----------------------------+  |
 |  |     CONTROL PLANE      |      |       WORKER NODES         |  |
-|  |    (Géré par OVH)      |      |  (Votre responsabilité)    |  |
+|  |  (Géré par OVHcloud)   |      |  (Votre responsabilité)    |  |
 |  +------------------------+      +----------------------------+  |
 |  |                        |      |                            |  |
 |  |  +------------------+  |      |  +---------+  +---------+  |  |
@@ -72,7 +72,7 @@ OVHcloud gère tous les aspects opérationnels du control plane :
 
 L'architecture du control plane diffère significativement entre les plans :
 
-```
+```text
 PLAN FREE                                PLAN STANDARD
 +--------------------+                   +------------------------------------------------+
 |   Zone unique      |                   |              Déploiement Multi-AZ              |
@@ -123,7 +123,7 @@ Les worker nodes sont basés sur des instances OVHcloud Public Cloud. Quand vous
 
 Le CNI diffère selon votre plan :
 
-```
+```text
 PLAN FREE - Worker Node                     PLAN STANDARD - Worker Node
 +------------------------------+            +------------------------------+
 |                              |            |                              |
@@ -152,10 +152,10 @@ Les nodes sont organisés en node pools - des groupes de nodes partageant la mê
 - **Flavor** : Type d'instance (b3-8, b3-16, t1-45 pour GPU, etc.)
 - **Paramètres d'autoscaling** : Min/max nodes, seuils de scale-down
 - **Anti-affinité** : Distribuer les nodes sur différents hyperviseurs
-- **Facturation** : Horaire ou mensuelle
+- **Facturation** : Horaire ou mensuelle (pour les flavors gen2), Saving Plans pour gen3 et au-delà
 - **Labels et taints** : Pour le scheduling des workloads
 
-```
+```text
 +------------------------------------------------------------------+
 |                         CLUSTER KUBERNETES                        |
 +------------------------------------------------------------------+
@@ -186,7 +186,7 @@ Les nodes sont organisés en node pools - des groupes de nodes partageant la mê
 
 ### Cycle de vie des nodes
 
-```
+```text
                               CYCLE DE VIE NORMAL
   +------------+      +----------+      +-----------+      +------------+
   |            |      |          |      |           |      |            |
@@ -257,7 +257,7 @@ Cela garantit la stabilité du cluster mais signifie :
 
 Lors de la mise à jour des versions Kubernetes, MKS propose deux stratégies pour mettre à jour les worker nodes :
 
-```
+```text
 +===============================================================================+
 |                     STRATÉGIES DE MISE À JOUR DES NODES                       |
 +===============================================================================+
@@ -282,7 +282,7 @@ Lors de la mise à jour des versions Kubernetes, MKS propose deux stratégies po
 |      |                                                                        |
 |      | 2. Mise à jour                         +-------+                       |
 |      v    composants                          |Node 3 |  3. Migrer pods       |
-|  +-------+  +-------+  +-------+              |DRAIN  |     vers nouveaur node|
+|  +-------+  +-------+  +-------+              |DRAIN  |     vers nouveau node |
 |  |Node 1 |  |Node 2 |  |Node 3 |              +---+---+                       |
 |  | v1.34 |  | v1.33 |  | v1.33 |                  |                           |
 |  +-------+  +---+---+  +-------+                  | 4. Supprimer ancien node  |
@@ -329,7 +329,7 @@ Avec les mises à jour in-place, chaque worker node est mis à jour directement 
 
 #### Rolling upgrades
 
-Avec les rolling upgrades (actuellement disponible uniquement sur le plan Standard), de nouveaux worker nodes sont créés avec la version Kubernetes cible :
+Avec les rolling upgrades (actuellement disponibles uniquement sur le plan Standard), de nouveaux worker nodes sont créés avec la version Kubernetes cible :
 
 1. MKS **crée** un nouveau node avec la version cible
 2. MKS met en **cordon et draine** un ancien node
@@ -377,13 +377,13 @@ Chaque worker node réserve des ressources pour les composants système Kubernet
 | RAM | Fixe 1590 MB |
 | Stockage | log10(stockage total en GB) * 10 + 10% du stockage total |
 
-Exemple pour la flavor b3-16 : 170ms CPU, 1.59GB RAM, 30GB stockage réservés.
+Exemple pour la flavor b3-16 : 170m CPU, 1.59GB RAM, 30GB stockage réservés.
 
 ## Architecture réseau
 
 ### Vue d'ensemble du réseau cluster
 
-```
+```text
 +====================================================================================+
 |                             ARCHITECTURE RÉSEAU                                     |
 +====================================================================================+
@@ -393,7 +393,7 @@ Exemple pour la flavor b3-16 : 170ms CPU, 1.59GB RAM, 30GB stockage réservés.
 |   |      |                                                                         |
 |   +--+---+                                                                         |
 |      |                                                                             |
-|      +------------------+------------------------+.                                |
+|      +------------------+------------------------+                                 |
 |      |                  ^                        ^                                 |
 |      | OPTION 1         | OPTION 2               | OPTION 3                        |
 |      | Load Balancer    | Floating IPs nodes     | Gateway (SNAT)                  |
@@ -505,7 +505,7 @@ Sous-réseaux réservés (ne pas utiliser dans votre réseau privé) :
 
 Les Services Kubernetes peuvent être exposés de plusieurs façons :
 
-```
+```text
 +------------------------------------------------------------------+
 |                    OPTIONS D'EXPOSITION DES SERVICES              |
 +------------------------------------------------------------------+
@@ -584,7 +584,7 @@ C'est l'option la plus simple quand vous avez uniquement besoin de connectivité
 
 Pour une interconnectivité plus large entre les univers produits OVHcloud et entre régions :
 
-```
+```text
 +------------------------------------------------------------------+
 |                      INTÉGRATION vRack                            |
 +------------------------------------------------------------------+
@@ -610,6 +610,7 @@ Pour une interconnectivité plus large entre les univers produits OVHcloud et en
 ```
 
 Le vRack permet :
+
 - Connectivité privée inter-régions
 - Interconnexion avec les serveurs Bare Metal
 - Interconnexion avec Hosted Private Cloud (VMware)
@@ -626,7 +627,7 @@ Le vRack permet :
 
 MKS utilise le driver OpenStack Cinder CSI pour le stockage persistant :
 
-```
+```text
 +------------------------------------------------------------------+
 |                    ARCHITECTURE DE STOCKAGE                       |
 +------------------------------------------------------------------+
@@ -693,7 +694,7 @@ MKS utilise le driver OpenStack Cinder CSI pour le stockage persistant :
 
 ### Responsabilité partagée
 
-```
+```text
 +------------------------------------------------------------------+
 |                    MODÈLE DE RESPONSABILITÉ PARTAGÉE              |
 +------------------------------------------------------------------+
@@ -756,7 +757,7 @@ Pour la matrice complète des versions, consultez [Plugins Kubernetes et version
 
 ## Diagramme d'architecture : vue complète
 
-```
+```text
 +=======================================================================================+
 |                        OVHCLOUD MANAGED KUBERNETES SERVICE                             |
 +=======================================================================================+

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/understanding-mks-architecture/meta.yaml
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/understanding-mks-architecture/meta.yaml
@@ -1,0 +1,2 @@
+id: 5a38ac4a-9986-4a9b-83d3-9a74e12017d7
+full_slug: public-cloud-kubernetes-understanding-mks-architecture

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.de-de.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-asia.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-au.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-ca.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-gb.md
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-gb.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-ie.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-sg.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.en-us.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.es-es.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.es-us.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.fr-ca.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.it-it.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.pl-pl.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-example-k8s-and-pci/guide.pt-pt.md
@@ -1,6 +1,6 @@
 ---
 title: Working with vRack example - Managed Kubernetes and Public Cloud instances
-updated: 2021-12-21
+updated: 2026-02-25
 ---
 
 ## Objective
@@ -279,9 +279,9 @@ Switched to context "kubernetes-admin@my-cluster-vrack".
 
 $ kubectl get nodes
 NAME                                         STATUS   ROLES    AGE   VERSION
-nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.22.2
-nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.22.2
+nodepool-59d0ba5f-2fce-4a47-89-node-05134b   Ready    <none>   18h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-46cbc9   Ready    <none>   17h   v1.34.0
+nodepool-59d0ba5f-2fce-4a47-89-node-ea4d0a   Ready    <none>   18h   v1.34.0
 ```
 
 And then execute the following comand:

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.de-de.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-asia.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-au.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-gb.md
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-ie.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-sg.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.es-es.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.es-us.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.fr-ca.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.it-it.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.pl-pl.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.pt-pt.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/vrack-k8s-custom-gateway/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Using a custom gateway on an OVHcloud Managed Kubernetes cluster
 excerpt: Find out how to use a custom gateway on an OVHcloud Managed Kubernetes working with vRack private network.
-updated: 2025-01-06
+updated: 2026-02-25
 ---
 
 ## Objectives
@@ -319,7 +319,7 @@ Now the network is ready. Create an OVHcloud Managed Kubernetes cluster, specify
 > Note: until the end of this tutorial, we are only using the `GRA9` region, but you can repeat the exact same steps to create a cluster on the `GRA11` region.
 
 > [!primary]
-> In this guide we defined `1.23` version for the Kubernetes cluster but you can use another supported version.
+> In this guide we defined `1.34` version for the Kubernetes cluster but you can use another supported version.
 >
 
 First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the OVHcloud Managed Kubernetes Cluster, and finally get the cluster ID (kubeId):
@@ -332,7 +332,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >> "region": "GRA9",
 >> "name": "demo",
->> "version": "1.23",
+>> "version": "1.34",
 >> "nodepool": {
 >>   "flavorName": "b2-7",
 >>   "antiAffinity": false,
@@ -369,7 +369,7 @@ First, get the private network IDs (pvnwGRA9Id & pvnwGRA11Id), then create the O
 >> {
 >>   "region": "GRA9",
 >>   "name": "demo",
->>   "version": "1.23",
+>>   "version": "1.34",
 >>   "nodepool": {
 >>     "flavorName": "b2-7",
 >>     "antiAffinity": false,
@@ -487,9 +487,9 @@ You should obtain a result like this:
 ```console
 $ kubectl --kubeconfig=kubeconfig-demo get no -o wide
 NAME                                         STATUS   ROLES    AGE   VERSION   INTERNAL-IP    EXTERNAL-IP      OS-IMAGE             KERNEL-VERSION       CONTAINER-RUNTIME
-nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.23.6   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.23.6   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
-nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.23.6   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c74f26   Ready    <none>   56m   v1.34.0   192.168.0.71   141.94.215.23    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-c9bf60   Ready    <none>   57m   v1.34.0   192.168.0.96   141.94.208.78    Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
+nodepool-8f0b4d98-874a-4cfd-b8-node-e666f5   Ready    <none>   56m   v1.34.0   192.168.0.31   141.94.212.214   Ubuntu 18.04.6 LTS   4.15.0-189-generic   containerd://1.4.6
 ```
 
 Now test the cluster by running a simple container that requests its published IP address.


### PR DESCRIPTION
## What type of Pull Request is this?
- New guide(s)
- Update of existing guide(s)

## Description

- Add a new comprehensive guide "Understanding OVHcloud Managed Kubernetes architecture" (EN + FR) covering control plane, worker nodes, networking, and storage architecture
- Update obsolete Kubernetes version references (v1.22, v1.27, v1.28 → v1.34) across multiple existing MKS guides
- Register the new guide in the documentation index under "Key concepts"

## Mandatory information

The translations in this Pull Request have been done using:
- [ x] Other tool (specify which tool was used) -> Claude, can be retranslated by OVHcloud tool if necessary 



- This Pull Request can be merged as soon as possible.

- This Pull Request content should be replicated for the US OVHcloud documentation : YES