### PR TITLE
[Audit] WEB - Emails - multiple update and fix EU/CA/US/APAC

### DIFF
--- a/pages/web_cloud/domains/dns_zone_spf/guide.en-ca.md
+++ b/pages/web_cloud/domains/dns_zone_spf/guide.en-ca.md
@@ -111,7 +111,7 @@ To add an SPF record, click on `Add an entry`{.action} in the right-hand menu.
 
 In the window that pops up, the configuration assistant offers several different types of DNS records. There are two ways of adding an SPF record:
 
-- [Add an OVHcloud SPF record](#spfrecordovhcloud) **and use the OVHcloud configuration**: For users who only have OVHcloud email offers on their domain name (excluding [Private Exchange](/links/web/emails-private-exchange)).
+- [Add an OVHcloud SPF record](#spfrecordovhcloud) **and use the OVHcloud configuration**: For users who only have OVHcloud email offers on their domain name.
 - [Add an SPF record](#spfrecord): For users who do not have the entire record. For example, you only have an IP address or the host name of the email server.
 - [Add a TXT record](#txtrecord): For users who are experienced or already have the full record. For example, your email solution provider will send you the value.
 
@@ -206,38 +206,6 @@ The configuration is as follows:
 ```bash
 mydomain.ovh IN TXT "v=spf1 include:mx.ovh.ca ~all"
 ```
-
-### OVHcloud SPF configuration for Private Exchange 
-
-For the Private Exchange solution, you need to enter your email server’s IP addresses. To do this, use the `ip4` argument to enter the IPv4 address (**A**) and the `ip6` argument for the IPv6 address (**AAAA**) of your Private Exchange server.
-
-```bash
-mydomain.ovh IN TXT "v=spf1 ip4:203.0.113.099 ip6:2001:db8:88:b999::1000:2233 ~all"
-```
-
-If you also use a [shared email service](#ovhcloudspfvalue), you can add the argument `include:mx.ovh.ca` to the SPF record, with the following result:
-
-```bash
-mydomain.ovh IN TXT "v=spf1 ip4:203.0.113.099 ip6:2001:db8:88:b999::1000:2233 include:mx.ovh.ca ~all"
-```
-
-/// details | How do I retrieve the IP addresses of a Private Exchange server?
-
-To retrieve the IP address of the Private Exchange server, click `Microsoft`{.action}, then `Exchange`{.action}. Next, click on the name of the Private Exchange service concerned.
-
-In the `General Information`{.action} tab, click on the `A` and `AAAA` in the `Server Diagnostics` section. In the window that appears, read the value.
-
-![domain](/pages/assets/screens/control_panel/product-selection/web-cloud/microsoft/exchange/general-information/spf_records_ip.png){.thumbnail .w-400}
-
-If the boxes `A` and `AAAA` are green, you will not see the IP addresses by clicking on them. You will need to retrieve this information from the DNS zone for the domain name attached to your Private Exchange platform. To do this, retrieve the webmail link from the `General information`{.action} tab, in the `Connection` box.
-
-![domain](/pages/assets/screens/control_panel/product-selection/web-cloud/microsoft/exchange/general-information/spf_records_ip2.png){.thumbnail .w-400}
-
-Go to the `Domain names`{.action} section, select the domain name attached to your private Exchange platform, then click on the `DNS zone`{.action} tab. Retrieve the IPv4 (record `A`) and IPv6 (record `AAAA`) addresses corresponding to the webmail URL.
-
-![domain](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/spf_records_ip3.png){.thumbnail .w-400}
-
-///
 
 ## Go further
 

--- a/pages/web_cloud/domains/dns_zone_spf/guide.en-us.md
+++ b/pages/web_cloud/domains/dns_zone_spf/guide.en-us.md
@@ -111,7 +111,7 @@ To add an SPF record, click on `Add an entry`{.action} in the right-hand menu.
 
 In the window that pops up, the configuration assistant offers several different types of DNS records. There are two ways of adding an SPF record:
 
-- [Add an OVHcloud SPF record](#spfrecordovhcloud) **and use the OVHcloud configuration**: For users who only have OVHcloud email offers on their domain name (excluding [Private Exchange](/links/web/emails-private-exchange)).
+- [Add an OVHcloud SPF record](#spfrecordovhcloud) **and use the OVHcloud configuration**: For users who only have OVHcloud email offers on their domain name.
 - [Add an SPF record](#spfrecord): For users who do not have the entire record. For example, you only have an IP address or the host name of the email server.
 - [Add a TXT record](#txtrecord): For users who are experienced or already have the full record. For example, your email solution provider will send you the value.
 
@@ -206,38 +206,6 @@ The configuration is as follows:
 ```bash
 mydomain.ovh IN TXT "v=spf1 include:mx.ovh.ca ~all"
 ```
-
-### OVHcloud SPF configuration for Private Exchange 
-
-For the Private Exchange solution, you need to enter your email server’s IP addresses. To do this, use the `ip4` argument to enter the IPv4 address (**A**) and the `ip6` argument for the IPv6 address (**AAAA**) of your Private Exchange server.
-
-```bash
-mydomain.ovh IN TXT "v=spf1 ip4:203.0.113.099 ip6:2001:db8:88:b999::1000:2233 ~all"
-```
-
-If you also use a [shared email service](#ovhcloudspfvalue), you can add the argument `include:mx.ovh.ca` to the SPF record, with the following result:
-
-```bash
-mydomain.ovh IN TXT "v=spf1 ip4:203.0.113.099 ip6:2001:db8:88:b999::1000:2233 include:mx.ovh.ca ~all"
-```
-
-/// details | How do I retrieve the IP addresses of a Private Exchange server?
-
-To retrieve the IP address of the Private Exchange server, click `Microsoft`{.action}, then `Exchange`{.action}. Next, click on the name of the Private Exchange service concerned.
-
-In the `General Information`{.action} tab, click on the `A` and `AAAA` in the `Server Diagnostics` section. In the window that appears, read the value.
-
-![domain](/pages/assets/screens/control_panel/product-selection/web-cloud/microsoft/exchange/general-information/spf_records_ip.png){.thumbnail .w-400}
-
-If the boxes `A` and `AAAA` are green, you will not see the IP addresses by clicking on them. You will need to retrieve this information from the DNS zone for the domain name attached to your Private Exchange platform. To do this, retrieve the webmail link from the `General information`{.action} tab, in the `Connection` box.
-
-![domain](/pages/assets/screens/control_panel/product-selection/web-cloud/microsoft/exchange/general-information/spf_records_ip2.png){.thumbnail .w-400}
-
-Go to the `Domain names`{.action} section, select the domain name attached to your private Exchange platform, then click on the `DNS zone`{.action} tab. Retrieve the IPv4 (record `A`) and IPv6 (record `AAAA`) addresses corresponding to the webmail URL.
-
-![domain](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/spf_records_ip3.png){.thumbnail .w-400}
-
-///
 
 ## Go further
 

--- a/pages/web_cloud/domains/dns_zone_spf/guide.es-us.md
+++ b/pages/web_cloud/domains/dns_zone_spf/guide.es-us.md
@@ -117,7 +117,7 @@ Para añadir un registro SPF, haga clic en `Añadir un registro`{.action}.
 
 Se abrirá una ventana en la que podrá elegir entre varios registros DNS. Para añadir un SPF, existen dos posibilidades:
 
-- [Añadir un registro SPF](#spfrecordovhcloud)**y utilizar la configuración de OVHcloud**: para los usuarios que solo posean los productos de correo electrónico de OVHcloud en su nombre de dominio (excepto [Private Exchange](/links/web/emails-hosted-exchange) y Exchange Provider).
+- [Añadir un registro SPF](#spfrecordovhcloud)**y utilizar la configuración de OVHcloud**: para los usuarios que solo posean los productos de correo electrónico de OVHcloud en su nombre de dominio.
 - [Añadir un registro SPF](#spfrecord) : para los usuarios que no dispongan del registro completo. Por ejemplo, solo tiene una dirección IP o el nombre del host del servidor de correo.
 - [Añadir un registro TXT](#txtrecord) : para usuarios avanzados o que ya dispongan del registro completo. Por ejemplo, su proveedor de soluciones de correo electrónico transmite el valor.
 
@@ -214,38 +214,6 @@ La configuración es la siguiente:
 ```bash
 mydomain.ovh IN TXT "v=spf1 include:mx.ovh.ca ~all"
 ```
-
-### Configuración SPF OVHcloud para Private Exchange
-
-Para la solución Private Exchange, es necesario indicar las direcciones IP del servidor de correo. Para ello, utilice el argumento `ip4` para introducir la dirección IPv4 (**A**) y el argumento `ip6` para la dirección IPv6 (**AAAA**) de su servidor Private Exchange.
-
-```bash
-mydomain.ovh IN TXT "v=spf1 ip4:11.22.33.444 ~all"
-```
-
-Si también utiliza [una solución de correo en alojamiento compartido](#ovhcloudspfvalue), puede añadir el argumento `include:mx.ovh.ca` al registro anterior, que proporciona el siguiente valor:
-
-```bash
-mydomain.ovh IN TXT "v=spf1 ip4:203.0.113.099 ip6:2001:db8:88:b999::1000:2233 include:mx.ovh.ca ~all"
-```
-
-/// details | ¿Cómo recuperar las direcciones IP de un servidor Private Exchange?
-
-Para obtener la dirección IP del servidor Private Exchange, haga clic en `Microsoft`{.action} y seleccione `Exchange`{.action}. y seleccione el servicio Private Exchange correspondiente.
-
-En la ficha `Información general`{.action}, haga clic en `A` y `AAAA` en la sección `Diagnóstico del servidor`. En la ventana que aparece, lea el valor.
-
-![Nombre de dominio](/pages/assets/screens/control_panel/product-selection/web-cloud/microsoft/exchange/general-information/spf_records_ip.png){.thumbnail .w-400}
-
-Si las etiquetas `A` y `AAAA` son verdes, no verá las direcciones IP al hacer clic en ellas. Deberá recuperarlas desde la zona DNS del dominio asociado a su plataforma Private Exchange. Para ello, consulte el enlace del webmail en la pestaña `Información general`{.action}, en el recuadro `Conexión`.
-
-![nombre de dominio](/pages/assets/screens/control_panel/product-selection/web-cloud/microsoft/exchange/general-information/spf_records_ip2.png){.thumbnail .w-400}
-
-Acceda a la sección `Nombres de dominio`{.action} de la columna izquierda y seleccione el nombre de dominio asociado a su plataforma Private Exchange. A continuación, abra la pestaña de la columna izquierda y haga clic en `Zona DNS`{.action}. Obtenga las direcciones IPv4 (registro `A`) y IPv6 (registro `AAAA`) correspondientes a la URL del webmail.
-
-![nombre de dominio](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/spf_records_ip3.png){.thumbnail .w-400}
-
-///
 
 ## Más información
 

--- a/pages/web_cloud/domains/dns_zone_spf/guide.fr-ca.md
+++ b/pages/web_cloud/domains/dns_zone_spf/guide.fr-ca.md
@@ -117,7 +117,7 @@ Pour ajouter un enregistrement SPF, cliquez sur `Ajouter une entrée`{.action}.
 
 Dans la fenêtre qui s’affiche, plusieurs enregistrements DNS vous sont proposés. Concernant l’ajout d’un SPF, deux possibilités s’offrent à vous :
 
-- [Ajouter un enregistrement SPF OVHcloud](#spfrecordovhcloud) **et utiliser la configuration OVHcloud**: pour les utilisateurs possédant uniquement les offres e-mail OVHcloud sur leur nom de domaine (Hors [Private Exchange](/links/web/emails-hosted-exchange) et Exchange Provider).
+- [Ajouter un enregistrement SPF OVHcloud](#spfrecordovhcloud) **et utiliser la configuration OVHcloud**: pour les utilisateurs possédant uniquement les offres e-mail OVHcloud sur leur nom de domaine.
 - [Ajouter un enregistrement SPF](#spfrecord) : pour les utilisateurs ne possédant pas l'intégralité de l'enregistrement. Par exemple, vous disposez uniquement d'une adresse IP ou du nom d'hôte du serveur e-mail.
 - [Ajouter un enregistrement TXT](#txtrecord) : pour les utilisateurs avertis ou disposant déjà de l'enregistrement complet. Par exemple, votre fournisseur de solution e-mail vous transmet la valeur.
 
@@ -214,52 +214,6 @@ La configuration est la suivante :
 ```bash
 mydomain.ovh IN TXT "v=spf1 include:mx.ovh.ca ~all"
 ```
-
-### Configuration SPF OVHcloud pour Exchange Provider
-
-Pour l'offre Exchange Provider, la configuration est la suivante :
-
-```bash
-mydomain.ovh IN TXT "v=spf1 include:mx.ovh.ca ~all"
-```
-
-En revanche, la configuration est la suivante si vous souhaitez aussi déclarer la *gateway* du service **Exchange Provider** :
-
-```bash
-mydomain.ovh IN TXT "v=spf1 include:mx.ovh.ca a:gw.ex-mail.biz ~all"
-```
-
-### Configuration SPF OVHcloud pour Private Exchange
-
-Pour l'offre Private Exchange, il est nécessaire de renseigner les adresses IP de votre serveur e-mail. Pour cela, utilisez l'argument `ip4` pour renseigner l'adresse IPv4 (**A**) et l'argument `ip6` pour l'adresse IPv6 (**AAAA**) de votre serveur Private Exchange.
-
-```bash
-mydomain.ovh IN TXT "v=spf1 ip4:203.0.113.099 ip6:2001:db8:88:b999::1000:2233 ~all"
-```
-
-Si vous utilisez également [une offre e-mail mutualisée](#ovhcloudspfvalue), vous pouvez ajouter l'argument `include:mx.ovh.ca` à l'enregistrement ci-dessus, ce qui donnera la valeur suivante :
-
-```bash
-mydomain.ovh IN TXT "v=spf1 ip4:203.0.113.099 ip6:2001:db8:88:b999::1000:2233 include:mx.ovh.ca ~all"
-```
-
-/// details | Comment récupérer les adresses IP d'un serveur Private Exchange ?
-
-Cliquez sur `Microsoft`{.action} puis sur `Exchange`{.action}. Cliquez enfin sur le nom du service Private Exchange concerné.
-
-Dans l'onglet `Informations générales`{.action}, cliquez sur le `A` et le `AAAA` dans la partie `Diagnostic serveur`. Dans la fenêtre qui s'affiche, relevez la valeur.
-
-![domain](/pages/assets/screens/control_panel/product-selection/web-cloud/microsoft/exchange/general-information/spf_records_ip.png){.thumbnail .w-400}
-
-Si les pastilles `A` et `AAAA` sont vertes, vous ne verrez pas les adresses IP en cliquant dessus. Vous devrez récupérer celles-ci depuis la zone DNS du nom de domaine attaché à votre plateforme Private Exchange. Pour cela, récupérez le lien du webmail depuis l'onglet `Informations générales`{.action}, dans le cadre `Connexion`.
-
-![domain](/pages/assets/screens/control_panel/product-selection/web-cloud/microsoft/exchange/general-information/spf_records_ip2.png){.thumbnail .w-400}
-
-Dirigez-vous ensuite dans la section `Noms de domaine`{.action}, sélectionnez le nom de domaine attaché à votre plateforme Private Exchange, puis cliquez sur l'onglet `Zone DNS`{.action}. Récupérez les adresses IPv4 (enregistrement `A`) et IPv6 (enregistrement `AAAA`) correspondant à l'URL du webmail.
-
-![domain](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/spf_records_ip3.png){.thumbnail .w-400}
-
-///
 
 ## Aller plus loin
 

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android/guide.en-ca.md
@@ -94,8 +94,6 @@ Once you have configured your email account, you can start using it! You can now
 
 [MX Plan - Configuring an email address in Gmail for Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android).
 
-[Email Pro - Configuring an email address in Gmail for Android](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_android).
-
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android/guide.en-us.md
@@ -94,8 +94,6 @@ Once you have configured your email account, you can start using it! You can now
 
 [MX Plan - Configuring an email address in Gmail for Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android).
 
-[Email Pro - Configuring an email address in Gmail for Android](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_android).
-
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
  
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android/guide.es-us.md
@@ -101,8 +101,6 @@ Una vez que haya configurado la dirección de correo electrónico, ya puede empe
 
 [MX Plan - Configurar una dirección de correo electrónico en Gmail para Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android).
 
-[Email Pro - Configurar una dirección de correo electrónico en Gmail para Android](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_android).
-
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](/links/support).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android/guide.fr-ca.md
@@ -95,8 +95,6 @@ Une fois l'adresse e-mail configurée, il ne reste plus qu’à l'utiliser ! Vou
 
 [MX Plan - Configurer une adresse e-mail dans Gmail pour Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android).
 
-[E-mail Pro - Configurer une adresse e-mail dans Gmail pour Android](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_android).
-
 Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos/guide.en-ca.md
@@ -97,8 +97,6 @@ If your email account is already set up and you need to access the account setti
 
 [FAQ emails](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails)
 
-[Configure your Email Pro account on macOS Mail](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos)
-
 [Configure your MX Plan email account on macOS Mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos/guide.en-us.md
@@ -97,8 +97,6 @@ If your email account is already set up and you need to access the account setti
 
 [FAQ emails](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails)
 
-[Configure your Email Pro account on macOS Mail](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos)
-
 [Configure your MX Plan email account on macOS Mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos/guide.es-us.md
@@ -92,8 +92,6 @@ Si su cuenta de correo ya está configurada y debe acceder a los parámetros de 
 
 [FAQ e-mails](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails)
 
-[Configurar una cuenta Email Pro en Mail de macOS](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos)
-
 [Configurar una cuenta MX plan en Mail de macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos/guide.fr-ca.md
@@ -74,7 +74,7 @@ Les comptes Exchange peuvent être configurés sur différents logiciels de mess
 
 Une fois l'adresse e-mail configurée, il ne reste plus qu’à l'utiliser ! Vous pouvez dès à présent envoyer et recevoir des messages.
 
-OVHcloud propose aussi une application web permettant d'accéder à votre adresse e-mail depuis un navigateur internet. Celle-ci est accessible à l’adresse [Webmail](/links/web/email). Vous pouvez vous y connecter grâce aux identifiants de votre adresse e-mail. Pour toute question relative à son utilisation, aidez-vous de notre guide [Consulter son compte Exchange depuis l’interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) ou [Utiliser son adresse e-mail depuis le webmail RoundCube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube#ou-et-comment-se-connecter-au-webmail-roundcube).
+OVHcloud propose aussi une application web permettant d'accéder à votre adresse e-mail depuis un navigateur internet. Celle-ci est accessible à l’adresse [Webmail](/links/web/email). Vous pouvez vous y connecter grâce aux identifiants de votre adresse e-mail. Pour toute question relative à son utilisation, aidez-vous de notre guide [Consulter son compte Exchange depuis l’interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Récupérer une sauvegarde de votre adresse e-mail
 
@@ -96,8 +96,6 @@ Si votre compte e-mail est déjà paramétré et que vous devez accéder aux par
 > Pour plus d'informations sur la configuration d'une adresse e-mail depuis l'application Mail sur macOS, consultez [le centre d'aide Apple](https://support.apple.com/fr-fr/guide/mail/mail35803/mac).
 
 [FAQ e-mails](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails)
-
-[Configurer votre compte E-mail Pro sur Mail de macOS](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos)
 
 [Configurer votre compte e-mail MX plan sur Mail de macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/guide.en-ca.md
@@ -160,6 +160,4 @@ If you need to make a change that could lead to the loss of your email account d
 
 [Configuring your MX Plan address in Outlook for Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016)
 
-[Configuring your Email Pro account in Outlook for Windows](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_2016)
-
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/guide.en-us.md
@@ -160,6 +160,4 @@ If you need to make a change that could lead to the loss of your email account d
 
 [Configuring your MX Plan address in Outlook for Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016)
 
-[Configuring your Email Pro account in Outlook for Windows](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_2016)
-
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/guide.es-us.md
@@ -160,6 +160,4 @@ Si necesita realizar alguna operación que pueda provocar la pérdida de los dat
 
 [Configurar una cuenta de correo electrónico en Outlook para Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016)
 
-[Configurar una cuenta Email Pro en Outlook para Windows](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_2016)
-
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/guide.fr-ca.md
@@ -160,6 +160,4 @@ Si vous devez effectuer une manipulation qui risquerait d'entrainer la perte des
 
 [Configurer son adresse e-mail comprise dans l’offre MX Plan ou dans une offre d’hébergement web sur Outlook pour Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016)
 
-[Configurer son compte E-mail Pro sur Outlook pour Windows](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_2016)
-
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10/guide.en-ca.md
@@ -64,6 +64,4 @@ OVHcloud also offers a web application that includes various [collaborative feat
 
 [Configuring an email address included in an MX Plan or web hosting plan on the Mail application for Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
 
-[Configuring your Email Pro account in the Mail app for Windows](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_windows_10)
-
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10/guide.en-us.md
@@ -64,6 +64,4 @@ OVHcloud also offers a web application that includes various [collaborative feat
 
 [Configuring an email address included in an MX Plan or web hosting plan on the Mail application for Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
 
-[Configuring your Email Pro account in the Mail app for Windows](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_windows_10)
-
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10/guide.es-us.md
@@ -63,6 +63,4 @@ OVHcloud ofrece una aplicación web que tiene [funciones colaborativas](/links/w
 
 [Configurar una cuenta de correo electrónico en la aplicación Correo de Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
 
-[Configurar una cuenta Email Pro en la aplicación Correo de Windows](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_windows_10)
-
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10/guide.fr-ca.md
@@ -71,6 +71,4 @@ OVHcloud propose également une application web disposant de [fonctions collabor
 
 [Configurer son adresse e-mail comprise dans l’offre MX Plan ou dans une offre d’hébergement web sur l'application Courrier pour Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
 
-[Configurer son compte E-mail Pro sur l'application Courrier pour Windows](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_windows_10)
-
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation/guide.en-asia.md
@@ -27,7 +27,6 @@ You have just purchased an MX Plan email solution. It allows you to benefit from
 >
 > **Special cases**
 >
-> - Regarding the 100M free hosting solution, you will need to [activate it](/pages/web_cloud/web_hosting/activate_start10m) in order to create an email account. You can do this from your [OVHcloud Control Panel](/links/manager) by selecting the domain name concerned.
 > - For [Web Hosting plans](/links/web/hosting), you will need to activate your MX Plan package before continuing to follow this guide. To do this, please refer to our guide on [Activating the email addresses included in your web hosting plan](/pages/web_cloud/web_hosting/activate-email-hosting).
 
 ## Instructions <a name="instructions"></a>

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation/guide.en-au.md
@@ -27,7 +27,6 @@ You have just purchased an MX Plan email solution. It allows you to benefit from
 >
 > **Special cases**
 >
-> - Regarding the 100M free hosting solution, you will need to [activate it](/pages/web_cloud/web_hosting/activate_start10m) in order to create an email account. You can do this from your [OVHcloud Control Panel](/links/manager) by selecting the domain name concerned.
 > - For [Web Hosting plans](/links/web/hosting), you will need to activate your MX Plan package before continuing to follow this guide. To do this, please refer to our guide on [Activating the email addresses included in your web hosting plan](/pages/web_cloud/web_hosting/activate-email-hosting).
 
 ## Instructions <a name="instructions"></a>

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation/guide.en-ca.md
@@ -19,7 +19,6 @@ You have just purchased an MX Plan email solution. It allows you to benefit from
 >
 > **Special cases**
 >
-> - Regarding the 100M free hosting solution, you will need to [activate it](/pages/web_cloud/web_hosting/activate_start10m) in order to create an email account. You can do this from your [OVHcloud Control Panel](/links/manager) by selecting the domain name concerned.
 > - For [Web Hosting plans](/links/web/hosting), you will need to activate your MX Plan package before continuing to follow this guide. To do this, please refer to our guide on [Activating the email addresses included in your web hosting plan](/pages/web_cloud/web_hosting/activate-email-hosting).
 
 ## Instructions <a name="instructions"></a>
@@ -123,7 +122,7 @@ Repeat this step as necessary according to the number of accounts to create.
 
 On the [Webmail login page](/links/web/email), enter your email address and password. Then click the `Login`{.action} button.
 
-Your inbox will then appear. You can find more information in our guide on [Using your email account via the RoundCube webmail interface](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+Your inbox will then appear. You can find more information in our guide on [Using your email account via the Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ![email](images/mxplan-creation-legacy-step4.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation/guide.en-sg.md
@@ -27,7 +27,6 @@ You have just purchased an MX Plan email solution. It allows you to benefit from
 >
 > **Special cases**
 >
-> - Regarding the 100M free hosting solution, you will need to [activate it](/pages/web_cloud/web_hosting/activate_start10m) in order to create an email account. You can do this from your [OVHcloud Control Panel](/links/manager) by selecting the domain name concerned.
 > - For [Web Hosting plans](/links/web/hosting), you will need to activate your MX Plan package before continuing to follow this guide. To do this, please refer to our guide on [Activating the email addresses included in your web hosting plan](/pages/web_cloud/web_hosting/activate-email-hosting).
 
 ## Instructions <a name="instructions"></a>

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation/guide.en-us.md
@@ -27,7 +27,6 @@ You have just purchased an MX Plan email solution. It allows you to benefit from
 >
 > **Special cases**
 >
-> - Regarding the 100M free hosting solution, you will need to [activate it](/pages/web_cloud/web_hosting/activate_start10m) in order to create an email account. You can do this from your [OVHcloud Control Panel](/links/manager) by selecting the domain name concerned.
 > - For [Web Hosting plans](/links/web/hosting), you will need to activate your MX Plan package before continuing to follow this guide. To do this, please refer to our guide on [Activating the email addresses included in your web hosting plan](/pages/web_cloud/web_hosting/activate-email-hosting).
 
 ## Instructions <a name="instructions"></a>

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-asia.md
@@ -38,17 +38,6 @@ If you have just purchased an MX Plan solution, this means you have email addres
 1. Open the `Web Cloud`{.action} section.
 1. Click `MX Plan`{.action}.
 1. Select the domain concerned.
-1. **Continue with the email technology used by your MX Plan service**.
-
-> [!primary]
->
-> **Identify the email technology for your MX Plan solution.**
->
-> Depending on the activation date of your MX Plan solution, or on a recent migration, the email technology associated with it may differ. This version is characterized by its webmail interface. To identify it:
->
-> - In the `General information`{.action} tab, note the technology used under the **** comment in the `Subscription`{.action} or `Connection`{.action} box.
->
-> ![mx plan](images/technology-email.png){.thumbnail .w-500}Webmail
 
 **Contents**
 
@@ -63,45 +52,22 @@ If you have just purchased an MX Plan solution, this means you have email addres
 
 ### Create an email address <a name="create-email"></a>
 
-To find out how to create an email address, click on the tab corresponding to the email technology used by your MX Plan service:
+To create an email address, go to the `Email accounts`{.action} tab. The window that opens will list the accounts that are already available, as well as those that you can still create. To add a new email account, click the `Add an account`{.action} button.
 
-> [!tabs]
-> **Roundcube**
->>
->> To create an email address, go to the `Emails`{.action} tab. The window that opens will list the accounts that have already been created. To add a new email account, click the `Add an account`{.action} button.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> In the window that pops up, enter the following information:
->>
->> - **Account name**: Enter your new email address (e.g. first name.surname). The domain name that makes up the email address is already pre-selected in the list.
->> - **Account description**: Information on the email address, visible only in the table in the `Emails`{.action} tab of your email service.
->> - **Account size**: Determine the size you would like to assign to the email account.
->> - **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
->>
->> Once you have filled in the fields, click `Next`{.action}, then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
->>
->> ![email](images/mxplan-creation-new-step3-roundcube.png){.thumbnail .w-500}
->>
-> **Zimbra and OWA**
->>
->> To create an email address, go to the `Email accounts`{.action} tab. The window that opens will list the accounts that are already available, as well as those that you can still create. To add a new email account, click the `Add an account`{.action} button.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> In the window that pops up, enter the following information:
->>
->> - **Email account**: A temporary name is already pre-filled in the text box: delete it and enter your new email address (e.g. your first name.surname). The domain name that makes up the email address is already pre-selected in the list.
->> - **First name**: Enter a first name.
->> - **Name**: Enter a name.
->> - **Display name**: Enter the name that will be displayed as a sender when emails are sent from this address.
->> - **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
->> - **Quota**: Determine the size you would like to assign to the email account.
->>
->> Once you have filled in the fields, click `Next`{.action} , then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
->>
->> ![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
->>
+![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
+
+In the window that pops up, enter the following information:
+
+- **Email account**: A temporary name is already pre-filled in the text box: delete it and enter your new email address (e.g. your first name.surname). The domain name that makes up the email address is already pre-selected in the list.
+- **First name**: Enter a first name.
+- **Name**: Enter a name.
+- **Display name**: Enter the name that will be displayed as a sender when emails are sent from this address.
+- **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
+- **Quota**: Determine the size you would like to assign to the email account.
+
+Once you have filled in the fields, click `Next`{.action} , then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
+
+![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
 
 ### Use your email addresses <a name="consult-emails"></a>
 
@@ -111,31 +77,11 @@ Once you have created your email addresses, you can start using them. There are 
 
 Go to the [Webmail login](/links/web/email) page, then enter the email address and password. Then click the `Login`{.action} button.
 
-Select the tab corresponding to the email technology of your MX Plan solution:
+When you log in to webmail for the first time, you are prompted to set the interface language and the time zone you are in. Your inbox will then appear.
 
-> [!tabs]
-> **Roundcube**
->>
->> You should see an interface similar to the image below with the word "Roundcube" in the top left.  
->> To find out how to use the Roundcube interface, please read our guide on [Using an email address via the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube) .
->>
->> ![email](images/mxplan-webmail-roundcube01.png){.thumbnail .w-500}
->>
-> **Zimbra**
->>
->> As shown in the image below, a window will appear with the word "Zimbra" in the top left-hand corner.  
->> To find out how to use your email address via Zimbra webmail, please refer to our guide on [Using Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra) .
->>
->> ![email](images/mxplan-webmail-zimbra01.png){.thumbnail .w-500}
->>
-> **OWA**
->>
->> When you log in to webmail for the first time, you are prompted to set the interface language and the time zone you are in. Your inbox will then appear.
->>
->> To find out how to use your email address via OWA webmail, please refer to our guide on [Using your email address via Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
->>
->> ![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
->>
+To find out how to use your email address via OWA webmail, please refer to our guide on [Using your email address via Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
+
+![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
 
 #### Use an email client <a name="consult-emails-client"></a>
 
@@ -213,62 +159,25 @@ Below are the **SMTP** settings to use when sending emails:
 
 Do you want to redirect your emails to another recipient, create an alias or systematically copy another email address?
 
-To do this, click on the tab corresponding to your email technology:
+You can do this in two ways:
 
-> [!tabs]
-> **Roundcube**
->>
->> To add a redirection or an alias, click on the `Emails`{.action} tab of your MX Plan service, then click on the `Manage redirections`{.action} button on the right.  
->> The table of redirections that are already active appears. On the right, click `Add a redirection`{.action} to start creating your redirection or alias.
->>
->> - `From address`: Enter the email address you would like to redirect.<br>
->> - `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
->> - `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
->>
->> To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
->>
-> **OWA and Zimbra**
->>
->> When you are using **OWA** or **Zimbra**, you can do this in two ways:
->>
->> 1. **Create your redirection via webmail**: Via inbox rules or filters. These rules, which are applied when an email is received, allow an email to be forwarded or redirected. To do this, please follow our guide on [Inbox rules via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan), or read the Filters section of our guide on [Using webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra).
->>
->> 2. **Create your redirection and alias via the OVHcloud Control Panel**: To add a redirection or alias, click on the `Redirections`{.action} tab. The table of redirections that are already active is displayed. On the right, click `Add a redirection`{.action}.
->>
->> - `From address`: Enter the email address you would like to redirect.<br>
->> - `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
->> - `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
->>
->> To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
+1. **Create your redirection via webmail**: Via inbox rules or filters. These rules, which are applied when an email is received, allow an email to be forwarded or redirected. To do this, please follow our guide on [Inbox rules via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+
+2. **Create your redirection and alias via the OVHcloud Control Panel**: To add a redirection or alias, click on the `Redirections`{.action} tab. The table of redirections that are already active is displayed. On the right, click `Add a redirection`{.action}.
+
+- `From address`: Enter the email address you would like to redirect.<br>
+- `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
+- `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
+
+To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
 
 ### Automatic reply <a name="autoreply"></a>
 
 It is important to be able to set up an automatic response in case you cannot view or process your emails.
 
-Select the tab corresponding to the email technology of your MX Plan solution:
-
-> [!tabs]
-> **Roundcube**
->>
->> To add an automatic reply to one of your email addresses, click on the `Emails`{.action} tab of your MX Plan service, then click the `Manage replies`{.action} button on the right.  
->> The table of auto-replies that are already active is displayed. On the right, click `Add auto-reply`{.action} to start creating your redirection or alias.
->>
->> For more details on setting up an automatic response from your MX Plan service in the OVHcloud Control Panel, please read our guide on “[MX Plan - Creating an automatic response on an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)”.
->>
-> **Zimbra**
->>
->> You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to our guide on [Using Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra), in the section “Automatic replies/Voicemail”.
->>
-> **OWA**
->>
->> You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to the section "Adding automatic replies" in our guide on [Using an email address via the Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
->>
+You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to the section “Adding automatic replies” in our guide on [Using an email address via the Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ## Go further <a name="go-further"></a>
-
-[Use Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-
-[Use Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
 [Use Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-au.md
@@ -38,17 +38,6 @@ If you have just purchased an MX Plan solution, this means you have email addres
 1. Open the `Web Cloud`{.action} section.
 1. Click `MX Plan`{.action}.
 1. Select the domain concerned.
-1. **Continue with the email technology used by your MX Plan service**.
-
-> [!primary]
->
-> **Identify the email technology for your MX Plan solution.**
->
-> Depending on the activation date of your MX Plan solution, or on a recent migration, the email technology associated with it may differ. This version is characterized by its webmail interface. To identify it:
->
-> - In the `General information`{.action} tab, note the technology used under the **** comment in the `Subscription`{.action} or `Connection`{.action} box.
->
-> ![mx plan](images/technology-email.png){.thumbnail .w-500}Webmail
 
 **Contents**
 
@@ -63,45 +52,22 @@ If you have just purchased an MX Plan solution, this means you have email addres
 
 ### Create an email address <a name="create-email"></a>
 
-To find out how to create an email address, click on the tab corresponding to the email technology used by your MX Plan service:
+To create an email address, go to the `Email accounts`{.action} tab. The window that opens will list the accounts that are already available, as well as those that you can still create. To add a new email account, click the `Add an account`{.action} button.
 
-> [!tabs]
-> **Roundcube**
->>
->> To create an email address, go to the `Emails`{.action} tab. The window that opens will list the accounts that have already been created. To add a new email account, click the `Add an account`{.action} button.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> In the window that pops up, enter the following information:
->>
->> - **Account name**: Enter your new email address (e.g. first name.surname). The domain name that makes up the email address is already pre-selected in the list.
->> - **Account description**: Information on the email address, visible only in the table in the `Emails`{.action} tab of your email service.
->> - **Account size**: Determine the size you would like to assign to the email account.
->> - **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
->>
->> Once you have filled in the fields, click `Next`{.action}, then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
->>
->> ![email](images/mxplan-creation-new-step3-roundcube.png){.thumbnail .w-500}
->>
-> **Zimbra and OWA**
->>
->> To create an email address, go to the `Email accounts`{.action} tab. The window that opens will list the accounts that are already available, as well as those that you can still create. To add a new email account, click the `Add an account`{.action} button.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> In the window that pops up, enter the following information:
->>
->> - **Email account**: A temporary name is already pre-filled in the text box: delete it and enter your new email address (e.g. your first name.surname). The domain name that makes up the email address is already pre-selected in the list.
->> - **First name**: Enter a first name.
->> - **Name**: Enter a name.
->> - **Display name**: Enter the name that will be displayed as a sender when emails are sent from this address.
->> - **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
->> - **Quota**: Determine the size you would like to assign to the email account.
->>
->> Once you have filled in the fields, click `Next`{.action} , then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
->>
->> ![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
->>
+![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
+
+In the window that pops up, enter the following information:
+
+- **Email account**: A temporary name is already pre-filled in the text box: delete it and enter your new email address (e.g. your first name.surname). The domain name that makes up the email address is already pre-selected in the list.
+- **First name**: Enter a first name.
+- **Name**: Enter a name.
+- **Display name**: Enter the name that will be displayed as a sender when emails are sent from this address.
+- **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
+- **Quota**: Determine the size you would like to assign to the email account.
+
+Once you have filled in the fields, click `Next`{.action} , then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
+
+![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
 
 ### Use your email addresses <a name="consult-emails"></a>
 
@@ -111,31 +77,11 @@ Once you have created your email addresses, you can start using them. There are 
 
 Go to the [Webmail login](/links/web/email) page, then enter the email address and password. Then click the `Login`{.action} button.
 
-Select the tab corresponding to the email technology of your MX Plan solution:
+When you log in to webmail for the first time, you are prompted to set the interface language and the time zone you are in. Your inbox will then appear.
 
-> [!tabs]
-> **Roundcube**
->>
->> You should see an interface similar to the image below with the word "Roundcube" in the top left.  
->> To find out how to use the Roundcube interface, please read our guide on [Using an email address via the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube) .
->>
->> ![email](images/mxplan-webmail-roundcube01.png){.thumbnail .w-500}
->>
-> **Zimbra**
->>
->> As shown in the image below, a window will appear with the word "Zimbra" in the top left-hand corner.  
->> To find out how to use your email address via Zimbra webmail, please refer to our guide on [Using Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra) .
->>
->> ![email](images/mxplan-webmail-zimbra01.png){.thumbnail .w-500}
->>
-> **OWA**
->>
->> When you log in to webmail for the first time, you are prompted to set the interface language and the time zone you are in. Your inbox will then appear.
->>
->> To find out how to use your email address via OWA webmail, please refer to our guide on [Using your email address via Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
->>
->> ![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
->>
+To find out how to use your email address via OWA webmail, please refer to our guide on [Using your email address via Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
+
+![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
 
 #### Use an email client <a name="consult-emails-client"></a>
 
@@ -213,62 +159,25 @@ Below are the **SMTP** settings to use when sending emails:
 
 Do you want to redirect your emails to another recipient, create an alias or systematically copy another email address?
 
-To do this, click on the tab corresponding to your email technology:
+You can do this in two ways:
 
-> [!tabs]
-> **Roundcube**
->>
->> To add a redirection or an alias, click on the `Emails`{.action} tab of your MX Plan service, then click on the `Manage redirections`{.action} button on the right.  
->> The table of redirections that are already active appears. On the right, click `Add a redirection`{.action} to start creating your redirection or alias.
->>
->> - `From address`: Enter the email address you would like to redirect.<br>
->> - `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
->> - `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
->>
->> To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
->>
-> **OWA and Zimbra**
->>
->> When you are using **OWA** or **Zimbra**, you can do this in two ways:
->>
->> 1. **Create your redirection via webmail**: Via inbox rules or filters. These rules, which are applied when an email is received, allow an email to be forwarded or redirected. To do this, please follow our guide on [Inbox rules via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan), or read the Filters section of our guide on [Using webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra).
->>
->> 2. **Create your redirection and alias via the OVHcloud Control Panel**: To add a redirection or alias, click on the `Redirections`{.action} tab. The table of redirections that are already active is displayed. On the right, click `Add a redirection`{.action}.
->>
->> - `From address`: Enter the email address you would like to redirect.<br>
->> - `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
->> - `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
->>
->> To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
+1. **Create your redirection via webmail**: Via inbox rules or filters. These rules, which are applied when an email is received, allow an email to be forwarded or redirected. To do this, please follow our guide on [Inbox rules via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+
+2. **Create your redirection and alias via the OVHcloud Control Panel**: To add a redirection or alias, click on the `Redirections`{.action} tab. The table of redirections that are already active is displayed. On the right, click `Add a redirection`{.action}.
+
+- `From address`: Enter the email address you would like to redirect.<br>
+- `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
+- `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
+
+To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
 
 ### Automatic reply <a name="autoreply"></a>
 
 It is important to be able to set up an automatic response in case you cannot view or process your emails.
 
-Select the tab corresponding to the email technology of your MX Plan solution:
-
-> [!tabs]
-> **Roundcube**
->>
->> To add an automatic reply to one of your email addresses, click on the `Emails`{.action} tab of your MX Plan service, then click the `Manage replies`{.action} button on the right.  
->> The table of auto-replies that are already active is displayed. On the right, click `Add auto-reply`{.action} to start creating your redirection or alias.
->>
->> For more details on setting up an automatic response from your MX Plan service in the OVHcloud Control Panel, please read our guide on “[MX Plan - Creating an automatic response on an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)”.
->>
-> **Zimbra**
->>
->> You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to our guide on [Using Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra), in the section “Automatic replies/Voicemail”.
->>
-> **OWA**
->>
->> You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to the section "Adding automatic replies" in our guide on [Using an email address via the Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
->>
+You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to the section “Adding automatic replies” in our guide on [Using an email address via the Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ## Go further <a name="go-further"></a>
-
-[Use Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-
-[Use Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
 [Use Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-ca.md
@@ -38,17 +38,6 @@ If you have just purchased an MX Plan solution, this means you have email addres
 1. Open the `Web Cloud`{.action} section.
 1. Click `MX Plan`{.action}.
 1. Select the domain concerned.
-1. **Continue with the email technology used by your MX Plan service**.
-
-> [!primary]
->
-> **Identify the email technology for your MX Plan solution.**
->
-> Depending on the activation date of your MX Plan solution, or on a recent migration, the email technology associated with it may differ. This version is characterized by its webmail interface. To identify it:
->
-> - In the `General information`{.action} tab, note the technology used under the **** comment in the `Subscription`{.action} or `Connection`{.action} box.
->
-> ![mx plan](images/technology-email.png){.thumbnail .w-500}Webmail
 
 **Contents**
 
@@ -63,45 +52,22 @@ If you have just purchased an MX Plan solution, this means you have email addres
 
 ### Create an email address <a name="create-email"></a>
 
-To find out how to create an email address, click on the tab corresponding to the email technology used by your MX Plan service:
+To create an email address, go to the `Email accounts`{.action} tab. The window that opens will list the accounts that are already available, as well as those that you can still create. To add a new email account, click the `Add an account`{.action} button.
 
-> [!tabs]
-> **Roundcube**
->>
->> To create an email address, go to the `Emails`{.action} tab. The window that opens will list the accounts that have already been created. To add a new email account, click the `Add an account`{.action} button.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> In the window that pops up, enter the following information:
->>
->> - **Account name**: Enter your new email address (e.g. first name.surname). The domain name that makes up the email address is already pre-selected in the list.
->> - **Account description**: Information on the email address, visible only in the table in the `Emails`{.action} tab of your email service.
->> - **Account size**: Determine the size you would like to assign to the email account.
->> - **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
->>
->> Once you have filled in the fields, click `Next`{.action}, then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
->>
->> ![email](images/mxplan-creation-new-step3-roundcube.png){.thumbnail .w-500}
->>
-> **Zimbra and OWA**
->>
->> To create an email address, go to the `Email accounts`{.action} tab. The window that opens will list the accounts that are already available, as well as those that you can still create. To add a new email account, click the `Add an account`{.action} button.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> In the window that pops up, enter the following information:
->>
->> - **Email account**: A temporary name is already pre-filled in the text box: delete it and enter your new email address (e.g. your first name.surname). The domain name that makes up the email address is already pre-selected in the list.
->> - **First name**: Enter a first name.
->> - **Name**: Enter a name.
->> - **Display name**: Enter the name that will be displayed as a sender when emails are sent from this address.
->> - **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
->> - **Quota**: Determine the size you would like to assign to the email account.
->>
->> Once you have filled in the fields, click `Next`{.action} , then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
->>
->> ![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
->>
+![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
+
+In the window that pops up, enter the following information:
+
+- **Email account**: A temporary name is already pre-filled in the text box: delete it and enter your new email address (e.g. your first name.surname). The domain name that makes up the email address is already pre-selected in the list.
+- **First name**: Enter a first name.
+- **Name**: Enter a name.
+- **Display name**: Enter the name that will be displayed as a sender when emails are sent from this address.
+- **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
+- **Quota**: Determine the size you would like to assign to the email account.
+
+Once you have filled in the fields, click `Next`{.action} , then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
+
+![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
 
 ### Use your email addresses <a name="consult-emails"></a>
 
@@ -111,31 +77,11 @@ Once you have created your email addresses, you can start using them. There are 
 
 Go to the [Webmail login](/links/web/email) page, then enter the email address and password. Then click the `Login`{.action} button.
 
-Select the tab corresponding to the email technology of your MX Plan solution:
+When you log in to webmail for the first time, you are prompted to set the interface language and the time zone you are in. Your inbox will then appear.
 
-> [!tabs]
-> **Roundcube**
->>
->> You should see an interface similar to the image below with the word "Roundcube" in the top left.  
->> To find out how to use the Roundcube interface, please read our guide on [Using an email address via the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube) .
->>
->> ![email](images/mxplan-webmail-roundcube01.png){.thumbnail .w-500}
->>
-> **Zimbra**
->>
->> As shown in the image below, a window will appear with the word "Zimbra" in the top left-hand corner.  
->> To find out how to use your email address via Zimbra webmail, please refer to our guide on [Using Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra) .
->>
->> ![email](images/mxplan-webmail-zimbra01.png){.thumbnail .w-500}
->>
-> **OWA**
->>
->> When you log in to webmail for the first time, you are prompted to set the interface language and the time zone you are in. Your inbox will then appear.
->>
->> To find out how to use your email address via OWA webmail, please refer to our guide on [Using your email address via Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
->>
->> ![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
->>
+To find out how to use your email address via OWA webmail, please refer to our guide on [Using your email address via Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
+
+![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
 
 #### Use an email client <a name="consult-emails-client"></a>
 
@@ -213,62 +159,25 @@ Below are the **SMTP** settings to use when sending emails:
 
 Do you want to redirect your emails to another recipient, create an alias or systematically copy another email address?
 
-To do this, click on the tab corresponding to your email technology:
+You can do this in two ways:
 
-> [!tabs]
-> **Roundcube**
->>
->> To add a redirection or an alias, click on the `Emails`{.action} tab of your MX Plan service, then click on the `Manage redirections`{.action} button on the right.  
->> The table of redirections that are already active appears. On the right, click `Add a redirection`{.action} to start creating your redirection or alias.
->>
->> - `From address`: Enter the email address you would like to redirect.<br>
->> - `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
->> - `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
->>
->> To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
->>
-> **OWA and Zimbra**
->>
->> When you are using **OWA** or **Zimbra**, you can do this in two ways:
->>
->> 1. **Create your redirection via webmail**: Via inbox rules or filters. These rules, which are applied when an email is received, allow an email to be forwarded or redirected. To do this, please follow our guide on [Inbox rules via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan), or read the Filters section of our guide on [Using webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra).
->>
->> 2. **Create your redirection and alias via the OVHcloud Control Panel**: To add a redirection or alias, click on the `Redirections`{.action} tab. The table of redirections that are already active is displayed. On the right, click `Add a redirection`{.action}.
->>
->> - `From address`: Enter the email address you would like to redirect.<br>
->> - `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
->> - `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
->>
->> To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
+1. **Create your redirection via webmail**: Via inbox rules or filters. These rules, which are applied when an email is received, allow an email to be forwarded or redirected. To do this, please follow our guide on [Inbox rules via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+
+2. **Create your redirection and alias via the OVHcloud Control Panel**: To add a redirection or alias, click on the `Redirections`{.action} tab. The table of redirections that are already active is displayed. On the right, click `Add a redirection`{.action}.
+
+- `From address`: Enter the email address you would like to redirect.<br>
+- `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
+- `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
+
+To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
 
 ### Automatic reply <a name="autoreply"></a>
 
 It is important to be able to set up an automatic response in case you cannot view or process your emails.
 
-Select the tab corresponding to the email technology of your MX Plan solution:
-
-> [!tabs]
-> **Roundcube**
->>
->> To add an automatic reply to one of your email addresses, click on the `Emails`{.action} tab of your MX Plan service, then click the `Manage replies`{.action} button on the right.  
->> The table of auto-replies that are already active is displayed. On the right, click `Add auto-reply`{.action} to start creating your redirection or alias.
->>
->> For more details on setting up an automatic response from your MX Plan service in the OVHcloud Control Panel, please read our guide on “[MX Plan - Creating an automatic response on an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)”.
->>
-> **Zimbra**
->>
->> You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to our guide on [Using Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra), in the section “Automatic replies/Voicemail”.
->>
-> **OWA**
->>
->> You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to the section "Adding automatic replies" in our guide on [Using an email address via the Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
->>
+You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to the section “Adding automatic replies” in our guide on [Using an email address via the Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ## Go further <a name="go-further"></a>
-
-[Use Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-
-[Use Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
 [Use Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-sg.md
@@ -38,17 +38,6 @@ If you have just purchased an MX Plan solution, this means you have email addres
 1. Open the `Web Cloud`{.action} section.
 1. Click `MX Plan`{.action}.
 1. Select the domain concerned.
-1. **Continue with the email technology used by your MX Plan service**.
-
-> [!primary]
->
-> **Identify the email technology for your MX Plan solution.**
->
-> Depending on the activation date of your MX Plan solution, or on a recent migration, the email technology associated with it may differ. This version is characterized by its webmail interface. To identify it:
->
-> - In the `General information`{.action} tab, note the technology used under the **** comment in the `Subscription`{.action} or `Connection`{.action} box.
->
-> ![mx plan](images/technology-email.png){.thumbnail .w-500}Webmail
 
 **Contents**
 
@@ -63,45 +52,22 @@ If you have just purchased an MX Plan solution, this means you have email addres
 
 ### Create an email address <a name="create-email"></a>
 
-To find out how to create an email address, click on the tab corresponding to the email technology used by your MX Plan service:
+To create an email address, go to the `Email accounts`{.action} tab. The window that opens will list the accounts that are already available, as well as those that you can still create. To add a new email account, click the `Add an account`{.action} button.
 
-> [!tabs]
-> **Roundcube**
->>
->> To create an email address, go to the `Emails`{.action} tab. The window that opens will list the accounts that have already been created. To add a new email account, click the `Add an account`{.action} button.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> In the window that pops up, enter the following information:
->>
->> - **Account name**: Enter your new email address (e.g. first name.surname). The domain name that makes up the email address is already pre-selected in the list.
->> - **Account description**: Information on the email address, visible only in the table in the `Emails`{.action} tab of your email service.
->> - **Account size**: Determine the size you would like to assign to the email account.
->> - **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
->>
->> Once you have filled in the fields, click `Next`{.action}, then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
->>
->> ![email](images/mxplan-creation-new-step3-roundcube.png){.thumbnail .w-500}
->>
-> **Zimbra and OWA**
->>
->> To create an email address, go to the `Email accounts`{.action} tab. The window that opens will list the accounts that are already available, as well as those that you can still create. To add a new email account, click the `Add an account`{.action} button.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> In the window that pops up, enter the following information:
->>
->> - **Email account**: A temporary name is already pre-filled in the text box: delete it and enter your new email address (e.g. your first name.surname). The domain name that makes up the email address is already pre-selected in the list.
->> - **First name**: Enter a first name.
->> - **Name**: Enter a name.
->> - **Display name**: Enter the name that will be displayed as a sender when emails are sent from this address.
->> - **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
->> - **Quota**: Determine the size you would like to assign to the email account.
->>
->> Once you have filled in the fields, click `Next`{.action} , then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
->>
->> ![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
->>
+![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
+
+In the window that pops up, enter the following information:
+
+- **Email account**: A temporary name is already pre-filled in the text box: delete it and enter your new email address (e.g. your first name.surname). The domain name that makes up the email address is already pre-selected in the list.
+- **First name**: Enter a first name.
+- **Name**: Enter a name.
+- **Display name**: Enter the name that will be displayed as a sender when emails are sent from this address.
+- **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
+- **Quota**: Determine the size you would like to assign to the email account.
+
+Once you have filled in the fields, click `Next`{.action} , then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
+
+![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
 
 ### Use your email addresses <a name="consult-emails"></a>
 
@@ -111,31 +77,11 @@ Once you have created your email addresses, you can start using them. There are 
 
 Go to the [Webmail login](/links/web/email) page, then enter the email address and password. Then click the `Login`{.action} button.
 
-Select the tab corresponding to the email technology of your MX Plan solution:
+When you log in to webmail for the first time, you are prompted to set the interface language and the time zone you are in. Your inbox will then appear.
 
-> [!tabs]
-> **Roundcube**
->>
->> You should see an interface similar to the image below with the word "Roundcube" in the top left.  
->> To find out how to use the Roundcube interface, please read our guide on [Using an email address via the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube) .
->>
->> ![email](images/mxplan-webmail-roundcube01.png){.thumbnail .w-500}
->>
-> **Zimbra**
->>
->> As shown in the image below, a window will appear with the word "Zimbra" in the top left-hand corner.  
->> To find out how to use your email address via Zimbra webmail, please refer to our guide on [Using Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra) .
->>
->> ![email](images/mxplan-webmail-zimbra01.png){.thumbnail .w-500}
->>
-> **OWA**
->>
->> When you log in to webmail for the first time, you are prompted to set the interface language and the time zone you are in. Your inbox will then appear.
->>
->> To find out how to use your email address via OWA webmail, please refer to our guide on [Using your email address via Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
->>
->> ![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
->>
+To find out how to use your email address via OWA webmail, please refer to our guide on [Using your email address via Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
+
+![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
 
 #### Use an email client <a name="consult-emails-client"></a>
 
@@ -213,62 +159,25 @@ Below are the **SMTP** settings to use when sending emails:
 
 Do you want to redirect your emails to another recipient, create an alias or systematically copy another email address?
 
-To do this, click on the tab corresponding to your email technology:
+You can do this in two ways:
 
-> [!tabs]
-> **Roundcube**
->>
->> To add a redirection or an alias, click on the `Emails`{.action} tab of your MX Plan service, then click on the `Manage redirections`{.action} button on the right.  
->> The table of redirections that are already active appears. On the right, click `Add a redirection`{.action} to start creating your redirection or alias.
->>
->> - `From address`: Enter the email address you would like to redirect.<br>
->> - `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
->> - `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
->>
->> To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
->>
-> **OWA and Zimbra**
->>
->> When you are using **OWA** or **Zimbra**, you can do this in two ways:
->>
->> 1. **Create your redirection via webmail**: Via inbox rules or filters. These rules, which are applied when an email is received, allow an email to be forwarded or redirected. To do this, please follow our guide on [Inbox rules via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan), or read the Filters section of our guide on [Using webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra).
->>
->> 2. **Create your redirection and alias via the OVHcloud Control Panel**: To add a redirection or alias, click on the `Redirections`{.action} tab. The table of redirections that are already active is displayed. On the right, click `Add a redirection`{.action}.
->>
->> - `From address`: Enter the email address you would like to redirect.<br>
->> - `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
->> - `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
->>
->> To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
+1. **Create your redirection via webmail**: Via inbox rules or filters. These rules, which are applied when an email is received, allow an email to be forwarded or redirected. To do this, please follow our guide on [Inbox rules via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+
+2. **Create your redirection and alias via the OVHcloud Control Panel**: To add a redirection or alias, click on the `Redirections`{.action} tab. The table of redirections that are already active is displayed. On the right, click `Add a redirection`{.action}.
+
+- `From address`: Enter the email address you would like to redirect.<br>
+- `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
+- `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
+
+To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
 
 ### Automatic reply <a name="autoreply"></a>
 
 It is important to be able to set up an automatic response in case you cannot view or process your emails.
 
-Select the tab corresponding to the email technology of your MX Plan solution:
-
-> [!tabs]
-> **Roundcube**
->>
->> To add an automatic reply to one of your email addresses, click on the `Emails`{.action} tab of your MX Plan service, then click the `Manage replies`{.action} button on the right.  
->> The table of auto-replies that are already active is displayed. On the right, click `Add auto-reply`{.action} to start creating your redirection or alias.
->>
->> For more details on setting up an automatic response from your MX Plan service in the OVHcloud Control Panel, please read our guide on “[MX Plan - Creating an automatic response on an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)”.
->>
-> **Zimbra**
->>
->> You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to our guide on [Using Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra), in the section “Automatic replies/Voicemail”.
->>
-> **OWA**
->>
->> You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to the section "Adding automatic replies" in our guide on [Using an email address via the Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
->>
+You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to the section “Adding automatic replies” in our guide on [Using an email address via the Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ## Go further <a name="go-further"></a>
-
-[Use Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-
-[Use Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
 [Use Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-us.md
@@ -38,17 +38,6 @@ If you have just purchased an MX Plan solution, this means you have email addres
 1. Open the `Web Cloud`{.action} section.
 1. Click `MX Plan`{.action}.
 1. Select the domain concerned.
-1. **Continue with the email technology used by your MX Plan service**.
-
-> [!primary]
->
-> **Identify the email technology for your MX Plan solution.**
->
-> Depending on the activation date of your MX Plan solution, or on a recent migration, the email technology associated with it may differ. This version is characterized by its webmail interface. To identify it:
->
-> - In the `General information`{.action} tab, note the technology used under the **** comment in the `Subscription`{.action} or `Connection`{.action} box.
->
-> ![mx plan](images/technology-email.png){.thumbnail .w-500}Webmail
 
 **Contents**
 
@@ -63,45 +52,22 @@ If you have just purchased an MX Plan solution, this means you have email addres
 
 ### Create an email address <a name="create-email"></a>
 
-To find out how to create an email address, click on the tab corresponding to the email technology used by your MX Plan service:
+To create an email address, go to the `Email accounts`{.action} tab. The window that opens will list the accounts that are already available, as well as those that you can still create. To add a new email account, click the `Add an account`{.action} button.
 
-> [!tabs]
-> **Roundcube**
->>
->> To create an email address, go to the `Emails`{.action} tab. The window that opens will list the accounts that have already been created. To add a new email account, click the `Add an account`{.action} button.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> In the window that pops up, enter the following information:
->>
->> - **Account name**: Enter your new email address (e.g. first name.surname). The domain name that makes up the email address is already pre-selected in the list.
->> - **Account description**: Information on the email address, visible only in the table in the `Emails`{.action} tab of your email service.
->> - **Account size**: Determine the size you would like to assign to the email account.
->> - **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
->>
->> Once you have filled in the fields, click `Next`{.action}, then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
->>
->> ![email](images/mxplan-creation-new-step3-roundcube.png){.thumbnail .w-500}
->>
-> **Zimbra and OWA**
->>
->> To create an email address, go to the `Email accounts`{.action} tab. The window that opens will list the accounts that are already available, as well as those that you can still create. To add a new email account, click the `Add an account`{.action} button.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> In the window that pops up, enter the following information:
->>
->> - **Email account**: A temporary name is already pre-filled in the text box: delete it and enter your new email address (e.g. your first name.surname). The domain name that makes up the email address is already pre-selected in the list.
->> - **First name**: Enter a first name.
->> - **Name**: Enter a name.
->> - **Display name**: Enter the name that will be displayed as a sender when emails are sent from this address.
->> - **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
->> - **Quota**: Determine the size you would like to assign to the email account.
->>
->> Once you have filled in the fields, click `Next`{.action} , then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
->>
->> ![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
->>
+![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
+
+In the window that pops up, enter the following information:
+
+- **Email account**: A temporary name is already pre-filled in the text box: delete it and enter your new email address (e.g. your first name.surname). The domain name that makes up the email address is already pre-selected in the list.
+- **First name**: Enter a first name.
+- **Name**: Enter a name.
+- **Display name**: Enter the name that will be displayed as a sender when emails are sent from this address.
+- **Password**: [Enter a password](/pages/account_and_service_management/account_information/manage-ovh-password) and confirm it. For security reasons, we recommend not using the same password twice, choosing one that does not contain any personal information (e.g. your surname, first name and date of birth), and renewing it regularly.
+- **Quota**: Determine the size you would like to assign to the email account.
+
+Once you have filled in the fields, click `Next`{.action} , then check the information that appears in the summary. If the information is correct, click `Confirm`{.action}. Repeat this step as necessary, depending on the number of accounts you have.
+
+![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
 
 ### Use your email addresses <a name="consult-emails"></a>
 
@@ -111,31 +77,11 @@ Once you have created your email addresses, you can start using them. There are 
 
 Go to the [Webmail login](/links/web/email) page, then enter the email address and password. Then click the `Login`{.action} button.
 
-Select the tab corresponding to the email technology of your MX Plan solution:
+When you log in to webmail for the first time, you are prompted to set the interface language and the time zone you are in. Your inbox will then appear.
 
-> [!tabs]
-> **Roundcube**
->>
->> You should see an interface similar to the image below with the word "Roundcube" in the top left.  
->> To find out how to use the Roundcube interface, please read our guide on [Using an email address via the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube) .
->>
->> ![email](images/mxplan-webmail-roundcube01.png){.thumbnail .w-500}
->>
-> **Zimbra**
->>
->> As shown in the image below, a window will appear with the word "Zimbra" in the top left-hand corner.  
->> To find out how to use your email address via Zimbra webmail, please refer to our guide on [Using Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra) .
->>
->> ![email](images/mxplan-webmail-zimbra01.png){.thumbnail .w-500}
->>
-> **OWA**
->>
->> When you log in to webmail for the first time, you are prompted to set the interface language and the time zone you are in. Your inbox will then appear.
->>
->> To find out how to use your email address via OWA webmail, please refer to our guide on [Using your email address via Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
->>
->> ![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
->>
+To find out how to use your email address via OWA webmail, please refer to our guide on [Using your email address via Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
+
+![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
 
 #### Use an email client <a name="consult-emails-client"></a>
 
@@ -213,62 +159,25 @@ Below are the **SMTP** settings to use when sending emails:
 
 Do you want to redirect your emails to another recipient, create an alias or systematically copy another email address?
 
-To do this, click on the tab corresponding to your email technology:
+You can do this in two ways:
 
-> [!tabs]
-> **Roundcube**
->>
->> To add a redirection or an alias, click on the `Emails`{.action} tab of your MX Plan service, then click on the `Manage redirections`{.action} button on the right.  
->> The table of redirections that are already active appears. On the right, click `Add a redirection`{.action} to start creating your redirection or alias.
->>
->> - `From address`: Enter the email address you would like to redirect.<br>
->> - `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
->> - `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
->>
->> To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
->>
-> **OWA and Zimbra**
->>
->> When you are using **OWA** or **Zimbra**, you can do this in two ways:
->>
->> 1. **Create your redirection via webmail**: Via inbox rules or filters. These rules, which are applied when an email is received, allow an email to be forwarded or redirected. To do this, please follow our guide on [Inbox rules via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan), or read the Filters section of our guide on [Using webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra).
->>
->> 2. **Create your redirection and alias via the OVHcloud Control Panel**: To add a redirection or alias, click on the `Redirections`{.action} tab. The table of redirections that are already active is displayed. On the right, click `Add a redirection`{.action}.
->>
->> - `From address`: Enter the email address you would like to redirect.<br>
->> - `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
->> - `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
->>
->> To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
+1. **Create your redirection via webmail**: Via inbox rules or filters. These rules, which are applied when an email is received, allow an email to be forwarded or redirected. To do this, please follow our guide on [Inbox rules via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+
+2. **Create your redirection and alias via the OVHcloud Control Panel**: To add a redirection or alias, click on the `Redirections`{.action} tab. The table of redirections that are already active is displayed. On the right, click `Add a redirection`{.action}.
+
+- `From address`: Enter the email address you would like to redirect.<br>
+- `To address`: Enter the address you would like to redirect to here. This can be one of your OVHcloud email addresses, or an external email address.<br>
+- `Choose a copy method`: Define whether you want to keep a copy of the email received at the targeted email address (`From address`) or directly redirect to the redirection address (`To address`) without saving a copy.
+
+To understand how to use redirections and aliases on your MX Plan service, please read our full guide: “[Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)”.
 
 ### Automatic reply <a name="autoreply"></a>
 
 It is important to be able to set up an automatic response in case you cannot view or process your emails.
 
-Select the tab corresponding to the email technology of your MX Plan solution:
-
-> [!tabs]
-> **Roundcube**
->>
->> To add an automatic reply to one of your email addresses, click on the `Emails`{.action} tab of your MX Plan service, then click the `Manage replies`{.action} button on the right.  
->> The table of auto-replies that are already active is displayed. On the right, click `Add auto-reply`{.action} to start creating your redirection or alias.
->>
->> For more details on setting up an automatic response from your MX Plan service in the OVHcloud Control Panel, please read our guide on “[MX Plan - Creating an automatic response on an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)”.
->>
-> **Zimbra**
->>
->> You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to our guide on [Using Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra), in the section “Automatic replies/Voicemail”.
->>
-> **OWA**
->>
->> You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to the section "Adding automatic replies" in our guide on [Using an email address via the Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
->>
+You can set up an automatic reply directly by logging in to your email account via Webmail. For further details, please refer to the section “Adding automatic replies” in our guide on [Using an email address via the Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ## Go further <a name="go-further"></a>
-
-[Use Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-
-[Use Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
 [Use Outlook Web App (OWA) webmail](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.es-us.md
@@ -38,17 +38,6 @@ Usted acaba de adquirir una solución MX Plan que permite disfrutar de direccion
 1. Acceda a la sección `Web Cloud`{.action}.
 1. Haga clic en `MX Plan`{.action}.
 1. Seleccione el dominio.
-1. **Prosiga con la tecnología de correo electrónico que utiliza su servicio MX Plan**.
-
-> [!primary]
->
-> **Identificar la tecnología de correo electrónico de su solución MX Plan.**
->
-> En función de la fecha de activación de su MX Plan o de una migración reciente, la tecnología de correo asociada puede diferir. Esta versión se caracteriza por la interfaz de su webmail. Para identificarlo:
->
-> - En la pestaña `Información general`{.action}, consulte la tecnología utilizada bajo la mención **Webmail** que aparece en el recuadro `Suscripción`{.action} o `Webmail`{.action}.
->
-> ![MX plan](images/technology-email.png){.thumbnail .w-500}
 
 **Contenido**
 
@@ -63,45 +52,22 @@ Usted acaba de adquirir una solución MX Plan que permite disfrutar de direccion
 
 ### Crear una dirección de correo electrónico <a name="create-email"></a>
 
-Para más información sobre cómo crear una dirección de correo electrónico, haga clic en la pestaña correspondiente a la tecnología de correo electrónico utilizada por su servicio MX Plan:
+Para crear una dirección de correo, abra la pestaña `Cuentas de correo`{.action}. Se abrirá una ventana en la que se mostrarán las cuentas que ya están disponibles y las que puede crear. Para añadir una nueva cuenta de correo, haga clic en el botón `Añadir una cuenta`{.action}.
 
-> [!tabs]
-> **Roundcube**
->>
->> Para crear una dirección de correo electrónico, abra la pestaña `Emails`{.action}. Se abrirá una ventana en la que se mostrarán las cuentas creadas. Para añadir una nueva cuenta de correo, haga clic en el botón `Añadir una cuenta`{.action}.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> Introduzca la información solicitada:
->>
->> - **Nombre de cuenta**: Introduzca su nueva dirección de correo electrónico (por ejemplo, su nombre.apellido). El dominio que compone la dirección de correo ya está preseleccionado en la lista.
->> - **Descripción de la cuenta**: Información sobre la dirección de correo electrónico, visible únicamente en la tabla de la pestaña «`Correo`{.action} del servicio de correo.
->> - **Tamaño de la cuenta**: Indique el tamaño que quiere asignar a la cuenta de correo.
->> - **Contraseña**: [Establezca una contraseña](/pages/account_and_service_management/account_information/manage-ovh-password) y confírmela. Por motivos de seguridad, le recomendamos que no utilice dos veces la misma contraseña, que la contraseña no guarde ninguna relación con sus datos personales (evite, por ejemplo, mencionar su nombre, apellidos y fecha de nacimiento) y que la cambie periódicamente.
->>
->> Una vez que haya completado todos los campos, haga clic en `Siguiente`{.action} y compruebe que la información mostrada en el resumen es correcta. Si son correctos, haga clic en `Aceptar`{.action}. Realice esta acción tantas veces como sea necesario, en función del número de cuentas de que disponga.
->>
->> ![email](images/mxplan-creation-new-step3-roundcube.png){.thumbnail .w-500}
->>
-> **Zimbra y OWA**
->>
->> Para crear una dirección de correo, abra la pestaña `Cuentas de correo`{.action}. Se abrirá una ventana en la que se mostrarán las cuentas que ya están disponibles y las que puede crear. Para añadir una nueva cuenta de correo, haga clic en el botón `Añadir una cuenta`{.action}.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> Introduzca la información solicitada:
->>
->> - **Cuenta de correo**: El cuadro de texto ya incluye un nombre temporal que deberá eliminar e introducir su nueva dirección de correo electrónico (por ejemplo, su nombre.apellido). El dominio que compone la dirección de correo ya está preseleccionado en la lista.
->> - **Nombre**: Introduzca un nombre.
->> - **Apellido**: Introduzca un apellido.
->> - **Nombre mostrado**: Especifique el nombre que se mostrará como remitente cuando se envíen mensajes de correo electrónico con esta dirección.
->> - **Contraseña**: [Establezca una contraseña](/pages/account_and_service_management/account_information/manage-ovh-password) y confírmela. Por motivos de seguridad, le recomendamos que no utilice dos veces la misma contraseña, que la contraseña no guarde ninguna relación con sus datos personales (evite, por ejemplo, mencionar su nombre, apellidos y fecha de nacimiento) y que la cambie periódicamente.
->> - **Capacidad**: Determine el tamaño que desea asignar a la cuenta de correo.
->>
->> Una vez que haya completado todos los campos, haga clic en `Siguiente`{.action} y compruebe que la información mostrada en el resumen es correcta. Si son correctos, haga clic en `Aceptar`{.action}. Realice esta acción tantas veces como sea necesario, en función del número de cuentas de que disponga.
->>
->> ![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
->>
+![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
+
+Introduzca la información solicitada:
+
+- **Cuenta de correo**: El cuadro de texto ya incluye un nombre temporal que deberá eliminar e introducir su nueva dirección de correo electrónico (por ejemplo, su nombre.apellido). El dominio que compone la dirección de correo ya está preseleccionado en la lista.
+- **Nombre**: Introduzca un nombre.
+- **Apellido**: Introduzca un apellido.
+- **Nombre mostrado**: Especifique el nombre que se mostrará como remitente cuando se envíen mensajes de correo electrónico con esta dirección.
+- **Contraseña**: [Establezca una contraseña](/pages/account_and_service_management/account_information/manage-ovh-password) y confírmela. Por motivos de seguridad, le recomendamos que no utilice dos veces la misma contraseña, que la contraseña no guarde ninguna relación con sus datos personales (evite, por ejemplo, mencionar su nombre, apellidos y fecha de nacimiento) y que la cambie periódicamente.
+- **Capacidad**: Determine el tamaño que desea asignar a la cuenta de correo.
+
+Una vez que haya completado todos los campos, haga clic en `Siguiente`{.action} y compruebe que la información mostrada en el resumen es correcta. Si son correctos, haga clic en `Aceptar`{.action}. Realice esta acción tantas veces como sea necesario, en función del número de cuentas de que disponga.
+
+![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
 
 ### Utilizar sus direcciones de correo <a name="consult-emails"></a>
 
@@ -111,31 +77,11 @@ Una vez creadas las direcciones de correo, ya puede empezar a utilizarlas. Para 
 
 Vaya a la página de «[Conexión al webmail](/links/web/email)» e introduzca su dirección de correo y contraseña. A continuación, haga clic en el botón `Conectar`{.action}.
 
-Seleccione la pestaña correspondiente a la tecnología de correo de su solución MX Plan:
+La primera vez que se conecte al webmail, deberá indicar el idioma de la interfaz y la zona horaria en la que se encuentra. Se abrirá la bandeja de entrada.
 
-> [!tabs]
-> **Roundcube**
->>
->> Debería obtener una interfaz similar a la imagen de abajo con la indicación «Rouncube» en la parte superior izquierda.
->> Para descubrir la interfaz Roundcube y su uso, consulte nuestra guía «[Utilizar su dirección de correo electrónico desde el webmail Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)».
->>
->> ![email](images/mxplan-webmail-roundcube01.png){.thumbnail .w-500}
->>
-> **Zimbra**
->>
->> Como en la imagen de abajo, aparece una ventana con la indicación «Zimbra» en la parte superior izquierda.
->> Para más información sobre cómo utilizar una dirección de correo electrónico desde el webmail Zimbra, consulte nuestra guía «[Utilizar el webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)».
->>
->> ![email](images/mxplan-webmail-zimbra01.png){.thumbnail .w-500}
->>
-> **OWA**
->>
->> La primera vez que se conecte al webmail, deberá indicar el idioma de la interfaz y la zona horaria en la que se encuentra. Se abrirá la bandeja de entrada.
->>
->> Para más información sobre cómo utilizar una dirección de correo electrónico desde el webmail Outlook en la Web, consulte nuestra guía «[Utilizar una dirección de correo electrónico desde el webmail Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)».
->>
->> ![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
->>
+Para más información sobre cómo utilizar una dirección de correo electrónico desde el webmail Outlook en la Web, consulte nuestra guía «[Utilizar una dirección de correo electrónico desde el webmail Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)».
+
+![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
 
 #### Utilizar un cliente de correo <a name="consult-emails-client"></a>
 
@@ -213,62 +159,25 @@ Para el envío de mensajes de correo, consulte a continuación los parámetros *
 
 ¿Quiere redirigir su correo a otro destinatario, crear un alias o copiar sistemáticamente otra dirección de correo?
 
-Para ello, abra la pestaña correspondiente a su tecnología de correo:
+Puede realizar las siguientes acciones:
 
-> [!tabs]
-> **Roundcube**
->>
->> Para añadir una redirección o un alias, haga clic en la pestaña `Emails`{.action} de su servicio MX Plan y seleccione el botón `Gestión de las redirecciones`{.action} a la derecha.
->> Se mostrará una tabla con las redirecciones activas. A la derecha, haga clic en el botón `Añadir una redirección`{.action} para crear su redirección o alias.
->>
->> - `De la dirección`: Introduzca aquí la dirección de correo electrónico que quiera redirigir.<br>
->> - `Hacia la dirección`: Introduzca aquí la dirección de destino de su redirección. Puede ser una de sus direcciones de correo electrónico de OVHcloud o una dirección de correo electrónico externa.<br>
->> - `Elija un modo de copia`: Indique si desea conservar una copia del correo electrónico recibido en la dirección de correo electrónico de destino (`De la dirección`) o reenviar directamente a la dirección de redirección (`A la dirección`) sin conservar una copia.
->>
->> Para entender el uso de las redirecciones y alias en su servicio MX Plan, consulte nuestra guía completa: «[Utilizar las redirecciones de correo](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)».
->>
-> **OWA y Zimbra**
->>
->> Si utiliza la tecnología **OWA** o **Zimbra**, puede realizar las siguientes acciones:
->>
->> 1. **Crear una redirección desde el webmail**: Mediante las reglas de la bandeja de entrada o filtros. Estas reglas, que se aplican al recibir un email, permiten transferir o redirigir un email. Para ello, puede consultar nuestra guía «[Reglas de la Bandeja de entrada desde la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan)» o consultar el capítulo «Filtros» de nuestra guía «[Utilizar el webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)».
->>
->> 2. **Crear una redirección y un alias desde el área de cliente de OVHcloud**: Para añadir una redirección o un alias, haga clic en la pestaña `Redirecciones`{.action}. Se mostrará una tabla con las redirecciones activas. A la derecha, haga clic en el botón `Añadir una redirección`{.action}.
->>
->> - `De la dirección`: Introduzca aquí la dirección de correo electrónico que quiera redirigir.<br>
->> - `Hacia la dirección`: Introduzca aquí la dirección de destino de su redirección. Puede ser una de sus direcciones de correo electrónico de OVHcloud o una dirección de correo electrónico externa.<br>
->> - `Elija un modo de copia`: Indique si desea conservar una copia del correo electrónico recibido en la dirección de correo electrónico de destino (`De la dirección`) o reenviar directamente a la dirección de redirección (`A la dirección`) sin conservar una copia.
->>
->> Para entender el uso de las redirecciones y alias en su servicio MX Plan, consulte nuestra guía completa: «[Utilizar las redirecciones de correo](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)».
+1. **Crear una redirección desde el webmail**: Mediante las reglas de la bandeja de entrada o filtros. Estas reglas, que se aplican al recibir un email, permiten transferir o redirigir un email. Para ello, puede consultar nuestra guía «[Reglas de la Bandeja de entrada desde la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan)».
+
+2. **Crear una redirección y un alias desde el área de cliente de OVHcloud**: Para añadir una redirección o un alias, haga clic en la pestaña `Redirecciones`{.action}. Se mostrará una tabla con las redirecciones activas. A la derecha, haga clic en el botón `Añadir una redirección`{.action}.
+
+- `De la dirección`: Introduzca aquí la dirección de correo electrónico que quiera redirigir.<br>
+- `Hacia la dirección`: Introduzca aquí la dirección de destino de su redirección. Puede ser una de sus direcciones de correo electrónico de OVHcloud o una dirección de correo electrónico externa.<br>
+- `Elija un modo de copia`: Indique si desea conservar una copia del correo electrónico recibido en la dirección de correo electrónico de destino (`De la dirección`) o reenviar directamente a la dirección de redirección (`A la dirección`) sin conservar una copia.
+
+Para entender el uso de las redirecciones y alias en su servicio MX Plan, consulte nuestra guía completa: «[Utilizar las redirecciones de correo](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)».
 
 ### Respuesta automática <a name="autoreply"></a>
 
 Cuando se ausente, es importante que pueda configurar una respuesta automática para indicar que no puede consultar o procesar su correo.
 
-Seleccione la pestaña correspondiente a la tecnología de correo de su solución MX Plan:
-
-> [!tabs]
-> **Roundcube**
->>
->> Para añadir una respuesta automática a una de sus direcciones de correo, haga clic en la pestaña `Emails`{.action} de su servicio MX Plan y seleccione el botón `Gestión de los contestadores`{.action} a la derecha.
->> Se muestra la tabla de contestadores activos. A la derecha, haga clic en el botón `Añadir un contestador`{.action} para crear su redirección o alias.
->>
->> Para más información sobre la puesta en marcha de una respuesta automática desde el servicio MX Plan en el área de cliente de OVHcloud, consulte nuestra guía «[MX Plan - Crear una respuesta automática en una dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)».
->>
-> **Zimbra**
->>
->> La puesta en marcha de una respuesta automática se realiza directamente conectándose a la dirección de correo desde el webmail. Para más información, consulte nuestra guía «[Utilizar el webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)». Seleccione «Respuestas automáticas / Contestador» en la página de resumen.
->>
-> **OWA**
->>
->> La puesta en marcha de una respuesta automática se realiza directamente conectándose a la dirección de correo desde el webmail. Para más información, consulte nuestra guía «[Utilizar su dirección de correo electrónico desde el webmail Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)».
->>
+La puesta en marcha de una respuesta automática se realiza directamente conectándose a la dirección de correo desde el webmail. Para más información, consulte nuestra guía «[Utilizar su dirección de correo electrónico desde el webmail Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)».
 
 ## Más información <a name="go-further"></a>
-
-[Utilizar el webmail Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-
-[Utilizar el webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
 [Utilizar el webmail Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.fr-ca.md
@@ -38,17 +38,6 @@ Vous venez d'acquérir une solution MX Plan. Celle-ci vous permet de bénéficie
 1. Rendez-vous dans la partie `Web Cloud`{.action}.
 1. Cliquez sur `MX Plan`{.action}.
 1. Sélectionnez le domaine concerné.
-1. **Poursuivez selon la technologie e-mail utilisée par votre service MX Plan**.
-
-> [!primary]
->
-> **Identifier la technologie e-mail de votre offre MX Plan.**
->
-> En fonction de la date d’activation de votre offre MX Plan ou d’une migration récente, la technologie e-mail associée peut différer. Cette version est caractérisée par l'interface de son webmail. Pour l'identifier :
->
-> - Depuis l'onglet `Informations Générales`{.action}, relevez la technologie utilisée sous la mention **Webmail** présente dans l'encadré `Abonnement`{.action} sous `Webmail`{.action}.
->
-> ![MX plan](images/technology-email.png){.thumbnail .w-500}
 
 **Sommaire**
 
@@ -63,45 +52,22 @@ Vous venez d'acquérir une solution MX Plan. Celle-ci vous permet de bénéficie
 
 ### Créer une adresse e-mail <a name="create-email"></a>
 
-Pour découvrir comment créer une adresse e-mail, cliquez sur l'onglet correspondant à la technologie e-mail utilisée par votre service MX Plan :
+Pour créer une adresse e-mail, positionnez-vous sur l'onglet `Comptes e-mail`{.action}. La fenêtre qui apparaît liste les comptes déjà disponibles, ainsi que ceux que vous pouvez encore créer. Pour ajouter un nouveau compte e-mail, cliquez sur le bouton `Ajouter un compte`{.action}.
 
-> [!tabs]
-> **Roundcube**
->>
->> Pour créer une adresse e-mail, positionnez-vous sur l'onglet `Emails`{.action}. La fenêtre qui apparaît liste les comptes déjà créés. Pour ajouter un nouveau compte e-mail, cliquez sur le bouton `Ajouter un compte`{.action}.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> Dans la fenêtre qui s'affiche, renseignez les informations demandées :
->>
->> - **Nom du compte** : Indiquez votre nouvelle adresse e-mail (par exemple, votre prénom.nom). Le nom de domaine composant l'adresse e-mail est déjà présélectionné dans la liste.
->> - **Description du compte** : Information sur l'adresse e-mail, visible uniquement dans le tableau de l'onglet `Emails`{.action} de votre service e-mail.
->> - **Taille du compte** : Déterminez la taille que vous souhaitez attribuer au compte e-mail.
->> - **Mot de passe** : [Définissez un mot de passe](/pages/account_and_service_management/account_information/manage-ovh-password) et confirmez-le. Pour des raisons de sécurité, nous vous recommandons de ne pas utiliser deux fois le même mot de passe, d'en choisir un qui n'a aucun rapport avec vos informations personnelles (évitez par exemple les mentions à vos nom, prénom et date de naissance) et de le renouveler régulièrement.
->>
->> Une fois les champs complétés, cliquez sur `Suivant`{.action} puis vérifiez les informations qui s'affichent dans le récapitulatif. Si celles-ci sont correctes, cliquez sur `Valider`{.action}. Réalisez cette étape autant de fois que nécessaire, selon le nombre de comptes à votre disposition.
->>
->> ![email](images/mxplan-creation-new-step3-roundcube.png){.thumbnail .w-500}
->>
-> **Zimbra et OWA**
->>
->> Pour créer une adresse e-mail, positionnez-vous sur l'onglet `Comptes e-mail`{.action}. La fenêtre qui apparaît liste les comptes déjà disponibles, ainsi que ceux que vous pouvez encore créer. Pour ajouter un nouveau compte e-mail, cliquez sur le bouton `Ajouter un compte`{.action}.
->>
->> ![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
->>
->> Dans la fenêtre qui s'affiche, renseignez les informations demandées :
->>
->> - **Compte e-mail** : Un nom temporaire est déjà prérempli dans la zone de texte : supprimez-le et indiquez votre nouvelle adresse e-mail (par exemple, votre prénom.nom). Le nom de domaine composant l'adresse e-mail est déjà présélectionné dans la liste.
->> - **Prénom** : Renseignez un prénom.
->> - **Nom** : Renseignez un nom.
->> - **Nom à afficher** : Indiquez le nom qui s'affichera en tant qu'expéditeur lorsque des e-mails seront envoyés avec cette adresse.
->> - **Mot de passe** : [Définissez un mot de passe](/pages/account_and_service_management/account_information/manage-ovh-password) et confirmez-le. Pour des raisons de sécurité, nous vous recommandons de ne pas utiliser deux fois le même mot de passe, d'en choisir un qui n'a aucun rapport avec vos informations personnelles (évitez par exemple les mentions à vos nom, prénom et date de naissance) et de le renouveler régulièrement.
->> - **Quota** : Déterminez la taille que vous souhaitez attribuer au compte e-mail.
->>
->> Une fois les champs complétés, cliquez sur `Suivant`{.action} puis vérifiez les informations qui s'affichent dans le récapitulatif. Si celles-ci sont correctes, cliquez sur `Valider`{.action}. Réalisez cette étape autant de fois que nécessaire, selon le nombre de comptes à votre disposition.
->>
->> ![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
->>
+![email](images/mxplan-starter-new-step2.png){.thumbnail .w-500}
+
+Dans la fenêtre qui s'affiche, renseignez les informations demandées :
+
+- **Compte e-mail** : Un nom temporaire est déjà prérempli dans la zone de texte : supprimez-le et indiquez votre nouvelle adresse e-mail (par exemple, votre prénom.nom). Le nom de domaine composant l'adresse e-mail est déjà présélectionné dans la liste.
+- **Prénom** : Renseignez un prénom.
+- **Nom** : Renseignez un nom.
+- **Nom à afficher** : Indiquez le nom qui s'affichera en tant qu'expéditeur lorsque des e-mails seront envoyés avec cette adresse.
+- **Mot de passe** : [Définissez un mot de passe](/pages/account_and_service_management/account_information/manage-ovh-password) et confirmez-le. Pour des raisons de sécurité, nous vous recommandons de ne pas utiliser deux fois le même mot de passe, d'en choisir un qui n'a aucun rapport avec vos informations personnelles (évitez par exemple les mentions à vos nom, prénom et date de naissance) et de le renouveler régulièrement.
+- **Quota** : Déterminez la taille que vous souhaitez attribuer au compte e-mail.
+
+Une fois les champs complétés, cliquez sur `Suivant`{.action} puis vérifiez les informations qui s'affichent dans le récapitulatif. Si celles-ci sont correctes, cliquez sur `Valider`{.action}. Réalisez cette étape autant de fois que nécessaire, selon le nombre de comptes à votre disposition.
+
+![email](images/mxplan-starter-new-step3.png){.thumbnail .w-500}
 
 ### Utiliser vos adresses e-mail <a name="consult-emails"></a>
 
@@ -111,31 +77,11 @@ Une fois vos adresses e-mail créées, vous pouvez commencer à les utiliser. Po
 
 Accédez à la page de « [Connexion au webmail](/links/web/email) », puis renseignez l'adresse e-mail concernée ainsi que son mot de passe. Cliquez ensuite sur le bouton `Connexion`{.action}.
 
-Sélectionnez l'onglet correspondant à la technologie e-mail de votre offre MX Plan :
+Lors d'une première connexion au webmail, vous êtes invité à définir la langue de l'interface ainsi que le fuseau horaire sur lequel vous vous trouvez. Votre boîte de réception s'affiche ensuite.
 
-> [!tabs]
-> **Roundcube**
->>
->> Vous devriez obtenir une interface ressemblante à l'image ci-dessous avec la mention « Rouncube » en haut à gauche.
->> Pour découvrir l'interface Roundcube et son utilisation, consultez notre guide « [Utiliser son adresse e-mail depuis le webmail Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube) ».
->>
->> ![email](images/mxplan-webmail-roundcube01.png){.thumbnail .w-500}
->>
-> **Zimbra**
->>
->> Comme sur l'image ci-dessous, une fenêtre s'affiche avec la mention « Zimbra » en haut à gauche.
->> Pour découvrir comment utiliser votre adresse e-mail depuis le webmail Zimbra, aidez-vous de notre guide « [Utiliser le webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra) ».
->>
->> ![email](images/mxplan-webmail-zimbra01.png){.thumbnail .w-500}
->>
-> **OWA**
->>
->> Lors d'une première connexion au webmail, vous êtes invité à définir la langue de l'interface ainsi que le fuseau horaire sur lequel vous vous trouvez. Votre boîte de réception s'affiche ensuite.
->>
->> Pour découvrir comment utiliser votre adresse e-mail depuis le webmail OWA, aidez-vous de notre guide « [Utiliser son adresse e-mail depuis le webmail Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) ».
->>
->> ![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
->>
+Pour découvrir comment utiliser votre adresse e-mail depuis le webmail OWA, aidez-vous de notre guide « [Utiliser son adresse e-mail depuis le webmail Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) ».
+
+![email](images/mxplan-webmail-owa01.png){.thumbnail .w-500}
 
 #### Utiliser un client de messagerie <a name="consult-emails-client"></a>
 
@@ -213,62 +159,25 @@ Pour l'envoi des e-mails, retrouvez ci-dessous les paramètres **SMTP** à utili
 
 Vous souhaitez rediriger vos e-mails vers un autre destinataire, créer un alias ou encore mettre systématiquement en copie une autre adresse e-mail ?
 
-Pour ce faire, cliquez sur l'onglet correspondant à votre technologie e-mail :
+Vous pouvez procéder de deux manières :
 
-> [!tabs]
-> **Roundcube**
->>
->> Pour ajouter une redirection ou un alias, cliquez sur l'onglet `Emails`{.action} de votre service MX Plan puis cliquez sur le bouton `Gestion des redirections`{.action} à droite.
->> Le tableau des redirections déjà actives s'affiche. À droite, cliquez sur le bouton `Ajouter une redirection`{.action} pour lancer la création de votre redirection ou alias.
->>
->> - `De l'adresse` : Renseignez ici l'adresse e-mail que vous souhaitez rediriger.<br>
->> - `Vers l'adresse` : Renseignez ici l'adresse de destination de votre redirection. Il peut s'agir de l'une de vos adresses e-mail OVHcloud, ou d'une adresse e-mail externe.<br>
->> - `Choisissez un mode de copie` : Définissez si vous souhaitez conserver une copie de l'e-mail reçu sur l'adresse e-mail ciblée (`De l'adresse`) ou directement renvoyer vers l'adresse de redirection (`Vers l'adresse`) sans conserver de copie.
->>
->> Pour comprendre l'utilisation des redirections et alias sur votre service MX Plan, consultez notre guide complet : « [Utiliser les redirections e-mail](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections) ».
->>
-> **OWA et Zimbra**
->>
->> Lorsque vous êtes sur une technologie **OWA** ou **Zimbra**, vous pouvez procéder de deux manières :
->>
->> 1. **Créer votre redirection depuis le webmail** : Via les règles de boîte de réception ou filtres. En effet ces règles que l'on applique lors de la réception d'un e-mail permettent de transférer ou rediriger un e-mail. Pour cela, nous vous invitons à suivre notre guide « [Règles de boîte de réception depuis l’interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan) » ou à consulter le chapitre « Filtres » de notre guide « [Utiliser le webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra) ».
->>
->> 2. **Créer votre redirection et alias depuis votre espace client OVHcloud** : Pour ajouter une redirection ou un alias, cliquez sur l'onglet `Redirections`{.action}. Le tableau des redirections déjà actives s'affiche. À droite, cliquez sur le bouton `Ajouter une redirection`{.action}.
->>
->> - `De l'adresse` : Renseignez ici l'adresse e-mail que vous souhaitez rediriger.<br>
->> - `Vers l'adresse` : Renseignez ici l'adresse de destination de votre redirection. Il peut s'agir de l'une de vos adresses e-mail OVHcloud, ou d'une adresse e-mail externe.<br>
->> - `Choisissez un mode de copie` : Définissez si vous souhaitez conserver une copie de l'e-mail reçu sur l'adresse e-mail ciblée (`De l'adresse`) ou directement renvoyer vers l'adresse de redirection (`Vers l'adresse`) sans conserver de copie.
->>
->> Pour comprendre l'utilisation des redirections et alias sur votre service MX Plan, consultez notre guide complet : « [Utiliser les redirections e-mail](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections) ».
+1. **Créer votre redirection depuis le webmail** : Via les règles de boîte de réception ou filtres. En effet ces règles que l'on applique lors de la réception d'un e-mail permettent de transférer ou rediriger un e-mail. Pour cela, nous vous invitons à suivre notre guide « [Règles de boîte de réception depuis l'interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan) ».
+
+2. **Créer votre redirection et alias depuis votre espace client OVHcloud** : Pour ajouter une redirection ou un alias, cliquez sur l'onglet `Redirections`{.action}. Le tableau des redirections déjà actives s'affiche. À droite, cliquez sur le bouton `Ajouter une redirection`{.action}.
+
+- `De l'adresse` : Renseignez ici l'adresse e-mail que vous souhaitez rediriger.<br>
+- `Vers l'adresse` : Renseignez ici l'adresse de destination de votre redirection. Il peut s'agir de l'une de vos adresses e-mail OVHcloud, ou d'une adresse e-mail externe.<br>
+- `Choisissez un mode de copie` : Définissez si vous souhaitez conserver une copie de l'e-mail reçu sur l'adresse e-mail ciblée (`De l'adresse`) ou directement renvoyer vers l'adresse de redirection (`Vers l'adresse`) sans conserver de copie.
+
+Pour comprendre l'utilisation des redirections et alias sur votre service MX Plan, consultez notre guide complet : « [Utiliser les redirections e-mail](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections) ».
 
 ### Réponse automatique <a name="autoreply"></a>
 
 Lorsque vous devez vous absenter, il est important de pouvoir mettre en place une réponse automatique pour indiquer que vous ne pouvez pas consulter ou traiter vos e-mails.
 
-Sélectionnez l'onglet correspondant à la technologie e-mail de votre offre MX Plan :
-
-> [!tabs]
-> **Roundcube**
->>
->> Pour ajouter une réponse automatique à l'une de vos adresses e-mail, cliquez sur l'onglet `Emails`{.action} de votre service MX Plan puis cliquez sur le bouton `Gestion des répondeurs`{.action} à droite.
->> Le tableau des répondeurs déjà actifs s'affiche. À droite, cliquez sur le bouton `Ajouter un répondeur`{.action} pour lancer la création de votre redirection ou alias.
->>
->> Pour obtenir plus de détails sur la mise en place d'une réponse automatique depuis votre service MX Plan dans votre espace client OVHcloud, consultez notre guide « [MX Plan - Créer une réponse automatique sur une adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses) ».
->>
-> **Zimbra**
->>
->> La mise en place d'une réponse automatique se réalise directement en se connectant à l'adresse e-mail depuis le Webmail. Pour obtenir les détails, référez-vous à notre guide « [Utiliser le webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra) », sélectionnez « Réponses automatiques / Répondeur » dans le sommaire.
->>
-> **OWA**
->>
->> La mise en place d'une réponse automatique se réalise directement en se connectant à l'adresse e-mail depuis le Webmail. Pour obtenir les détails, référez-vous à notre guide « [Utiliser son adresse e-mail depuis le webmail Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) », allez directement au chapitre « Ajouter la réponse automatique ».
->>
+La mise en place d'une réponse automatique se réalise directement en se connectant à l'adresse e-mail depuis le Webmail. Pour obtenir les détails, référez-vous à notre guide « [Utiliser son adresse e-mail depuis le webmail Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) », allez directement au chapitre « Ajouter la réponse automatique ».
 
 ## Aller plus loin
-
-[Utiliser le webmail Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-
-[Utiliser le webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
 [Utiliser le webmail Outlook Web App (OWA)](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.en-asia.md
@@ -103,7 +103,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email address, you can start using it! You can now send and receive messages.
 
-OVHcloud also offers a web application that can be used to access your email address from a web browser. You can access it here: [Webmail](/links/web/email). You can log in using your email credentials. If you have any questions on how to use it, please use our guides [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) or [Use your email address via the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+OVHcloud also offers a web application that can be used to access your email address from a web browser. You can access it here: [Webmail](/links/web/email). You can log in using your email credentials. If you have any questions on how to use it, please use our guide [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Modify existing settings <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.en-au.md
@@ -103,7 +103,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email address, you can start using it! You can now send and receive messages.
 
-OVHcloud also offers a web application that can be used to access your email address from a web browser. You can access it here: [Webmail](/links/web/email). You can log in using your email credentials. If you have any questions on how to use it, please use our guides [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) or [Use your email address via the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+OVHcloud also offers a web application that can be used to access your email address from a web browser. You can access it here: [Webmail](/links/web/email). You can log in using your email credentials. If you have any questions on how to use it, please use our guide [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Modify existing settings <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.en-ca.md
@@ -103,7 +103,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email address, you can start using it! You can now send and receive messages.
 
-OVHcloud also offers a web application that can be used to access your email address from a web browser. You can access it here: [Webmail](/links/web/email). You can log in using your email credentials. If you have any questions on how to use it, please use our guides [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) or [Use your email address via the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+OVHcloud also offers a web application that can be used to access your email address from a web browser. You can access it here: [Webmail](/links/web/email). You can log in using your email credentials. If you have any questions on how to use it, please use our guide [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Modify existing settings <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.en-sg.md
@@ -103,7 +103,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email address, you can start using it! You can now send and receive messages.
 
-OVHcloud also offers a web application that can be used to access your email address from a web browser. You can access it here: [Webmail](/links/web/email). You can log in using your email credentials. If you have any questions on how to use it, please use our guides [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) or [Use your email address via the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+OVHcloud also offers a web application that can be used to access your email address from a web browser. You can access it here: [Webmail](/links/web/email). You can log in using your email credentials. If you have any questions on how to use it, please use our guide [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Modify existing settings <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.en-us.md
@@ -103,7 +103,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email address, you can start using it! You can now send and receive messages.
 
-OVHcloud also offers a web application that can be used to access your email address from a web browser. You can access it here: [Webmail](/links/web/email). You can log in using your email credentials. If you have any questions on how to use it, please use our guides [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) or [Use your email address via the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+OVHcloud also offers a web application that can be used to access your email address from a web browser. You can access it here: [Webmail](/links/web/email). You can log in using your email credentials. If you have any questions on how to use it, please use our guide [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Modify existing settings <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.es-us.md
@@ -103,7 +103,7 @@ Siga los etapas de instalación haciendo clic en las fichas siguientes:
 
 Una vez que haya configurado la dirección de correo electrónico, ¡ya puede empezar a utilizarla! Ya puede enviar y recibir mensajes.
 
-OVHcloud ofrece una aplicación web con la que podrá acceder a su dirección de correo electrónico desde el navegador. Puede consultarla en el siguiente enlace: [Webmail](/links/web/email). Puede conectarse con las claves de su dirección de correo electrónico. Si tiene cualquier duda relativa a su uso, puede consultar nuestras guías [Consultar su cuenta desde la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) o [Utilizar su dirección de correo electrónico desde el webmail RoundCube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+OVHcloud ofrece una aplicación web con la que podrá acceder a su dirección de correo electrónico desde el navegador. Puede consultarla en el siguiente enlace: [Webmail](/links/web/email). Puede conectarse con las claves de su dirección de correo electrónico. Si tiene cualquier duda relativa a su uso, puede consultar nuestra guía [Consultar su cuenta desde la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Cambiar la configuración existente <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_android/guide.fr-ca.md
@@ -103,7 +103,7 @@ Suivez les étapes d'installation en cliquant sur les onglets ci-dessous :
 
 Une fois l'adresse e-mail configurée, il ne reste plus qu’à l'utiliser ! Vous pouvez dès à présent envoyer et recevoir des messages.
 
-OVHcloud propose aussi une application web permettant d'accéder à votre adresse e-mail depuis un navigateur internet. Celle-ci est accessible via ce lien : [Webmail](/links/web/email). Vous pouvez vous y connecter grâce aux identifiants de votre adresse e-mail. Pour toute question relative à son utilisation, aidez-vous de nos guides [Consulter son compte depuis l’interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) ou [Utiliser son adresse e-mail depuis le webmail RoundCube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+OVHcloud propose aussi une application web permettant d'accéder à votre adresse e-mail depuis un navigateur internet. Celle-ci est accessible via ce lien : [Webmail](/links/web/email). Vous pouvez vous y connecter grâce aux identifiants de votre adresse e-mail. Pour toute question relative à son utilisation, aidez-vous de notre guide [Consulter son compte depuis l’interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Modifier les paramètres existants <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.en-asia.md
@@ -92,11 +92,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email account, you can start using it! You can now send and receive messages.
 
-OVHcloud also offers a web application you can use to access your email account from your browser. You can log in with your email credentials here: [Webmail](/links/web/email). If you have any questions on how to use the webmail associated with your solution, please refer to our guides:
-
-- [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
-- [Use your email account from the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-- [Use Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
+OVHcloud also offers a web application you can use to access your email account from your browser. You can log in with your email credentials here: [Webmail](/links/web/email). If you have any questions on how to use it, please refer to our guide "[View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)".
 
 ### Modify existing settings <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.en-au.md
@@ -92,11 +92,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email account, you can start using it! You can now send and receive messages.
 
-OVHcloud also offers a web application you can use to access your email account from your browser. You can log in with your email credentials here: [Webmail](/links/web/email). If you have any questions on how to use the webmail associated with your solution, please refer to our guides:
-
-- [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
-- [Use your email account from the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-- [Use Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
+OVHcloud also offers a web application you can use to access your email account from your browser. You can log in with your email credentials here: [Webmail](/links/web/email). If you have any questions on how to use it, please refer to our guide "[View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)".
 
 ### Modify existing settings <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.en-ca.md
@@ -92,11 +92,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email account, you can start using it! You can now send and receive messages.
 
-OVHcloud also offers a web application you can use to access your email account from your browser. You can log in with your email credentials here: [Webmail](/links/web/email). If you have any questions on how to use the webmail associated with your solution, please refer to our guides:
-
-- [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
-- [Use your email account from the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-- [Use Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
+OVHcloud also offers a web application you can use to access your email account from your browser. You can log in with your email credentials here: [Webmail](/links/web/email). If you have any questions on how to use it, please refer to our guide "[View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)".
 
 ### Modify existing settings <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.en-sg.md
@@ -92,11 +92,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email account, you can start using it! You can now send and receive messages.
 
-OVHcloud also offers a web application you can use to access your email account from your browser. You can log in with your email credentials here: [Webmail](/links/web/email). If you have any questions on how to use the webmail associated with your solution, please refer to our guides:
-
-- [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
-- [Use your email account from the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-- [Use Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
+OVHcloud also offers a web application you can use to access your email account from your browser. You can log in with your email credentials here: [Webmail](/links/web/email). If you have any questions on how to use it, please refer to our guide "[View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)".
 
 ### Modify existing settings <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.en-us.md
@@ -92,11 +92,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email account, you can start using it! You can now send and receive messages.
 
-OVHcloud also offers a web application you can use to access your email account from your browser. You can log in with your email credentials here: [Webmail](/links/web/email). If you have any questions on how to use the webmail associated with your solution, please refer to our guides:
-
-- [View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
-- [Use your email account from the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-- [Use Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
+OVHcloud also offers a web application you can use to access your email account from your browser. You can log in with your email credentials here: [Webmail](/links/web/email). If you have any questions on how to use it, please refer to our guide "[View your account via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)".
 
 ### Modify existing settings <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.es-us.md
@@ -89,11 +89,7 @@ Siga los pasos de instalación haciendo clic en las fichas siguientes:
 
 Una vez que haya configurado la dirección de correo electrónico, ¡ya puede empezar a utilizarla! Ya puede enviar y recibir mensajes.
 
-OVHcloud ofrece una aplicación web con la que podrá acceder a su dirección de correo electrónico desde el navegador. Puede consultarla en el siguiente enlace: [Webmail](/links/web/email). Puede conectarse con las claves de su dirección de correo electrónico. Si tiene cualquier duda relativa a su uso y en función del webmail asociado a su producto, consulte nuestras guías:
-
-- [Consultar su cuenta desde la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
-- [Utilizar una dirección de correo electrónico desde el webmail RoundCube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-- [Utilizar el webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra).
+OVHcloud ofrece una aplicación web con la que podrá acceder a su dirección de correo electrónico desde el navegador. Puede consultarla en el siguiente enlace: [Webmail](/links/web/email). Puede conectarse con las claves de su dirección de correo electrónico. Si tiene cualquier duda relativa a su uso, consulte nuestra guía « [Consultar su cuenta desde la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) ».
 
 ### Cambiar la configuración existente <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_outlook_app_ios/guide.fr-ca.md
@@ -89,11 +89,7 @@ Suivez les étapes d'installation en cliquant sur les onglets ci-dessous :
 
 Une fois l'adresse e-mail configurée, il ne reste plus qu’à l'utiliser ! Vous pouvez dès à présent envoyer et recevoir des messages.
 
-OVHcloud propose aussi une application web permettant d'accéder à votre adresse e-mail depuis un navigateur internet. Celle-ci est accessible via ce lien : [Webmail](/links/web/email). Vous pouvez vous y connecter grâce aux identifiants de votre adresse e-mail. Pour toute question relative à son utilisation et en fonction du webmail associé à votre offre, aidez-vous de nos guides :
-
-- [Consulter son compte depuis l’interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)
-- [Utiliser son adresse e-mail depuis le webmail RoundCube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube)
-- [Utiliser le webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra).
+OVHcloud propose aussi une application web permettant d'accéder à votre adresse e-mail depuis un navigateur internet. Celle-ci est accessible via ce lien : [Webmail](/links/web/email). Vous pouvez vous y connecter grâce aux identifiants de votre adresse e-mail. Pour toute question relative à son utilisation, aidez-vous de notre guide « [Consulter son compte depuis l’interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) ».
 
 ### Modifier les paramètres existants <a name="modify-settings"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-asia.md
@@ -27,28 +27,15 @@ On this page, you will find the most frequently asked questions regarding the us
 
 ### Email offers with OVHcloud
 
-OVHcloud currently offers 4 email solutions. To understand their specifics, navigate through the tabs below:
+OVHcloud offers the following email solution:
 
-> [!tabs]
-> **Emails/MX Plan**
->>
->> ![MX Plan](images/mxplan01.png){.thumbnail .w-500}
->>
->> 1. OVHcloud's oldest email solution, which includes the essential features of an email service with 5GB of storage space per email account.
->> 2. Included with web hosting plans and can be ordered via the [OVHcloud Control Panel](/links/manager).
->> 3. This solution uses the **OWA** (Outlook Web Access) webmail interface.
->>
-> **Exchange**
->>
->> ![Exchange](images/exchange01.png){.thumbnail .w-500}
->>
->> 1. A comprehensive email solution with collaborative features, with 50GB or 300GB of storage space.
->> 2. Included with web hosting plans and can be ordered via the [OVHcloud Control Panel](/links/manager).
->> 3. This solution uses the **OWA** (Outlook Web Access) webmail interface.
->>
+**Emails/MX Plan**
 
-> [!success]
-> Unless specified, the questions listed below concern all OVHcloud email solutions.
+![MX Plan](images/mxplan01.png){.thumbnail .w-500}
+
+1. OVHcloud's oldest email solution, which includes the essential features of an email service with 5GB of storage space per email account.
+2. Included with web hosting plans and can be ordered via the [OVHcloud Control Panel](/links/manager).
+3. This solution uses the **OWA** (Outlook Web Access) webmail interface.
 
 /// details | What should I know before I create an email address?
 
@@ -137,24 +124,7 @@ To do this, we provide guides to set up your email address. You can find them on
 >> **Android Smartphone or tablet**
 >> - [Gmail for Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android).
 >>
-> **Microsoft Exchange**
->>
->> **Windows PC**
->> - [Outlook for Windows](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016)
->> - [Thunderbird for Windows](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_thunderbird).
->> - [Mail for Windows](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10).
->>
->> **Apple Mac**
->> - [Outlook for macOS](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016_mac)
->> - [Mail for macOS](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos).
->> - [Thunderbird for macOS](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_thunderbird_mac).
->>
->> **iPhone or iPad**
->> - [Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios).
->>
->> **Android Smartphone or tablet**
->> - [Gmail for Android](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android).
->>
+
 
 With [webmail](/links/web/email), you can access your email at any time, from any connected device. Once you have created your email account, log in here to access it.
 
@@ -225,7 +195,6 @@ If you have signed up to [one of our OVHcloud email solutions](/links/web/emails
 
 Want to change your [email solution](/links/web/emails) to get more space and features, but want to keep the content of your existing email address? To do this, please follow the migration guide that corresponds to your needs:
 
-- [Migrate an MX Plan email address to an Exchange account](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrate your email addresses from one OVHcloud email platform to another](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrate your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration).
 - [Migrate email accounts via the OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-au.md
@@ -27,28 +27,15 @@ On this page, you will find the most frequently asked questions regarding the us
 
 ### Email offers with OVHcloud
 
-OVHcloud currently offers 4 email solutions. To understand their specifics, navigate through the tabs below:
+OVHcloud offers the following email solution:
 
-> [!tabs]
-> **Emails/MX Plan**
->>
->> ![MX Plan](images/mxplan01.png){.thumbnail .w-500}
->>
->> 1. OVHcloud's oldest email solution, which includes the essential features of an email service with 5GB of storage space per email account.
->> 2. Included with web hosting plans and can be ordered via the [OVHcloud Control Panel](/links/manager).
->> 3. This solution uses the **OWA** (Outlook Web Access) webmail interface.
->>
-> **Exchange**
->>
->> ![Exchange](images/exchange01.png){.thumbnail .w-500}
->>
->> 1. A comprehensive email solution with collaborative features, with 50GB or 300GB of storage space.
->> 2. Included with web hosting plans and can be ordered via the [OVHcloud Control Panel](/links/manager).
->> 3. This solution uses the **OWA** (Outlook Web Access) webmail interface.
->>
+**Emails/MX Plan**
 
-> [!success]
-> Unless specified, the questions listed below concern all OVHcloud email solutions.
+![MX Plan](images/mxplan01.png){.thumbnail .w-500}
+
+1. OVHcloud's oldest email solution, which includes the essential features of an email service with 5GB of storage space per email account.
+2. Included with web hosting plans and can be ordered via the [OVHcloud Control Panel](/links/manager).
+3. This solution uses the **OWA** (Outlook Web Access) webmail interface.
 
 /// details | What should I know before I create an email address?
 
@@ -137,24 +124,7 @@ To do this, we provide guides to set up your email address. You can find them on
 >> **Android Smartphone or tablet**
 >> - [Gmail for Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android).
 >>
-> **Microsoft Exchange**
->>
->> **Windows PC**
->> - [Outlook for Windows](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016)
->> - [Thunderbird for Windows](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_thunderbird).
->> - [Mail for Windows](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10).
->>
->> **Apple Mac**
->> - [Outlook for macOS](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016_mac)
->> - [Mail for macOS](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos).
->> - [Thunderbird for macOS](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_thunderbird_mac).
->>
->> **iPhone or iPad**
->> - [Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios).
->>
->> **Android Smartphone or tablet**
->> - [Gmail for Android](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android).
->>
+
 
 With [webmail](/links/web/email), you can access your email at any time, from any connected device. Once you have created your email account, log in here to access it.
 
@@ -225,7 +195,6 @@ If you have signed up to [one of our OVHcloud email solutions](/links/web/emails
 
 Want to change your [email solution](/links/web/emails) to get more space and features, but want to keep the content of your existing email address? To do this, please follow the migration guide that corresponds to your needs:
 
-- [Migrate an MX Plan email address to an Exchange account](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrate your email addresses from one OVHcloud email platform to another](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrate your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration).
 - [Migrate email accounts via the OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-sg.md
@@ -27,28 +27,15 @@ On this page, you will find the most frequently asked questions regarding the us
 
 ### Email offers with OVHcloud
 
-OVHcloud currently offers 4 email solutions. To understand their specifics, navigate through the tabs below:
+OVHcloud offers the following email solution:
 
-> [!tabs]
-> **Emails/MX Plan**
->>
->> ![MX Plan](images/mxplan01.png){.thumbnail .w-500}
->>
->> 1. OVHcloud's oldest email solution, which includes the essential features of an email service with 5GB of storage space per email account.
->> 2. Included with web hosting plans and can be ordered via the [OVHcloud Control Panel](/links/manager).
->> 3. This solution uses the **OWA** (Outlook Web Access) webmail interface.
->>
-> **Exchange**
->>
->> ![Exchange](images/exchange01.png){.thumbnail .w-500}
->>
->> 1. A comprehensive email solution with collaborative features, with 50GB or 300GB of storage space.
->> 2. Included with web hosting plans and can be ordered via the [OVHcloud Control Panel](/links/manager).
->> 3. This solution uses the **OWA** (Outlook Web Access) webmail interface.
->>
+**Emails/MX Plan**
 
-> [!success]
-> Unless specified, the questions listed below concern all OVHcloud email solutions.
+![MX Plan](images/mxplan01.png){.thumbnail .w-500}
+
+1. OVHcloud's oldest email solution, which includes the essential features of an email service with 5GB of storage space per email account.
+2. Included with web hosting plans and can be ordered via the [OVHcloud Control Panel](/links/manager).
+3. This solution uses the **OWA** (Outlook Web Access) webmail interface.
 
 /// details | What should I know before I create an email address?
 
@@ -137,24 +124,7 @@ To do this, we provide guides to set up your email address. You can find them on
 >> **Android Smartphone or tablet**
 >> - [Gmail for Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android).
 >>
-> **Microsoft Exchange**
->>
->> **Windows PC**
->> - [Outlook for Windows](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016)
->> - [Thunderbird for Windows](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_thunderbird).
->> - [Mail for Windows](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_windows_10).
->>
->> **Apple Mac**
->> - [Outlook for macOS](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016_mac)
->> - [Mail for macOS](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos).
->> - [Thunderbird for macOS](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_thunderbird_mac).
->>
->> **iPhone or iPad**
->> - [Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios).
->>
->> **Android Smartphone or tablet**
->> - [Gmail for Android](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_android).
->>
+
 
 With [webmail](/links/web/email), you can access your email at any time, from any connected device. Once you have created your email account, log in here to access it.
 
@@ -225,7 +195,6 @@ If you have signed up to [one of our OVHcloud email solutions](/links/web/emails
 
 Want to change your [email solution](/links/web/emails) to get more space and features, but want to keep the content of your existing email address? To do this, please follow the migration guide that corresponds to your needs:
 
-- [Migrate an MX Plan email address to an Exchange account](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrate your email addresses from one OVHcloud email platform to another](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrate your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration).
 - [Migrate email accounts via the OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.es-us.md
@@ -50,22 +50,6 @@ OVHcloud ofrece actualmente 4 soluciones de correo. Para entender sus especifica
 > [!success]
 > A menos que se indique lo contrario, las siguientes preguntas afectan a todos los servicios de correo de OVHcloud.
 
-/// details | ¿En qué se diferencian las tecnologías de correo electrónico de las ofertas **MX Plan**?
-
-La solución MX Plan se distingue por su evolución, que se basa en tres tecnologías de correo distintas. Cada una de ellas tiene su propia interfaz webmail:
-
-- **Roundcube**.
-- **OWA** (Outlook Web Access).
-- **Zimbra**.
-
-Esta diversidad de tecnologías implica una ergonomía de funcionamiento diferente para cada interfaz. Algunas funcionalidades pueden configurarse a través del área de cliente, mientras que otras pueden configurarse a través del webmail.
-
-A continuación, se ofrece un resumen de las principales funcionalidades de correo electrónico, clasificadas por tecnología y ubicación de configuración:
-
-![MX plan](images/email_feature_table.png){.thumbnail .w-500}
-
-///
-
 /// details | ¿Qué hay que saber antes de crear una dirección de correo electrónico?
 
 Crear una dirección de correo electrónico no es una tarea compleja, pero es necesario seguir unas reglas que determinen el **nombre de su dirección de correo electrónico** y su **contraseña**.

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.en-asia.md
@@ -82,7 +82,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email address, you can start using it! You can now send and receive emails.
 
-OVHcloud also has a web application you can use to access your email address from your browser. You can access this application at [Webmail](/links/web/email). You can log in using your email credentials. If you have any question about how to use it, you can refer to our guide on [Using an account in the OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) interface or use your email address via the RoundCube webmail.
+OVHcloud also has a web application you can use to access your email address from your browser. You can access this application at [Webmail](/links/web/email). You can log in using your email credentials. If you have any question about how to use it, you can refer to our guide on [Using an account in the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Retrieve a backup of your email address
 
@@ -177,12 +177,6 @@ For sending emails, if you have to enter the **SMTP** settings manually in your 
 > For more information on configuring an email address from the Mail app on macOS, see [the Apple Help Center](https://support.apple.com/en-gb/guide/mail/mail35803/mac).
 
 [MX Plan - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
-
-[Email Pro - Configuring your email account on Mail for macOS](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos)<br>
-[Email Pro - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_ios)
-
-[Exchange - Configuring your email account on macOS Mail](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios)<br>
-[Exchange - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos)
 
 For specialized services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.en-au.md
@@ -82,7 +82,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email address, you can start using it! You can now send and receive emails.
 
-OVHcloud also has a web application you can use to access your email address from your browser. You can access this application at [Webmail](/links/web/email). You can log in using your email credentials. If you have any question about how to use it, you can refer to our guide on [Using an account in the OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) interface or use your email address via the RoundCube webmail.
+OVHcloud also has a web application you can use to access your email address from your browser. You can access this application at [Webmail](/links/web/email). You can log in using your email credentials. If you have any question about how to use it, you can refer to our guide on [Using an account in the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Retrieve a backup of your email address
 
@@ -177,12 +177,6 @@ For sending emails, if you have to enter the **SMTP** settings manually in your 
 > For more information on configuring an email address from the Mail app on macOS, see [the Apple Help Center](https://support.apple.com/en-gb/guide/mail/mail35803/mac).
 
 [MX Plan - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
-
-[Email Pro - Configuring your email account on Mail for macOS](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos)<br>
-[Email Pro - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_ios)
-
-[Exchange - Configuring your email account on macOS Mail](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios)<br>
-[Exchange - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos)
 
 For specialized services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.en-ca.md
@@ -82,7 +82,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email address, you can start using it! You can now send and receive emails.
 
-OVHcloud also has a web application you can use to access your email address from your browser. You can access this application at [Webmail](/links/web/email). You can log in using your email credentials. If you have any question about how to use it, you can refer to our guide on [Using an account in the OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) interface or use your email address via the RoundCube webmail.
+OVHcloud also has a web application you can use to access your email address from your browser. You can access this application at [Webmail](/links/web/email). You can log in using your email credentials. If you have any question about how to use it, you can refer to our guide on [Using an account in the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Retrieve a backup of your email address
 
@@ -177,9 +177,6 @@ For sending emails, if you have to enter the **SMTP** settings manually in your 
 > For more information on configuring an email address from the Mail app on macOS, see [the Apple Help Center](https://support.apple.com/en-gb/guide/mail/mail35803/mac).
 
 [MX Plan - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
-
-[Email Pro - Configuring your email account on Mail for macOS](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos)<br>
-[Email Pro - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_ios)
 
 [Exchange - Configuring your email account on macOS Mail](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios)<br>
 [Exchange - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos)

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.en-sg.md
@@ -82,7 +82,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email address, you can start using it! You can now send and receive emails.
 
-OVHcloud also has a web application you can use to access your email address from your browser. You can access this application at [Webmail](/links/web/email). You can log in using your email credentials. If you have any question about how to use it, you can refer to our guide on [Using an account in the OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) interface or use your email address via the RoundCube webmail.
+OVHcloud also has a web application you can use to access your email address from your browser. You can access this application at [Webmail](/links/web/email). You can log in using your email credentials. If you have any question about how to use it, you can refer to our guide on [Using an account in the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Retrieve a backup of your email address
 
@@ -177,12 +177,6 @@ For sending emails, if you have to enter the **SMTP** settings manually in your 
 > For more information on configuring an email address from the Mail app on macOS, see [the Apple Help Center](https://support.apple.com/en-gb/guide/mail/mail35803/mac).
 
 [MX Plan - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
-
-[Email Pro - Configuring your email account on Mail for macOS](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos)<br>
-[Email Pro - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_ios)
-
-[Exchange - Configuring your email account on macOS Mail](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios)<br>
-[Exchange - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos)
 
 For specialized services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.en-us.md
@@ -82,7 +82,7 @@ Follow the installation steps by clicking on the tabs below:
 
 Once you have configured your email address, you can start using it! You can now send and receive emails.
 
-OVHcloud also has a web application you can use to access your email address from your browser. You can access this application at [Webmail](/links/web/email). You can log in using your email credentials. If you have any question about how to use it, you can refer to our guide on [Using an account in the OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) interface or use your email address via the RoundCube webmail.
+OVHcloud also has a web application you can use to access your email address from your browser. You can access this application at [Webmail](/links/web/email). You can log in using your email credentials. If you have any question about how to use it, you can refer to our guide on [Using an account in the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Retrieve a backup of your email address
 
@@ -177,9 +177,6 @@ For sending emails, if you have to enter the **SMTP** settings manually in your 
 > For more information on configuring an email address from the Mail app on macOS, see [the Apple Help Center](https://support.apple.com/en-gb/guide/mail/mail35803/mac).
 
 [MX Plan - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
-
-[Email Pro - Configuring your email account on Mail for macOS](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos)<br>
-[Email Pro - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_ios)
 
 [Exchange - Configuring your email account on macOS Mail](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios)<br>
 [Exchange - Configuring your email account on Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos)

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.es-us.md
@@ -82,7 +82,7 @@ Siga los etapas de instalación haciendo clic en las fichas siguientes:
 
 Una vez que haya configurado la dirección de correo electrónico, ya puede empezar a utilizarla enviando y recibiendo mensajes.
 
-OVHcloud también ofrece una aplicación web que permite acceder a su dirección de correo electrónico desde un navegador de internet. y está disponible en la dirección [Webmail](/links/web/email). Puede conectarse con las credenciales de acceso de su dirección de correo electrónico. Si tiene cualquier duda sobre su uso, consulte nuestra guía [Usar Outlook Web App con una cuenta Exchange](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) o [Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+OVHcloud también ofrece una aplicación web que permite acceder a su dirección de correo electrónico desde un navegador de internet. y está disponible en la dirección [Webmail](/links/web/email). Puede conectarse con las credenciales de acceso de su dirección de correo electrónico. Si tiene cualquier duda sobre su uso, consulte nuestra guía [Usar Outlook Web App con una cuenta Exchange](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Obtener una copia de seguridad de su dirección de correo
 
@@ -177,9 +177,6 @@ Para el envío de mensajes de correo electrónico, si debe introducir manualment
 > Para más información sobre la configuración de una dirección de correo electrónico desde la aplicación Mail en macOS, consulte [el centro de ayuda de Apple](https://support.apple.com/es-es/guide/mail/mail35803/mac).
 
 [MX Plan - Configurar una cuenta de correo electrónico en Mail para iPhone e iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
-
-[Email Pro - Configurar una cuenta de correo electrónico en Mail para macOS](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos)<br>
-[Email Pro - Configurar una cuenta de correo electrónico en Mail para iPhone e iPad](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_ios)
 
 [Exchange - Configurar una cuenta de correo electrónico en Mail de macOS](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios)<br>
 [Exchange - Configurar una cuenta de correo electrónico en Mail para iPhone e iPad](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos)

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos/guide.fr-ca.md
@@ -82,7 +82,7 @@ Suivez les étapes d'installation en cliqueant sur les onglets ci-dessous :
 
 Une fois l'adresse e-mail configurée, il ne reste plus qu’à l'utiliser ! Vous pouvez dès à présent envoyer et recevoir des messages.
 
-OVHcloud propose aussi une application web permettant d'accéder à votre adresse e-mail depuis un navigateur internet. Celle-ci est accessible à l’adresse [Webmail](/links/web/email). Vous pouvez vous y connecter grâce aux identifiants de votre adresse e-mail. Pour toute question relative à son utilisation, aidez-vous de notre guide [Consulter son compte depuis l’interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa) ou [Utiliser son adresse e-mail depuis le webmail RoundCube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube#ou-et-comment-se-connecter-au-webmail-roundcube).
+OVHcloud propose aussi une application web permettant d'accéder à votre adresse e-mail depuis un navigateur internet. Celle-ci est accessible à l’adresse [Webmail](/links/web/email). Vous pouvez vous y connecter grâce aux identifiants de votre adresse e-mail. Pour toute question relative à son utilisation, aidez-vous de notre guide [Consulter son compte depuis l’interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Récupérer une sauvegarde de votre adresse e-mail
 
@@ -177,9 +177,6 @@ Pour l'envoi des e-mails, si vous devez renseigner manuellement les paramètres 
 > Pour plus d'informations sur la configuration d'une adresse e-mail depuis l'application Mail sur macOS, consultez [le centre d'aide Apple](https://support.apple.com/fr-fr/guide/mail/mail35803/mac).
 
 [MX Plan - Configurer son compte e-mail sur Mail pour iPhone et iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
-
-[E-mail Pro - Configurer son compte e-mail sur Mail pour macOS](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_mail_macos)<br>
-[E-mail Pro - Configurer son compte e-mail sur Mail pour iPhone et iPad](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_ios)
 
 [Exchange - Configurer son compte e-mail sur Mail de macOS](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_ios)<br>
 [Exchange - Configurer son compte e-mail sur Mail pour iPhone et iPad](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_mail_macos)

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016/guide.en-asia.md
@@ -214,7 +214,7 @@ To configure your email address, follow the steps by clicking on the tabs below.
 
 Once the e-mail address is configured, you can now use it! You can now send and receive messages.
 
-OVHcloud also offers a web application allowing you to access your e-mail address from a web browser. OVHcloud Webmail is available [here](/links/web/email). You can log in using the credentials of your e-mail address. For any questions regarding its use, feel free to consult our guide "[Accessing your Exchange account from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)".
+OVHcloud also offers a web application allowing you to access your e-mail address from a web browser. OVHcloud Webmail is available [here](/links/web/email). You can log in using the credentials of your e-mail address. For any questions regarding its use, feel free to consult our guide "[Using the OWA webmail interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)".
 
 ### Recover a backup of your e-mail address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016/guide.en-au.md
@@ -214,7 +214,7 @@ To configure your email address, follow the steps by clicking on the tabs below.
 
 Once the e-mail address is configured, you can now use it! You can now send and receive messages.
 
-OVHcloud also offers a web application allowing you to access your e-mail address from a web browser. OVHcloud Webmail is available [here](/links/web/email). You can log in using the credentials of your e-mail address. For any questions regarding its use, feel free to consult our guide "[Accessing your Exchange account from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)".
+OVHcloud also offers a web application allowing you to access your e-mail address from a web browser. OVHcloud Webmail is available [here](/links/web/email). You can log in using the credentials of your e-mail address. For any questions regarding its use, feel free to consult our guide "[Using the OWA webmail interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)".
 
 ### Recover a backup of your e-mail address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016/guide.en-sg.md
@@ -214,7 +214,7 @@ To configure your email address, follow the steps by clicking on the tabs below.
 
 Once the e-mail address is configured, you can now use it! You can now send and receive messages.
 
-OVHcloud also offers a web application allowing you to access your e-mail address from a web browser. OVHcloud Webmail is available [here](/links/web/email). You can log in using the credentials of your e-mail address. For any questions regarding its use, feel free to consult our guide "[Accessing your Exchange account from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)".
+OVHcloud also offers a web application allowing you to access your e-mail address from a web browser. OVHcloud Webmail is available [here](/links/web/email). You can log in using the credentials of your e-mail address. For any questions regarding its use, feel free to consult our guide "[Using the OWA webmail interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa)".
 
 ### Recover a backup of your e-mail address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016/guide.es-us.md
@@ -338,8 +338,6 @@ Para entender la diferencia entre el uso del protocolo POP e IMAP, vamos a detal
 >
 > Para obtener más información sobre la configuración de una dirección de correo electrónico desde la aplicación Outlook en macOS, consulte [el Centro de ayuda de Microsoft](https://support.microsoft.com/es-es/office/agregar-cuenta-de-correo-en-outlook-6e27792a-9267-4aa4-8bb6-c84ef146101b).
 
-[Configurar una cuenta Email Pro en Outlook para Windows](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_2016)
-
 [Configurar una cuenta Exchange en Outlook para Windows](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016)
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016/guide.fr-ca.md
@@ -338,8 +338,6 @@ Pour comprendre la différence entre l'utilisation du protocole POP et IMAP, nou
 >
 > Pour plus d'informations sur la configuration d'une adresse e-mail depuis l'application Outlook sur macOS, consultez [le centre d'aide Microsoft](https://support.microsoft.com/fr-fr/office/ajouter-un-compte-de-courrier-dans-outlook-6e27792a-9267-4aa4-8bb6-c84ef146101b).
 
-[Configurer son compte E-mail Pro sur Outlook pour Windows](/pages/web_cloud/email_and_collaborative_solutions/email_pro/how_to_configure_outlook_2016)
-
 [Configurer son compte Exchange sur Outlook pour Windows](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016)
 
 Échangez avec notre [communauté d'utilisateurs](/links/community)

--- a/pages/web_cloud/email_and_collaborative_solutions/troubleshooting/diagnostic_advanced/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/troubleshooting/diagnostic_advanced/guide.en-asia.md
@@ -93,7 +93,7 @@ From your computer browser or smartphone, go to the address [Webmail](/links/web
 
 /// details | I cannot log in to webmail
 
-Make sure you have the right password. If necessary, you can modify it. Also check if two-factor authentication is enabled ([Exchange](/links/web/emails-hosted-exchange) only).
+Make sure you have the right password. If necessary, you can modify it.
 
 To change the password for an email address, please refer to our guide "[Changing a password for an MX Plan email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)".
 

--- a/pages/web_cloud/email_and_collaborative_solutions/troubleshooting/diagnostic_advanced/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/troubleshooting/diagnostic_advanced/guide.en-au.md
@@ -93,7 +93,7 @@ From your computer browser or smartphone, go to the address [Webmail](/links/web
 
 /// details | I cannot log in to webmail
 
-Make sure you have the right password. If necessary, you can modify it. Also check if two-factor authentication is enabled ([Exchange](/links/web/emails-hosted-exchange) only).
+Make sure you have the right password. If necessary, you can modify it.
 
 To change the password for an email address, please refer to our guide "[Changing a password for an MX Plan email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)".
 

--- a/pages/web_cloud/email_and_collaborative_solutions/troubleshooting/diagnostic_advanced/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/troubleshooting/diagnostic_advanced/guide.en-sg.md
@@ -93,7 +93,7 @@ From your computer browser or smartphone, go to the address [Webmail](/links/web
 
 /// details | I cannot log in to webmail
 
-Make sure you have the right password. If necessary, you can modify it. Also check if two-factor authentication is enabled ([Exchange](/links/web/emails-hosted-exchange) only).
+Make sure you have the right password. If necessary, you can modify it.
 
 To change the password for an email address, please refer to our guide "[Changing a password for an MX Plan email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)".
 

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan/guide.en-asia.md
@@ -19,7 +19,7 @@ With the "Inbox rules" option, you can create an elaborate set of rules to handl
 
 ### Step 1: Navigating to the options section
 
-Log in to your Exchange account via the [OVHcloud webmail](/links/web/email). Click on the gear symbol on the top right to unfold the "Options" menu and select `Options`{.action}.
+Log in to your email account via the [OVHcloud webmail](/links/web/email). Click on the gear symbol on the top right to unfold the "Options" menu and select `Options`{.action}.
 
 ![inboxrules](images/exchange-rules-step1.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan/guide.en-au.md
@@ -19,7 +19,7 @@ With the "Inbox rules" option, you can create an elaborate set of rules to handl
 
 ### Step 1: Navigating to the options section
 
-Log in to your Exchange account via the [OVHcloud webmail](/links/web/email). Click on the gear symbol on the top right to unfold the "Options" menu and select `Options`{.action}.
+Log in to your email account via the [OVHcloud webmail](/links/web/email). Click on the gear symbol on the top right to unfold the "Options" menu and select `Options`{.action}.
 
 ![inboxrules](images/exchange-rules-step1.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan/guide.en-sg.md
@@ -19,7 +19,7 @@ With the "Inbox rules" option, you can create an elaborate set of rules to handl
 
 ### Step 1: Navigating to the options section
 
-Log in to your Exchange account via the [OVHcloud webmail](/links/web/email). Click on the gear symbol on the top right to unfold the "Options" menu and select `Options`{.action}.
+Log in to your email account via the [OVHcloud webmail](/links/web/email). Click on the gear symbol on the top right to unfold the "Options" menu and select `Options`{.action}.
 
 ![inboxrules](images/exchange-rules-step1.png){.thumbnail}
 


### PR DESCRIPTION


## What type of Pull Request is this?

- Update of existing guides
- Fix
- Optimization

## Description

- Fix non-EU MX Plan guides: remove Zimbra, Roundcube, Email Pro and Exchange references
- Remove Zimbra mentions from email_generalities, email_outlook_app_ios, faq-emails (7 locales CA/US/APAC)
- Remove Roundcube mentions from email_generalities, email_outlook_app_ios, email_outlook_app_android, how_to_configure_mail_macos, email_creation, faq-emails (7 locales + 1 Exchange fr-ca)
- Remove Email Pro cross-links from MX Plan and Exchange "Go further" sections (CA/US)
- Remove Exchange references from MX Plan guides (APAC: faq-emails, how_to_configure_mail_macos, how_to_configure_outlook_2016, creating-inbox-rules-in-owa, diagnostic_advanced)
- Fix singular/plural after link removal: "guides:" + bullet list → "guide" + inline link (email_outlook_app_ios, email_outlook_app_android)
- Remove Private Exchange (and Exchange Provider for fr-ca) sections and exclusion mentions from the 4 CA/US locale files of the SPF guide, as these products are only available in EU+IE.

## Mandatory information

The translations in this Pull Request have been done using:
- [x] OVHcloud integrated translation LLM <!-- If you're interested in this new option, contact the Guides team -->
- [ ] Systran
- [ ] Other tool (specify which tool was used)
- [ ] This Pull Request didn't require any translation.

