### PR TITLE
[SK-2606-2608] -WEB- Emails-Migration - update and fix

### DIFF
--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.de-de.md
@@ -34,9 +34,9 @@ Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister]
 - **Direkter Link:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Navigationspfad:** `Web Cloud`{.action} > `MX Plan`{.action} > Wählen Sie Ihren MX Plan Dienst aus
 
-**Email Pro:**
+**E-Mail Pro:**
 
-- **Direkter Link:** [Email Pro](/links/control-panel/web-email-pro)
+- **Direkter Link:** [E-Mail Pro](/links/control-panel/web-email-pro)
 - **Navigationspfad:** `Web Cloud`{.action} > `E-Mail Pro`{.action} > Wählen Sie Ihre Plattform aus
 
 **Exchange:**

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.de-de.md
@@ -66,11 +66,11 @@ Die folgenden Anweisungen sind in zwei Teile gegliedert:
 
 Wenn Sie einen OVHcloud [Exchange E-Mail-Account](/links/web/emails-hosted-exchange) haben, können Sie diesen direkt im PST-Format über das Kundencenter exportieren.
 
-Klicken Sie rechts neben dem zu exportierenden E-Mail-Account auf `...`{.action} und dann auf `Als PST-Datei exportieren`{.action}.
+Im Tab `E-Mail-Accounts`{.action} Ihres Exchange-Dienstes klicken Sie rechts neben dem zu exportierenden E-Mail-Account auf `...`{.action} und dann auf `In PST-Format exportieren`{.action}.
 
 ![E-Mails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-Danach muss die Dauer des Exports abgewartet werden, die je nach Größe des Exports einige Minuten bis mehrere Stunden in Anspruch nehmen kann. Am Ende dieses Vorgangs gehen Sie einfach zurück zum Button `Als PST-Datei exportieren`{.action}, um einen Download-Link abzurufen.
+Danach muss die Dauer des Exports abgewartet werden, die je nach Größe des Exports einige Minuten bis mehrere Stunden in Anspruch nehmen kann. Am Ende dieses Vorgangs gehen Sie einfach zurück zum Button `In PST-Format exportieren`{.action}, um einen Download-Link abzurufen.
 
 ![E-Mails](images/manager-export-pst02.png){.thumbnail .w-640}
 
@@ -79,15 +79,15 @@ Danach muss die Dauer des Exports abgewartet werden, die je nach Größe des Exp
 > [!tabs]
 > **Exportieren**
 >>
->> - Klicken Sie oben links auf `Datei`, dann auf `Öffnen und Exportieren` und dann auf `importieren/exportieren`.
+>> - Klicken Sie oben links auf `Datei`{.action}, dann auf `Öffnen und Exportieren`{.action} und dann auf `importieren/exportieren`{.action}.
 >>
 >> ![E-Mails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Wählen Sie `Daten in eine Datei exportieren` und klicken Sie dann auf `Weiter`.
+>> - Wählen Sie `Daten in eine Datei exportieren`{.action} und klicken Sie dann auf `Weiter`{.action}.
 >>
 >> ![E-Mails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Wählen Sie `Outlook Datendatei (.pst)` und klicken Sie auf `Weiter`.
+>> - Wählen Sie `Outlook Datendatei (.pst)`{.action} und klicken Sie auf `Weiter`{.action}.
 >>
 >> ![E-Mails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -96,11 +96,11 @@ Danach muss die Dauer des Exports abgewartet werden, die je nach Größe des Exp
 >> > [!primary]
 >> > Sie können nur einen Account gleichzeitig exportieren.
 >>
->> Setzen Sie ein Häkchen bei `Unterordner einbeziehen` und klicken Sie dann auf `Weiter`.
+>> Setzen Sie ein Häkchen bei `Unterordner einbeziehen`{.action} und klicken Sie dann auf `Weiter`{.action}.
 >>
 >> ![E-Mails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Wählen Sie den Zielordner Ihres Backups aus und geben Sie einen Namen für dieses ein, indem Sie auf `Durchsuchen` klicken. Wählen Sie die für Sie passende Option aus und klicken Sie dann auf `Beenden`.
+>> - Wählen Sie den Zielordner Ihres Backups aus und geben Sie einen Namen für dieses ein, indem Sie auf `Durchsuchen`{.action} klicken. Wählen Sie die für Sie passende Option aus und klicken Sie dann auf `Beenden`{.action}.
 >>
 >> ![E-Mails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -110,25 +110,25 @@ Danach muss die Dauer des Exports abgewartet werden, die je nach Größe des Exp
 >>
 > **Importieren**
 >>
->> - Klicken Sie oben links auf `Datei`, dann auf `Öffnen und Exportieren` und dann auf `importieren/exportieren`.
+>> - Klicken Sie oben links auf `Datei`{.action}, dann auf `Öffnen und Exportieren`{.action} und dann auf `importieren/exportieren`{.action}.
 >>
 >> ![E-Mails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Wählen Sie `Aus einem anderen Programm oder einer anderen Datei importieren` und klicken Sie dann auf `Weiter`.
+>> - Wählen Sie `Aus einem anderen Programm oder einer anderen Datei importieren`{.action} und klicken Sie dann auf `Weiter`{.action}.
 >>
 >> ![E-Mails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Wählen Sie `Outlook Datendatei (.pst)` und klicken Sie auf `Weiter`.
+>> - Wählen Sie `Outlook Datendatei (.pst)`{.action} und klicken Sie auf `Weiter`{.action}.
 >>
 >> ![E-Mails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Wählen Sie Ihre Backup-Datei aus, indem Sie auf `Durchsuchen` klicken. Wählen Sie die für Sie passende Option aus und klicken Sie dann auf `Beenden`.
+>> - Wählen Sie Ihre Backup-Datei aus, indem Sie auf `Durchsuchen`{.action} klicken. Wählen Sie die für Sie passende Option aus und klicken Sie dann auf `Beenden`{.action}.
 >>
 >> ![E-Mails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - Wenn Sie ein Passwort in Ihrer Backup-Datei festgelegt haben, geben Sie dieses ein und klicken Sie dann auf `OK`.
+>> - Wenn Sie ein Passwort in Ihrer Backup-Datei festgelegt haben, geben Sie dieses ein und klicken Sie dann auf `OK`{.action}.
 >>
->> - Wählen Sie `Elemente in den aktiven Ordner importieren` und klicken Sie dann auf `Beenden`.
+>> - Wählen Sie `Elemente in den aktiven Ordner importieren`{.action} und klicken Sie dann auf `Beenden`{.action}.
 >>
 >> Der Import Ihres Backups beginnt.
 
@@ -137,46 +137,46 @@ Danach muss die Dauer des Exports abgewartet werden, die je nach Größe des Exp
 > [!tabs]
 > **Exportieren**
 >>
->> Klicken Sie im Tab `Werkzeuge` in Ihrem Outlook-Fenster auf `Exportieren`.
+>> Klicken Sie im Tab `Werkzeuge`{.action} in Ihrem Outlook-Fenster auf `Exportieren`{.action}.
 >>
 >> ![E-Mails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> Wählen Sie im Fenster "In eine Archivdatei (.olm) exportieren" die Elemente aus, die Sie zu Ihrer Backup-Datei hinzufügen möchten, und klicken Sie dann auf `Weiter`.
+>> Wählen Sie im Fenster "In eine Archivdatei (.olm) exportieren" die Elemente aus, die Sie zu Ihrer Backup-Datei hinzufügen möchten, und klicken Sie dann auf `Weiter`{.action}.
 >>
 >> ![E-Mails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Wählen Sie anschließend den Zielordner für Ihr Backup aus und klicken Sie auf `Speichern`.
+>> Wählen Sie anschließend den Zielordner für Ihr Backup aus und klicken Sie auf `Speichern`{.action}.
 >>
 >> ![E-Mails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> Es wird ein Fortschrittsfenster angezeigt, klicken Sie auf Am Ende der Operation fortfahren. Sie finden Ihre Backup-Datei im zuvor gewählten Ordner.
+>> Es wird ein Fortschrittsfenster angezeigt. Klicken Sie auf `Am Ende der Operation fortfahren`{.action}. Sie finden Ihre Backup-Datei im zuvor gewählten Ordner.
 >>
 > **Importieren**
 >>
->> Klicken Sie im Tab `Werkzeuge` in Ihrem Outlook-Fenster auf `Importieren`.
+>> Klicken Sie im Tab `Werkzeuge`{.action} in Ihrem Outlook-Fenster auf `Importieren`{.action}.
 >>
 >> ![E-Mails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Wählen Sie das Backup-Format aus, das Sie importieren möchten, und klicken Sie dann auf `Weiter`.
+>> Wählen Sie das Backup-Format aus, das Sie importieren möchten, und klicken Sie dann auf `Weiter`{.action}.
 >>
 >> ![E-Mails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Wählen Sie Ihre Backup-Datei aus und klicken Sie dann auf `importieren`.
+>> Wählen Sie Ihre Backup-Datei aus und klicken Sie dann auf `Importieren`{.action}.
 >>
 >> ![E-Mails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> Es wird ein Fortschrittsfenster angezeigt. Klicken Sie am Ende der Operation auf `Weiter`.
+>> Es wird ein Fortschrittsfenster angezeigt. Klicken Sie am Ende der Operation auf `Weiter`{.action}.
 
 ### Mail auf Mac OS
 
 > [!tabs]
 > **Exportieren**
 >>
->> Wählen Sie in der linken Spalte einen oder mehrere E-Mail-Accounts aus. Klicken Sie im horizontalen Menü auf `Mailbox` und dann auf `Mailbox exportieren`.
+>> Wählen Sie in der linken Spalte einen oder mehrere E-Mail-Accounts aus. Klicken Sie im horizontalen Menü auf `Mailbox`{.action} und dann auf `Mailbox exportieren`{.action}.
 >>
 >> ![E-Mails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Wählen Sie den Ordner Ihrer Wahl aus oder erstellen Sie einen neuen Ordner und klicken Sie dann auf `Auswählen`.
+>> Wählen Sie den Ordner Ihrer Wahl aus oder erstellen Sie einen neuen Ordner und klicken Sie dann auf `Auswählen`{.action}.
 >>
 >> ![E-Mails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -184,11 +184,11 @@ Danach muss die Dauer des Exports abgewartet werden, die je nach Größe des Exp
 >>
 > **Importieren**
 >>
->> Klicken Sie im horizontalen Menü auf Datei und dann auf `Briefkästen importieren`.
+>> Klicken Sie im horizontalen Menü auf `Datei`{.action} und dann auf `Briefkästen importieren`{.action}.
 >>
 >> ![E-Mails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Wählen Sie Ihre Backup-Datei im Format ".mbox" aus und klicken Sie dann auf `Weiter`.
+>> Wählen Sie Ihre Backup-Datei im Format ".mbox" aus und klicken Sie dann auf `Weiter`{.action}.
 >>
 >> ![E-Mails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -201,11 +201,11 @@ Es gibt derzeit keine native Funktion zum Export oder Import eines E-Mail-Accoun
 > [!tabs]
 > **Exportieren**
 >>
->> Klicken Sie im Hauptfenster oben rechts auf das Menü, dann auf `Hilfe` und schließlich auf `Troubleshooting Information`.
+>> Klicken Sie im Hauptfenster oben rechts auf das Menü, dann auf `Hilfe`{.action} und schließlich auf `Informationen zur Fehlerbehebung`{.action}.
 >>
 >> ![E-Mails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> Es erscheint eine Tabelle. Wählen Sie die Zeile `Profilverzeichnis` aus und klicken Sie auf den Button `Den zugehörigen Ordner öffnen`.
+>> Es erscheint eine Tabelle. Wählen Sie die Zeile `Profilverzeichnis`{.action} aus und klicken Sie auf den Button `Den zugehörigen Ordner öffnen`{.action}.
 >>
 >> ![E-Mails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -226,7 +226,7 @@ Es gibt derzeit keine native Funktion zum Export oder Import eines E-Mail-Accoun
 >>
 >> Starten Sie zuerst Thunderbird über die Profilverwaltung.
 >>
->> - Gehen Sie in Windows ins Startmenü und dann auf `Ausführen`. Geben Sie dort `thunderbird.exe -ProfileManager` ein und klicken Sie auf `OK`.
+>> - Gehen Sie in Windows ins Startmenü und dann auf `Ausführen`{.action}. Geben Sie dort `thunderbird.exe -ProfileManager` ein und klicken Sie auf `OK`{.action}.
 >>
 >> ![E-Mails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
@@ -234,7 +234,7 @@ Es gibt derzeit keine native Funktion zum Export oder Import eines E-Mail-Accoun
 >>
 >> ![E-Mails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> Im folgenden Fenster werden die vorhandenen Profile angezeigt. Klicken Sie auf `Profil erstellen` und dann auf `Weiter`, wenn die Informationsnachricht angezeigt wird.
+>> Im folgenden Fenster werden die vorhandenen Profile angezeigt. Klicken Sie auf `Profil erstellen`{.action} und dann auf `Weiter`{.action}, wenn die Informationsnachricht angezeigt wird.
 >>
 >> ![E-Mails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -245,9 +245,9 @@ Es gibt derzeit keine native Funktion zum Export oder Import eines E-Mail-Accoun
 >> > [!primary]
 >> > Wir empfehlen Ihnen, die Sicherung Ihres Thunderbird-Profils in den Thunderbird-Profilordner zu kopieren.
 >>
->> Klicken Sie auf `Ordner auswählen...` um den Ordner auszuwählen, der Ihr Backup enthält. Klicken Sie auf `Beenden`, um das Profil mit Ihrem Backup zu erstellen.
+>> Klicken Sie auf `Ordner auswählen...`{.action} um den Ordner auszuwählen, der Ihr Backup enthält. Klicken Sie auf `Beenden`{.action}, um das Profil mit Ihrem Backup zu erstellen.
 >>
->> Sie finden das Fenster zur Auswahl Ihres Profils mit Ihrem neuen ausgewählten Profil. Klicken Sie auf `Thunderbird starten`, Thunderbird wird mit allen Elementen, die Sie in Ihrem Backup hatten, gestartet.
+>> Sie finden das Fenster zur Auswahl Ihres Profils mit Ihrem neuen ausgewählten Profil. Klicken Sie auf `Thunderbird starten`{.action}, Thunderbird wird mit allen Elementen, die Sie in Ihrem Backup hatten, gestartet.
 
 ### Import auf der neuen E-Mail-Adresse überprüfen
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.de-de.md
@@ -34,9 +34,9 @@ Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister]
 - **Direkter Link:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Navigationspfad:** `Web Cloud`{.action} > `MX Plan`{.action} > Wählen Sie Ihren MX Plan Dienst aus
 
-**E-Mail Pro:**
+**Email Pro:**
 
-- **Direkter Link:** [E-Mail Pro](/links/control-panel/web-email-pro)
+- **Direkter Link:** [Email Pro](/links/control-panel/web-email-pro)
 - **Navigationspfad:** `Web Cloud`{.action} > `E-Mail Pro`{.action} > Wählen Sie Ihre Plattform aus
 
 **Exchange:**
@@ -66,11 +66,11 @@ Die folgenden Anweisungen sind in zwei Teile gegliedert:
 
 Wenn Sie einen OVHcloud [Exchange E-Mail-Account](/links/web/emails-hosted-exchange) haben, können Sie diesen direkt im PST-Format über das Kundencenter exportieren.
 
-Klicken Sie rechts neben dem zu exportierenden E-Mail-Account auf `...`{.action} und dann auf `In PST-Format exportieren`{.action}.
+Klicken Sie rechts neben dem zu exportierenden E-Mail-Account auf `...`{.action} und dann auf `Als PST-Datei exportieren`{.action}.
 
 ![E-Mails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-Danach muss die Dauer des Exports abgewartet werden, die je nach Größe des Exports einige Minuten bis mehrere Stunden in Anspruch nehmen kann. Am Ende dieses Vorgangs gehen Sie einfach zurück zum Button `In PST-Format exportieren`{.action}, um einen Download-Link abzurufen.
+Danach muss die Dauer des Exports abgewartet werden, die je nach Größe des Exports einige Minuten bis mehrere Stunden in Anspruch nehmen kann. Am Ende dieses Vorgangs gehen Sie einfach zurück zum Button `Als PST-Datei exportieren`{.action}, um einen Download-Link abzurufen.
 
 ![E-Mails](images/manager-export-pst02.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.de-de.md
@@ -27,21 +27,21 @@ Bei Schwierigkeiten kontaktieren Sie bitte einen [spezialisierten Dienstleister]
 <!-- CP-NAV-START:web-exchange -->
 ---
 
-### Zugang zum OVHcloud Kundencenter
+### Zugriff auf das OVHcloud Kundencenter
 
 **MX Plan:**
 
-- **Direktlink:** [MX Plan](/links/control-panel/web-mx-plan)
+- **Direkter Link:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Navigationspfad:** `Web Cloud`{.action} > `MX Plan`{.action} > Wählen Sie Ihren MX Plan Dienst aus
 
 **E-Mail Pro:**
 
-- **Direktlink:** [E-Mail Pro](/links/control-panel/web-email-pro)
+- **Direkter Link:** [E-Mail Pro](/links/control-panel/web-email-pro)
 - **Navigationspfad:** `Web Cloud`{.action} > `E-Mail Pro`{.action} > Wählen Sie Ihre Plattform aus
 
 **Exchange:**
 
-- **Direktlink:** [Exchange](/links/control-panel/web-exchange)
+- **Direkter Link:** [Exchange](/links/control-panel/web-exchange)
 - **Navigationspfad:** `Web Cloud`{.action} > `Exchange`{.action} > Wählen Sie Ihre Plattform aus
 
 ---
@@ -66,184 +66,188 @@ Die folgenden Anweisungen sind in zwei Teile gegliedert:
 
 Wenn Sie einen OVHcloud [Exchange E-Mail-Account](/links/web/emails-hosted-exchange) haben, können Sie diesen direkt im PST-Format über das Kundencenter exportieren.
 
-1. Loggen Sie sich in Ihr [OVHcloud Kundencenter](/links/manager) ein.
-1. Öffnen Sie den Bereich `Web Cloud`{.action}.
-1. In der Rubrik `MICROSOFT`{.action}, klicken Sie auf `Exchange`{.action}.
-1. Wählen Sie den gewünschten Dienst aus.
-1. Klicken Sie rechts neben dem zu exportierenden E-Mail-Account auf `...`{.action} und dann auf `In PST-Format exportieren`{.action}.
+Klicken Sie rechts neben dem zu exportierenden E-Mail-Account auf `...`{.action} und dann auf `In PST-Format exportieren`{.action}.
 
-![E-Mails](images/manager-export-pst01.png){.thumbnail}
+![E-Mails](images/manager-export-pst01.png){.thumbnail .w-640}
 
 Danach muss die Dauer des Exports abgewartet werden, die je nach Größe des Exports einige Minuten bis mehrere Stunden in Anspruch nehmen kann. Am Ende dieses Vorgangs gehen Sie einfach zurück zum Button `In PST-Format exportieren`{.action}, um einen Download-Link abzurufen.
 
-![E-Mails](images/manager-export-pst02.png){.thumbnail}
+![E-Mails](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Über Windows exportieren
+#### Windows
 
-- Klicken Sie oben links auf `Datei`, dann auf `Öffnen und Exportieren` und dann auf `importieren/exportieren`.
+> [!tabs]
+> **Exportieren**
+>>
+>> - Klicken Sie oben links auf `Datei`, dann auf `Öffnen und Exportieren` und dann auf `importieren/exportieren`.
+>>
+>> ![E-Mails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Wählen Sie `Daten in eine Datei exportieren` und klicken Sie dann auf `Weiter`.
+>>
+>> ![E-Mails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Wählen Sie `Outlook Datendatei (.pst)` und klicken Sie auf `Weiter`.
+>>
+>> ![E-Mails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Wählen Sie den Namen des zu exportierenden E-Mail-Accounts aus.
+>>
+>> > [!primary]
+>> > Sie können nur einen Account gleichzeitig exportieren.
+>>
+>> Setzen Sie ein Häkchen bei `Unterordner einbeziehen` und klicken Sie dann auf `Weiter`.
+>>
+>> ![E-Mails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Wählen Sie den Zielordner Ihres Backups aus und geben Sie einen Namen für dieses ein, indem Sie auf `Durchsuchen` klicken. Wählen Sie die für Sie passende Option aus und klicken Sie dann auf `Beenden`.
+>>
+>> ![E-Mails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> Der Export Ihrer Datei beginnt. Bei der Erstellung einer Datei werden Sie aufgefordert, ein Passwort festzulegen (optional).
+>>
+>> ![E-Mails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Importieren**
+>>
+>> - Klicken Sie oben links auf `Datei`, dann auf `Öffnen und Exportieren` und dann auf `importieren/exportieren`.
+>>
+>> ![E-Mails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Wählen Sie `Aus einem anderen Programm oder einer anderen Datei importieren` und klicken Sie dann auf `Weiter`.
+>>
+>> ![E-Mails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Wählen Sie `Outlook Datendatei (.pst)` und klicken Sie auf `Weiter`.
+>>
+>> ![E-Mails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Wählen Sie Ihre Backup-Datei aus, indem Sie auf `Durchsuchen` klicken. Wählen Sie die für Sie passende Option aus und klicken Sie dann auf `Beenden`.
+>>
+>> ![E-Mails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - Wenn Sie ein Passwort in Ihrer Backup-Datei festgelegt haben, geben Sie dieses ein und klicken Sie dann auf `OK`.
+>>
+>> - Wählen Sie `Elemente in den aktiven Ordner importieren` und klicken Sie dann auf `Beenden`.
+>>
+>> Der Import Ihres Backups beginnt.
 
-![E-Mails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Wählen Sie `Daten in eine Datei exportieren` und klicken Sie dann auf `Weiter`.
-
-![E-Mails](images/outlook-export-win02.png){.thumbnail}
-
-- Wählen Sie `Outlook Datendatei (.pst)` und klicken Sie auf `Weiter`.
-
-![E-Mails](images/outlook-export-win03.png){.thumbnail}
-
-- Wählen Sie den Namen des zu exportierenden E-Mail-Accounts aus.
-
-> [!primary]
-> Sie können nur einen Account gleichzeitig exportieren.
-
-Setzen Sie ein Häkchen bei `Unterordner einbeziehen` und klicken Sie dann auf `Weiter`.
-
-![E-Mails](images/outlook-export-win04.png){.thumbnail}
-
-- Wählen Sie den Zielordner Ihres Backups aus und geben Sie einen Namen für dieses ein, indem Sie auf `Durchsuchen` klicken. Wählen Sie die für Sie passende Option aus und klicken Sie dann auf `Beenden`.
-
-![E-Mails](images/outlook-export-win05.png){.thumbnail}
-
-Der Export Ihrer Datei beginnt. Bei der Erstellung einer Datei werden Sie aufgefordert, ein Passwort festzulegen (optional).
-
-![E-Mails](images/outlook-export-win06.png){.thumbnail}
-
-#### Von Windows importieren
-
-- Klicken Sie oben links auf `Datei`, dann auf `Öffnen und Exportieren` und dann auf `importieren/exportieren`.
-
-![E-Mails](images/outlook-export-import-win.png){.thumbnail}
-
-- Wählen Sie `Aus einem anderen Programm oder einer anderen Datei importieren` und klicken Sie dann auf `Weiter`.
-
-![E-Mails](images/outlook-import-win02.png){.thumbnail}
-
-- Wählen Sie `Outlook Datendatei (.pst)` und klicken Sie auf `Weiter`.
-
-![E-Mails](images/outlook-import-win03.png){.thumbnail}
-
-- Wählen Sie Ihre Backup-Datei aus, indem Sie auf `Durchsuchen` klicken. Wählen Sie die für Sie passende Option aus und klicken Sie dann auf `Beenden`.
-
-![E-Mails](images/outlook-import-win04.png){.thumbnail}
-
-- Wenn Sie ein Passwort in Ihrer Backup-Datei festgelegt haben, geben Sie dieses ein und klicken Sie dann auf `OK`.
-
-- Wählen Sie `Elemente in den aktiven Ordner importieren` und klicken Sie dann auf `Beenden`.
-
-Der Import Ihres Backups beginnt.
-
-#### Über Mac OS exportieren
-
-Klicken Sie im Tab `Werkzeuge` in Ihrem Outlook-Fenster auf `Exportieren`.
-
-![E-Mails](images/outlook-export-mac01.png){.thumbnail}
-
-Wählen Sie im Fenster "In eine Archivdatei (.olm) exportieren" die Elemente aus, die Sie zu Ihrer Backup-Datei hinzufügen möchten, und klicken Sie dann auf `Weiter`.
-
-![E-Mails](images/outlook-export-mac02.png){.thumbnail}
-
-Wählen Sie anschließend den Zielordner für Ihr Backup aus und klicken Sie auf `Speichern`.
-
-![E-Mails](images/outlook-export-mac03.png){.thumbnail}
-
-Es wird ein Fortschrittsfenster angezeigt, klicken Sie auf `Am` Ende der Operation fortfahren. Sie finden Ihre Backup-Datei im zuvor gewählten Ordner.
-
-#### Von Mac OS importieren
-
-Klicken Sie im Tab `Werkzeuge` in Ihrem Outlook-Fenster auf `Importieren`.
-
-![E-Mails](images/outlook-import-mac01.png){.thumbnail}
-
-Wählen Sie das Backup-Format aus, das Sie importieren möchten, und klicken Sie dann auf `Weiter`.
-
-![E-Mails](images/outlook-import-mac02.png){.thumbnail}
-
-Wählen Sie Ihre Backup-Datei aus und klicken Sie dann auf `importieren`.
-
-![E-Mails](images/outlook-import-mac03.png){.thumbnail}
-
-Es wird ein Fortschrittsfenster angezeigt. Klicken Sie auf am Ende der Operation auf `Weiter`.
+> [!tabs]
+> **Exportieren**
+>>
+>> Klicken Sie im Tab `Werkzeuge` in Ihrem Outlook-Fenster auf `Exportieren`.
+>>
+>> ![E-Mails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> Wählen Sie im Fenster "In eine Archivdatei (.olm) exportieren" die Elemente aus, die Sie zu Ihrer Backup-Datei hinzufügen möchten, und klicken Sie dann auf `Weiter`.
+>>
+>> ![E-Mails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Wählen Sie anschließend den Zielordner für Ihr Backup aus und klicken Sie auf `Speichern`.
+>>
+>> ![E-Mails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> Es wird ein Fortschrittsfenster angezeigt, klicken Sie auf Am Ende der Operation fortfahren. Sie finden Ihre Backup-Datei im zuvor gewählten Ordner.
+>>
+> **Importieren**
+>>
+>> Klicken Sie im Tab `Werkzeuge` in Ihrem Outlook-Fenster auf `Importieren`.
+>>
+>> ![E-Mails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Wählen Sie das Backup-Format aus, das Sie importieren möchten, und klicken Sie dann auf `Weiter`.
+>>
+>> ![E-Mails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Wählen Sie Ihre Backup-Datei aus und klicken Sie dann auf `importieren`.
+>>
+>> ![E-Mails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> Es wird ein Fortschrittsfenster angezeigt. Klicken Sie am Ende der Operation auf `Weiter`.
 
 ### Mail auf Mac OS
 
-#### Exportieren
-
-Wählen Sie in der linken Spalte einen oder mehrere E-Mail-Accounts aus. Klicken Sie im horizontalen Menü auf `Mailbox` und dann auf `Mailbox exportieren`.
-
-![E-Mails](images/mail-export-mac01.png){.thumbnail}
-
-Wählen Sie den Ordner Ihrer Wahl aus oder erstellen Sie einen neuen Ordner und klicken Sie dann auf `Auswählen`.
-
-![E-Mails](images/mail-export-mac02.png){.thumbnail}
-
-Ihre Ausfuhr erfolgt in Form einer ".mbox" Datei.
-
-#### Importieren
-
-Klicken Sie `im` horizontalen Menü auf Datei und dann auf `Briefkästen importieren`.
-
-![E-Mails](images/mail-import-mac01.png){.thumbnail}
-
-Wählen Sie Ihre Backup-Datei im Format ".mbox" aus und klicken Sie dann auf `Weiter`.
-
-![E-Mails](images/mail-import-mac02.png){.thumbnail}
-
-In der linken Spalte befinden sich die importierten E-Mails in einem neuen E-Mail-Account namens "Import". Sie können die Ordner und Nachrichten vom Import-Account auf Ihre bereits konfigurierten E-Mail-Accounts verschieben. Sobald Ihre Transfers abgeschlossen sind, können Sie den Account "Import" löschen.
+> [!tabs]
+> **Exportieren**
+>>
+>> Wählen Sie in der linken Spalte einen oder mehrere E-Mail-Accounts aus. Klicken Sie im horizontalen Menü auf `Mailbox` und dann auf `Mailbox exportieren`.
+>>
+>> ![E-Mails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Wählen Sie den Ordner Ihrer Wahl aus oder erstellen Sie einen neuen Ordner und klicken Sie dann auf `Auswählen`.
+>>
+>> ![E-Mails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> Ihre Ausfuhr erfolgt in Form einer ".mbox" Datei.
+>>
+> **Importieren**
+>>
+>> Klicken Sie im horizontalen Menü auf Datei und dann auf `Briefkästen importieren`.
+>>
+>> ![E-Mails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Wählen Sie Ihre Backup-Datei im Format ".mbox" aus und klicken Sie dann auf `Weiter`.
+>>
+>> ![E-Mails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> In der linken Spalte befinden sich die importierten E-Mails in einem neuen E-Mail-Account namens "Import". Sie können die Ordner und Nachrichten vom Import-Account auf Ihre bereits konfigurierten E-Mail-Accounts verschieben. Sobald Ihre Transfers abgeschlossen sind, können Sie den Account "Import" löschen.
 
 ### Thunderbird
 
 Es gibt derzeit keine native Funktion zum Export oder Import eines E-Mail-Accounts aus Thunderbird. Es ist jedoch möglich, ein Thunderbird-Profil zu sichern. Es enthält alle Accounts und E-Mails auf Ihrem lokalen Computer. Der folgende Abschnitt erklärt, wie ein Thunderbird-Profil gesichert und es in eine neue Thunderbird-Instanz integriert wird.
 
-#### Exportieren
-
-Klicken Sie im Hauptfenster oben rechts auf das Menü, dann auf `Hilfe` und schließlich auf `Troubleshooting Information`.
-
-![E-Mails](images/thunderbird_menu.png){.thumbnail}
-
-Es erscheint eine Tabelle. Wählen Sie die Zeile `Profilverzeichnis` aus und klicken Sie auf den Button `Den zugehörigen Ordner öffnen`.
-
-![E-Mails](images/thunderbird_open_folder.png){.thumbnail}
-
-Sie werden dann zum Profilordner geleitet. Gehen Sie von einem Ordner in die Baumstruktur.
-
-![E-Mails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Kopieren Sie den Profilordner mit einem Rechtsklick auf diesen und fügen Sie diesen Ordner in den Ordner oder Support Ihrer Wahl ein.
-
-![E-Mails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importieren
-
-Statt einzelne Elemente zu importieren, wird hier ein komplettes Profil eingespielt.<br>
-Wenn E-Mail-Accounts auf der Ziel-Thunderbird-Instanz eingerichtet sind, gehören diese zum bereits aktiven Profil (Profil A).
-Wenn Thunderbird ein neues Profil (Profil B) öffnen soll, können **nur** die Elemente dieses Profils B geladen werden.
-Daher empfehlen wir Ihnen, zuerst das neue Profil (Profil B) zu laden und die E-Mail-Accounts aus Profil A darauf zu konfigurieren.
-
-Starten Sie zuerst Thunderbird über die Profilverwaltung.
-
-- Gehen Sie in Windows ins Startmenü und dann auf `Ausführen`. Geben Sie dort `thunderbird.exe -ProfileManager` ein und klicken Sie auf `OK`.
-
-![E-Mails](images/thunderbird-run-profil.png){.thumbnail}
-
-- Starten Sie auf Mac OS die Terminal-Anwendung und legen Sie dann Ihre Thunderbird-Anwendung im Fenster des Terminals ab, indem Sie `/Contents/MacOS/thunderbird-bin -ProfileManager` einfügen. Klicken Sie auf `Enter` (⏎), um zu bestätigen.
-
-![E-Mails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-Im folgenden Fenster werden die vorhandenen Profile angezeigt. Klicken Sie auf `Profil erstellen` und dann auf `Weiter`, wenn die Informationsnachricht angezeigt wird.
-
-![E-Mails](images/thunderbird-profil-create01.png){.thumbnail}
-
-Im nächsten Schritt benennen Sie Ihr Profil und identifizieren Sie den Ordner, in dem das Profil erstellt wird unterhalb von "Ihre Benutzereinstellungen, Einstellungen und weitere persönlichen Daten werden gespeichert in:".
-
-![E-Mails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> Wir empfehlen Ihnen, die Sicherung Ihres Thunderbird-Profils in den Thunderbird-Profilordner zu kopieren.
-
-Klicken Sie auf `Ordner auswählen...` um den Ordner auszuwählen, der Ihr Backup enthält. Klicken Sie auf `Beenden`, um das Profil mit Ihrem Backup zu erstellen.
-
-Sie finden das Fenster zur Auswahl Ihres Profils mit Ihrem neuen ausgewählten Profil. Klicken Sie auf `Thunderbird starten`, Thunderbird wird mit allen Elementen, die Sie in Ihrem Backup hatten, gestartet.
+> [!tabs]
+> **Exportieren**
+>>
+>> Klicken Sie im Hauptfenster oben rechts auf das Menü, dann auf `Hilfe` und schließlich auf `Troubleshooting Information`.
+>>
+>> ![E-Mails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> Es erscheint eine Tabelle. Wählen Sie die Zeile `Profilverzeichnis` aus und klicken Sie auf den Button `Den zugehörigen Ordner öffnen`.
+>>
+>> ![E-Mails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> Sie werden dann zum Profilordner geleitet. Gehen Sie von einem Ordner in die Baumstruktur.
+>>
+>> ![E-Mails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Kopieren Sie den Profilordner mit einem Rechtsklick auf diesen und fügen Sie diesen Ordner in den Ordner oder Support Ihrer Wahl ein.
+>>
+>> ![E-Mails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Importieren**
+>>
+>> Statt einzelne Elemente zu importieren, wird hier ein komplettes Profil eingespielt.
+>> Wenn E-Mail-Accounts auf der Ziel-Thunderbird-Instanz eingerichtet sind, gehören diese zum bereits aktiven Profil (Profil A).
+>> Wenn Thunderbird ein neues Profil (Profil B) öffnen soll, können **nur** die Elemente dieses Profils B geladen werden.
+>> Daher empfehlen wir Ihnen, zuerst das neue Profil (Profil B) zu laden und die E-Mail-Accounts aus Profil A darauf zu konfigurieren.
+>>
+>> Starten Sie zuerst Thunderbird über die Profilverwaltung.
+>>
+>> - Gehen Sie in Windows ins Startmenü und dann auf `Ausführen`. Geben Sie dort `thunderbird.exe -ProfileManager` ein und klicken Sie auf `OK`.
+>>
+>> ![E-Mails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - Starten Sie auf Mac OS die Terminal-Anwendung und legen Sie dann Ihre Thunderbird-Anwendung im Fenster des Terminals ab, indem Sie `/Contents/MacOS/thunderbird-bin -ProfileManager` einfügen. Klicken Sie auf `Enter` (⏎), um zu bestätigen.
+>>
+>> ![E-Mails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> Im folgenden Fenster werden die vorhandenen Profile angezeigt. Klicken Sie auf `Profil erstellen` und dann auf `Weiter`, wenn die Informationsnachricht angezeigt wird.
+>>
+>> ![E-Mails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> Im nächsten Schritt benennen Sie Ihr Profil und identifizieren Sie den Ordner, in dem das Profil erstellt wird unterhalb von "Ihre Benutzereinstellungen, Einstellungen und weitere persönlichen Daten werden gespeichert in:".
+>>
+>> ![E-Mails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > Wir empfehlen Ihnen, die Sicherung Ihres Thunderbird-Profils in den Thunderbird-Profilordner zu kopieren.
+>>
+>> Klicken Sie auf `Ordner auswählen...` um den Ordner auszuwählen, der Ihr Backup enthält. Klicken Sie auf `Beenden`, um das Profil mit Ihrem Backup zu erstellen.
+>>
+>> Sie finden das Fenster zur Auswahl Ihres Profils mit Ihrem neuen ausgewählten Profil. Klicken Sie auf `Thunderbird starten`, Thunderbird wird mit allen Elementen, die Sie in Ihrem Backup hatten, gestartet.
 
 ### Import auf der neuen E-Mail-Adresse überprüfen
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-asia.md
@@ -52,15 +52,15 @@ The following instructions are divided into two parts:
 > [!tabs]
 > **Export**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Export to a file` and then click `Next`.
+>> - Select `Export to a file`{.action} and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -69,11 +69,11 @@ The following instructions are divided into two parts:
 >> > [!primary]
 >> > You can only export one account at a time.
 >>
->> Select `Include subfolders`, then click `Next`.
+>> Select `Include subfolders`{.action}, then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`{.action}. Select the option you want, and then click `Finish`{.action}.
 >>
 >> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -83,25 +83,25 @@ The following instructions are divided into two parts:
 >>
 > **Import**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Import from another program or file` and click `Next`.
+>> - Select `Import from another program or file`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>> - Choose your backup file by clicking `Browse`{.action}. Select the option you want, and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - If you need to set a password on your backup file, enter the password and click `OK`.
+>> - If you need to set a password on your backup file, enter the password and click `OK`{.action}.
 >>
->> - Select `Import items to the current folder` and then click `Finish`.
+>> - Select `Import items to the current folder`{.action} and then click `Finish`{.action}.
 >>
 >> Your backup will be imported.
 
@@ -110,46 +110,46 @@ The following instructions are divided into two parts:
 > [!tabs]
 > **Export**
 >>
->> In the `Tools` tab of your Outlook window, click `Export`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Export`{.action}.
 >>
 >> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Then select the destination folder for your backup, and click `Save`.
+>> Then select the destination folder for your backup, and click `Save`{.action}.
 >>
 >> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. You will find your backup file in the folder you selected earlier.
 >>
 > **Import**
 >>
->> In the `Tools` tab of your Outlook window, click `Import`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Choose the backup format you want to import, and then click `Continue`.
+>> Choose the backup format you want to import, and then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Select your backup file, and then click `import`.
+>> Select your backup file, and then click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
 > [!tabs]
 > **Export**
 >>
->> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>> In the left-hand column, select one or more email accounts. Click `Mailbox`{.action} in the horizontal menu, and then click `Export Mailbox`{.action}.
 >>
 >> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Select the folder you want, or create a new folder, and then click `Choose`.
+>> Select the folder you want, or create a new folder, and then click `Choose`{.action}.
 >>
 >> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -157,11 +157,11 @@ The following instructions are divided into two parts:
 >>
 > **Import**
 >>
->> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>> Click `File`{.action} on the horizontal menu, and then click `Import Mailboxes`{.action}.
 >>
 >> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Select your .mbox backup file, and then click `Continue`.
+>> Select your .mbox backup file, and then click `Continue`{.action}.
 >>
 >> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -174,11 +174,11 @@ There is currently no native feature to export or import an email account from T
 > [!tabs]
 > **Export**
 >>
->> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>> In the main window, click on the menu in the top right-hand corner, then `Help`{.action}, then `Troubleshooting Information`{.action}.
 >>
 >> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>> A table appears. Identify the `Profile Folder`{.action} line and click the `Open Folder`{.action} button.
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -199,7 +199,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> You must first start Thunderbird via the profile manager.
 >>
->> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>> - On Windows, go to the `Start`{.action} menu and open the `Run`{.action} application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
@@ -207,7 +207,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>> The following window displays the existing profiles. Click `Create Profile`{.action} and then click `Next`{.action} when the information message appears.
 >>
 >> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -218,9 +218,9 @@ There is currently no native feature to export or import an email account from T
 >> > [!primary]
 >> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
 >>
->> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>> Click `Choose Folder...`{.action} to select the folder that contains your backup. Click `Finish`{.action} to create the profile with your backup.
 >>
->> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`{.action}, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-asia.md
@@ -47,172 +47,180 @@ The following instructions are divided into two parts:
 
 ### Outlook
 
-#### Exporting from Windows
+#### Windows
 
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+> [!tabs]
+> **Export**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Export to a file` and then click `Next`.
+>>
+>> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Select the name of the email account to export.
+>>
+>> > [!primary]
+>> > You can only export one account at a time.
+>>
+>> Select `Include subfolders`, then click `Next`.
+>>
+>> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>>
+>> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
+>>
+>> ![emails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Import from another program or file` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>>
+>> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - If you need to set a password on your backup file, enter the password and click `OK`.
+>>
+>> - Select `Import items to the current folder` and then click `Finish`.
+>>
+>> Your backup will be imported.
 
-![emails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Select `Export to a file` and then click `Next`.
-
-![emails](images/outlook-export-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-export-win03.png){.thumbnail}
-
-- Select the name of the email account to export.
-
-> [!primary]
-> You can only export one account at a time.
-
-Select `Include subfolders`, then click `Next`.
-
-![emails](images/outlook-export-win04.png){.thumbnail}
-
-- Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
-
-![emails](images/outlook-export-win05.png){.thumbnail}
-
-Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
-
-![emails](images/outlook-export-win06.png){.thumbnail}
-
-#### Importing from Windows
-
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
-
-![emails](images/outlook-export-import-win.png){.thumbnail}
-
-- Select `Import from another program or file` and click `Next`.
-
-![emails](images/outlook-import-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-import-win03.png){.thumbnail}
-
-- Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
-
-![emails](images/outlook-import-win04.png){.thumbnail}
-
-- If you need to set a password on your backup file, enter the password and click `OK`.
-
-- Select `Import items to the current folder` and then click `Finish`.
-
-Your backup will be imported.
-
-#### Exporting from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Export`.
-
-![emails](images/outlook-export-mac01.png){.thumbnail}
-
-In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
-
-![emails](images/outlook-export-mac02.png){.thumbnail}
-
-Then select the destination folder for your backup, and click `Save`.
-
-![emails](images/outlook-export-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
-
-#### Importing from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Import`.
-
-![emails](images/outlook-import-mac01.png){.thumbnail}
-
-Choose the backup format you want to import, and then click `Continue`.
-
-![emails](images/outlook-import-mac02.png){.thumbnail}
-
-Select your backup file, and then click `import`.
-
-![emails](images/outlook-import-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+> [!tabs]
+> **Export**
+>>
+>> In the `Tools` tab of your Outlook window, click `Export`.
+>>
+>> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>>
+>> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Then select the destination folder for your backup, and click `Save`.
+>>
+>> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>>
+> **Import**
+>>
+>> In the `Tools` tab of your Outlook window, click `Import`.
+>>
+>> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Choose the backup format you want to import, and then click `Continue`.
+>>
+>> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Select your backup file, and then click `import`.
+>>
+>> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
-#### Exporting
-
-In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
-
-![emails](images/mail-export-mac01.png){.thumbnail}
-
-Select the folder you want, or create a new folder, and then click `Choose`.
-
-![emails](images/mail-export-mac02.png){.thumbnail}
-
-Your export is in the form of a .mbox file.
-
-#### Importing
-
-Click `File` on the horizontal menu, and then click `Import Mailboxes`.
-
-![emails](images/mail-import-mac01.png){.thumbnail}
-
-Select your .mbox backup file, and then click `Continue`.
-
-![emails](images/mail-import-mac02.png){.thumbnail}
-
-In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
+> [!tabs]
+> **Export**
+>>
+>> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>>
+>> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Select the folder you want, or create a new folder, and then click `Choose`.
+>>
+>> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> Your export is in the form of a .mbox file.
+>>
+> **Import**
+>>
+>> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>>
+>> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Select your .mbox backup file, and then click `Continue`.
+>>
+>> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
 
 ### Thunderbird
 
 There is currently no native feature to export or import an email account from Thunderbird. However, you can save a Thunderbird profile. It contains all accounts and emails locally stored on your computer. We will look at how to back up a Thunderbird profile and reintegrate it into a new Thunderbird instance.
 
-#### Exporting
-
-In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
-
-![emails](images/thunderbird_menu.png){.thumbnail}
-
-A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
-
-![emails](images/thunderbird_open_folder.png){.thumbnail}
-
-You will then be directed to the profile folder. Move up one folder in the tree.
-
-![emails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Right-click the profile folder and paste it into the folder or media of your choice.
-
-![emails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importing
-
-Rather than an import, this will be a profile load.<br>
-If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
-When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
-For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
-
-You must first start Thunderbird via the profile manager.
-
-- On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
-
-![emails](images/thunderbird-run-profil.png){.thumbnail}
-
-- On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
-
-![emails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
-
-![emails](images/thunderbird-profil-create01.png){.thumbnail}
-
-In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
-
-![emails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
-
-Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
-
-You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+> [!tabs]
+> **Export**
+>>
+>> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>>
+>> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>>
+>> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> You will then be directed to the profile folder. Move up one folder in the tree.
+>>
+>> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Right-click the profile folder and paste it into the folder or media of your choice.
+>>
+>> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> Rather than an import, this will be a profile load.
+>> If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
+>> When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
+>> For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
+>>
+>> You must first start Thunderbird via the profile manager.
+>>
+>> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>>
+>> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
+>>
+>> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>>
+>> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
+>>
+>> ![emails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
+>>
+>> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>>
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-au.md
@@ -52,15 +52,15 @@ The following instructions are divided into two parts:
 > [!tabs]
 > **Export**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Export to a file` and then click `Next`.
+>> - Select `Export to a file`{.action} and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -69,11 +69,11 @@ The following instructions are divided into two parts:
 >> > [!primary]
 >> > You can only export one account at a time.
 >>
->> Select `Include subfolders`, then click `Next`.
+>> Select `Include subfolders`{.action}, then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`{.action}. Select the option you want, and then click `Finish`{.action}.
 >>
 >> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -83,25 +83,25 @@ The following instructions are divided into two parts:
 >>
 > **Import**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Import from another program or file` and click `Next`.
+>> - Select `Import from another program or file`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>> - Choose your backup file by clicking `Browse`{.action}. Select the option you want, and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - If you need to set a password on your backup file, enter the password and click `OK`.
+>> - If you need to set a password on your backup file, enter the password and click `OK`{.action}.
 >>
->> - Select `Import items to the current folder` and then click `Finish`.
+>> - Select `Import items to the current folder`{.action} and then click `Finish`{.action}.
 >>
 >> Your backup will be imported.
 
@@ -110,46 +110,46 @@ The following instructions are divided into two parts:
 > [!tabs]
 > **Export**
 >>
->> In the `Tools` tab of your Outlook window, click `Export`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Export`{.action}.
 >>
 >> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Then select the destination folder for your backup, and click `Save`.
+>> Then select the destination folder for your backup, and click `Save`{.action}.
 >>
 >> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. You will find your backup file in the folder you selected earlier.
 >>
 > **Import**
 >>
->> In the `Tools` tab of your Outlook window, click `Import`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Choose the backup format you want to import, and then click `Continue`.
+>> Choose the backup format you want to import, and then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Select your backup file, and then click `import`.
+>> Select your backup file, and then click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
 > [!tabs]
 > **Export**
 >>
->> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>> In the left-hand column, select one or more email accounts. Click `Mailbox`{.action} in the horizontal menu, and then click `Export Mailbox`{.action}.
 >>
 >> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Select the folder you want, or create a new folder, and then click `Choose`.
+>> Select the folder you want, or create a new folder, and then click `Choose`{.action}.
 >>
 >> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -157,11 +157,11 @@ The following instructions are divided into two parts:
 >>
 > **Import**
 >>
->> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>> Click `File`{.action} on the horizontal menu, and then click `Import Mailboxes`{.action}.
 >>
 >> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Select your .mbox backup file, and then click `Continue`.
+>> Select your .mbox backup file, and then click `Continue`{.action}.
 >>
 >> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -174,11 +174,11 @@ There is currently no native feature to export or import an email account from T
 > [!tabs]
 > **Export**
 >>
->> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>> In the main window, click on the menu in the top right-hand corner, then `Help`{.action}, then `Troubleshooting Information`{.action}.
 >>
 >> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>> A table appears. Identify the `Profile Folder`{.action} line and click the `Open Folder`{.action} button.
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -199,7 +199,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> You must first start Thunderbird via the profile manager.
 >>
->> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>> - On Windows, go to the `Start`{.action} menu and open the `Run`{.action} application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
@@ -207,7 +207,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>> The following window displays the existing profiles. Click `Create Profile`{.action} and then click `Next`{.action} when the information message appears.
 >>
 >> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -218,9 +218,9 @@ There is currently no native feature to export or import an email account from T
 >> > [!primary]
 >> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
 >>
->> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>> Click `Choose Folder...`{.action} to select the folder that contains your backup. Click `Finish`{.action} to create the profile with your backup.
 >>
->> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`{.action}, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-au.md
@@ -47,172 +47,180 @@ The following instructions are divided into two parts:
 
 ### Outlook
 
-#### Exporting from Windows
+#### Windows
 
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+> [!tabs]
+> **Export**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Export to a file` and then click `Next`.
+>>
+>> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Select the name of the email account to export.
+>>
+>> > [!primary]
+>> > You can only export one account at a time.
+>>
+>> Select `Include subfolders`, then click `Next`.
+>>
+>> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>>
+>> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
+>>
+>> ![emails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Import from another program or file` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>>
+>> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - If you need to set a password on your backup file, enter the password and click `OK`.
+>>
+>> - Select `Import items to the current folder` and then click `Finish`.
+>>
+>> Your backup will be imported.
 
-![emails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Select `Export to a file` and then click `Next`.
-
-![emails](images/outlook-export-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-export-win03.png){.thumbnail}
-
-- Select the name of the email account to export.
-
-> [!primary]
-> You can only export one account at a time.
-
-Select `Include subfolders`, then click `Next`.
-
-![emails](images/outlook-export-win04.png){.thumbnail}
-
-- Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
-
-![emails](images/outlook-export-win05.png){.thumbnail}
-
-Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
-
-![emails](images/outlook-export-win06.png){.thumbnail}
-
-#### Importing from Windows
-
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
-
-![emails](images/outlook-export-import-win.png){.thumbnail}
-
-- Select `Import from another program or file` and click `Next`.
-
-![emails](images/outlook-import-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-import-win03.png){.thumbnail}
-
-- Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
-
-![emails](images/outlook-import-win04.png){.thumbnail}
-
-- If you need to set a password on your backup file, enter the password and click `OK`.
-
-- Select `Import items to the current folder` and then click `Finish`.
-
-Your backup will be imported.
-
-#### Exporting from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Export`.
-
-![emails](images/outlook-export-mac01.png){.thumbnail}
-
-In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
-
-![emails](images/outlook-export-mac02.png){.thumbnail}
-
-Then select the destination folder for your backup, and click `Save`.
-
-![emails](images/outlook-export-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
-
-#### Importing from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Import`.
-
-![emails](images/outlook-import-mac01.png){.thumbnail}
-
-Choose the backup format you want to import, and then click `Continue`.
-
-![emails](images/outlook-import-mac02.png){.thumbnail}
-
-Select your backup file, and then click `import`.
-
-![emails](images/outlook-import-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+> [!tabs]
+> **Export**
+>>
+>> In the `Tools` tab of your Outlook window, click `Export`.
+>>
+>> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>>
+>> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Then select the destination folder for your backup, and click `Save`.
+>>
+>> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>>
+> **Import**
+>>
+>> In the `Tools` tab of your Outlook window, click `Import`.
+>>
+>> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Choose the backup format you want to import, and then click `Continue`.
+>>
+>> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Select your backup file, and then click `import`.
+>>
+>> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
-#### Exporting
-
-In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
-
-![emails](images/mail-export-mac01.png){.thumbnail}
-
-Select the folder you want, or create a new folder, and then click `Choose`.
-
-![emails](images/mail-export-mac02.png){.thumbnail}
-
-Your export is in the form of a .mbox file.
-
-#### Importing
-
-Click `File` on the horizontal menu, and then click `Import Mailboxes`.
-
-![emails](images/mail-import-mac01.png){.thumbnail}
-
-Select your .mbox backup file, and then click `Continue`.
-
-![emails](images/mail-import-mac02.png){.thumbnail}
-
-In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
+> [!tabs]
+> **Export**
+>>
+>> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>>
+>> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Select the folder you want, or create a new folder, and then click `Choose`.
+>>
+>> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> Your export is in the form of a .mbox file.
+>>
+> **Import**
+>>
+>> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>>
+>> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Select your .mbox backup file, and then click `Continue`.
+>>
+>> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
 
 ### Thunderbird
 
 There is currently no native feature to export or import an email account from Thunderbird. However, you can save a Thunderbird profile. It contains all accounts and emails locally stored on your computer. We will look at how to back up a Thunderbird profile and reintegrate it into a new Thunderbird instance.
 
-#### Exporting
-
-In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
-
-![emails](images/thunderbird_menu.png){.thumbnail}
-
-A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
-
-![emails](images/thunderbird_open_folder.png){.thumbnail}
-
-You will then be directed to the profile folder. Move up one folder in the tree.
-
-![emails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Right-click the profile folder and paste it into the folder or media of your choice.
-
-![emails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importing
-
-Rather than an import, this will be a profile load.<br>
-If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
-When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
-For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
-
-You must first start Thunderbird via the profile manager.
-
-- On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
-
-![emails](images/thunderbird-run-profil.png){.thumbnail}
-
-- On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
-
-![emails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
-
-![emails](images/thunderbird-profil-create01.png){.thumbnail}
-
-In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
-
-![emails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
-
-Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
-
-You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+> [!tabs]
+> **Export**
+>>
+>> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>>
+>> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>>
+>> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> You will then be directed to the profile folder. Move up one folder in the tree.
+>>
+>> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Right-click the profile folder and paste it into the folder or media of your choice.
+>>
+>> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> Rather than an import, this will be a profile load.
+>> If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
+>> When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
+>> For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
+>>
+>> You must first start Thunderbird via the profile manager.
+>>
+>> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>>
+>> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
+>>
+>> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>>
+>> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
+>>
+>> ![emails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
+>>
+>> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>>
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ca.md
@@ -58,184 +58,188 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-1. Log in to your [OVHcloud Control Panel](/links/manager).
-1. Open the `Web Cloud`{.action} section.
-1. In the `MICROSOFT` section, click `Exchange`{.action}.
-1. Select the service concerned.
-1. In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
+In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
 
-![emails](images/manager-export-pst01.png){.thumbnail}
+![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
 You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export to PST`{.action} button to retrieve a link to download the file.
 
-![emails](images/manager-export-pst02.png){.thumbnail}
+![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Exporting from Windows
+#### Windows
 
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+> [!tabs]
+> **Export**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Export to a file` and then click `Next`.
+>>
+>> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Select the name of the email account to export.
+>>
+>> > [!primary]
+>> > You can only export one account at a time.
+>>
+>> Select `Include subfolders`, then click `Next`.
+>>
+>> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>>
+>> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
+>>
+>> ![emails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Import from another program or file` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>>
+>> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - If you need to set a password on your backup file, enter the password and click `OK`.
+>>
+>> - Select `Import items to the current folder` and then click `Finish`.
+>>
+>> Your backup will be imported.
 
-![emails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Select `Export to a file` and then click `Next`.
-
-![emails](images/outlook-export-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-export-win03.png){.thumbnail}
-
-- Select the name of the email account to export.
-
-> [!primary]
-> You can only export one account at a time.
-
-Select `Include subfolders`, then click `Next`.
-
-![emails](images/outlook-export-win04.png){.thumbnail}
-
-- Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
-
-![emails](images/outlook-export-win05.png){.thumbnail}
-
-Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
-
-![emails](images/outlook-export-win06.png){.thumbnail}
-
-#### Importing from Windows
-
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
-
-![emails](images/outlook-export-import-win.png){.thumbnail}
-
-- Select `Import from another program or file` and click `Next`.
-
-![emails](images/outlook-import-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-import-win03.png){.thumbnail}
-
-- Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
-
-![emails](images/outlook-import-win04.png){.thumbnail}
-
-- If you need to set a password on your backup file, enter the password and click `OK`.
-
-- Select `Import items to the current folder` and then click `Finish`.
-
-Your backup will be imported.
-
-#### Exporting from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Export`.
-
-![emails](images/outlook-export-mac01.png){.thumbnail}
-
-In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
-
-![emails](images/outlook-export-mac02.png){.thumbnail}
-
-Then select the destination folder for your backup, and click `Save`.
-
-![emails](images/outlook-export-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
-
-#### Importing from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Import`.
-
-![emails](images/outlook-import-mac01.png){.thumbnail}
-
-Choose the backup format you want to import, and then click `Continue`.
-
-![emails](images/outlook-import-mac02.png){.thumbnail}
-
-Select your backup file, and then click `import`.
-
-![emails](images/outlook-import-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+> [!tabs]
+> **Export**
+>>
+>> In the `Tools` tab of your Outlook window, click `Export`.
+>>
+>> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>>
+>> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Then select the destination folder for your backup, and click `Save`.
+>>
+>> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>>
+> **Import**
+>>
+>> In the `Tools` tab of your Outlook window, click `Import`.
+>>
+>> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Choose the backup format you want to import, and then click `Continue`.
+>>
+>> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Select your backup file, and then click `import`.
+>>
+>> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
-#### Exporting
-
-In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
-
-![emails](images/mail-export-mac01.png){.thumbnail}
-
-Select the folder you want, or create a new folder, and then click `Choose`.
-
-![emails](images/mail-export-mac02.png){.thumbnail}
-
-Your export is in the form of a .mbox file.
-
-#### Importing
-
-Click `File` on the horizontal menu, and then click `Import Mailboxes`.
-
-![emails](images/mail-import-mac01.png){.thumbnail}
-
-Select your .mbox backup file, and then click `Continue`.
-
-![emails](images/mail-import-mac02.png){.thumbnail}
-
-In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
+> [!tabs]
+> **Export**
+>>
+>> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>>
+>> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Select the folder you want, or create a new folder, and then click `Choose`.
+>>
+>> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> Your export is in the form of a .mbox file.
+>>
+> **Import**
+>>
+>> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>>
+>> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Select your .mbox backup file, and then click `Continue`.
+>>
+>> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
 
 ### Thunderbird
 
 There is currently no native feature to export or import an email account from Thunderbird. However, you can save a Thunderbird profile. It contains all accounts and emails locally stored on your computer. We will look at how to back up a Thunderbird profile and reintegrate it into a new Thunderbird instance.
 
-#### Exporting
-
-In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
-
-![emails](images/thunderbird_menu.png){.thumbnail}
-
-A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
-
-![emails](images/thunderbird_open_folder.png){.thumbnail}
-
-You will then be directed to the profile folder. Move up one folder in the tree.
-
-![emails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Right-click the profile folder and paste it into the folder or media of your choice.
-
-![emails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importing
-
-Rather than an import, this will be a profile load.<br>
-If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
-When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
-For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
-
-You must first start Thunderbird via the profile manager.
-
-- On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
-
-![emails](images/thunderbird-run-profil.png){.thumbnail}
-
-- On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
-
-![emails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
-
-![emails](images/thunderbird-profil-create01.png){.thumbnail}
-
-In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
-
-![emails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
-
-Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
-
-You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+> [!tabs]
+> **Export**
+>>
+>> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>>
+>> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>>
+>> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> You will then be directed to the profile folder. Move up one folder in the tree.
+>>
+>> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Right-click the profile folder and paste it into the folder or media of your choice.
+>>
+>> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> Rather than an import, this will be a profile load.
+>> If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
+>> When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
+>> For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
+>>
+>> You must first start Thunderbird via the profile manager.
+>>
+>> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>>
+>> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
+>>
+>> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>>
+>> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
+>>
+>> ![emails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
+>>
+>> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>>
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ca.md
@@ -58,11 +58,11 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export as a .PST`{.action} format.
+Once on your Exchange service page, in the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST format`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export as a .PST`{.action} button to retrieve a link to download the file.
+You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export in PST format`{.action} button to retrieve a link to download the file.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
@@ -71,15 +71,15 @@ You will then need to wait for the export process to complete, which may take fr
 > [!tabs]
 > **Export**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Export to a file` and then click `Next`.
+>> - Select `Export to a file`{.action} and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -88,11 +88,11 @@ You will then need to wait for the export process to complete, which may take fr
 >> > [!primary]
 >> > You can only export one account at a time.
 >>
->> Select `Include subfolders`, then click `Next`.
+>> Select `Include subfolders`{.action}, then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`{.action}. Select the option you want, and then click `Finish`{.action}.
 >>
 >> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -102,25 +102,25 @@ You will then need to wait for the export process to complete, which may take fr
 >>
 > **Import**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Import from another program or file` and click `Next`.
+>> - Select `Import from another program or file`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>> - Choose your backup file by clicking `Browse`{.action}. Select the option you want, and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - If you need to set a password on your backup file, enter the password and click `OK`.
+>> - If you need to set a password on your backup file, enter the password and click `OK`{.action}.
 >>
->> - Select `Import items to the current folder` and then click `Finish`.
+>> - Select `Import items to the current folder`{.action} and then click `Finish`{.action}.
 >>
 >> Your backup will be imported.
 
@@ -129,46 +129,46 @@ You will then need to wait for the export process to complete, which may take fr
 > [!tabs]
 > **Export**
 >>
->> In the `Tools` tab of your Outlook window, click `Export`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Export`{.action}.
 >>
 >> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Then select the destination folder for your backup, and click `Save`.
+>> Then select the destination folder for your backup, and click `Save`{.action}.
 >>
 >> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. You will find your backup file in the folder you selected earlier.
 >>
 > **Import**
 >>
->> In the `Tools` tab of your Outlook window, click `Import`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Choose the backup format you want to import, and then click `Continue`.
+>> Choose the backup format you want to import, and then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Select your backup file, and then click `import`.
+>> Select your backup file, and then click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
 > [!tabs]
 > **Export**
 >>
->> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>> In the left-hand column, select one or more email accounts. Click `Mailbox`{.action} in the horizontal menu, and then click `Export Mailbox`{.action}.
 >>
 >> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Select the folder you want, or create a new folder, and then click `Choose`.
+>> Select the folder you want, or create a new folder, and then click `Choose`{.action}.
 >>
 >> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -176,11 +176,11 @@ You will then need to wait for the export process to complete, which may take fr
 >>
 > **Import**
 >>
->> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>> Click `File`{.action} on the horizontal menu, and then click `Import Mailboxes`{.action}.
 >>
 >> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Select your .mbox backup file, and then click `Continue`.
+>> Select your .mbox backup file, and then click `Continue`{.action}.
 >>
 >> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -193,11 +193,11 @@ There is currently no native feature to export or import an email account from T
 > [!tabs]
 > **Export**
 >>
->> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>> In the main window, click on the menu in the top right-hand corner, then `Help`{.action}, then `Troubleshooting Information`{.action}.
 >>
 >> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>> A table appears. Identify the `Profile Folder`{.action} line and click the `Open Folder`{.action} button.
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -218,7 +218,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> You must first start Thunderbird via the profile manager.
 >>
->> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>> - On Windows, go to the `Start`{.action} menu and open the `Run`{.action} application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
@@ -226,7 +226,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>> The following window displays the existing profiles. Click `Create Profile`{.action} and then click `Next`{.action} when the information message appears.
 >>
 >> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -237,9 +237,9 @@ There is currently no native feature to export or import an email account from T
 >> > [!primary]
 >> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
 >>
->> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>> Click `Choose Folder...`{.action} to select the folder that contains your backup. Click `Finish`{.action} to create the profile with your backup.
 >>
->> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`{.action}, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ca.md
@@ -58,11 +58,11 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
+In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export as a .PST`{.action} format.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export to PST`{.action} button to retrieve a link to download the file.
+You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export as a .PST`{.action} button to retrieve a link to download the file.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-gb.md
@@ -65,11 +65,11 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
+In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export as a .PST`{.action} format.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export to PST`{.action} button to retrieve a link to download the file.
+You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export as a .PST`{.action} button to retrieve a link to download the file.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-gb.md
@@ -223,9 +223,9 @@ There is currently no native feature to export or import an email account from T
 >> When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
 >> For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
 >>
->> You must first start Thunderbird via the profile manager.
+>> First, launch Thunderbird via the Profile Manager.
 >>
->> - On Windows, go to the `Start`{.action} menu and open the `Run`{.action} application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`{.action}.
+>> - On Windows, go to the `Start`{.action} menu and open the `Run`{.action} application. In the Run dialog, type `thunderbird.exe -ProfileManager` and click `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-gb.md
@@ -6,7 +6,7 @@ updated: 2026-01-16
 
 ## Objective
 
-You can [migrate an email address automatically](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm) via our [OVHcloud Mail Migrator](/links/web/omm) tool. You can also manually migrate your email address using an email client.
+You can [migrate an email address automatically](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm) via our [OVHcloud Mail Migrator](/links/web/omm) tool. You can also migrate your email address manually using an email client.
 
 **Find out how to migrate your email address manually.**
 
@@ -65,184 +65,188 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-1. Log in to your [OVHcloud Control Panel](/links/manager).
-1. Open the `Web Cloud`{.action} section.
-1. In the `MICROSOFT` section, click `Exchange`{.action}.
-1. Select the service concerned.
-1. In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
+In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
 
-![emails](images/manager-export-pst01.png){.thumbnail}
+![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
 You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export to PST`{.action} button to retrieve a link to download the file.
 
-![emails](images/manager-export-pst02.png){.thumbnail}
+![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Exporting from Windows
+#### Windows
 
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+> [!tabs]
+> **Export**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Export to a file` and then click `Next`.
+>>
+>> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Select the name of the email account to export.
+>>
+>> > [!primary]
+>> > You can only export one account at a time.
+>>
+>> Select `Include subfolders`, then click `Next`.
+>>
+>> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>>
+>> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
+>>
+>> ![emails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Import from another program or file` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>>
+>> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - If you need to set a password on your backup file, enter the password and click `OK`.
+>>
+>> - Select `Import items to the current folder` and then click `Finish`.
+>>
+>> Your backup will be imported.
 
-![emails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Select `Export to a file` and then click `Next`.
-
-![emails](images/outlook-export-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-export-win03.png){.thumbnail}
-
-- Select the name of the email account to export.
-
-> [!primary]
-> You can only export one account at a time.
-
-Select `Include subfolders`, then click `Next`.
-
-![emails](images/outlook-export-win04.png){.thumbnail}
-
-- Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
-
-![emails](images/outlook-export-win05.png){.thumbnail}
-
-Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
-
-![emails](images/outlook-export-win06.png){.thumbnail}
-
-#### Importing from Windows
-
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
-
-![emails](images/outlook-export-import-win.png){.thumbnail}
-
-- Select `Import from another program or file` and click `Next`.
-
-![emails](images/outlook-import-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-import-win03.png){.thumbnail}
-
-- Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
-
-![emails](images/outlook-import-win04.png){.thumbnail}
-
-- If you need to set a password on your backup file, enter the password and click `OK`.
-
-- Select `Import items to the current folder` and then click `Finish`.
-
-Your backup will be imported.
-
-#### Exporting from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Export`.
-
-![emails](images/outlook-export-mac01.png){.thumbnail}
-
-In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
-
-![emails](images/outlook-export-mac02.png){.thumbnail}
-
-Then select the destination folder for your backup, and click `Save`.
-
-![emails](images/outlook-export-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
-
-#### Importing from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Import`.
-
-![emails](images/outlook-import-mac01.png){.thumbnail}
-
-Choose the backup format you want to import, and then click `Continue`.
-
-![emails](images/outlook-import-mac02.png){.thumbnail}
-
-Select your backup file, and then click `import`.
-
-![emails](images/outlook-import-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+> [!tabs]
+> **Export**
+>>
+>> In the `Tools` tab of your Outlook window, click `Export`.
+>>
+>> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>>
+>> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Then select the destination folder for your backup, and click `Save`.
+>>
+>> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>>
+> **Import**
+>>
+>> In the `Tools` tab of your Outlook window, click `Import`.
+>>
+>> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Choose the backup format you want to import, and then click `Continue`.
+>>
+>> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Select your backup file, and then click `import`.
+>>
+>> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
-#### Exporting
-
-In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
-
-![emails](images/mail-export-mac01.png){.thumbnail}
-
-Select the folder you want, or create a new folder, and then click `Choose`.
-
-![emails](images/mail-export-mac02.png){.thumbnail}
-
-Your export is in the form of a .mbox file.
-
-#### Importing
-
-Click `File` on the horizontal menu, and then click `Import Mailboxes`.
-
-![emails](images/mail-import-mac01.png){.thumbnail}
-
-Select your .mbox backup file, and then click `Continue`.
-
-![emails](images/mail-import-mac02.png){.thumbnail}
-
-In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
+> [!tabs]
+> **Export**
+>>
+>> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>>
+>> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Select the folder you want, or create a new folder, and then click `Choose`.
+>>
+>> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> Your export is in the form of a .mbox file.
+>>
+> **Import**
+>>
+>> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>>
+>> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Select your .mbox backup file, and then click `Continue`.
+>>
+>> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
 
 ### Thunderbird
 
 There is currently no native feature to export or import an email account from Thunderbird. However, you can save a Thunderbird profile. It contains all accounts and emails locally stored on your computer. We will look at how to back up a Thunderbird profile and reintegrate it into a new Thunderbird instance.
 
-#### Exporting
-
-In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
-
-![emails](images/thunderbird_menu.png){.thumbnail}
-
-A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
-
-![emails](images/thunderbird_open_folder.png){.thumbnail}
-
-You will then be directed to the profile folder. Move up one folder in the tree.
-
-![emails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Right-click the profile folder and paste it into the folder or media of your choice.
-
-![emails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importing
-
-Rather than an import, this will be a profile load.<br>
-If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
-When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
-For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
-
-You must first start Thunderbird via the profile manager.
-
-- On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
-
-![emails](images/thunderbird-run-profil.png){.thumbnail}
-
-- On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
-
-![emails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
-
-![emails](images/thunderbird-profil-create01.png){.thumbnail}
-
-In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
-
-![emails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
-
-Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
-
-You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+> [!tabs]
+> **Export**
+>>
+>> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>>
+>> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>>
+>> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> You will then be directed to the profile folder. Move up one folder in the tree.
+>>
+>> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Right-click the profile folder and paste it into the folder or media of your choice.
+>>
+>> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> Rather than an import, this will be a profile load.
+>> If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
+>> When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
+>> For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
+>>
+>> You must first start Thunderbird via the profile manager.
+>>
+>> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>>
+>> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
+>>
+>> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>>
+>> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
+>>
+>> ![emails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
+>>
+>> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>>
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-gb.md
@@ -65,11 +65,11 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export as a .PST`{.action} format.
+Once on your Exchange service page, in the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST format`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export as a .PST`{.action} button to retrieve a link to download the file.
+You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export in PST format`{.action} button to retrieve a link to download the file.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
@@ -78,15 +78,15 @@ You will then need to wait for the export process to complete, which may take fr
 > [!tabs]
 > **Export**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Export to a file` and then click `Next`.
+>> - Select `Export to a file`{.action} and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -95,11 +95,11 @@ You will then need to wait for the export process to complete, which may take fr
 >> > [!primary]
 >> > You can only export one account at a time.
 >>
->> Select `Include subfolders`, then click `Next`.
+>> Select `Include subfolders`{.action}, then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`{.action}. Select the option you want, and then click `Finish`{.action}.
 >>
 >> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -109,25 +109,25 @@ You will then need to wait for the export process to complete, which may take fr
 >>
 > **Import**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Import from another program or file` and click `Next`.
+>> - Select `Import from another program or file`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>> - Choose your backup file by clicking `Browse`{.action}. Select the option you want, and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - If you need to set a password on your backup file, enter the password and click `OK`.
+>> - If you need to set a password on your backup file, enter the password and click `OK`{.action}.
 >>
->> - Select `Import items to the current folder` and then click `Finish`.
+>> - Select `Import items to the current folder`{.action} and then click `Finish`{.action}.
 >>
 >> Your backup will be imported.
 
@@ -136,46 +136,46 @@ You will then need to wait for the export process to complete, which may take fr
 > [!tabs]
 > **Export**
 >>
->> In the `Tools` tab of your Outlook window, click `Export`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Export`{.action}.
 >>
 >> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Then select the destination folder for your backup, and click `Save`.
+>> Then select the destination folder for your backup, and click `Save`{.action}.
 >>
 >> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. You will find your backup file in the folder you selected earlier.
 >>
 > **Import**
 >>
->> In the `Tools` tab of your Outlook window, click `Import`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Choose the backup format you want to import, and then click `Continue`.
+>> Choose the backup format you want to import, and then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Select your backup file, and then click `import`.
+>> Select your backup file, and then click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
 > [!tabs]
 > **Export**
 >>
->> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>> In the left-hand column, select one or more email accounts. Click `Mailbox`{.action} in the horizontal menu, and then click `Export Mailbox`{.action}.
 >>
 >> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Select the folder you want, or create a new folder, and then click `Choose`.
+>> Select the folder you want, or create a new folder, and then click `Choose`{.action}.
 >>
 >> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -183,11 +183,11 @@ You will then need to wait for the export process to complete, which may take fr
 >>
 > **Import**
 >>
->> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>> Click `File`{.action} on the horizontal menu, and then click `Import Mailboxes`{.action}.
 >>
 >> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Select your .mbox backup file, and then click `Continue`.
+>> Select your .mbox backup file, and then click `Continue`{.action}.
 >>
 >> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -200,11 +200,11 @@ There is currently no native feature to export or import an email account from T
 > [!tabs]
 > **Export**
 >>
->> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>> In the main window, click on the menu in the top right-hand corner, then `Help`{.action}, then `Troubleshooting Information`{.action}.
 >>
 >> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>> A table appears. Identify the `Profile Folder`{.action} line and click the `Open Folder`{.action} button.
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -225,7 +225,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> You must first start Thunderbird via the profile manager.
 >>
->> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>> - On Windows, go to the `Start`{.action} menu and open the `Run`{.action} application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
@@ -233,7 +233,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>> The following window displays the existing profiles. Click `Create Profile`{.action} and then click `Next`{.action} when the information message appears.
 >>
 >> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -244,9 +244,9 @@ There is currently no native feature to export or import an email account from T
 >> > [!primary]
 >> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
 >>
->> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>> Click `Choose Folder...`{.action} to select the folder that contains your backup. Click `Finish`{.action} to create the profile with your backup.
 >>
->> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`{.action}, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ie.md
@@ -65,184 +65,188 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-1. Log in to your [OVHcloud Control Panel](/links/manager).
-1. Open the `Web Cloud`{.action} section.
-1. In the `MICROSOFT` section, click `Exchange`{.action}.
-1. Select the service concerned.
-1. In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
+In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
 
-![emails](images/manager-export-pst01.png){.thumbnail}
+![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
 You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export to PST`{.action} button to retrieve a link to download the file.
 
-![emails](images/manager-export-pst02.png){.thumbnail}
+![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Exporting from Windows
+#### Windows
 
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+> [!tabs]
+> **Export**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Export to a file` and then click `Next`.
+>>
+>> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Select the name of the email account to export.
+>>
+>> > [!primary]
+>> > You can only export one account at a time.
+>>
+>> Select `Include subfolders`, then click `Next`.
+>>
+>> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>>
+>> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
+>>
+>> ![emails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Import from another program or file` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>>
+>> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - If you need to set a password on your backup file, enter the password and click `OK`.
+>>
+>> - Select `Import items to the current folder` and then click `Finish`.
+>>
+>> Your backup will be imported.
 
-![emails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Select `Export to a file` and then click `Next`.
-
-![emails](images/outlook-export-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-export-win03.png){.thumbnail}
-
-- Select the name of the email account to export.
-
-> [!primary]
-> You can only export one account at a time.
-
-Select `Include subfolders`, then click `Next`.
-
-![emails](images/outlook-export-win04.png){.thumbnail}
-
-- Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
-
-![emails](images/outlook-export-win05.png){.thumbnail}
-
-Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
-
-![emails](images/outlook-export-win06.png){.thumbnail}
-
-#### Importing from Windows
-
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
-
-![emails](images/outlook-export-import-win.png){.thumbnail}
-
-- Select `Import from another program or file` and click `Next`.
-
-![emails](images/outlook-import-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-import-win03.png){.thumbnail}
-
-- Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
-
-![emails](images/outlook-import-win04.png){.thumbnail}
-
-- If you need to set a password on your backup file, enter the password and click `OK`.
-
-- Select `Import items to the current folder` and then click `Finish`.
-
-Your backup will be imported.
-
-#### Exporting from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Export`.
-
-![emails](images/outlook-export-mac01.png){.thumbnail}
-
-In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
-
-![emails](images/outlook-export-mac02.png){.thumbnail}
-
-Then select the destination folder for your backup, and click `Save`.
-
-![emails](images/outlook-export-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
-
-#### Importing from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Import`.
-
-![emails](images/outlook-import-mac01.png){.thumbnail}
-
-Choose the backup format you want to import, and then click `Continue`.
-
-![emails](images/outlook-import-mac02.png){.thumbnail}
-
-Select your backup file, and then click `import`.
-
-![emails](images/outlook-import-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+> [!tabs]
+> **Export**
+>>
+>> In the `Tools` tab of your Outlook window, click `Export`.
+>>
+>> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>>
+>> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Then select the destination folder for your backup, and click `Save`.
+>>
+>> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>>
+> **Import**
+>>
+>> In the `Tools` tab of your Outlook window, click `Import`.
+>>
+>> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Choose the backup format you want to import, and then click `Continue`.
+>>
+>> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Select your backup file, and then click `import`.
+>>
+>> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
-#### Exporting
-
-In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
-
-![emails](images/mail-export-mac01.png){.thumbnail}
-
-Select the folder you want, or create a new folder, and then click `Choose`.
-
-![emails](images/mail-export-mac02.png){.thumbnail}
-
-Your export is in the form of a .mbox file.
-
-#### Importing
-
-Click `File` on the horizontal menu, and then click `Import Mailboxes`.
-
-![emails](images/mail-import-mac01.png){.thumbnail}
-
-Select your .mbox backup file, and then click `Continue`.
-
-![emails](images/mail-import-mac02.png){.thumbnail}
-
-In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
+> [!tabs]
+> **Export**
+>>
+>> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>>
+>> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Select the folder you want, or create a new folder, and then click `Choose`.
+>>
+>> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> Your export is in the form of a .mbox file.
+>>
+> **Import**
+>>
+>> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>>
+>> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Select your .mbox backup file, and then click `Continue`.
+>>
+>> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
 
 ### Thunderbird
 
 There is currently no native feature to export or import an email account from Thunderbird. However, you can save a Thunderbird profile. It contains all accounts and emails locally stored on your computer. We will look at how to back up a Thunderbird profile and reintegrate it into a new Thunderbird instance.
 
-#### Exporting
-
-In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
-
-![emails](images/thunderbird_menu.png){.thumbnail}
-
-A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
-
-![emails](images/thunderbird_open_folder.png){.thumbnail}
-
-You will then be directed to the profile folder. Move up one folder in the tree.
-
-![emails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Right-click the profile folder and paste it into the folder or media of your choice.
-
-![emails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importing
-
-Rather than an import, this will be a profile load.<br>
-If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
-When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
-For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
-
-You must first start Thunderbird via the profile manager.
-
-- On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
-
-![emails](images/thunderbird-run-profil.png){.thumbnail}
-
-- On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
-
-![emails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
-
-![emails](images/thunderbird-profil-create01.png){.thumbnail}
-
-In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
-
-![emails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
-
-Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
-
-You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+> [!tabs]
+> **Export**
+>>
+>> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>>
+>> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>>
+>> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> You will then be directed to the profile folder. Move up one folder in the tree.
+>>
+>> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Right-click the profile folder and paste it into the folder or media of your choice.
+>>
+>> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> Rather than an import, this will be a profile load.
+>> If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
+>> When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
+>> For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
+>>
+>> You must first start Thunderbird via the profile manager.
+>>
+>> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>>
+>> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
+>>
+>> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>>
+>> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
+>>
+>> ![emails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
+>>
+>> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>>
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ie.md
@@ -65,11 +65,11 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
+In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export as a .PST`{.action} format.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export to PST`{.action} button to retrieve a link to download the file.
+You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export as a .PST`{.action} button to retrieve a link to download the file.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-ie.md
@@ -65,11 +65,11 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export as a .PST`{.action} format.
+Once on your Exchange service page, in the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST format`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export as a .PST`{.action} button to retrieve a link to download the file.
+You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export in PST format`{.action} button to retrieve a link to download the file.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
@@ -78,15 +78,15 @@ You will then need to wait for the export process to complete, which may take fr
 > [!tabs]
 > **Export**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Export to a file` and then click `Next`.
+>> - Select `Export to a file`{.action} and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -95,11 +95,11 @@ You will then need to wait for the export process to complete, which may take fr
 >> > [!primary]
 >> > You can only export one account at a time.
 >>
->> Select `Include subfolders`, then click `Next`.
+>> Select `Include subfolders`{.action}, then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`{.action}. Select the option you want, and then click `Finish`{.action}.
 >>
 >> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -109,25 +109,25 @@ You will then need to wait for the export process to complete, which may take fr
 >>
 > **Import**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Import from another program or file` and click `Next`.
+>> - Select `Import from another program or file`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>> - Choose your backup file by clicking `Browse`{.action}. Select the option you want, and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - If you need to set a password on your backup file, enter the password and click `OK`.
+>> - If you need to set a password on your backup file, enter the password and click `OK`{.action}.
 >>
->> - Select `Import items to the current folder` and then click `Finish`.
+>> - Select `Import items to the current folder`{.action} and then click `Finish`{.action}.
 >>
 >> Your backup will be imported.
 
@@ -136,46 +136,46 @@ You will then need to wait for the export process to complete, which may take fr
 > [!tabs]
 > **Export**
 >>
->> In the `Tools` tab of your Outlook window, click `Export`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Export`{.action}.
 >>
 >> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Then select the destination folder for your backup, and click `Save`.
+>> Then select the destination folder for your backup, and click `Save`{.action}.
 >>
 >> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. You will find your backup file in the folder you selected earlier.
 >>
 > **Import**
 >>
->> In the `Tools` tab of your Outlook window, click `Import`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Choose the backup format you want to import, and then click `Continue`.
+>> Choose the backup format you want to import, and then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Select your backup file, and then click `import`.
+>> Select your backup file, and then click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
 > [!tabs]
 > **Export**
 >>
->> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>> In the left-hand column, select one or more email accounts. Click `Mailbox`{.action} in the horizontal menu, and then click `Export Mailbox`{.action}.
 >>
 >> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Select the folder you want, or create a new folder, and then click `Choose`.
+>> Select the folder you want, or create a new folder, and then click `Choose`{.action}.
 >>
 >> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -183,11 +183,11 @@ You will then need to wait for the export process to complete, which may take fr
 >>
 > **Import**
 >>
->> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>> Click `File`{.action} on the horizontal menu, and then click `Import Mailboxes`{.action}.
 >>
 >> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Select your .mbox backup file, and then click `Continue`.
+>> Select your .mbox backup file, and then click `Continue`{.action}.
 >>
 >> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -200,11 +200,11 @@ There is currently no native feature to export or import an email account from T
 > [!tabs]
 > **Export**
 >>
->> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>> In the main window, click on the menu in the top right-hand corner, then `Help`{.action}, then `Troubleshooting Information`{.action}.
 >>
 >> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>> A table appears. Identify the `Profile Folder`{.action} line and click the `Open Folder`{.action} button.
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -225,7 +225,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> You must first start Thunderbird via the profile manager.
 >>
->> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>> - On Windows, go to the `Start`{.action} menu and open the `Run`{.action} application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
@@ -233,7 +233,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>> The following window displays the existing profiles. Click `Create Profile`{.action} and then click `Next`{.action} when the information message appears.
 >>
 >> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -244,9 +244,9 @@ There is currently no native feature to export or import an email account from T
 >> > [!primary]
 >> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
 >>
->> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>> Click `Choose Folder...`{.action} to select the folder that contains your backup. Click `Finish`{.action} to create the profile with your backup.
 >>
->> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`{.action}, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-sg.md
@@ -52,15 +52,15 @@ The following instructions are divided into two parts:
 > [!tabs]
 > **Export**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Export to a file` and then click `Next`.
+>> - Select `Export to a file`{.action} and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -69,11 +69,11 @@ The following instructions are divided into two parts:
 >> > [!primary]
 >> > You can only export one account at a time.
 >>
->> Select `Include subfolders`, then click `Next`.
+>> Select `Include subfolders`{.action}, then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`{.action}. Select the option you want, and then click `Finish`{.action}.
 >>
 >> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -83,25 +83,25 @@ The following instructions are divided into two parts:
 >>
 > **Import**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Import from another program or file` and click `Next`.
+>> - Select `Import from another program or file`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>> - Choose your backup file by clicking `Browse`{.action}. Select the option you want, and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - If you need to set a password on your backup file, enter the password and click `OK`.
+>> - If you need to set a password on your backup file, enter the password and click `OK`{.action}.
 >>
->> - Select `Import items to the current folder` and then click `Finish`.
+>> - Select `Import items to the current folder`{.action} and then click `Finish`{.action}.
 >>
 >> Your backup will be imported.
 
@@ -110,46 +110,46 @@ The following instructions are divided into two parts:
 > [!tabs]
 > **Export**
 >>
->> In the `Tools` tab of your Outlook window, click `Export`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Export`{.action}.
 >>
 >> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Then select the destination folder for your backup, and click `Save`.
+>> Then select the destination folder for your backup, and click `Save`{.action}.
 >>
 >> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. You will find your backup file in the folder you selected earlier.
 >>
 > **Import**
 >>
->> In the `Tools` tab of your Outlook window, click `Import`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Choose the backup format you want to import, and then click `Continue`.
+>> Choose the backup format you want to import, and then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Select your backup file, and then click `import`.
+>> Select your backup file, and then click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
 > [!tabs]
 > **Export**
 >>
->> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>> In the left-hand column, select one or more email accounts. Click `Mailbox`{.action} in the horizontal menu, and then click `Export Mailbox`{.action}.
 >>
 >> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Select the folder you want, or create a new folder, and then click `Choose`.
+>> Select the folder you want, or create a new folder, and then click `Choose`{.action}.
 >>
 >> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -157,11 +157,11 @@ The following instructions are divided into two parts:
 >>
 > **Import**
 >>
->> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>> Click `File`{.action} on the horizontal menu, and then click `Import Mailboxes`{.action}.
 >>
 >> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Select your .mbox backup file, and then click `Continue`.
+>> Select your .mbox backup file, and then click `Continue`{.action}.
 >>
 >> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -174,11 +174,11 @@ There is currently no native feature to export or import an email account from T
 > [!tabs]
 > **Export**
 >>
->> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>> In the main window, click on the menu in the top right-hand corner, then `Help`{.action}, then `Troubleshooting Information`{.action}.
 >>
 >> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>> A table appears. Identify the `Profile Folder`{.action} line and click the `Open Folder`{.action} button.
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -199,7 +199,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> You must first start Thunderbird via the profile manager.
 >>
->> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>> - On Windows, go to the `Start`{.action} menu and open the `Run`{.action} application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
@@ -207,7 +207,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>> The following window displays the existing profiles. Click `Create Profile`{.action} and then click `Next`{.action} when the information message appears.
 >>
 >> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -218,9 +218,9 @@ There is currently no native feature to export or import an email account from T
 >> > [!primary]
 >> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
 >>
->> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>> Click `Choose Folder...`{.action} to select the folder that contains your backup. Click `Finish`{.action} to create the profile with your backup.
 >>
->> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`{.action}, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-sg.md
@@ -47,172 +47,180 @@ The following instructions are divided into two parts:
 
 ### Outlook
 
-#### Exporting from Windows
+#### Windows
 
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+> [!tabs]
+> **Export**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Export to a file` and then click `Next`.
+>>
+>> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Select the name of the email account to export.
+>>
+>> > [!primary]
+>> > You can only export one account at a time.
+>>
+>> Select `Include subfolders`, then click `Next`.
+>>
+>> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>>
+>> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
+>>
+>> ![emails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Import from another program or file` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>>
+>> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - If you need to set a password on your backup file, enter the password and click `OK`.
+>>
+>> - Select `Import items to the current folder` and then click `Finish`.
+>>
+>> Your backup will be imported.
 
-![emails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Select `Export to a file` and then click `Next`.
-
-![emails](images/outlook-export-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-export-win03.png){.thumbnail}
-
-- Select the name of the email account to export.
-
-> [!primary]
-> You can only export one account at a time.
-
-Select `Include subfolders`, then click `Next`.
-
-![emails](images/outlook-export-win04.png){.thumbnail}
-
-- Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
-
-![emails](images/outlook-export-win05.png){.thumbnail}
-
-Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
-
-![emails](images/outlook-export-win06.png){.thumbnail}
-
-#### Importing from Windows
-
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
-
-![emails](images/outlook-export-import-win.png){.thumbnail}
-
-- Select `Import from another program or file` and click `Next`.
-
-![emails](images/outlook-import-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-import-win03.png){.thumbnail}
-
-- Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
-
-![emails](images/outlook-import-win04.png){.thumbnail}
-
-- If you need to set a password on your backup file, enter the password and click `OK`.
-
-- Select `Import items to the current folder` and then click `Finish`.
-
-Your backup will be imported.
-
-#### Exporting from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Export`.
-
-![emails](images/outlook-export-mac01.png){.thumbnail}
-
-In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
-
-![emails](images/outlook-export-mac02.png){.thumbnail}
-
-Then select the destination folder for your backup, and click `Save`.
-
-![emails](images/outlook-export-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
-
-#### Importing from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Import`.
-
-![emails](images/outlook-import-mac01.png){.thumbnail}
-
-Choose the backup format you want to import, and then click `Continue`.
-
-![emails](images/outlook-import-mac02.png){.thumbnail}
-
-Select your backup file, and then click `import`.
-
-![emails](images/outlook-import-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+> [!tabs]
+> **Export**
+>>
+>> In the `Tools` tab of your Outlook window, click `Export`.
+>>
+>> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>>
+>> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Then select the destination folder for your backup, and click `Save`.
+>>
+>> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>>
+> **Import**
+>>
+>> In the `Tools` tab of your Outlook window, click `Import`.
+>>
+>> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Choose the backup format you want to import, and then click `Continue`.
+>>
+>> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Select your backup file, and then click `import`.
+>>
+>> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
-#### Exporting
-
-In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
-
-![emails](images/mail-export-mac01.png){.thumbnail}
-
-Select the folder you want, or create a new folder, and then click `Choose`.
-
-![emails](images/mail-export-mac02.png){.thumbnail}
-
-Your export is in the form of a .mbox file.
-
-#### Importing
-
-Click `File` on the horizontal menu, and then click `Import Mailboxes`.
-
-![emails](images/mail-import-mac01.png){.thumbnail}
-
-Select your .mbox backup file, and then click `Continue`.
-
-![emails](images/mail-import-mac02.png){.thumbnail}
-
-In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
+> [!tabs]
+> **Export**
+>>
+>> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>>
+>> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Select the folder you want, or create a new folder, and then click `Choose`.
+>>
+>> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> Your export is in the form of a .mbox file.
+>>
+> **Import**
+>>
+>> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>>
+>> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Select your .mbox backup file, and then click `Continue`.
+>>
+>> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
 
 ### Thunderbird
 
 There is currently no native feature to export or import an email account from Thunderbird. However, you can save a Thunderbird profile. It contains all accounts and emails locally stored on your computer. We will look at how to back up a Thunderbird profile and reintegrate it into a new Thunderbird instance.
 
-#### Exporting
-
-In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
-
-![emails](images/thunderbird_menu.png){.thumbnail}
-
-A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
-
-![emails](images/thunderbird_open_folder.png){.thumbnail}
-
-You will then be directed to the profile folder. Move up one folder in the tree.
-
-![emails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Right-click the profile folder and paste it into the folder or media of your choice.
-
-![emails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importing
-
-Rather than an import, this will be a profile load.<br>
-If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
-When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
-For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
-
-You must first start Thunderbird via the profile manager.
-
-- On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
-
-![emails](images/thunderbird-run-profil.png){.thumbnail}
-
-- On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
-
-![emails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
-
-![emails](images/thunderbird-profil-create01.png){.thumbnail}
-
-In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
-
-![emails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
-
-Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
-
-You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+> [!tabs]
+> **Export**
+>>
+>> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>>
+>> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>>
+>> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> You will then be directed to the profile folder. Move up one folder in the tree.
+>>
+>> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Right-click the profile folder and paste it into the folder or media of your choice.
+>>
+>> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> Rather than an import, this will be a profile load.
+>> If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
+>> When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
+>> For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
+>>
+>> You must first start Thunderbird via the profile manager.
+>>
+>> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>>
+>> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
+>>
+>> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>>
+>> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
+>>
+>> ![emails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
+>>
+>> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>>
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-us.md
@@ -58,184 +58,188 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-1. Log in to your [OVHcloud Control Panel](/links/manager).
-1. Open the `Web Cloud`{.action} section.
-1. In the `MICROSOFT` section, click `Exchange`{.action}.
-1. Select the service concerned.
-1. In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
+In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
 
-![emails](images/manager-export-pst01.png){.thumbnail}
+![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
 You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export to PST`{.action} button to retrieve a link to download the file.
 
-![emails](images/manager-export-pst02.png){.thumbnail}
+![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Exporting from Windows
+#### Windows
 
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+> [!tabs]
+> **Export**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Export to a file` and then click `Next`.
+>>
+>> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Select the name of the email account to export.
+>>
+>> > [!primary]
+>> > You can only export one account at a time.
+>>
+>> Select `Include subfolders`, then click `Next`.
+>>
+>> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>>
+>> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
+>>
+>> ![emails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Select `Import from another program or file` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Select `Outlook Data File (.pst)` and click `Next`.
+>>
+>> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>>
+>> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - If you need to set a password on your backup file, enter the password and click `OK`.
+>>
+>> - Select `Import items to the current folder` and then click `Finish`.
+>>
+>> Your backup will be imported.
 
-![emails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Select `Export to a file` and then click `Next`.
-
-![emails](images/outlook-export-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-export-win03.png){.thumbnail}
-
-- Select the name of the email account to export.
-
-> [!primary]
-> You can only export one account at a time.
-
-Select `Include subfolders`, then click `Next`.
-
-![emails](images/outlook-export-win04.png){.thumbnail}
-
-- Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
-
-![emails](images/outlook-export-win05.png){.thumbnail}
-
-Your file is being exported. When you create a file, you will be asked to set a password. This is optional.
-
-![emails](images/outlook-export-win06.png){.thumbnail}
-
-#### Importing from Windows
-
-- Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
-
-![emails](images/outlook-export-import-win.png){.thumbnail}
-
-- Select `Import from another program or file` and click `Next`.
-
-![emails](images/outlook-import-win02.png){.thumbnail}
-
-- Select `Outlook Data File (.pst)` and click `Next`.
-
-![emails](images/outlook-import-win03.png){.thumbnail}
-
-- Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
-
-![emails](images/outlook-import-win04.png){.thumbnail}
-
-- If you need to set a password on your backup file, enter the password and click `OK`.
-
-- Select `Import items to the current folder` and then click `Finish`.
-
-Your backup will be imported.
-
-#### Exporting from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Export`.
-
-![emails](images/outlook-export-mac01.png){.thumbnail}
-
-In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
-
-![emails](images/outlook-export-mac02.png){.thumbnail}
-
-Then select the destination folder for your backup, and click `Save`.
-
-![emails](images/outlook-export-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
-
-#### Importing from Mac OS
-
-In the `Tools` tab of your Outlook window, click `Import`.
-
-![emails](images/outlook-import-mac01.png){.thumbnail}
-
-Choose the backup format you want to import, and then click `Continue`.
-
-![emails](images/outlook-import-mac02.png){.thumbnail}
-
-Select your backup file, and then click `import`.
-
-![emails](images/outlook-import-mac03.png){.thumbnail}
-
-A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+> [!tabs]
+> **Export**
+>>
+>> In the `Tools` tab of your Outlook window, click `Export`.
+>>
+>> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>>
+>> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Then select the destination folder for your backup, and click `Save`.
+>>
+>> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>>
+> **Import**
+>>
+>> In the `Tools` tab of your Outlook window, click `Import`.
+>>
+>> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Choose the backup format you want to import, and then click `Continue`.
+>>
+>> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Select your backup file, and then click `import`.
+>>
+>> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
-#### Exporting
-
-In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
-
-![emails](images/mail-export-mac01.png){.thumbnail}
-
-Select the folder you want, or create a new folder, and then click `Choose`.
-
-![emails](images/mail-export-mac02.png){.thumbnail}
-
-Your export is in the form of a .mbox file.
-
-#### Importing
-
-Click `File` on the horizontal menu, and then click `Import Mailboxes`.
-
-![emails](images/mail-import-mac01.png){.thumbnail}
-
-Select your .mbox backup file, and then click `Continue`.
-
-![emails](images/mail-import-mac02.png){.thumbnail}
-
-In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
+> [!tabs]
+> **Export**
+>>
+>> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>>
+>> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Select the folder you want, or create a new folder, and then click `Choose`.
+>>
+>> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> Your export is in the form of a .mbox file.
+>>
+> **Import**
+>>
+>> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>>
+>> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Select your .mbox backup file, and then click `Continue`.
+>>
+>> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> In the left-hand column, the imported emails are stored in a new email account named Import. You can drag folders and messages from the "Import" account to your already configured email accounts. Once your transfers are complete, you can delete the "Import" account.
 
 ### Thunderbird
 
 There is currently no native feature to export or import an email account from Thunderbird. However, you can save a Thunderbird profile. It contains all accounts and emails locally stored on your computer. We will look at how to back up a Thunderbird profile and reintegrate it into a new Thunderbird instance.
 
-#### Exporting
-
-In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
-
-![emails](images/thunderbird_menu.png){.thumbnail}
-
-A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
-
-![emails](images/thunderbird_open_folder.png){.thumbnail}
-
-You will then be directed to the profile folder. Move up one folder in the tree.
-
-![emails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Right-click the profile folder and paste it into the folder or media of your choice.
-
-![emails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importing
-
-Rather than an import, this will be a profile load.<br>
-If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
-When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
-For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
-
-You must first start Thunderbird via the profile manager.
-
-- On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
-
-![emails](images/thunderbird-run-profil.png){.thumbnail}
-
-- On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
-
-![emails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
-
-![emails](images/thunderbird-profil-create01.png){.thumbnail}
-
-In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
-
-![emails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
-
-Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
-
-You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+> [!tabs]
+> **Export**
+>>
+>> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>>
+>> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>>
+>> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> You will then be directed to the profile folder. Move up one folder in the tree.
+>>
+>> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Right-click the profile folder and paste it into the folder or media of your choice.
+>>
+>> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> Rather than an import, this will be a profile load.
+>> If email accounts have already been configured on the destination Thunderbird instance, they will be present on a profile (profile A).
+>> When Thunderbird loads a new profile (profile B), it can **only** load the elements of **this particular** profile.
+>> For this reason, we recommend loading the new profile (profile B) first, then configuring the email accounts from profile A.
+>>
+>> You must first start Thunderbird via the profile manager.
+>>
+>> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>>
+>> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - On Mac OS, launch the Terminal application then drag and drop your Thunderbird application into the Terminal window, adding it to the line `/Contents/MacOS/thunderbird-bin -ProfileManager`. Press the `Enter` (⏎) key to validate.
+>>
+>> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>>
+>> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> In the next step, name your profile and identify the folder where the profile will be created, below the sentence "Your user settings, preferences and other user-related data will be stored in":
+>>
+>> ![emails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
+>>
+>> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>>
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-us.md
@@ -58,11 +58,11 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export as a .PST`{.action} format.
+Once on your Exchange service page, in the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST format`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export as a .PST`{.action} button to retrieve a link to download the file.
+You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export in PST format`{.action} button to retrieve a link to download the file.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
@@ -71,15 +71,15 @@ You will then need to wait for the export process to complete, which may take fr
 > [!tabs]
 > **Export**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Export to a file` and then click `Next`.
+>> - Select `Export to a file`{.action} and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -88,11 +88,11 @@ You will then need to wait for the export process to complete, which may take fr
 >> > [!primary]
 >> > You can only export one account at a time.
 >>
->> Select `Include subfolders`, then click `Next`.
+>> Select `Include subfolders`{.action}, then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`. Select the option you want, and then click `Finish`.
+>> - Choose the destination folder for your backup and enter a name for it by clicking `Browse`{.action}. Select the option you want, and then click `Finish`{.action}.
 >>
 >> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -102,25 +102,25 @@ You will then need to wait for the export process to complete, which may take fr
 >>
 > **Import**
 >>
->> - Click `File` in the top left-hand corner, then `Open and Export`, and then `Import/Export`.
+>> - Click `File`{.action} in the top left-hand corner, then `Open and Export`{.action}, and then `Import/Export`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Select `Import from another program or file` and click `Next`.
+>> - Select `Import from another program or file`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Select `Outlook Data File (.pst)` and click `Next`.
+>> - Select `Outlook Data File (.pst)`{.action} and click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Choose your backup file by clicking `Browse`. Select the option you want, and then click `Next`.
+>> - Choose your backup file by clicking `Browse`{.action}. Select the option you want, and then click `Next`{.action}.
 >>
 >> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - If you need to set a password on your backup file, enter the password and click `OK`.
+>> - If you need to set a password on your backup file, enter the password and click `OK`{.action}.
 >>
->> - Select `Import items to the current folder` and then click `Finish`.
+>> - Select `Import items to the current folder`{.action} and then click `Finish`{.action}.
 >>
 >> Your backup will be imported.
 
@@ -129,46 +129,46 @@ You will then need to wait for the export process to complete, which may take fr
 > [!tabs]
 > **Export**
 >>
->> In the `Tools` tab of your Outlook window, click `Export`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Export`{.action}.
 >>
 >> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`.
+>> In the Export to archive (.olm) window, tick the items you want to add to your backup file, then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Then select the destination folder for your backup, and click `Save`.
+>> Then select the destination folder for your backup, and click `Save`{.action}.
 >>
 >> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. You will find your backup file in the folder you selected earlier.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. You will find your backup file in the folder you selected earlier.
 >>
 > **Import**
 >>
->> In the `Tools` tab of your Outlook window, click `Import`.
+>> In the `Tools`{.action} tab of your Outlook window, click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Choose the backup format you want to import, and then click `Continue`.
+>> Choose the backup format you want to import, and then click `Continue`{.action}.
 >>
 >> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Select your backup file, and then click `import`.
+>> Select your backup file, and then click `Import`{.action}.
 >>
 >> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> A progress window will appear, click `Continue` at the end of the operation. Your backup is then deployed on your Outlook.
+>> A progress window will appear, click `Continue`{.action} at the end of the operation. Your backup is then deployed on your Outlook.
 
 ### Mail on Mac OS
 
 > [!tabs]
 > **Export**
 >>
->> In the left-hand column, select one or more email accounts. Click `Mailbox` in the horizontal menu, and then click `Export Mailbox`.
+>> In the left-hand column, select one or more email accounts. Click `Mailbox`{.action} in the horizontal menu, and then click `Export Mailbox`{.action}.
 >>
 >> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Select the folder you want, or create a new folder, and then click `Choose`.
+>> Select the folder you want, or create a new folder, and then click `Choose`{.action}.
 >>
 >> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -176,11 +176,11 @@ You will then need to wait for the export process to complete, which may take fr
 >>
 > **Import**
 >>
->> Click `File` on the horizontal menu, and then click `Import Mailboxes`.
+>> Click `File`{.action} on the horizontal menu, and then click `Import Mailboxes`{.action}.
 >>
 >> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Select your .mbox backup file, and then click `Continue`.
+>> Select your .mbox backup file, and then click `Continue`{.action}.
 >>
 >> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -193,11 +193,11 @@ There is currently no native feature to export or import an email account from T
 > [!tabs]
 > **Export**
 >>
->> In the main window, click on the menu in the top right-hand corner, then `Help`, then `Troubleshooting Information`.
+>> In the main window, click on the menu in the top right-hand corner, then `Help`{.action}, then `Troubleshooting Information`{.action}.
 >>
 >> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> A table appears. Identify the `Profile Folder` line and click the `Open Folder` button.
+>> A table appears. Identify the `Profile Folder`{.action} line and click the `Open Folder`{.action} button.
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -218,7 +218,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> You must first start Thunderbird via the profile manager.
 >>
->> - On Windows, go to the `Start` menu and open the `Run` application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`.
+>> - On Windows, go to the `Start`{.action} menu and open the `Run`{.action} application. On the latter, type `thunderbird.exe -ProfileManager` and click `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
@@ -226,7 +226,7 @@ There is currently no native feature to export or import an email account from T
 >>
 >> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> The following window displays the existing profiles. Click `Create Profile` and then click `Next` when the information message appears.
+>> The following window displays the existing profiles. Click `Create Profile`{.action} and then click `Next`{.action} when the information message appears.
 >>
 >> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -237,9 +237,9 @@ There is currently no native feature to export or import an email account from T
 >> > [!primary]
 >> > We recommend copying your Thunderbird profile backup to the Thunderbird profile folder.
 >>
->> Click `Choose Folder...` to select the folder that contains your backup. Click `Finish` to create the profile with your backup.
+>> Click `Choose Folder...`{.action} to select the folder that contains your backup. Click `Finish`{.action} to create the profile with your backup.
 >>
->> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`, Thunderbird will be launched with all the items you had in your backup.
+>> You will find your profile selection window with your new profile selected. When you click `Start Thunderbird`{.action}, Thunderbird will be launched with all the items you had in your backup.
 
 ### Checking the import on the new email address
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.en-us.md
@@ -58,11 +58,11 @@ The following instructions are divided into two parts:
 
 If you have an [OVHcloud Exchange email account](/links/web/emails-hosted-exchange), you can export it directly in PST format via the OVHcloud Control Panel.
 
-In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export in PST`{.action} format.
+In the `Email accounts`{.action} tab, click the `...`{.action} button to the right of the email account you want to export, then `Export as a .PST`{.action} format.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export to PST`{.action} button to retrieve a link to download the file.
+You will then need to wait for the export process to complete, which may take from a few minutes to several hours, depending on the size of the export. At the end of it, you just need to return to the `Export as a .PST`{.action} button to retrieve a link to download the file.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-es.md
@@ -80,7 +80,7 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 > [!tabs]
 > **Exportar**
 >>
->> - Haga clic en `archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `importar y exportar`{.action}.
+>> - Haga clic en `Archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `Importar y exportar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
@@ -111,7 +111,7 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 >>
 > **Importar**
 >>
->> - Haga clic en `archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `importar y exportar`{.action}.
+>> - Haga clic en `Archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `Importar y exportar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-es.md
@@ -67,11 +67,11 @@ Las instrucciones siguientes se dividen en dos partes:
 
 Si tiene una cuenta de correo [Exchange de OVHcloud](/links/web/emails-hosted-exchange), puede exportarla directamente en formato PST desde el área de cliente.
 
-En la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar a PST`{.action}.
+Una vez en la página de su servicio Exchange, en la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar en formato PST`{.action}.
 
 ![correo electrónico](images/manager-export-pst01.png){.thumbnail .w-640}
 
-A continuación, habrá que esperar el tiempo de la exportación, que puede tardar unos minutos a varias horas, según el tamaño de la exportación. Al final del archivo, solo tendrá que volver al botón `Exportar a PST`{.action} para descargar el archivo.
+A continuación, habrá que esperar el tiempo de la exportación, que puede tardar unos minutos a varias horas, según el tamaño de la exportación. Al final del archivo, solo tendrá que volver al botón `Exportar en formato PST`{.action} para descargar el archivo.
 
 ![correo electrónico](images/manager-export-pst02.png){.thumbnail .w-640}
 
@@ -80,15 +80,15 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 > [!tabs]
 > **Exportar**
 >>
->> - Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
+>> - Haga clic en `archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `importar y exportar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Seleccione `Exportar datos a un archivo` y haga clic en `Siguiente`.
+>> - Seleccione `Exportar datos a un archivo`{.action} y haga clic en `Siguiente`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
+>> - Seleccione `Archivo de datos Outlook (.pst)`{.action} y haga clic en `Siguiente`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -97,11 +97,11 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 >> > [!primary]
 >> > Solo puede exportar una cuenta a la vez.
 >>
->> Marque `Incluir las subcarpetas` y haga clic en `Siguiente`.
+>> Marque `Incluir las subcarpetas`{.action} y haga clic en `Siguiente`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Seleccione la carpeta de destino de la copia de seguridad e introduzca un nombre para ella haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
+>> - Seleccione la carpeta de destino de la copia de seguridad e introduzca un nombre para ella haciendo clic en `Navegar`{.action}. Seleccione la opción más adecuada y haga clic en `Finalizar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -111,25 +111,25 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 >>
 > **Importar**
 >>
->> - Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
+>> - Haga clic en `archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `importar y exportar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Seleccione `Importar de otro programa o archivo` y haga clic en `Siguiente`.
+>> - Seleccione `Importar de otro programa o archivo`{.action} y haga clic en `Siguiente`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
+>> - Seleccione `Archivo de datos Outlook (.pst)`{.action} y haga clic en `Siguiente`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Seleccione el archivo de backup haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
+>> - Seleccione el archivo de backup haciendo clic en `Navegar`{.action}. Seleccione la opción más adecuada y haga clic en `Finalizar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - Si ha establecido una contraseña en el archivo de backup, introdúzcala y haga clic en `Aceptar`.
+>> - Si ha establecido una contraseña en el archivo de backup, introdúzcala y haga clic en `Aceptar`{.action}.
 >>
->> - Seleccione `Importar elementos a la carpeta actual` y haga clic en `Finalizar`.
+>> - Seleccione `Importar elementos a la carpeta actual`{.action} y haga clic en `Finalizar`{.action}.
 >>
 >> Se inicia la importación de la copia de seguridad.
 
@@ -138,46 +138,46 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 > [!tabs]
 > **Exportar**
 >>
->> En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Exportar`.
+>> En la pestaña `Herramientas`{.action} de su ventana de Outlook, haga clic en `Exportar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> En la ventana Exportar a archivo.olm, marque los elementos que quiera añadir al archivo de backup y haga clic en `Continuar`.
+>> En la ventana Exportar a archivo.olm, marque los elementos que quiera añadir al archivo de backup y haga clic en `Continuar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> A continuación, seleccione la carpeta de destino para la copia de seguridad y haga clic en `Guardar`.
+>> A continuación, seleccione la carpeta de destino para la copia de seguridad y haga clic en `Guardar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. El archivo de backup aparecerá en la carpeta que haya elegido anteriormente.
+>> Se abrirá una ventana de progreso. Haga clic en `Continuar`{.action} al finalizar la operación. El archivo de backup aparecerá en la carpeta que haya elegido anteriormente.
 >>
 > **Importar**
 >>
->> En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Importar`.
+>> En la pestaña `Herramientas`{.action} de su ventana de Outlook, haga clic en `Importar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Seleccione el formato de la copia de seguridad que quiera importar y haga clic en `Continuar`.
+>> Seleccione el formato de la copia de seguridad que quiera importar y haga clic en `Continuar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Seleccione el archivo de backup y haga clic en `importar`.
+>> Seleccione el archivo de backup y haga clic en `Importar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. La copia de seguridad se desplegará en su Outlook.
+>> Se abrirá una ventana de progreso. Haga clic en `Continuar`{.action} al finalizar la operación. La copia de seguridad se desplegará en su Outlook.
 
 ### Correo electrónico en Mac OS
 
 > [!tabs]
 > **Exportar**
 >>
->> En la columna izquierda, seleccione una o más cuentas de correo. En el menú horizontal, haga clic en `Buzón de correo` y seleccione `Exportar buzón`.
+>> En la columna izquierda, seleccione una o más cuentas de correo. En el menú horizontal, haga clic en `Buzón de correo`{.action} y seleccione `Exportar buzón`{.action}.
 >>
 >> ![correo electrónico](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Seleccione la carpeta que desee o cree una nueva, y haga clic en `Elegir`.
+>> Seleccione la carpeta que desee o cree una nueva, y haga clic en `Elegir`{.action}.
 >>
 >> ![correo electrónico](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -185,11 +185,11 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 >>
 > **Importar**
 >>
->> Haga clic en `Archivo` en el menú horizontal y seleccione `Importar buzones de correo`.
+>> Haga clic en `Archivo`{.action} en el menú horizontal y seleccione `Importar buzones de correo`{.action}.
 >>
 >> ![correo electrónico](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Seleccione el archivo de backup en formato ".mbox" y haga clic en `Continuar`.
+>> Seleccione el archivo de backup en formato ".mbox" y haga clic en `Continuar`{.action}.
 >>
 >> ![correo electrónico](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -202,11 +202,11 @@ Actualmente no hay ninguna funcionalidad nativa para exportar o importar una cue
 > [!tabs]
 > **Exportar**
 >>
->> En la ventana principal, haga clic en el menú situado en la esquina superior derecha y seleccione `Ayuda` y luego en `Información de reparación`.
+>> En la ventana principal, haga clic en el menú situado en la esquina superior derecha y seleccione `Ayuda`{.action} y luego en `Información de reparación`{.action}.
 >>
 >> ![correo electrónico](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> Se mostrará una tabla. Identifique la línea `Directorio de perfil` y haga clic en el botón `Abrir carpeta correspondiente`.
+>> Se mostrará una tabla. Identifique la línea `Directorio de perfil`{.action} y haga clic en el botón `Abrir carpeta correspondiente`{.action}.
 >>
 >> ![correo electrónico](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -227,15 +227,15 @@ Actualmente no hay ninguna funcionalidad nativa para exportar o importar una cue
 >>
 >> En primer lugar, debe iniciar Thunderbird a través del gestor de perfiles.
 >>
->> - En Windows, abra el menú `Iniciar` y seleccione el programa `Ejecutar`. Introduzca `thunderbird.exe -ProfileManager` y haga clic en `OK`.
+>> - En Windows, abra el menú `Iniciar`{.action} y seleccione el programa `Ejecutar`{.action}. Introduzca `thunderbird.exe -ProfileManager` y haga clic en `OK`{.action}.
 >>
 >> ![correo electrónico](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
->> - En Mac OS, ejecute la aplicación Terminal y arrastre y coloque su aplicación Thunderbird en la ventana de la Terminal, añadiendo a la línea `/Contents/MacOS/thunderbird-bin -ProfileManager`. Pulse la tecla `Entrar` (⏎) para aceptar.
+>> - En Mac OS, ejecute la aplicación Terminal y arrastre y coloque su aplicación Thunderbird en la ventana de la Terminal, añadiendo a la línea `/Contents/MacOS/thunderbird-bin -ProfileManager`. Pulse la tecla `Entrar`{.action} (⏎) para aceptar.
 >>
 >> ![correo electrónico](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> La siguiente ventana muestra los perfiles existentes. Haga clic en `Crear un perfil` y luego en `Siguiente` cuando aparezca el mensaje informativo.
+>> La siguiente ventana muestra los perfiles existentes. Haga clic en `Crear un perfil`{.action} y luego en `Siguiente`{.action} cuando aparezca el mensaje informativo.
 >>
 >> ![correo electrónico](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -246,9 +246,9 @@ Actualmente no hay ninguna funcionalidad nativa para exportar o importar una cue
 >> > [!primary]
 >> > Le recomendamos que copie el backup de su perfil de Thunderbird en la carpeta de perfiles de Thunderbird.
 >>
->> Haga clic en `Elegir carpeta...` para seleccionar la carpeta que contenga la copia de seguridad. Haga clic en `Finalizar` para crear el perfil con la copia de seguridad.
+>> Haga clic en `Elegir carpeta...`{.action} para seleccionar la carpeta que contenga la copia de seguridad. Haga clic en `Finalizar`{.action} para crear el perfil con la copia de seguridad.
 >>
->> A continuación, encontrará la ventana de selección de su perfil con el nuevo perfil seleccionado. Haga clic en `Iniciar Thunderbird`. Thunderbird se ejecutará con todos los elementos que tenga en su copia de seguridad.
+>> A continuación, encontrará la ventana de selección de su perfil con el nuevo perfil seleccionado. Haga clic en `Iniciar Thunderbird`{.action}. Thunderbird se ejecutará con todos los elementos que tenga en su copia de seguridad.
 
 ### Comprobar la importación en la nueva dirección de correo
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-es.md
@@ -67,184 +67,188 @@ Las instrucciones siguientes se dividen en dos partes:
 
 Si tiene una cuenta de correo [Exchange de OVHcloud](/links/web/emails-hosted-exchange), puede exportarla directamente en formato PST desde el área de cliente.
 
-1. Conéctese al [área de cliente de OVHcloud](/links/manager).
-1. Acceda al apartado `Web Cloud`{.action}.
-1. En la sección `MICROSOFT`, haga clic en `Exchange`{.action}.
-1. Seleccione la plataforma correspondiente.
-1. En la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar en formato PST`{.action}.
+En la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar en formato PST`{.action}.
 
-![correo electrónico](images/manager-export-pst01.png){.thumbnail}
+![correo electrónico](images/manager-export-pst01.png){.thumbnail .w-640}
 
 A continuación, habrá que esperar el tiempo de la exportación, que puede tardar unos minutos a varias horas, según el tamaño de la exportación. Al final del archivo, solo tendrá que volver al botón `Exportar en formato PST`{.action} para descargar el archivo.
 
-![correo electrónico](images/manager-export-pst02.png){.thumbnail}
+![correo electrónico](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Exportar desde Windows
+#### Windows
 
-- Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
+> [!tabs]
+> **Exportar**
+>>
+>> - Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
+>>
+>> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Seleccione `Exportar datos a un archivo` y haga clic en `Siguiente`.
+>>
+>> ![correo electrónico](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
+>>
+>> ![correo electrónico](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Seleccione el nombre de la cuenta de correo que quiera exportar.
+>>
+>> > [!primary]
+>> > Solo puede exportar una cuenta a la vez.
+>>
+>> Marque `Incluir las subcarpetas` y haga clic en `Siguiente`.
+>>
+>> ![correo electrónico](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Seleccione la carpeta de destino de la copia de seguridad e introduzca un nombre para ella haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
+>>
+>> ![correo electrónico](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> Comienza la exportación de su archivo. Al crear un archivo, se le pedirá que establezca una contraseña. Es opcional.
+>>
+>> ![correo electrónico](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Importar**
+>>
+>> - Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
+>>
+>> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Seleccione `Importar de otro programa o archivo` y haga clic en `Siguiente`.
+>>
+>> ![correo electrónico](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
+>>
+>> ![correo electrónico](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Seleccione el archivo de backup haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
+>>
+>> ![correo electrónico](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - Si ha establecido una contraseña en el archivo de backup, introdúzcala y haga clic en `Aceptar`.
+>>
+>> - Seleccione `Importar elementos a la carpeta actual` y haga clic en `Finalizar`.
+>>
+>> Se inicia la importación de la copia de seguridad.
 
-![correo electrónico](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Seleccione `Exportar datos a un archivo` y haga clic en `Siguiente`.
-
-![correo electrónico](images/outlook-export-win02.png){.thumbnail}
-
-- Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
-
-![correo electrónico](images/outlook-export-win03.png){.thumbnail}
-
-- Seleccione el nombre de la cuenta de correo que quiera exportar.
-
-> [!primary]
-> Solo puede exportar una cuenta a la vez.
-
-Marque `Incluir las subcarpetas` y haga clic en `Siguiente`.
-
-![correo electrónico](images/outlook-export-win04.png){.thumbnail}
-
-- Seleccione la carpeta de destino de la copia de seguridad e introduzca un nombre para ella haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
-
-![correo electrónico](images/outlook-export-win05.png){.thumbnail}
-
-Comienza la exportación de su archivo. Al crear un archivo, se le pedirá que establezca una contraseña. Es opcional.
-
-![correo electrónico](images/outlook-export-win06.png){.thumbnail}
-
-#### Importar desde Windows
-
-- Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
-
-![correo electrónico](images/outlook-export-import-win.png){.thumbnail}
-
-- Seleccione `Importar de otro programa o archivo` y haga clic en `Siguiente`.
-
-![correo electrónico](images/outlook-import-win02.png){.thumbnail}
-
-- Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
-
-![correo electrónico](images/outlook-import-win03.png){.thumbnail}
-
-- Seleccione el archivo de backup haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
-
-![correo electrónico](images/outlook-import-win04.png){.thumbnail}
-
-- Si ha establecido una contraseña en el archivo de backup, introdúzcala y haga clic en `Aceptar`.
-
-- Seleccione `Importar elementos a la carpeta actual` y haga clic en `Finalizar`.
-
-Se inicia la importación de la copia de seguridad.
-
-#### Exportar desde Mac OS
-
-En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Exportar`.
-
-![correo electrónico](images/outlook-export-mac01.png){.thumbnail}
-
-En la ventana Exportar a archivo.olm, marque los elementos que quiera añadir al archivo de backup y haga clic en `Continuar`.
-
-![correo electrónico](images/outlook-export-mac02.png){.thumbnail}
-
-A continuación, seleccione la carpeta de destino para la copia de seguridad y haga clic en `Guardar`.
-
-![correo electrónico](images/outlook-export-mac03.png){.thumbnail}
-
-Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. El archivo de backup aparecerá en la carpeta que haya elegido anteriormente.
-
-#### Importar desde Mac OS
-
-En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Importar`.
-
-![correo electrónico](images/outlook-import-mac01.png){.thumbnail}
-
-Seleccione el formato de la copia de seguridad que quiera importar y haga clic en `Continuar`.
-
-![correo electrónico](images/outlook-import-mac02.png){.thumbnail}
-
-Seleccione el archivo de backup y haga clic en `importar`.
-
-![correo electrónico](images/outlook-import-mac03.png){.thumbnail}
-
-Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. La copia de seguridad se desplegará en su Outlook.
+> [!tabs]
+> **Exportar**
+>>
+>> En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Exportar`.
+>>
+>> ![correo electrónico](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> En la ventana Exportar a archivo.olm, marque los elementos que quiera añadir al archivo de backup y haga clic en `Continuar`.
+>>
+>> ![correo electrónico](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> A continuación, seleccione la carpeta de destino para la copia de seguridad y haga clic en `Guardar`.
+>>
+>> ![correo electrónico](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. El archivo de backup aparecerá en la carpeta que haya elegido anteriormente.
+>>
+> **Importar**
+>>
+>> En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Importar`.
+>>
+>> ![correo electrónico](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Seleccione el formato de la copia de seguridad que quiera importar y haga clic en `Continuar`.
+>>
+>> ![correo electrónico](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Seleccione el archivo de backup y haga clic en `importar`.
+>>
+>> ![correo electrónico](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. La copia de seguridad se desplegará en su Outlook.
 
 ### Correo electrónico en Mac OS
 
-#### Exportar
-
-En la columna izquierda, seleccione una o más cuentas de correo. En el menú horizontal, haga clic en `Buzón de correo` y seleccione `Exportar buzón`.
-
-![correo electrónico](images/mail-export-mac01.png){.thumbnail}
-
-Seleccione la carpeta que desee o cree una nueva, y haga clic en `Elegir`.
-
-![correo electrónico](images/mail-export-mac02.png){.thumbnail}
-
-La exportación se presenta como archivo ".mbox".
-
-#### Importar
-
-Haga clic en `Archivo` en el menú horizontal y seleccione `Importar buzones de correo`.
-
-![correo electrónico](images/mail-import-mac01.png){.thumbnail}
-
-Seleccione el archivo de backup en formato ".mbox" y haga clic en `Continuar`.
-
-![correo electrónico](images/mail-import-mac02.png){.thumbnail}
-
-Desde la columna izquierda, los mensajes de correo importados se encuentran en una nueva cuenta de correo llamada "Importación". Puede arrastrar las carpetas y los mensajes desde la cuenta de importación a sus cuentas de correo ya configuradas. Una vez completadas las transferencias, podrá eliminar la cuenta de importación.
+> [!tabs]
+> **Exportar**
+>>
+>> En la columna izquierda, seleccione una o más cuentas de correo. En el menú horizontal, haga clic en `Buzón de correo` y seleccione `Exportar buzón`.
+>>
+>> ![correo electrónico](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Seleccione la carpeta que desee o cree una nueva, y haga clic en `Elegir`.
+>>
+>> ![correo electrónico](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> La exportación se presenta como archivo ".mbox".
+>>
+> **Importar**
+>>
+>> Haga clic en `Archivo` en el menú horizontal y seleccione `Importar buzones de correo`.
+>>
+>> ![correo electrónico](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Seleccione el archivo de backup en formato ".mbox" y haga clic en `Continuar`.
+>>
+>> ![correo electrónico](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> Desde la columna izquierda, los mensajes de correo importados se encuentran en una nueva cuenta de correo llamada "Importación". Puede arrastrar las carpetas y los mensajes desde la cuenta de importación a sus cuentas de correo ya configuradas. Una vez completadas las transferencias, podrá eliminar la cuenta de importación.
 
 ### Thunderbird
 
 Actualmente no hay ninguna funcionalidad nativa para exportar o importar una cuenta de correo desde Thunderbird. No obstante, es posible guardar un perfil Thunderbird. que contiene todas las cuentas y emails en local en su ordenador. Vamos a consultar cómo guardar un perfil Thunderbird y reintegrarlo en una nueva instancia de Thunderbird.
 
-#### Exportar
-
-En la ventana principal, haga clic en el menú situado en la esquina superior derecha y seleccione `Ayuda` y luego en `Información de reparación`.
-
-![correo electrónico](images/thunderbird_menu.png){.thumbnail}
-
-Se mostrará una tabla. Identifique la línea `Directorio de perfil` y haga clic en el botón `Abrir carpeta correspondiente`.
-
-![correo electrónico](images/thunderbird_open_folder.png){.thumbnail}
-
-El sistema le dirigirá a la carpeta del perfil. Suba una carpeta en el árbol.
-
-![correo electrónico](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Copie la carpeta del perfil haciendo clic derecho en ella y pegue la carpeta en la carpeta o el soporte que desee.
-
-![correo electrónico](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importar
-
-En lugar de importar, se tratará de cargar el perfil.
-Si ya hay cuentas de correo configuradas en la instancia Thunderbird de destino, estas estarán presentes en un perfil A.
-Cuando Thunderbird cargue un nuevo perfil (perfil B), solo podrá cargar **los** elementos de este perfil B.
-Por ese motivo, le recomendamos que cargue en primer lugar el nuevo perfil (perfil B) y luego configure las cuentas de correo del perfil A.
-
-En primer lugar, debe iniciar Thunderbird a través del gestor de perfiles.
-
-- En Windows, abra el menú `Iniciar` y seleccione el programa `Ejecutar`. Introduzca `thunderbird.exe -ProfileManager` y haga clic en `OK`.
-
-![correo electrónico](images/thunderbird-run-profil.png){.thumbnail}
-
-- En Mac OS, ejecute la aplicación Terminal y arrastre y coloque su aplicación Thunderbird en la ventana de la Terminal, añadiendo a la línea `/Contents/MacOS/thunderbird-bin-ProfileManager`. Pulse la tecla `Entrar` ( ⏎) para aceptar.
-
-![correo electrónico](images/thunderbird-terminal-profil.png){.thumbnail}
-
-La siguiente ventana muestra los perfiles existentes. Haga clic en `Crear un perfil` y luego en `Siguiente` cuando aparezca el mensaje informativo.
-
-![correo electrónico](images/thunderbird-profil-create01.png){.thumbnail}
-
-En el siguiente paso, asigne un nombre a su perfil e identifique la carpeta en la que se creará el perfil. Bajo la frase "Sus preferencias de usuario, preferencias y todos sus datos personales se guardarán en":
-
-![correo electrónico](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> Le recomendamos que copie el backup de su perfil de Thunderbird en la carpeta de perfiles de Thunderbird.
-
-Haga clic en `Elegir carpeta..` para seleccionar la carpeta que contenga la copia de seguridad. Haga clic en `Finalizar` para crear el perfil con la copia de seguridad.
-
-A continuación, encontrará la ventana de selección de su perfil con el nuevo perfil seleccionado. Haga clic en `Iniciar Thunderbird`. Thunderbird se ejecutará con todos los elementos que tenga en su copia de seguridad.
+> [!tabs]
+> **Exportar**
+>>
+>> En la ventana principal, haga clic en el menú situado en la esquina superior derecha y seleccione `Ayuda` y luego en `Información de reparación`.
+>>
+>> ![correo electrónico](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> Se mostrará una tabla. Identifique la línea `Directorio de perfil` y haga clic en el botón `Abrir carpeta correspondiente`.
+>>
+>> ![correo electrónico](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> El sistema le dirigirá a la carpeta del perfil. Suba una carpeta en el árbol.
+>>
+>> ![correo electrónico](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Copie la carpeta del perfil haciendo clic derecho en ella y pegue la carpeta en la carpeta o el soporte que desee.
+>>
+>> ![correo electrónico](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Importar**
+>>
+>> En lugar de importar, se tratará de cargar el perfil.
+>> Si ya hay cuentas de correo configuradas en la instancia Thunderbird de destino, estas estarán presentes en un perfil A.
+>> Cuando Thunderbird cargue un nuevo perfil (perfil B), solo podrá cargar **los** elementos de este perfil B.
+>> Por ese motivo, le recomendamos que cargue en primer lugar el nuevo perfil (perfil B) y luego configure las cuentas de correo del perfil A.
+>>
+>> En primer lugar, debe iniciar Thunderbird a través del gestor de perfiles.
+>>
+>> - En Windows, abra el menú `Iniciar` y seleccione el programa `Ejecutar`. Introduzca `thunderbird.exe -ProfileManager` y haga clic en `OK`.
+>>
+>> ![correo electrónico](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - En Mac OS, ejecute la aplicación Terminal y arrastre y coloque su aplicación Thunderbird en la ventana de la Terminal, añadiendo a la línea `/Contents/MacOS/thunderbird-bin -ProfileManager`. Pulse la tecla `Entrar` (⏎) para aceptar.
+>>
+>> ![correo electrónico](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> La siguiente ventana muestra los perfiles existentes. Haga clic en `Crear un perfil` y luego en `Siguiente` cuando aparezca el mensaje informativo.
+>>
+>> ![correo electrónico](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> En el siguiente paso, asigne un nombre a su perfil e identifique la carpeta en la que se creará el perfil, bajo la frase "Sus preferencias de usuario, preferencias y todos sus datos personales se guardarán en":
+>>
+>> ![correo electrónico](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > Le recomendamos que copie el backup de su perfil de Thunderbird en la carpeta de perfiles de Thunderbird.
+>>
+>> Haga clic en `Elegir carpeta...` para seleccionar la carpeta que contenga la copia de seguridad. Haga clic en `Finalizar` para crear el perfil con la copia de seguridad.
+>>
+>> A continuación, encontrará la ventana de selección de su perfil con el nuevo perfil seleccionado. Haga clic en `Iniciar Thunderbird`. Thunderbird se ejecutará con todos los elementos que tenga en su copia de seguridad.
 
 ### Comprobar la importación en la nueva dirección de correo
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-es.md
@@ -67,11 +67,11 @@ Las instrucciones siguientes se dividen en dos partes:
 
 Si tiene una cuenta de correo [Exchange de OVHcloud](/links/web/emails-hosted-exchange), puede exportarla directamente en formato PST desde el área de cliente.
 
-En la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar en formato PST`{.action}.
+En la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar a PST`{.action}.
 
 ![correo electrónico](images/manager-export-pst01.png){.thumbnail .w-640}
 
-A continuación, habrá que esperar el tiempo de la exportación, que puede tardar unos minutos a varias horas, según el tamaño de la exportación. Al final del archivo, solo tendrá que volver al botón `Exportar en formato PST`{.action} para descargar el archivo.
+A continuación, habrá que esperar el tiempo de la exportación, que puede tardar unos minutos a varias horas, según el tamaño de la exportación. Al final del archivo, solo tendrá que volver al botón `Exportar a PST`{.action} para descargar el archivo.
 
 ![correo electrónico](images/manager-export-pst02.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-us.md
@@ -73,7 +73,7 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 > [!tabs]
 > **Exportar**
 >>
->> - Haga clic en `archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `importar y exportar`{.action}.
+>> - Haga clic en `Archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `Importar y exportar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
@@ -104,7 +104,7 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 >>
 > **Importar**
 >>
->> - Haga clic en `archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `importar y exportar`{.action}.
+>> - Haga clic en `Archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `Importar y exportar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-us.md
@@ -60,11 +60,11 @@ Las instrucciones siguientes se dividen en dos partes:
 
 Si tiene una cuenta de correo [Exchange de OVHcloud](/links/web/emails-hosted-exchange), puede exportarla directamente en formato PST desde el área de cliente.
 
-En la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar a PST`{.action}.
+Una vez en la página de su servicio Exchange, en la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar en formato PST`{.action}.
 
 ![correo electrónico](images/manager-export-pst01.png){.thumbnail .w-640}
 
-A continuación, habrá que esperar el tiempo de la exportación, que puede tardar unos minutos a varias horas, según el tamaño de la exportación. Al final del archivo, solo tendrá que volver al botón `Exportar a PST`{.action} para descargar el archivo.
+A continuación, habrá que esperar el tiempo de la exportación, que puede tardar unos minutos a varias horas, según el tamaño de la exportación. Al final del archivo, solo tendrá que volver al botón `Exportar en formato PST`{.action} para descargar el archivo.
 
 ![correo electrónico](images/manager-export-pst02.png){.thumbnail .w-640}
 
@@ -73,15 +73,15 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 > [!tabs]
 > **Exportar**
 >>
->> - Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
+>> - Haga clic en `archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `importar y exportar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Seleccione `Exportar datos a un archivo` y haga clic en `Siguiente`.
+>> - Seleccione `Exportar datos a un archivo`{.action} y haga clic en `Siguiente`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
+>> - Seleccione `Archivo de datos Outlook (.pst)`{.action} y haga clic en `Siguiente`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -90,11 +90,11 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 >> > [!primary]
 >> > Solo puede exportar una cuenta a la vez.
 >>
->> Marque `Incluir las subcarpetas` y haga clic en `Siguiente`.
+>> Marque `Incluir las subcarpetas`{.action} y haga clic en `Siguiente`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Seleccione la carpeta de destino de la copia de seguridad e introduzca un nombre para ella haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
+>> - Seleccione la carpeta de destino de la copia de seguridad e introduzca un nombre para ella haciendo clic en `Navegar`{.action}. Seleccione la opción más adecuada y haga clic en `Finalizar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -104,25 +104,25 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 >>
 > **Importar**
 >>
->> - Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
+>> - Haga clic en `archivo`{.action} en la parte superior izquierda, luego en `Abrir y Exportar`{.action} y, por último, en `importar y exportar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Seleccione `Importar de otro programa o archivo` y haga clic en `Siguiente`.
+>> - Seleccione `Importar de otro programa o archivo`{.action} y haga clic en `Siguiente`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
+>> - Seleccione `Archivo de datos Outlook (.pst)`{.action} y haga clic en `Siguiente`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Seleccione el archivo de backup haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
+>> - Seleccione el archivo de backup haciendo clic en `Navegar`{.action}. Seleccione la opción más adecuada y haga clic en `Finalizar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - Si ha establecido una contraseña en el archivo de backup, introdúzcala y haga clic en `Aceptar`.
+>> - Si ha establecido una contraseña en el archivo de backup, introdúzcala y haga clic en `Aceptar`{.action}.
 >>
->> - Seleccione `Importar elementos a la carpeta actual` y haga clic en `Finalizar`.
+>> - Seleccione `Importar elementos a la carpeta actual`{.action} y haga clic en `Finalizar`{.action}.
 >>
 >> Se inicia la importación de la copia de seguridad.
 
@@ -131,46 +131,46 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 > [!tabs]
 > **Exportar**
 >>
->> En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Exportar`.
+>> En la pestaña `Herramientas`{.action} de su ventana de Outlook, haga clic en `Exportar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> En la ventana Exportar a archivo.olm, marque los elementos que quiera añadir al archivo de backup y haga clic en `Continuar`.
+>> En la ventana Exportar a archivo.olm, marque los elementos que quiera añadir al archivo de backup y haga clic en `Continuar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> A continuación, seleccione la carpeta de destino para la copia de seguridad y haga clic en `Guardar`.
+>> A continuación, seleccione la carpeta de destino para la copia de seguridad y haga clic en `Guardar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. El archivo de backup aparecerá en la carpeta que haya elegido anteriormente.
+>> Se abrirá una ventana de progreso. Haga clic en `Continuar`{.action} al finalizar la operación. El archivo de backup aparecerá en la carpeta que haya elegido anteriormente.
 >>
 > **Importar**
 >>
->> En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Importar`.
+>> En la pestaña `Herramientas`{.action} de su ventana de Outlook, haga clic en `Importar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Seleccione el formato de la copia de seguridad que quiera importar y haga clic en `Continuar`.
+>> Seleccione el formato de la copia de seguridad que quiera importar y haga clic en `Continuar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Seleccione el archivo de backup y haga clic en `importar`.
+>> Seleccione el archivo de backup y haga clic en `Importar`{.action}.
 >>
 >> ![correo electrónico](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. La copia de seguridad se desplegará en su Outlook.
+>> Se abrirá una ventana de progreso. Haga clic en `Continuar`{.action} al finalizar la operación. La copia de seguridad se desplegará en su Outlook.
 
 ### Correo electrónico en Mac OS
 
 > [!tabs]
 > **Exportar**
 >>
->> En la columna izquierda, seleccione una o más cuentas de correo. En el menú horizontal, haga clic en `Buzón de correo` y seleccione `Exportar buzón`.
+>> En la columna izquierda, seleccione una o más cuentas de correo. En el menú horizontal, haga clic en `Buzón de correo`{.action} y seleccione `Exportar buzón`{.action}.
 >>
 >> ![correo electrónico](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Seleccione la carpeta que desee o cree una nueva, y haga clic en `Elegir`.
+>> Seleccione la carpeta que desee o cree una nueva, y haga clic en `Elegir`{.action}.
 >>
 >> ![correo electrónico](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -178,11 +178,11 @@ A continuación, habrá que esperar el tiempo de la exportación, que puede tard
 >>
 > **Importar**
 >>
->> Haga clic en `Archivo` en el menú horizontal y seleccione `Importar buzones de correo`.
+>> Haga clic en `Archivo`{.action} en el menú horizontal y seleccione `Importar buzones de correo`{.action}.
 >>
 >> ![correo electrónico](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Seleccione el archivo de backup en formato ".mbox" y haga clic en `Continuar`.
+>> Seleccione el archivo de backup en formato ".mbox" y haga clic en `Continuar`{.action}.
 >>
 >> ![correo electrónico](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -195,11 +195,11 @@ Actualmente no hay ninguna funcionalidad nativa para exportar o importar una cue
 > [!tabs]
 > **Exportar**
 >>
->> En la ventana principal, haga clic en el menú situado en la esquina superior derecha y seleccione `Ayuda` y luego en `Información de reparación`.
+>> En la ventana principal, haga clic en el menú situado en la esquina superior derecha y seleccione `Ayuda`{.action} y luego en `Información de reparación`{.action}.
 >>
 >> ![correo electrónico](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> Se mostrará una tabla. Identifique la línea `Directorio de perfil` y haga clic en el botón `Abrir carpeta correspondiente`.
+>> Se mostrará una tabla. Identifique la línea `Directorio de perfil`{.action} y haga clic en el botón `Abrir carpeta correspondiente`{.action}.
 >>
 >> ![correo electrónico](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -220,15 +220,15 @@ Actualmente no hay ninguna funcionalidad nativa para exportar o importar una cue
 >>
 >> En primer lugar, debe iniciar Thunderbird a través del gestor de perfiles.
 >>
->> - En Windows, abra el menú `Iniciar` y seleccione el programa `Ejecutar`. Introduzca `thunderbird.exe -ProfileManager` y haga clic en `OK`.
+>> - En Windows, abra el menú `Iniciar`{.action} y seleccione el programa `Ejecutar`{.action}. Introduzca `thunderbird.exe -ProfileManager` y haga clic en `OK`{.action}.
 >>
 >> ![correo electrónico](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
->> - En Mac OS, ejecute la aplicación Terminal y arrastre y coloque su aplicación Thunderbird en la ventana de la Terminal, añadiendo a la línea `/Contents/MacOS/thunderbird-bin -ProfileManager`. Pulse la tecla `Entrar` (⏎) para aceptar.
+>> - En Mac OS, ejecute la aplicación Terminal y arrastre y coloque su aplicación Thunderbird en la ventana de la Terminal, añadiendo a la línea `/Contents/MacOS/thunderbird-bin -ProfileManager`. Pulse la tecla `Entrar`{.action} (⏎) para aceptar.
 >>
 >> ![correo electrónico](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> La siguiente ventana muestra los perfiles existentes. Haga clic en `Crear un perfil` y luego en `Siguiente` cuando aparezca el mensaje informativo.
+>> La siguiente ventana muestra los perfiles existentes. Haga clic en `Crear un perfil`{.action} y luego en `Siguiente`{.action} cuando aparezca el mensaje informativo.
 >>
 >> ![correo electrónico](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -239,9 +239,9 @@ Actualmente no hay ninguna funcionalidad nativa para exportar o importar una cue
 >> > [!primary]
 >> > Le recomendamos que copie el backup de su perfil de Thunderbird en la carpeta de perfiles de Thunderbird.
 >>
->> Haga clic en `Elegir carpeta..` para seleccionar la carpeta que contenga la copia de seguridad. Haga clic en `Finalizar` para crear el perfil con la copia de seguridad.
+>> Haga clic en `Elegir carpeta...`{.action} para seleccionar la carpeta que contenga la copia de seguridad. Haga clic en `Finalizar`{.action} para crear el perfil con la copia de seguridad.
 >>
->> A continuación, encontrará la ventana de selección de su perfil con el nuevo perfil seleccionado. Haga clic en `Iniciar Thunderbird`. Thunderbird se ejecutará con todos los elementos que tenga en su copia de seguridad.
+>> A continuación, encontrará la ventana de selección de su perfil con el nuevo perfil seleccionado. Haga clic en `Iniciar Thunderbird`{.action}. Thunderbird se ejecutará con todos los elementos que tenga en su copia de seguridad.
 
 ### Comprobar la importación en la nueva dirección de correo
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-us.md
@@ -3,7 +3,6 @@ title: Migrar manualmente una dirección de correo electrónico
 excerpt: Cómo migrar manualmente su dirección de correo a otra dirección de correo
 updated: 2026-01-16
 ---
- 
 
 ## Objetivo
 
@@ -53,7 +52,7 @@ En esta guía hemos realizado las operaciones con los tres programas de correo m
 
 Las instrucciones siguientes se dividen en dos partes:
 
-- **La exportación**. De este modo, podrá descargar una copia de seguridad completa de su dirección de correo para cambiarla a otro correo, programa de correo o importación a otra cuenta . Si debe mover elementos de una dirección de correo electrónico a otra dirección configurada en el mismo cliente de correo, puede copiar/pegar o arrastrar/soltar una a otra. No obstante, le recomendamos que utilice el sistema de exportación del programa que utilice.
+- **La exportación**. De este modo, podrá descargar una copia de seguridad completa de su dirección de correo para cambiarla a otro correo, programa de correo o importación a otra cuenta. Si debe mover elementos de una dirección de correo electrónico a otra dirección configurada en el mismo cliente de correo, puede copiar/pegar o arrastrar/soltar una a otra. No obstante, le recomendamos que utilice el sistema de exportación del programa que utilice.
 
 - **La importación**. para poder guardar una copia de seguridad en su nuevo equipo o software. Compruebe que el archivo de backup que vaya a importar sea compatible con el cliente de correo que utilice.
 
@@ -61,184 +60,188 @@ Las instrucciones siguientes se dividen en dos partes:
 
 Si tiene una cuenta de correo [Exchange de OVHcloud](/links/web/emails-hosted-exchange), puede exportarla directamente en formato PST desde el área de cliente.
 
-1. Conéctese al [área de cliente de OVHcloud](/links/manager).
-1. Acceda al apartado `Web Cloud`{.action}.
-1. En la sección `MICROSOFT`, haga clic en `Exchange`{.action}.
-1. Seleccione la plataforma correspondiente.
-1. En la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar en formato PST`{.action}.
+En la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar en formato PST`{.action}.
 
-![correo electrónico](images/manager-export-pst01.png){.thumbnail}
+![correo electrónico](images/manager-export-pst01.png){.thumbnail .w-640}
 
 A continuación, habrá que esperar el tiempo de la exportación, que puede tardar unos minutos a varias horas, según el tamaño de la exportación. Al final del archivo, solo tendrá que volver al botón `Exportar en formato PST`{.action} para descargar el archivo.
 
-![correo electrónico](images/manager-export-pst02.png){.thumbnail}
+![correo electrónico](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Exportar desde Windows
+#### Windows
 
-- Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
+> [!tabs]
+> **Exportar**
+>>
+>> - Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
+>>
+>> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Seleccione `Exportar datos a un archivo` y haga clic en `Siguiente`.
+>>
+>> ![correo electrónico](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
+>>
+>> ![correo electrónico](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Seleccione el nombre de la cuenta de correo que quiera exportar.
+>>
+>> > [!primary]
+>> > Solo puede exportar una cuenta a la vez.
+>>
+>> Marque `Incluir las subcarpetas` y haga clic en `Siguiente`.
+>>
+>> ![correo electrónico](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Seleccione la carpeta de destino de la copia de seguridad e introduzca un nombre para ella haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
+>>
+>> ![correo electrónico](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> Comienza la exportación de su archivo. Al crear un archivo, se le pedirá que establezca una contraseña. Es opcional.
+>>
+>> ![correo electrónico](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Importar**
+>>
+>> - Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
+>>
+>> ![correo electrónico](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Seleccione `Importar de otro programa o archivo` y haga clic en `Siguiente`.
+>>
+>> ![correo electrónico](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
+>>
+>> ![correo electrónico](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Seleccione el archivo de backup haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
+>>
+>> ![correo electrónico](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - Si ha establecido una contraseña en el archivo de backup, introdúzcala y haga clic en `Aceptar`.
+>>
+>> - Seleccione `Importar elementos a la carpeta actual` y haga clic en `Finalizar`.
+>>
+>> Se inicia la importación de la copia de seguridad.
 
-![correo electrónico](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Seleccione `Exportar datos a un archivo` y haga clic en `Siguiente`.
-
-![correo electrónico](images/outlook-export-win02.png){.thumbnail}
-
-- Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
-
-![correo electrónico](images/outlook-export-win03.png){.thumbnail}
-
-- Seleccione el nombre de la cuenta de correo que quiera exportar.
-
-> [!primary]
-> Solo puede exportar una cuenta a la vez.
-
-Marque `Incluir las subcarpetas` y haga clic en `Siguiente`.
-
-![correo electrónico](images/outlook-export-win04.png){.thumbnail}
-
-- Seleccione la carpeta de destino de la copia de seguridad e introduzca un nombre para ella haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
-
-![correo electrónico](images/outlook-export-win05.png){.thumbnail}
-
-Comienza la exportación de su archivo. Al crear un archivo, se le pedirá que establezca una contraseña. Es opcional.
-
-![correo electrónico](images/outlook-export-win06.png){.thumbnail}
-
-#### Importar desde Windows
-
-- Haga clic en `archivo` en la parte superior izquierda, luego en `Abrir y Exportar` y, por último, en `importar y exportar`.
-
-![correo electrónico](images/outlook-export-import-win.png){.thumbnail}
-
-- Seleccione `Importar de otro programa o archivo` y haga clic en `Siguiente`.
-
-![correo electrónico](images/outlook-import-win02.png){.thumbnail}
-
-- Seleccione `Archivo de datos Outlook (.pst)` y haga clic en `Siguiente`.
-
-![correo electrónico](images/outlook-import-win03.png){.thumbnail}
-
-- Seleccione el archivo de backup haciendo clic en `Navegar`. Seleccione la opción más adecuada y haga clic en `Finalizar`.
-
-![correo electrónico](images/outlook-import-win04.png){.thumbnail}
-
-- Si ha establecido una contraseña en el archivo de backup, introdúzcala y haga clic en `Aceptar`.
-
-- Seleccione `Importar elementos a la carpeta actual` y haga clic en `Finalizar`.
-
-Se inicia la importación de la copia de seguridad.
-
-#### Exportar desde Mac OS
-
-En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Exportar`.
-
-![correo electrónico](images/outlook-export-mac01.png){.thumbnail}
-
-En la ventana Exportar a archivo.olm, marque los elementos que quiera añadir al archivo de backup y haga clic en `Continuar`.
-
-![correo electrónico](images/outlook-export-mac02.png){.thumbnail}
-
-A continuación, seleccione la carpeta de destino para la copia de seguridad y haga clic en `Guardar`.
-
-![correo electrónico](images/outlook-export-mac03.png){.thumbnail}
-
-Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. El archivo de backup aparecerá en la carpeta que haya elegido anteriormente.
-
-#### Importar desde Mac OS
-
-En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Importar`.
-
-![correo electrónico](images/outlook-import-mac01.png){.thumbnail}
-
-Seleccione el formato de la copia de seguridad que quiera importar y haga clic en `Continuar`.
-
-![correo electrónico](images/outlook-import-mac02.png){.thumbnail}
-
-Seleccione el archivo de backup y haga clic en `importar`.
-
-![correo electrónico](images/outlook-import-mac03.png){.thumbnail}
-
-Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. La copia de seguridad se desplegará en su Outlook.
+> [!tabs]
+> **Exportar**
+>>
+>> En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Exportar`.
+>>
+>> ![correo electrónico](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> En la ventana Exportar a archivo.olm, marque los elementos que quiera añadir al archivo de backup y haga clic en `Continuar`.
+>>
+>> ![correo electrónico](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> A continuación, seleccione la carpeta de destino para la copia de seguridad y haga clic en `Guardar`.
+>>
+>> ![correo electrónico](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. El archivo de backup aparecerá en la carpeta que haya elegido anteriormente.
+>>
+> **Importar**
+>>
+>> En la pestaña `Herramientas` de su ventana de Outlook, haga clic en `Importar`.
+>>
+>> ![correo electrónico](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Seleccione el formato de la copia de seguridad que quiera importar y haga clic en `Continuar`.
+>>
+>> ![correo electrónico](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Seleccione el archivo de backup y haga clic en `importar`.
+>>
+>> ![correo electrónico](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> Se abrirá una ventana de progreso. Haga clic en `Continuar` al finalizar la operación. La copia de seguridad se desplegará en su Outlook.
 
 ### Correo electrónico en Mac OS
 
-#### Exportar
-
-En la columna izquierda, seleccione una o más cuentas de correo. En el menú horizontal, haga clic en `Buzón de correo` y seleccione `Exportar buzón`.
-
-![correo electrónico](images/mail-export-mac01.png){.thumbnail}
-
-Seleccione la carpeta que desee o cree una nueva, y haga clic en `Elegir`.
-
-![correo electrónico](images/mail-export-mac02.png){.thumbnail}
-
-La exportación se presenta como archivo ".mbox".
-
-#### Importar
-
-Haga clic en `Archivo` en el menú horizontal y seleccione `Importar buzones de correo`.
-
-![correo electrónico](images/mail-import-mac01.png){.thumbnail}
-
-Seleccione el archivo de backup en formato ".mbox" y haga clic en `Continuar`.
-
-![correo electrónico](images/mail-import-mac02.png){.thumbnail}
-
-Desde la columna izquierda, los mensajes de correo importados se encuentran en una nueva cuenta de correo llamada "Importación". Puede arrastrar las carpetas y los mensajes desde la cuenta de importación a sus cuentas de correo ya configuradas. Una vez completadas las transferencias, podrá eliminar la cuenta de importación.
+> [!tabs]
+> **Exportar**
+>>
+>> En la columna izquierda, seleccione una o más cuentas de correo. En el menú horizontal, haga clic en `Buzón de correo` y seleccione `Exportar buzón`.
+>>
+>> ![correo electrónico](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Seleccione la carpeta que desee o cree una nueva, y haga clic en `Elegir`.
+>>
+>> ![correo electrónico](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> La exportación se presenta como archivo ".mbox".
+>>
+> **Importar**
+>>
+>> Haga clic en `Archivo` en el menú horizontal y seleccione `Importar buzones de correo`.
+>>
+>> ![correo electrónico](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Seleccione el archivo de backup en formato ".mbox" y haga clic en `Continuar`.
+>>
+>> ![correo electrónico](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> Desde la columna izquierda, los mensajes de correo importados se encuentran en una nueva cuenta de correo llamada "Importación". Puede arrastrar las carpetas y los mensajes desde la cuenta de importación a sus cuentas de correo ya configuradas. Una vez completadas las transferencias, podrá eliminar la cuenta de importación.
 
 ### Thunderbird
 
 Actualmente no hay ninguna funcionalidad nativa para exportar o importar una cuenta de correo desde Thunderbird. No obstante, es posible guardar un perfil Thunderbird. que contiene todas las cuentas y emails en local en su ordenador. Vamos a consultar cómo guardar un perfil Thunderbird y reintegrarlo en una nueva instancia de Thunderbird.
 
-#### Exportar
-
-En la ventana principal, haga clic en el menú situado en la esquina superior derecha y seleccione `Ayuda` y luego en `Información de reparación`.
-
-![correo electrónico](images/thunderbird_menu.png){.thumbnail}
-
-Se mostrará una tabla. Identifique la línea `Directorio de perfil` y haga clic en el botón `Abrir carpeta correspondiente`.
-
-![correo electrónico](images/thunderbird_open_folder.png){.thumbnail}
-
-El sistema le dirigirá a la carpeta del perfil. Suba una carpeta en el árbol.
-
-![correo electrónico](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Copie la carpeta del perfil haciendo clic derecho en ella y pegue la carpeta en la carpeta o el soporte que desee.
-
-![correo electrónico](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importar
-
-En lugar de importar, se tratará de cargar el perfil.
-Si ya hay cuentas de correo configuradas en la instancia Thunderbird de destino, estas estarán presentes en un perfil A.
-Cuando Thunderbird cargue un nuevo perfil (perfil B), solo podrá cargar **los** elementos de este perfil B.
-Por ese motivo, le recomendamos que cargue en primer lugar el nuevo perfil (perfil B) y luego configure las cuentas de correo del perfil A.
-
-En primer lugar, debe iniciar Thunderbird a través del gestor de perfiles.
-
-- En Windows, abra el menú `Iniciar` y seleccione el programa `Ejecutar`. Introduzca `thunderbird.exe -ProfileManager` y haga clic en `OK`.
-
-![correo electrónico](images/thunderbird-run-profil.png){.thumbnail}
-
-- En Mac OS, ejecute la aplicación Terminal y arrastre y coloque su aplicación Thunderbird en la ventana de la Terminal, añadiendo a la línea `/Contents/MacOS/thunderbird-bin-ProfileManager`. Pulse la tecla `Entrar` ( ⏎) para aceptar.
-
-![correo electrónico](images/thunderbird-terminal-profil.png){.thumbnail}
-
-La siguiente ventana muestra los perfiles existentes. Haga clic en `Crear un perfil` y luego en `Siguiente` cuando aparezca el mensaje informativo.
-
-![correo electrónico](images/thunderbird-profil-create01.png){.thumbnail}
-
-En el siguiente paso, asigne un nombre a su perfil e identifique la carpeta en la que se creará el perfil. Bajo la frase "Sus preferencias de usuario, preferencias y todos sus datos personales se guardarán en":
-
-![correo electrónico](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> Le recomendamos que copie el backup de su perfil de Thunderbird en la carpeta de perfiles de Thunderbird.
-
-Haga clic en `Elegir carpeta..` para seleccionar la carpeta que contenga la copia de seguridad. Haga clic en `Finalizar` para crear el perfil con la copia de seguridad.
-
-A continuación, encontrará la ventana de selección de su perfil con el nuevo perfil seleccionado. Haga clic en `Iniciar Thunderbird`. Thunderbird se ejecutará con todos los elementos que tenga en su copia de seguridad.
+> [!tabs]
+> **Exportar**
+>>
+>> En la ventana principal, haga clic en el menú situado en la esquina superior derecha y seleccione `Ayuda` y luego en `Información de reparación`.
+>>
+>> ![correo electrónico](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> Se mostrará una tabla. Identifique la línea `Directorio de perfil` y haga clic en el botón `Abrir carpeta correspondiente`.
+>>
+>> ![correo electrónico](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> El sistema le dirigirá a la carpeta del perfil. Suba una carpeta en el árbol.
+>>
+>> ![correo electrónico](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Copie la carpeta del perfil haciendo clic derecho en ella y pegue la carpeta en la carpeta o el soporte que desee.
+>>
+>> ![correo electrónico](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Importar**
+>>
+>> En lugar de importar, se tratará de cargar el perfil.
+>> Si ya hay cuentas de correo configuradas en la instancia Thunderbird de destino, estas estarán presentes en un perfil A.
+>> Cuando Thunderbird cargue un nuevo perfil (perfil B), solo podrá cargar **los** elementos de este perfil B.
+>> Por ese motivo, le recomendamos que cargue en primer lugar el nuevo perfil (perfil B) y luego configure las cuentas de correo del perfil A.
+>>
+>> En primer lugar, debe iniciar Thunderbird a través del gestor de perfiles.
+>>
+>> - En Windows, abra el menú `Iniciar` y seleccione el programa `Ejecutar`. Introduzca `thunderbird.exe -ProfileManager` y haga clic en `OK`.
+>>
+>> ![correo electrónico](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - En Mac OS, ejecute la aplicación Terminal y arrastre y coloque su aplicación Thunderbird en la ventana de la Terminal, añadiendo a la línea `/Contents/MacOS/thunderbird-bin -ProfileManager`. Pulse la tecla `Entrar` (⏎) para aceptar.
+>>
+>> ![correo electrónico](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> La siguiente ventana muestra los perfiles existentes. Haga clic en `Crear un perfil` y luego en `Siguiente` cuando aparezca el mensaje informativo.
+>>
+>> ![correo electrónico](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> En el siguiente paso, asigne un nombre a su perfil e identifique la carpeta en la que se creará el perfil. Bajo la frase "Sus preferencias de usuario, preferencias y todos sus datos personales se guardarán en":
+>>
+>> ![correo electrónico](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > Le recomendamos que copie el backup de su perfil de Thunderbird en la carpeta de perfiles de Thunderbird.
+>>
+>> Haga clic en `Elegir carpeta..` para seleccionar la carpeta que contenga la copia de seguridad. Haga clic en `Finalizar` para crear el perfil con la copia de seguridad.
+>>
+>> A continuación, encontrará la ventana de selección de su perfil con el nuevo perfil seleccionado. Haga clic en `Iniciar Thunderbird`. Thunderbird se ejecutará con todos los elementos que tenga en su copia de seguridad.
 
 ### Comprobar la importación en la nueva dirección de correo
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.es-us.md
@@ -60,11 +60,11 @@ Las instrucciones siguientes se dividen en dos partes:
 
 Si tiene una cuenta de correo [Exchange de OVHcloud](/links/web/emails-hosted-exchange), puede exportarla directamente en formato PST desde el área de cliente.
 
-En la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar en formato PST`{.action}.
+En la pestaña `Cuentas de correo`{.action}, haga clic en el botón `...`{.action} a la derecha de la cuenta de correo que quiera exportar y luego en `Exportar a PST`{.action}.
 
 ![correo electrónico](images/manager-export-pst01.png){.thumbnail .w-640}
 
-A continuación, habrá que esperar el tiempo de la exportación, que puede tardar unos minutos a varias horas, según el tamaño de la exportación. Al final del archivo, solo tendrá que volver al botón `Exportar en formato PST`{.action} para descargar el archivo.
+A continuación, habrá que esperar el tiempo de la exportación, que puede tardar unos minutos a varias horas, según el tamaño de la exportación. Al final del archivo, solo tendrá que volver al botón `Exportar a PST`{.action} para descargar el archivo.
 
 ![correo electrónico](images/manager-export-pst02.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-ca.md
@@ -60,11 +60,11 @@ Les instructions qui suivent sont décomposées en deux parties :
 
 Si vous possédez un compte e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), il est possible de l'exporter directement au format PST depuis l'espace client.
 
-Dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter au format PST`{.action}.
+Dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter en PST`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter au format PST`{.action} pour récupérer un lien pour télécharger le fichier.
+Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter en PST`{.action} pour récupérer un lien pour télécharger le fichier.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-ca.md
@@ -1,12 +1,12 @@
 ---
-title: Migrer manuellement votre adresse e-mail 
+title: Migrer manuellement votre adresse e-mail
 excerpt: Découvrez comment migrer manuellement votre adresse e-mail vers une autre adresse e-mail
 updated: 2026-01-16
 ---
 
 ## Objectif
 
-[La migration automatique](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm) d’une adresse e-mail est possible via notre outil [OVHcloud Mail Migrator](/links/web/omm). Vous pouvez également migrer manuellement votre adresse e-mail par le biais des logiciels de messagerie.
+[La migration automatique](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm) d'une adresse e-mail est possible via notre outil [OVHcloud Mail Migrator](/links/web/omm). Vous pouvez également migrer manuellement votre adresse e-mail par le biais des logiciels de messagerie.
 
 **Découvrez comment migrer manuellement votre adresse e-mail.**
 
@@ -32,12 +32,12 @@ updated: 2026-01-16
 **MX Plan :**
 
 - **Lien direct :** [MX Plan](/links/control-panel/web-mx-plan)
-- **Chemin de navigation :** `Web Cloud`{.action} > `MX Plan`{.action} > Sélectionnez votre service MX Plan
+- **Pour accéder à vos services :** `Web Cloud`{.action} > `MX Plan`{.action} > Sélectionnez votre service MX Plan
 
 **Exchange :**
 
 - **Lien direct :** [Exchange](/links/control-panel/web-exchange)
-- **Chemin de navigation :** `Web Cloud`{.action} > `Exchange`{.action} > Sélectionnez votre plateforme
+- **Pour accéder à vos services :** `Web Cloud`{.action} > `Exchange`{.action} > Sélectionnez votre plateforme
 
 ---
 <!-- CP-NAV-END:web-exchange -->
@@ -52,7 +52,7 @@ Dans ce guide nous avons réalisé les opérations sur les 3 logiciels de messag
 
 Les instructions qui suivent sont décomposées en deux parties :
 
-- **L'exportation**. Cela vous permet d'extraire une sauvegarde complète de votre adresse e-mail pour la basculer vers un autre poste, logiciel de messagerie, ou import vers un autre compte . Si vous devez déplacer des éléments d'une adresse e-mail vers une autre adresse qui est configurée sur le même logiciel de messagerie, il est possible de copier/coller ou de glisser/déposer l'une vers l'autre. Il est néanmoins recommandé d'utiliser le système d'exportation du logiciel que vous utilisez.
+- **L'exportation**. Cela vous permet d'extraire une sauvegarde complète de votre adresse e-mail pour la basculer vers un autre poste, logiciel de messagerie, ou import vers un autre compte. Si vous devez déplacer des éléments d'une adresse e-mail vers une autre adresse qui est configurée sur le même logiciel de messagerie, il est possible de copier/coller ou de glisser/déposer l'une vers l'autre. Il est néanmoins recommandé d'utiliser le système d'exportation du logiciel que vous utilisez.
 
 - **L'importation**. Cela vous permet d'appliquer une sauvegarde que vous avez réalisée sur votre nouveau poste ou nouveau logiciel. Vérifiez que le fichier de sauvegarde à importer est compatible avec le logiciel de messagerie que vous utilisez.
 
@@ -60,184 +60,188 @@ Les instructions qui suivent sont décomposées en deux parties :
 
 Si vous possédez un compte e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), il est possible de l'exporter directement au format PST depuis l'espace client.
 
-1. Connectez-vous à votre [espace client OVHcloud](/links/manager).
-1. Rendez-vous dans la partie `Web Cloud`{.action}.
-1. Dans la rubrique `MICROSOFT`, cliquez sur `Exchange`{.action}.
-1. Sélectionnez la plateforme concernée.
-1. Dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter au format PST`{.action}.
+Dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter au format PST`{.action}.
 
-![emails](images/manager-export-pst01.png){.thumbnail}
+![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-Il faudra ensuite patienter le temps de l'export qui peut prendre quelque minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter au format PST`{.action} pour récupérer un lien pour télécharger le fichier.
+Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter au format PST`{.action} pour récupérer un lien pour télécharger le fichier.
 
-![emails](images/manager-export-pst02.png){.thumbnail}
+![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Exporter depuis Windows
+#### Windows
 
-- Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
+> [!tabs]
+> **Exporter**
+>>
+>> - Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Sélectionnez `Exporter des données vers un fichier` puis cliquez sur `Suivant`.
+>>
+>> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
+>>
+>> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Sélectionnez le nom du compte e-mail à exporter.
+>>
+>> > [!primary]
+>> > Vous ne pouvez exporter qu'un seul compte à la fois.
+>>
+>> Cochez bien `Inclure les sous-dossiers` puis cliquez sur `Suivant`.
+>>
+>> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Choisissez le dossier de destination de votre sauvegarde et entrez un nom pour celle-ci en cliquant sur `Parcourir`. Sélectionnez l'option qui vous convient puis cliquez sur `Terminer`.
+>>
+>> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> L'exportation de votre fichier commence. Lors de la création d'un fichier, il vous sera demandé de définir un mot de passe. Celui-ci est facultatif.
+>>
+>> ![emails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Importer**
+>>
+>> - Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Sélectionnez `Importer à partir d'un autre programme ou fichier` puis cliquez sur `Suivant`.
+>>
+>> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
+>>
+>> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Choisissez votre fichier de sauvegarde en cliquant sur `Parcourir`. Sélectionnez l'option qui vous convient puis cliquez sur `Terminer`.
+>>
+>> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - Si vous avez défini un mot de passe sur votre fichier de sauvegarde, entrez celui-ci puis cliquez sur `OK`.
+>>
+>> - Sélectionnez `Importer les éléments dans le dossier actif` puis cliquez sur `Terminer`.
+>>
+>> L'importation de votre sauvegarde se lance.
 
-![emails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Sélectionnez `Exporter des données vers un fichier` puis cliquez sur `Suivant`.
-
-![emails](images/outlook-export-win02.png){.thumbnail}
-
-- Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
-
-![emails](images/outlook-export-win03.png){.thumbnail}
-
-- Sélectionnez le nom du compte e-mail à exporter.
-
-> [!primary]
-> Vous ne pouvez exporter qu'un seul compte à la fois.
-
-Cochez bien `Inclure les sous-dossiers` puis cliquez sur `Suivant`.
-
-![emails](images/outlook-export-win04.png){.thumbnail}
-
-- Choisissez le dossier de destination de votre sauvegarde et entrez un nom pour celle-ci en cliquant sur `Parcourir`. Sélectionnez l'option qui vous convient puis cliquez sur `Terminer`.
-
-![emails](images/outlook-export-win05.png){.thumbnail}
-
-L'exportation de votre fichier commence. Lors de la création d'un fichier, il vous sera demandé de définir un mot de passe. Celui-ci est facultatif.
-
-![emails](images/outlook-export-win06.png){.thumbnail}
-
-#### Importer depuis Windows
-
-- Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
-
-![emails](images/outlook-export-import-win.png){.thumbnail}
-
-- Sélectionnez `Importer à partir d’un autre programme ou fichier` puis cliquez sur `Suivant`.
-
-![emails](images/outlook-import-win02.png){.thumbnail}
-
-- Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
-
-![emails](images/outlook-import-win03.png){.thumbnail}
-
-- Choisissez votre fichier de sauvegarde en cliquant sur `Parcourir`. Sélectionnez l'option qui vous convient puis cliquez sur `Terminer`.
-
-![emails](images/outlook-import-win04.png){.thumbnail}
-
-- Si vous avez défini un mot de passe sur votre fichier de sauvegarde, entrez celui-ci puis cliquez sur `OK`.
-
-- Sélectionnez `Importer les éléments dans le dossier actif` puis cliquez sur `Terminer`.
-
-L'importation de votre sauvegarde se lance.
-
-#### Exporter depuis Mac OS
-
-Dans l’onglet `Outils` de votre fenêtre Outlook, cliquez sur `Exporter`.
-
-![emails](images/outlook-export-mac01.png){.thumbnail}
-
-Depuis la fenêtre « Exporter vers un fichier archive (.olm) », cochez les éléments que vous souhaitez ajouter à votre fichier sauvegarde, puis cliquez sur `Continuer`.
-
-![emails](images/outlook-export-mac02.png){.thumbnail}
-
-Sélectionnez ensuite le dossier de destination pour votre sauvegarde, puis cliquez sur `Enregistrer`.
-
-![emails](images/outlook-export-mac03.png){.thumbnail}
-
-Une fenêtre de progression s'affichera, cliquez sur `Continuer` à la fin de l'opération. Vous retrouverez votre fichier de sauvegarde dans le dossier choisi précédemment.
-
-#### Importer depuis Mac OS
-
-Dans l’onglet `Outils` de votre fenêtre Outlook, cliquez sur `Importer`.
-
-![emails](images/outlook-import-mac01.png){.thumbnail}
-
-Choisissez le format de sauvegarde que vous allez importer, puis cliquez sur `Continuer`.
-
-![emails](images/outlook-import-mac02.png){.thumbnail}
-
-Sélectionnez votre fichier de sauvegarde, puis cliquez sur `importer`.
-
-![emails](images/outlook-import-mac03.png){.thumbnail}
-
-Une fenêtre de progression s'affichera, cliquez sur `Continuer` à la fin de l'opération. Votre sauvegarde est alors déployée sur votre Outlook.
+> [!tabs]
+> **Exporter**
+>>
+>> Dans l'onglet `Outils` de votre fenêtre Outlook, cliquez sur `Exporter`.
+>>
+>> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> Depuis la fenêtre « Exporter vers un fichier archive (.olm) », cochez les éléments que vous souhaitez ajouter à votre fichier sauvegarde, puis cliquez sur `Continuer`.
+>>
+>> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Sélectionnez ensuite le dossier de destination pour votre sauvegarde, puis cliquez sur `Enregistrer`.
+>>
+>> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> Une fenêtre de progression s'affichera, cliquez sur `Continuer` à la fin de l'opération. Vous retrouverez votre fichier de sauvegarde dans le dossier choisi précédemment.
+>>
+> **Importer**
+>>
+>> Dans l'onglet `Outils` de votre fenêtre Outlook, cliquez sur `Importer`.
+>>
+>> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Choisissez le format de sauvegarde que vous allez importer, puis cliquez sur `Continuer`.
+>>
+>> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Sélectionnez votre fichier de sauvegarde, puis cliquez sur `importer`.
+>>
+>> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> Une fenêtre de progression s'affichera, cliquez sur `Continuer` à la fin de l'opération. Votre sauvegarde est alors déployée sur votre Outlook.
 
 ### Mail sur Mac OS
 
-#### Exporter
-
-Depuis la colonne de gauche, sélectionnez un ou plusieurs comptes e-mail. Cliquez sur `Boîte aux lettres` dans le menu horizontal, puis sur `Exporter la boîte aux lettres`.
-
-![emails](images/mail-export-mac01.png){.thumbnail}
-
-Sélectionnez le dossier de votre choix ou créez-en un nouveau, puis cliquez sur `Choisir`.
-
-![emails](images/mail-export-mac02.png){.thumbnail}
-
-Votre exportation se présente sous forme d'un fichier « .mbox ».
-
-#### Importer
-
-Cliquez sur `Fichier` dans le menu horizontal, puis sur `Importer des boîtes aux lettres`.
-
-![emails](images/mail-import-mac01.png){.thumbnail}
-
-Sélectionnez votre fichier de sauvegarde au format « .mbox », puis cliquez sur `Continuer`.
-
-![emails](images/mail-import-mac02.png){.thumbnail}
-
-Depuis la colonne de gauche, les e-mails importés se trouvent dans un nouveau compte e-mail nommé « Importation ». Vous pouvez faire glisser les dossiers et les messages à partir du compte « Importation » vers vos comptes e-mail déjà configurés. Une fois vos transferts terminés, vous pourrez supprimer le compte « Importation ».
+> [!tabs]
+> **Exporter**
+>>
+>> Depuis la colonne de gauche, sélectionnez un ou plusieurs comptes e-mail. Cliquez sur `Boîte aux lettres` dans le menu horizontal, puis sur `Exporter la boîte aux lettres`.
+>>
+>> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Sélectionnez le dossier de votre choix ou créez-en un nouveau, puis cliquez sur `Choisir`.
+>>
+>> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> Votre exportation se présente sous forme d'un fichier « .mbox ».
+>>
+> **Importer**
+>>
+>> Cliquez sur `Fichier` dans le menu horizontal, puis sur `Importer des boîtes aux lettres`.
+>>
+>> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Sélectionnez votre fichier de sauvegarde au format « .mbox », puis cliquez sur `Continuer`.
+>>
+>> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> Depuis la colonne de gauche, les e-mails importés se trouvent dans un nouveau compte e-mail nommé « Importation ». Vous pouvez faire glisser les dossiers et les messages à partir du compte « Importation » vers vos comptes e-mail déjà configurés. Une fois vos transferts terminés, vous pourrez supprimer le compte « Importation ».
 
 ### Thunderbird
 
 Il n'existe actuellement pas de fonctionnalité native pour exporter ou importer un compte e-mail depuis Thunderbird. Il est néanmoins possible de sauvegarder un profil Thunderbird. Celui-ci contient l'ensemble des comptes et e-mails en local sur votre ordinateur. Nous allons voir comment sauvegarder un profil Thunderbird et le réintégrer sur une nouvelle instance de Thunderbird.
 
-#### Exporter
-
-Depuis la fenêtre principale, cliquez sur le menu en haut à droite puis sur `Aide` et enfin sur `Informations de dépannage`.
-
-![emails](images/thunderbird_menu.png){.thumbnail}
-
-Un tableau apparaît. Identifiez la ligne `Répertoire de profil` et cliquez sur le bouton `Ouvrir le dossier correspondant`.
-
-![emails](images/thunderbird_open_folder.png){.thumbnail}
-
-Vous serez alors dirigé dans le dossier du profil. Remontez d'un dossier dans l'arborescence.
-
-![emails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Copiez le dossier du profil via un clic-droit sur celui-ci, puis collez ce dossier dans le dossier ou support de votre choix.
-
-![emails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importer
-
-Plutôt qu'une importation, il sera question ici d'un chargement de profil.
-Si des comptes e-mail ont déjà été configurés sur l'instance Thunderbird de destination, ils seront présents sur un profil A.
-Lorsque Thunderbird va charger un nouveau profil (profil B), il ne pourra charger **que** les éléments de ce profil B.
-C’est pourquoi nous vous conseillons de charger d’abord le nouveau profil (profil B) puis d’y configurer les comptes e-mail provenant du profil A.
-
-Vous devez d'abord démarrer Thunderbird via le gestionnaire de profils.
-
-- Sur Windows, allez sur le menu `Démarrer` puis sur le programme `Exécuter`. Sur ce dernier, tapez `thunderbird.exe -ProfileManager`et cliquez sur `OK`.
-
-![emails](images/thunderbird-run-profil.png){.thumbnail}
-
-- Sur Mac OS, lancez l'application Terminal puis glissez-déposez votre application Thunderbird dans la fenêtre du Terminal, en ajoutant à la ligne `/Contents/MacOS/thunderbird-bin -ProfileManager`. Tapez sur la touche `Entrée` (⏎) pour valider.
-
-![emails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-La fenêtre suivante vous affiche les profils existants. Cliquez sur `Créer un profil` puis sur `Suivant` lorsque le message d'information s'affiche.
-
-![emails](images/thunderbird-profil-create01.png){.thumbnail}
-
-À l'étape suivante, nommez votre profil et identifiez le dossier dans lequel sera créé le profil, en dessous de la phrase « Vos paramètres utilisateur, préférences et toutes vos données personnelles seront enregistrées dans » :
-
-![emails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> Nous vous conseillons de copier la sauvegarde de votre profil Thunderbird dans le dossier de profils de Thunderbird.
-
-Cliquez sur `Choisir un dossier...` pour sélectionner le dossier contenant votre sauvegarde. Cliquez sur `Terminer` pour créer le profil avec votre sauvegarde.
-
-Vous retrouvez la fenêtre de choix de votre profil avec votre nouveau profil sélectionné. Cliquez sur `Démarrer Thunderbird`, Thunderbird sera lancé avec tous les éléments que vous aviez dans votre sauvegarde.
+> [!tabs]
+> **Exporter**
+>>
+>> Depuis la fenêtre principale, cliquez sur le menu en haut à droite puis sur `Aide` et enfin sur `Informations de dépannage`.
+>>
+>> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> Un tableau apparaît. Identifiez la ligne `Répertoire de profil` et cliquez sur le bouton `Ouvrir le dossier correspondant`.
+>>
+>> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> Vous serez alors dirigé dans le dossier du profil. Remontez d'un dossier dans l'arborescence.
+>>
+>> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Copiez le dossier du profil via un clic-droit sur celui-ci, puis collez ce dossier dans le dossier ou support de votre choix.
+>>
+>> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Importer**
+>>
+>> Plutôt qu'une importation, il sera question ici d'un chargement de profil.
+>> Si des comptes e-mail ont déjà été configurés sur l'instance Thunderbird de destination, ils seront présents sur un profil A.
+>> Lorsque Thunderbird va charger un nouveau profil (profil B), il ne pourra charger **que** les éléments de ce profil B.
+>> C'est pourquoi nous vous conseillons de charger d'abord le nouveau profil (profil B) puis d'y configurer les comptes e-mail provenant du profil A.
+>>
+>> Vous devez d'abord démarrer Thunderbird via le gestionnaire de profils.
+>>
+>> - Sur Windows, allez sur le menu `Démarrer` puis sur le programme `Exécuter`. Sur ce dernier, tapez `thunderbird.exe -ProfileManager` et cliquez sur `OK`.
+>>
+>> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - Sur Mac OS, lancez l'application Terminal puis glissez-déposez votre application Thunderbird dans la fenêtre du Terminal, en ajoutant à la ligne `/Contents/MacOS/thunderbird-bin -ProfileManager`. Tapez sur la touche `Entrée` (⏎) pour valider.
+>>
+>> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> La fenêtre suivante vous affiche les profils existants. Cliquez sur `Créer un profil` puis sur `Suivant` lorsque le message d'information s'affiche.
+>>
+>> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> À l'étape suivante, nommez votre profil et identifiez le dossier dans lequel sera créé le profil, en dessous de la phrase « Vos paramètres utilisateur, préférences et toutes vos données personnelles seront enregistrées dans » :
+>>
+>> ![emails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > Nous vous conseillons de copier la sauvegarde de votre profil Thunderbird dans le dossier de profils de Thunderbird.
+>>
+>> Cliquez sur `Choisir un dossier...` pour sélectionner le dossier contenant votre sauvegarde. Cliquez sur `Terminer` pour créer le profil avec votre sauvegarde.
+>>
+>> Vous retrouvez la fenêtre de choix de votre profil avec votre nouveau profil sélectionné. Cliquez sur `Démarrer Thunderbird`, Thunderbird sera lancé avec tous les éléments que vous aviez dans votre sauvegarde.
 
 ### Vérifier l'importation sur la nouvelle adresse e-mail
 
@@ -248,6 +252,7 @@ Connectez-vous au [webmail](/links/web/email).
 Vous retrouverez dans votre boite de réception et dans la colonne de gauche les dossiers et e-mails de votre adresse e-mail sauvegardée.
 
 > [!primary]
+>
 > Il faut tenir compte du délai de chargement des éléments présents sur votre ordinateur vers le serveur e-mail. Cela peut prendre plusieurs minutes ou plusieurs heures en fonction de votre connexion à Internet.
 
 ## Aller plus loin

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-ca.md
@@ -73,7 +73,7 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 > [!tabs]
 > **Exporter**
 >>
->> - Cliquez sur `fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `importer/exporter`{.action}.
+>> - Cliquez sur `Fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `Importer/Exporter`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
@@ -104,7 +104,7 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 >>
 > **Importer**
 >>
->> - Cliquez sur `fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `importer/exporter`{.action}.
+>> - Cliquez sur `Fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `Importer/Exporter`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-ca.md
@@ -60,11 +60,11 @@ Les instructions qui suivent sont décomposées en deux parties :
 
 Si vous possédez un compte e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), il est possible de l'exporter directement au format PST depuis l'espace client.
 
-Dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter en PST`{.action}.
+Une fois sur la page de votre service Exchange, dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter au format PST`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter en PST`{.action} pour récupérer un lien pour télécharger le fichier.
+Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter au format PST`{.action} pour récupérer un lien pour télécharger le fichier.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
@@ -73,15 +73,15 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 > [!tabs]
 > **Exporter**
 >>
->> - Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
+>> - Cliquez sur `fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `importer/exporter`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Sélectionnez `Exporter des données vers un fichier` puis cliquez sur `Suivant`.
+>> - Sélectionnez `Exporter des données vers un fichier`{.action} puis cliquez sur `Suivant`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
+>> - Sélectionnez `Fichier de données Outlook (.pst)`{.action} puis cliquez sur `Suivant`{.action}.
 >>
 >> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -90,11 +90,11 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 >> > [!primary]
 >> > Vous ne pouvez exporter qu'un seul compte à la fois.
 >>
->> Cochez bien `Inclure les sous-dossiers` puis cliquez sur `Suivant`.
+>> Cochez bien `Inclure les sous-dossiers`{.action} puis cliquez sur `Suivant`{.action}.
 >>
 >> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Choisissez le dossier de destination de votre sauvegarde et entrez un nom pour celle-ci en cliquant sur `Parcourir`. Sélectionnez l'option qui vous convient puis cliquez sur `Terminer`.
+>> - Choisissez le dossier de destination de votre sauvegarde et entrez un nom pour celle-ci en cliquant sur `Parcourir`{.action}. Sélectionnez l'option qui vous convient puis cliquez sur `Terminer`{.action}.
 >>
 >> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -104,25 +104,25 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 >>
 > **Importer**
 >>
->> - Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
+>> - Cliquez sur `fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `importer/exporter`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Sélectionnez `Importer à partir d'un autre programme ou fichier` puis cliquez sur `Suivant`.
+>> - Sélectionnez `Importer à partir d'un autre programme ou fichier`{.action} puis cliquez sur `Suivant`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
+>> - Sélectionnez `Fichier de données Outlook (.pst)`{.action} puis cliquez sur `Suivant`{.action}.
 >>
 >> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Choisissez votre fichier de sauvegarde en cliquant sur `Parcourir`. Sélectionnez l'option qui vous convient puis cliquez sur `Terminer`.
+>> - Choisissez votre fichier de sauvegarde en cliquant sur `Parcourir`{.action}. Sélectionnez l'option qui vous convient puis cliquez sur `Terminer`{.action}.
 >>
 >> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - Si vous avez défini un mot de passe sur votre fichier de sauvegarde, entrez celui-ci puis cliquez sur `OK`.
+>> - Si vous avez défini un mot de passe sur votre fichier de sauvegarde, entrez celui-ci puis cliquez sur `OK`{.action}.
 >>
->> - Sélectionnez `Importer les éléments dans le dossier actif` puis cliquez sur `Terminer`.
+>> - Sélectionnez `Importer les éléments dans le dossier actif`{.action} puis cliquez sur `Terminer`{.action}.
 >>
 >> L'importation de votre sauvegarde se lance.
 
@@ -131,46 +131,46 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 > [!tabs]
 > **Exporter**
 >>
->> Dans l'onglet `Outils` de votre fenêtre Outlook, cliquez sur `Exporter`.
+>> Dans l'onglet `Outils`{.action} de votre fenêtre Outlook, cliquez sur `Exporter`{.action}.
 >>
 >> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> Depuis la fenêtre « Exporter vers un fichier archive (.olm) », cochez les éléments que vous souhaitez ajouter à votre fichier sauvegarde, puis cliquez sur `Continuer`.
+>> Depuis la fenêtre « Exporter vers un fichier archive (.olm) », cochez les éléments que vous souhaitez ajouter à votre fichier sauvegarde, puis cliquez sur `Continuer`{.action}.
 >>
 >> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Sélectionnez ensuite le dossier de destination pour votre sauvegarde, puis cliquez sur `Enregistrer`.
+>> Sélectionnez ensuite le dossier de destination pour votre sauvegarde, puis cliquez sur `Enregistrer`{.action}.
 >>
 >> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> Une fenêtre de progression s'affichera, cliquez sur `Continuer` à la fin de l'opération. Vous retrouverez votre fichier de sauvegarde dans le dossier choisi précédemment.
+>> Une fenêtre de progression s'affichera, cliquez sur `Continuer`{.action} à la fin de l'opération. Vous retrouverez votre fichier de sauvegarde dans le dossier choisi précédemment.
 >>
 > **Importer**
 >>
->> Dans l'onglet `Outils` de votre fenêtre Outlook, cliquez sur `Importer`.
+>> Dans l'onglet `Outils`{.action} de votre fenêtre Outlook, cliquez sur `Importer`{.action}.
 >>
 >> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Choisissez le format de sauvegarde que vous allez importer, puis cliquez sur `Continuer`.
+>> Choisissez le format de sauvegarde que vous allez importer, puis cliquez sur `Continuer`{.action}.
 >>
 >> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Sélectionnez votre fichier de sauvegarde, puis cliquez sur `importer`.
+>> Sélectionnez votre fichier de sauvegarde, puis cliquez sur `Importer`{.action}.
 >>
 >> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> Une fenêtre de progression s'affichera, cliquez sur `Continuer` à la fin de l'opération. Votre sauvegarde est alors déployée sur votre Outlook.
+>> Une fenêtre de progression s'affichera, cliquez sur `Continuer`{.action} à la fin de l'opération. Votre sauvegarde est alors déployée sur votre Outlook.
 
 ### Mail sur Mac OS
 
 > [!tabs]
 > **Exporter**
 >>
->> Depuis la colonne de gauche, sélectionnez un ou plusieurs comptes e-mail. Cliquez sur `Boîte aux lettres` dans le menu horizontal, puis sur `Exporter la boîte aux lettres`.
+>> Depuis la colonne de gauche, sélectionnez un ou plusieurs comptes e-mail. Cliquez sur `Boîte aux lettres`{.action} dans le menu horizontal, puis sur `Exporter la boîte aux lettres`{.action}.
 >>
 >> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Sélectionnez le dossier de votre choix ou créez-en un nouveau, puis cliquez sur `Choisir`.
+>> Sélectionnez le dossier de votre choix ou créez-en un nouveau, puis cliquez sur `Choisir`{.action}.
 >>
 >> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -178,11 +178,11 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 >>
 > **Importer**
 >>
->> Cliquez sur `Fichier` dans le menu horizontal, puis sur `Importer des boîtes aux lettres`.
+>> Cliquez sur `Fichier`{.action} dans le menu horizontal, puis sur `Importer des boîtes aux lettres`{.action}.
 >>
 >> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Sélectionnez votre fichier de sauvegarde au format « .mbox », puis cliquez sur `Continuer`.
+>> Sélectionnez votre fichier de sauvegarde au format « .mbox », puis cliquez sur `Continuer`{.action}.
 >>
 >> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -195,11 +195,11 @@ Il n'existe actuellement pas de fonctionnalité native pour exporter ou importer
 > [!tabs]
 > **Exporter**
 >>
->> Depuis la fenêtre principale, cliquez sur le menu en haut à droite puis sur `Aide` et enfin sur `Informations de dépannage`.
+>> Depuis la fenêtre principale, cliquez sur le menu en haut à droite puis sur `Aide`{.action} et enfin sur `Informations de dépannage`{.action}.
 >>
 >> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> Un tableau apparaît. Identifiez la ligne `Répertoire de profil` et cliquez sur le bouton `Ouvrir le dossier correspondant`.
+>> Un tableau apparaît. Identifiez la ligne `Répertoire de profil`{.action} et cliquez sur le bouton `Ouvrir le dossier correspondant`{.action}.
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -220,15 +220,15 @@ Il n'existe actuellement pas de fonctionnalité native pour exporter ou importer
 >>
 >> Vous devez d'abord démarrer Thunderbird via le gestionnaire de profils.
 >>
->> - Sur Windows, allez sur le menu `Démarrer` puis sur le programme `Exécuter`. Sur ce dernier, tapez `thunderbird.exe -ProfileManager` et cliquez sur `OK`.
+>> - Sur Windows, allez sur le menu `Démarrer`{.action} puis sur le programme `Exécuter`{.action}. Sur ce dernier, tapez `thunderbird.exe -ProfileManager` et cliquez sur `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
->> - Sur Mac OS, lancez l'application Terminal puis glissez-déposez votre application Thunderbird dans la fenêtre du Terminal, en ajoutant à la ligne `/Contents/MacOS/thunderbird-bin -ProfileManager`. Tapez sur la touche `Entrée` (⏎) pour valider.
+>> - Sur Mac OS, lancez l'application Terminal puis glissez-déposez votre application Thunderbird dans la fenêtre du Terminal, en ajoutant à la ligne `/Contents/MacOS/thunderbird-bin -ProfileManager`. Tapez sur la touche `Entrée`{.action} (⏎) pour valider.
 >>
 >> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> La fenêtre suivante vous affiche les profils existants. Cliquez sur `Créer un profil` puis sur `Suivant` lorsque le message d'information s'affiche.
+>> La fenêtre suivante vous affiche les profils existants. Cliquez sur `Créer un profil`{.action} puis sur `Suivant`{.action} lorsque le message d'information s'affiche.
 >>
 >> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -239,9 +239,9 @@ Il n'existe actuellement pas de fonctionnalité native pour exporter ou importer
 >> > [!primary]
 >> > Nous vous conseillons de copier la sauvegarde de votre profil Thunderbird dans le dossier de profils de Thunderbird.
 >>
->> Cliquez sur `Choisir un dossier...` pour sélectionner le dossier contenant votre sauvegarde. Cliquez sur `Terminer` pour créer le profil avec votre sauvegarde.
+>> Cliquez sur `Choisir un dossier...`{.action} pour sélectionner le dossier contenant votre sauvegarde. Cliquez sur `Terminer`{.action} pour créer le profil avec votre sauvegarde.
 >>
->> Vous retrouvez la fenêtre de choix de votre profil avec votre nouveau profil sélectionné. Cliquez sur `Démarrer Thunderbird`, Thunderbird sera lancé avec tous les éléments que vous aviez dans votre sauvegarde.
+>> Vous retrouvez la fenêtre de choix de votre profil avec votre nouveau profil sélectionné. Cliquez sur `Démarrer Thunderbird`{.action}, Thunderbird sera lancé avec tous les éléments que vous aviez dans votre sauvegarde.
 
 ### Vérifier l'importation sur la nouvelle adresse e-mail
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-fr.md
@@ -67,11 +67,11 @@ Les instructions qui suivent sont décomposées en deux parties :
 
 Si vous possédez un compte e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), il est possible de l'exporter directement au format PST depuis l'espace client.
 
-Dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter au format PST`{.action}.
+Dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter en PST`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter au format PST`{.action} pour récupérer un lien pour télécharger le fichier.
+Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter en PST`{.action} pour récupérer un lien pour télécharger le fichier.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-fr.md
@@ -1,5 +1,5 @@
 ---
-title: Migrer manuellement votre adresse e-mail 
+title: Migrer manuellement votre adresse e-mail
 excerpt: Découvrez comment migrer manuellement votre adresse e-mail vers une autre adresse e-mail
 updated: 2026-01-16
 ---
@@ -59,7 +59,7 @@ Dans ce guide nous avons réalisé les opérations sur les 3 logiciels de messag
 
 Les instructions qui suivent sont décomposées en deux parties :
 
-- **L'exportation**. Cela vous permet d'extraire une sauvegarde complète de votre adresse e-mail pour la basculer vers un autre poste, logiciel de messagerie, ou import vers un autre compte . Si vous devez déplacer des éléments d'une adresse e-mail vers une autre adresse qui est configurée sur le même logiciel de messagerie, il est possible de copier/coller ou de glisser/déposer l'une vers l'autre. Il est néanmoins recommandé d'utiliser le système d'exportation du logiciel que vous utilisez.
+- **L'exportation**. Cela vous permet d'extraire une sauvegarde complète de votre adresse e-mail pour la basculer vers un autre poste, logiciel de messagerie, ou import vers un autre compte. Si vous devez déplacer des éléments d'une adresse e-mail vers une autre adresse qui est configurée sur le même logiciel de messagerie, il est possible de copier/coller ou de glisser/déposer l'une vers l'autre. Il est néanmoins recommandé d'utiliser le système d'exportation du logiciel que vous utilisez.
 
 - **L'importation**. Cela vous permet d'appliquer une sauvegarde que vous avez réalisée sur votre nouveau poste ou nouveau logiciel. Vérifiez que le fichier de sauvegarde à importer est compatible avec le logiciel de messagerie que vous utilisez.
 
@@ -67,184 +67,188 @@ Les instructions qui suivent sont décomposées en deux parties :
 
 Si vous possédez un compte e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), il est possible de l'exporter directement au format PST depuis l'espace client.
 
-1. Connectez-vous à votre [espace client OVHcloud](/links/manager).
-1. Rendez-vous dans la partie `Web Cloud`{.action}.
-1. Dans la rubrique `MICROSOFT`, cliquez sur `Exchange`{.action}.
-1. Sélectionnez la plateforme concernée.
-1. Dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter au format PST`{.action}.
+Dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter au format PST`{.action}.
 
-![emails](images/manager-export-pst01.png){.thumbnail}
+![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-Il faudra ensuite patienter le temps de l'export qui peut prendre quelque minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter au format PST`{.action} pour récupérer un lien pour télécharger le fichier.
+Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter au format PST`{.action} pour récupérer un lien pour télécharger le fichier.
 
-![emails](images/manager-export-pst02.png){.thumbnail}
+![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Exporter depuis Windows
+#### Windows
 
-- Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
+> [!tabs]
+> **Exporter**
+>>
+>> - Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Sélectionnez `Exporter des données vers un fichier` puis cliquez sur `Suivant`.
+>>
+>> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
+>>
+>> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Sélectionnez le nom du compte e-mail à exporter.
+>>
+>> > [!primary]
+>> > Vous ne pouvez exporter qu’un seul compte à la fois.
+>>
+>> Cochez bien `Inclure les sous-dossiers` puis cliquez sur `Suivant`.
+>>
+>> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Choisissez le dossier de destination de votre sauvegarde et entrez un nom pour celle-ci en cliquant sur `Parcourir`. Sélectionnez l’option qui vous convient puis cliquez sur `Terminer`.
+>>
+>> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> L’exportation de votre fichier commence. Lors de la création d’un fichier, il vous sera demandé de définir un mot de passe. Celui-ci est facultatif.
+>>
+>> ![emails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Importer**
+>>
+>> - Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Sélectionnez `Importer à partir d’un autre programme ou fichier` puis cliquez sur `Suivant`.
+>>
+>> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
+>>
+>> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Choisissez votre fichier de sauvegarde en cliquant sur `Parcourir`. Sélectionnez l’option qui vous convient puis cliquez sur `Terminer`.
+>>
+>> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - Si vous avez défini un mot de passe sur votre fichier de sauvegarde, entrez celui-ci puis cliquez sur `OK`.
+>>
+>> - Sélectionnez `Importer les éléments dans le dossier actif` puis cliquez sur `Terminer`.
+>>
+>> L’importation de votre sauvegarde se lance.
 
-![emails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Sélectionnez `Exporter des données vers un fichier` puis cliquez sur `Suivant`.
-
-![emails](images/outlook-export-win02.png){.thumbnail}
-
-- Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
-
-![emails](images/outlook-export-win03.png){.thumbnail}
-
-- Sélectionnez le nom du compte e-mail à exporter.
-
-> [!primary]
-> Vous ne pouvez exporter qu'un seul compte à la fois.
-
-Cochez bien `Inclure les sous-dossiers` puis cliquez sur `Suivant`.
-
-![emails](images/outlook-export-win04.png){.thumbnail}
-
-- Choisissez le dossier de destination de votre sauvegarde et entrez un nom pour celle-ci en cliquant sur `Parcourir`. Sélectionnez l'option qui vous convient puis cliquez sur `Terminer`.
-
-![emails](images/outlook-export-win05.png){.thumbnail}
-
-L'exportation de votre fichier commence. Lors de la création d'un fichier, il vous sera demandé de définir un mot de passe. Celui-ci est facultatif.
-
-![emails](images/outlook-export-win06.png){.thumbnail}
-
-#### Importer depuis Windows
-
-- Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
-
-![emails](images/outlook-export-import-win.png){.thumbnail}
-
-- Sélectionnez `Importer à partir d’un autre programme ou fichier` puis cliquez sur `Suivant`.
-
-![emails](images/outlook-import-win02.png){.thumbnail}
-
-- Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
-
-![emails](images/outlook-import-win03.png){.thumbnail}
-
-- Choisissez votre fichier de sauvegarde en cliquant sur `Parcourir`. Sélectionnez l'option qui vous convient puis cliquez sur `Terminer`.
-
-![emails](images/outlook-import-win04.png){.thumbnail}
-
-- Si vous avez défini un mot de passe sur votre fichier de sauvegarde, entrez celui-ci puis cliquez sur `OK`.
-
-- Sélectionnez `Importer les éléments dans le dossier actif` puis cliquez sur `Terminer`.
-
-L'importation de votre sauvegarde se lance.
-
-#### Exporter depuis Mac OS
-
-Dans l’onglet `Outils` de votre fenêtre Outlook, cliquez sur `Exporter`.
-
-![emails](images/outlook-export-mac01.png){.thumbnail}
-
-Depuis la fenêtre « Exporter vers un fichier archive (.olm) », cochez les éléments que vous souhaitez ajouter à votre fichier sauvegarde, puis cliquez sur `Continuer`.
-
-![emails](images/outlook-export-mac02.png){.thumbnail}
-
-Sélectionnez ensuite le dossier de destination pour votre sauvegarde, puis cliquez sur `Enregistrer`.
-
-![emails](images/outlook-export-mac03.png){.thumbnail}
-
-Une fenêtre de progression s'affichera, cliquez sur `Continuer` à la fin de l'opération. Vous retrouverez votre fichier de sauvegarde dans le dossier choisi précédemment.
-
-#### Importer depuis Mac OS
-
-Dans l’onglet `Outils` de votre fenêtre Outlook, cliquez sur `Importer`.
-
-![emails](images/outlook-import-mac01.png){.thumbnail}
-
-Choisissez le format de sauvegarde que vous allez importer, puis cliquez sur `Continuer`.
-
-![emails](images/outlook-import-mac02.png){.thumbnail}
-
-Sélectionnez votre fichier de sauvegarde, puis cliquez sur `importer`.
-
-![emails](images/outlook-import-mac03.png){.thumbnail}
-
-Une fenêtre de progression s'affichera, cliquez sur `Continuer` à la fin de l'opération. Votre sauvegarde est alors déployée sur votre Outlook.
+> [!tabs]
+> **Exporter**
+>>
+>> Dans l’onglet `Outils` de votre fenêtre Outlook, cliquez sur `Exporter`.
+>>
+>> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> Depuis la fenêtre « Exporter vers un fichier archive (.olm) », cochez les éléments que vous souhaitez ajouter à votre fichier sauvegarde, puis cliquez sur `Continuer`.
+>>
+>> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Sélectionnez ensuite le dossier de destination pour votre sauvegarde, puis cliquez sur `Enregistrer`.
+>>
+>> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> Une fenêtre de progression s’affichera, cliquez sur `Continuer` à la fin de l’opération. Vous retrouverez votre fichier de sauvegarde dans le dossier choisi précédemment.
+>>
+> **Importer**
+>>
+>> Dans l’onglet `Outils` de votre fenêtre Outlook, cliquez sur `Importer`.
+>>
+>> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Choisissez le format de sauvegarde que vous allez importer, puis cliquez sur `Continuer`.
+>>
+>> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Sélectionnez votre fichier de sauvegarde, puis cliquez sur `importer`.
+>>
+>> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> Une fenêtre de progression s’affichera, cliquez sur `Continuer` à la fin de l’opération. Votre sauvegarde est alors déployée sur votre Outlook.
 
 ### Mail sur Mac OS
 
-#### Exporter
-
-Depuis la colonne de gauche, sélectionnez un ou plusieurs comptes e-mail. Cliquez sur `Boîte aux lettres` dans le menu horizontal, puis sur `Exporter la boîte aux lettres`.
-
-![emails](images/mail-export-mac01.png){.thumbnail}
-
-Sélectionnez le dossier de votre choix ou créez-en un nouveau, puis cliquez sur `Choisir`.
-
-![emails](images/mail-export-mac02.png){.thumbnail}
-
-Votre exportation se présente sous forme d'un fichier « .mbox ».
-
-#### Importer
-
-Cliquez sur `Fichier` dans le menu horizontal, puis sur `Importer des boîtes aux lettres`.
-
-![emails](images/mail-import-mac01.png){.thumbnail}
-
-Sélectionnez votre fichier de sauvegarde au format « .mbox », puis cliquez sur `Continuer`.
-
-![emails](images/mail-import-mac02.png){.thumbnail}
-
-Depuis la colonne de gauche, les e-mails importés se trouvent dans un nouveau compte e-mail nommé « Importation ». Vous pouvez faire glisser les dossiers et les messages à partir du compte « Importation » vers vos comptes e-mail déjà configurés. Une fois vos transferts terminés, vous pourrez supprimer le compte « Importation ».
+> [!tabs]
+> **Exporter**
+>>
+>> Depuis la colonne de gauche, sélectionnez un ou plusieurs comptes e-mail. Cliquez sur `Boîte aux lettres` dans le menu horizontal, puis sur `Exporter la boîte aux lettres`.
+>>
+>> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Sélectionnez le dossier de votre choix ou créez-en un nouveau, puis cliquez sur `Choisir`.
+>>
+>> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> Votre exportation se présente sous forme d'un fichier « .mbox ».
+>>
+> **Importer**
+>>
+>> Cliquez sur `Fichier` dans le menu horizontal, puis sur `Importer des boîtes aux lettres`.
+>>
+>> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Sélectionnez votre fichier de sauvegarde au format « .mbox », puis cliquez sur `Continuer`.
+>>
+>> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> Depuis la colonne de gauche, les e-mails importés se trouvent dans un nouveau compte e-mail nommé « Importation ». Vous pouvez faire glisser les dossiers et les messages à partir du compte « Importation » vers vos comptes e-mail déjà configurés. Une fois vos transferts terminés, vous pourrez supprimer le compte « Importation ».
 
 ### Thunderbird
 
 Il n'existe actuellement pas de fonctionnalité native pour exporter ou importer un compte e-mail depuis Thunderbird. Il est néanmoins possible de sauvegarder un profil Thunderbird. Celui-ci contient l'ensemble des comptes et e-mails en local sur votre ordinateur. Nous allons voir comment sauvegarder un profil Thunderbird et le réintégrer sur une nouvelle instance de Thunderbird.
 
-#### Exporter
-
-Depuis la fenêtre principale, cliquez sur le menu en haut à droite puis sur `Aide` et enfin sur `Informations de dépannage`.
-
-![emails](images/thunderbird_menu.png){.thumbnail}
-
-Un tableau apparaît. Identifiez la ligne `Répertoire de profil` et cliquez sur le bouton `Ouvrir le dossier correspondant`.
-
-![emails](images/thunderbird_open_folder.png){.thumbnail}
-
-Vous serez alors dirigé dans le dossier du profil. Remontez d'un dossier dans l'arborescence.
-
-![emails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Copiez le dossier du profil via un clic-droit sur celui-ci, puis collez ce dossier dans le dossier ou support de votre choix.
-
-![emails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importer
-
-Plutôt qu'une importation, il sera question ici d'un chargement de profil.
-Si des comptes e-mail ont déjà été configurés sur l'instance Thunderbird de destination, ils seront présents sur un profil A.
-Lorsque Thunderbird va charger un nouveau profil (profil B), il ne pourra charger **que** les éléments de ce profil B.
-C’est pourquoi nous vous conseillons de charger d’abord le nouveau profil (profil B) puis d’y configurer les comptes e-mail provenant du profil A.
-
-Vous devez d'abord démarrer Thunderbird via le gestionnaire de profils.
-
-- Sur Windows, allez sur le menu `Démarrer` puis sur le programme `Exécuter`. Sur ce dernier, tapez `thunderbird.exe -ProfileManager`et cliquez sur `OK`.
-
-![emails](images/thunderbird-run-profil.png){.thumbnail}
-
-- Sur Mac OS, lancez l'application Terminal puis glissez-déposez votre application Thunderbird dans la fenêtre du Terminal, en ajoutant à la ligne `/Contents/MacOS/thunderbird-bin -ProfileManager`. Tapez sur la touche `Entrée` (⏎) pour valider.
-
-![emails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-La fenêtre suivante vous affiche les profils existants. Cliquez sur `Créer un profil` puis sur `Suivant` lorsque le message d'information s'affiche.
-
-![emails](images/thunderbird-profil-create01.png){.thumbnail}
-
-À l'étape suivante, nommez votre profil et identifiez le dossier dans lequel sera créé le profil, en dessous de la phrase « Vos paramètres utilisateur, préférences et toutes vos données personnelles seront enregistrées dans » :
-
-![emails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> Nous vous conseillons de copier la sauvegarde de votre profil Thunderbird dans le dossier de profils de Thunderbird.
-
-Cliquez sur `Choisir un dossier...` pour sélectionner le dossier contenant votre sauvegarde. Cliquez sur `Terminer` pour créer le profil avec votre sauvegarde.
-
-Vous retrouvez la fenêtre de choix de votre profil avec votre nouveau profil sélectionné. Cliquez sur `Démarrer Thunderbird`, Thunderbird sera lancé avec tous les éléments que vous aviez dans votre sauvegarde.
+> [!tabs]
+> **Exporter**
+>>
+>> Depuis la fenêtre principale, cliquez sur le menu en haut à droite puis sur `Aide` et enfin sur `Informations de dépannage`.
+>>
+>> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> Un tableau apparaît. Identifiez la ligne `Répertoire de profil` et cliquez sur le bouton `Ouvrir le dossier correspondant`.
+>>
+>> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> Vous serez alors dirigé dans le dossier du profil. Remontez d’un dossier dans l’arborescence.
+>>
+>> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Copiez le dossier du profil via un clic-droit sur celui-ci, puis collez ce dossier dans le dossier ou support de votre choix.
+>>
+>> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Importer**
+>>
+>> Plutôt qu’une importation, il sera question ici d’un chargement de profil.
+>> Si des comptes e-mail ont déjà été configurés sur l’instance Thunderbird de destination, ils seront présents sur un profil A.
+>> Lorsque Thunderbird va charger un nouveau profil (profil B), il ne pourra charger **que** les éléments de ce profil B.
+>> C’est pourquoi nous vous conseillons de charger d’abord le nouveau profil (profil B) puis d’y configurer les comptes e-mail provenant du profil A.
+>>
+>> Vous devez d’abord démarrer Thunderbird via le gestionnaire de profils.
+>>
+>> - Sur Windows, allez sur le menu `Démarrer` puis sur le programme `Exécuter`. Sur ce dernier, tapez `thunderbird.exe -ProfileManager` et cliquez sur `OK`.
+>>
+>> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - Sur Mac OS, lancez l’application Terminal puis glissez-déposez votre application Thunderbird dans la fenêtre du Terminal, en ajoutant à la ligne `/Contents/MacOS/thunderbird-bin -ProfileManager`. Tapez sur la touche `Entrée` (⏎) pour valider.
+>>
+>> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> La fenêtre suivante vous affiche les profils existants. Cliquez sur `Créer un profil` puis sur `Suivant` lorsque le message d’information s’affiche.
+>>
+>> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> À l’étape suivante, nommez votre profil et identifiez le dossier dans lequel sera créé le profil, en dessous de la phrase « Vos paramètres utilisateur, préférences et toutes vos données personnelles seront enregistrées dans » :
+>>
+>> ![emails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > Nous vous conseillons de copier la sauvegarde de votre profil Thunderbird dans le dossier de profils de Thunderbird.
+>>
+>> Cliquez sur `Choisir un dossier...` pour sélectionner le dossier contenant votre sauvegarde. Cliquez sur `Terminer` pour créer le profil avec votre sauvegarde.
+>>
+>> Vous retrouvez la fenêtre de choix de votre profil avec votre nouveau profil sélectionné. Cliquez sur `Démarrer Thunderbird`, Thunderbird sera lancé avec tous les éléments que vous aviez dans votre sauvegarde.
 
 ### Vérifier l'importation sur la nouvelle adresse e-mail
 
@@ -255,6 +259,7 @@ Connectez-vous au [webmail](/links/web/email).
 Vous retrouverez dans votre boite de réception et dans la colonne de gauche les dossiers et e-mails de votre adresse e-mail sauvegardée.
 
 > [!primary]
+>
 > Il faut tenir compte du délai de chargement des éléments présents sur votre ordinateur vers le serveur e-mail. Cela peut prendre plusieurs minutes ou plusieurs heures en fonction de votre connexion à Internet.
 
 ## Aller plus loin

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-fr.md
@@ -59,7 +59,7 @@ Dans ce guide nous avons réalisé les opérations sur les 3 logiciels de messag
 
 Les instructions qui suivent sont décomposées en deux parties :
 
-- **L'exportation**. Cela vous permet d'extraire une sauvegarde complète de votre adresse e-mail pour la basculer vers un autre poste, logiciel de messagerie, ou import vers un autre compte. Si vous devez déplacer des éléments d'une adresse e-mail vers une autre adresse qui est configurée sur le même logiciel de messagerie, il est possible de copier/coller ou de glisser/déposer l'une vers l'autre. Il est néanmoins recommandé d'utiliser le système d'exportation du logiciel que vous utilisez.
+- **L'exportation**. Cela vous permet d'extraire une sauvegarde complète de votre adresse e-mail pour la basculer vers un autre poste, logiciel de messagerie, ou import vers un autre compte. Si vous devez déplacer des éléments d'une adresse e-mail vers une autre adresse qui est configurée sur le même logiciel de messagerie, il est possible de copier/coller ou de glisser/déposer l'une vers l'autre. Nous vous recommandons néanmoins d'utiliser le système d'exportation de votre logiciel de messagerie.
 
 - **L'importation**. Cela vous permet d'appliquer une sauvegarde que vous avez réalisée sur votre nouveau poste ou nouveau logiciel. Vérifiez que le fichier de sauvegarde à importer est compatible avec le logiciel de messagerie que vous utilisez.
 
@@ -80,7 +80,7 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 > [!tabs]
 > **Exporter**
 >>
->> - Cliquez sur `fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `importer/exporter`{.action}.
+>> - Cliquez sur `Fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `Importer/Exporter`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
@@ -111,7 +111,7 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 >>
 > **Importer**
 >>
->> - Cliquez sur `fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `importer/exporter`{.action}.
+>> - Cliquez sur `Fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `Importer/Exporter`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
@@ -220,7 +220,7 @@ Il n'existe actuellement pas de fonctionnalité native pour exporter ou importer
 >>
 > **Importer**
 >>
->> Plutôt qu’une importation, il sera question ici d’un chargement de profil.
+>> Il ne s’agit pas d’une importation classique, mais d’un chargement de profil.
 >> Si des comptes e-mail ont déjà été configurés sur l’instance Thunderbird de destination, ils seront présents sur un profil A.
 >> Lorsque Thunderbird va charger un nouveau profil (profil B), il ne pourra charger **que** les éléments de ce profil B.
 >> C’est pourquoi nous vous conseillons de charger d’abord le nouveau profil (profil B) puis d’y configurer les comptes e-mail provenant du profil A.

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.fr-fr.md
@@ -67,11 +67,11 @@ Les instructions qui suivent sont décomposées en deux parties :
 
 Si vous possédez un compte e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), il est possible de l'exporter directement au format PST depuis l'espace client.
 
-Dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter en PST`{.action}.
+Une fois sur la page de votre service Exchange, dans l'onglet `Comptes e-mail`{.action}, cliquez sur le bouton `...`{.action} à droite du compte e-mail à exporter, puis sur `Exporter au format PST`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter en PST`{.action} pour récupérer un lien pour télécharger le fichier.
+Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minutes à plusieurs heures selon la taille de l'export. À la fin de celui-ci, il vous suffira de retourner sur le bouton `Exporter au format PST`{.action} pour récupérer un lien pour télécharger le fichier.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
@@ -80,15 +80,15 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 > [!tabs]
 > **Exporter**
 >>
->> - Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
+>> - Cliquez sur `fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `importer/exporter`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Sélectionnez `Exporter des données vers un fichier` puis cliquez sur `Suivant`.
+>> - Sélectionnez `Exporter des données vers un fichier`{.action} puis cliquez sur `Suivant`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
+>> - Sélectionnez `Fichier de données Outlook (.pst)`{.action} puis cliquez sur `Suivant`{.action}.
 >>
 >> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -97,11 +97,11 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 >> > [!primary]
 >> > Vous ne pouvez exporter qu’un seul compte à la fois.
 >>
->> Cochez bien `Inclure les sous-dossiers` puis cliquez sur `Suivant`.
+>> Cochez bien `Inclure les sous-dossiers`{.action} puis cliquez sur `Suivant`{.action}.
 >>
 >> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Choisissez le dossier de destination de votre sauvegarde et entrez un nom pour celle-ci en cliquant sur `Parcourir`. Sélectionnez l’option qui vous convient puis cliquez sur `Terminer`.
+>> - Choisissez le dossier de destination de votre sauvegarde et entrez un nom pour celle-ci en cliquant sur `Parcourir`{.action}. Sélectionnez l’option qui vous convient puis cliquez sur `Terminer`{.action}.
 >>
 >> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -111,25 +111,25 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 >>
 > **Importer**
 >>
->> - Cliquez sur `fichier` en haut à gauche, puis sur `Ouvrir et exporter` et enfin sur `importer/exporter`.
+>> - Cliquez sur `fichier`{.action} en haut à gauche, puis sur `Ouvrir et exporter`{.action} et enfin sur `importer/exporter`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Sélectionnez `Importer à partir d’un autre programme ou fichier` puis cliquez sur `Suivant`.
+>> - Sélectionnez `Importer à partir d’un autre programme ou fichier`{.action} puis cliquez sur `Suivant`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Sélectionnez `Fichier de données Outlook (.pst)` puis cliquez sur `Suivant`.
+>> - Sélectionnez `Fichier de données Outlook (.pst)`{.action} puis cliquez sur `Suivant`{.action}.
 >>
 >> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Choisissez votre fichier de sauvegarde en cliquant sur `Parcourir`. Sélectionnez l’option qui vous convient puis cliquez sur `Terminer`.
+>> - Choisissez votre fichier de sauvegarde en cliquant sur `Parcourir`{.action}. Sélectionnez l’option qui vous convient puis cliquez sur `Terminer`{.action}.
 >>
 >> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - Si vous avez défini un mot de passe sur votre fichier de sauvegarde, entrez celui-ci puis cliquez sur `OK`.
+>> - Si vous avez défini un mot de passe sur votre fichier de sauvegarde, entrez celui-ci puis cliquez sur `OK`{.action}.
 >>
->> - Sélectionnez `Importer les éléments dans le dossier actif` puis cliquez sur `Terminer`.
+>> - Sélectionnez `Importer les éléments dans le dossier actif`{.action} puis cliquez sur `Terminer`{.action}.
 >>
 >> L’importation de votre sauvegarde se lance.
 
@@ -138,46 +138,46 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 > [!tabs]
 > **Exporter**
 >>
->> Dans l’onglet `Outils` de votre fenêtre Outlook, cliquez sur `Exporter`.
+>> Dans l’onglet `Outils`{.action} de votre fenêtre Outlook, cliquez sur `Exporter`{.action}.
 >>
 >> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> Depuis la fenêtre « Exporter vers un fichier archive (.olm) », cochez les éléments que vous souhaitez ajouter à votre fichier sauvegarde, puis cliquez sur `Continuer`.
+>> Depuis la fenêtre « Exporter vers un fichier archive (.olm) », cochez les éléments que vous souhaitez ajouter à votre fichier sauvegarde, puis cliquez sur `Continuer`{.action}.
 >>
 >> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Sélectionnez ensuite le dossier de destination pour votre sauvegarde, puis cliquez sur `Enregistrer`.
+>> Sélectionnez ensuite le dossier de destination pour votre sauvegarde, puis cliquez sur `Enregistrer`{.action}.
 >>
 >> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> Une fenêtre de progression s’affichera, cliquez sur `Continuer` à la fin de l’opération. Vous retrouverez votre fichier de sauvegarde dans le dossier choisi précédemment.
+>> Une fenêtre de progression s’affichera, cliquez sur `Continuer`{.action} à la fin de l’opération. Vous retrouverez votre fichier de sauvegarde dans le dossier choisi précédemment.
 >>
 > **Importer**
 >>
->> Dans l’onglet `Outils` de votre fenêtre Outlook, cliquez sur `Importer`.
+>> Dans l’onglet `Outils`{.action} de votre fenêtre Outlook, cliquez sur `Importer`{.action}.
 >>
 >> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Choisissez le format de sauvegarde que vous allez importer, puis cliquez sur `Continuer`.
+>> Choisissez le format de sauvegarde que vous allez importer, puis cliquez sur `Continuer`{.action}.
 >>
 >> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Sélectionnez votre fichier de sauvegarde, puis cliquez sur `importer`.
+>> Sélectionnez votre fichier de sauvegarde, puis cliquez sur `Importer`{.action}.
 >>
 >> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> Une fenêtre de progression s’affichera, cliquez sur `Continuer` à la fin de l’opération. Votre sauvegarde est alors déployée sur votre Outlook.
+>> Une fenêtre de progression s’affichera, cliquez sur `Continuer`{.action} à la fin de l’opération. Votre sauvegarde est alors déployée sur votre Outlook.
 
 ### Mail sur Mac OS
 
 > [!tabs]
 > **Exporter**
 >>
->> Depuis la colonne de gauche, sélectionnez un ou plusieurs comptes e-mail. Cliquez sur `Boîte aux lettres` dans le menu horizontal, puis sur `Exporter la boîte aux lettres`.
+>> Depuis la colonne de gauche, sélectionnez un ou plusieurs comptes e-mail. Cliquez sur `Boîte aux lettres`{.action} dans le menu horizontal, puis sur `Exporter la boîte aux lettres`{.action}.
 >>
 >> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Sélectionnez le dossier de votre choix ou créez-en un nouveau, puis cliquez sur `Choisir`.
+>> Sélectionnez le dossier de votre choix ou créez-en un nouveau, puis cliquez sur `Choisir`{.action}.
 >>
 >> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -185,11 +185,11 @@ Il faudra ensuite patienter le temps de l'export qui peut prendre quelques minut
 >>
 > **Importer**
 >>
->> Cliquez sur `Fichier` dans le menu horizontal, puis sur `Importer des boîtes aux lettres`.
+>> Cliquez sur `Fichier`{.action} dans le menu horizontal, puis sur `Importer des boîtes aux lettres`{.action}.
 >>
 >> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Sélectionnez votre fichier de sauvegarde au format « .mbox », puis cliquez sur `Continuer`.
+>> Sélectionnez votre fichier de sauvegarde au format « .mbox », puis cliquez sur `Continuer`{.action}.
 >>
 >> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -202,11 +202,11 @@ Il n'existe actuellement pas de fonctionnalité native pour exporter ou importer
 > [!tabs]
 > **Exporter**
 >>
->> Depuis la fenêtre principale, cliquez sur le menu en haut à droite puis sur `Aide` et enfin sur `Informations de dépannage`.
+>> Depuis la fenêtre principale, cliquez sur le menu en haut à droite puis sur `Aide`{.action} et enfin sur `Informations de dépannage`{.action}.
 >>
 >> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> Un tableau apparaît. Identifiez la ligne `Répertoire de profil` et cliquez sur le bouton `Ouvrir le dossier correspondant`.
+>> Un tableau apparaît. Identifiez la ligne `Répertoire de profil`{.action} et cliquez sur le bouton `Ouvrir le dossier correspondant`{.action}.
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -227,15 +227,15 @@ Il n'existe actuellement pas de fonctionnalité native pour exporter ou importer
 >>
 >> Vous devez d’abord démarrer Thunderbird via le gestionnaire de profils.
 >>
->> - Sur Windows, allez sur le menu `Démarrer` puis sur le programme `Exécuter`. Sur ce dernier, tapez `thunderbird.exe -ProfileManager` et cliquez sur `OK`.
+>> - Sur Windows, allez sur le menu `Démarrer`{.action} puis sur le programme `Exécuter`{.action}. Sur ce dernier, tapez `thunderbird.exe -ProfileManager` et cliquez sur `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
->> - Sur Mac OS, lancez l’application Terminal puis glissez-déposez votre application Thunderbird dans la fenêtre du Terminal, en ajoutant à la ligne `/Contents/MacOS/thunderbird-bin -ProfileManager`. Tapez sur la touche `Entrée` (⏎) pour valider.
+>> - Sur Mac OS, lancez l’application Terminal puis glissez-déposez votre application Thunderbird dans la fenêtre du Terminal, en ajoutant à la ligne `/Contents/MacOS/thunderbird-bin -ProfileManager`. Tapez sur la touche `Entrée`{.action} (⏎) pour valider.
 >>
 >> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> La fenêtre suivante vous affiche les profils existants. Cliquez sur `Créer un profil` puis sur `Suivant` lorsque le message d’information s’affiche.
+>> La fenêtre suivante vous affiche les profils existants. Cliquez sur `Créer un profil`{.action} puis sur `Suivant`{.action} lorsque le message d’information s’affiche.
 >>
 >> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -246,9 +246,9 @@ Il n'existe actuellement pas de fonctionnalité native pour exporter ou importer
 >> > [!primary]
 >> > Nous vous conseillons de copier la sauvegarde de votre profil Thunderbird dans le dossier de profils de Thunderbird.
 >>
->> Cliquez sur `Choisir un dossier...` pour sélectionner le dossier contenant votre sauvegarde. Cliquez sur `Terminer` pour créer le profil avec votre sauvegarde.
+>> Cliquez sur `Choisir un dossier...`{.action} pour sélectionner le dossier contenant votre sauvegarde. Cliquez sur `Terminer`{.action} pour créer le profil avec votre sauvegarde.
 >>
->> Vous retrouvez la fenêtre de choix de votre profil avec votre nouveau profil sélectionné. Cliquez sur `Démarrer Thunderbird`, Thunderbird sera lancé avec tous les éléments que vous aviez dans votre sauvegarde.
+>> Vous retrouvez la fenêtre de choix de votre profil avec votre nouveau profil sélectionné. Cliquez sur `Démarrer Thunderbird`{.action}, Thunderbird sera lancé avec tous les éléments que vous aviez dans votre sauvegarde.
 
 ### Vérifier l'importation sur la nouvelle adresse e-mail
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.it-it.md
@@ -80,7 +80,7 @@ Attendi il completamento dell'operazione, che potrebbe richiedere da qualche min
 > [!tabs]
 > **Esportare**
 >>
->> - Clicca su `file`{.action} in alto a sinistra, poi su `Aprire ed esportare`{.action} e infine su `importare/esportare`{.action}.
+>> - Clicca su `File`{.action} in alto a sinistra, poi su `Aprire ed esportare`{.action} e infine su `Importare/Esportare`{.action}.
 >>
 >> ![email](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
@@ -105,13 +105,13 @@ Attendi il completamento dell'operazione, che potrebbe richiedere da qualche min
 >>
 >> ![email](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
->> L'esportazione del tuo file inizia. Durante la creazione di un file, ti verrà chiesto di definire una password. che è facoltativo.
+>> L'esportazione del tuo file inizia. Durante la creazione di un file, ti verrà chiesto di definire una password, che è facoltativo.
 >>
 >> ![email](images/outlook-export-win06.png){.thumbnail .w-640}
 >>
 > **Importare**
 >>
->> - Clicca su `file`{.action} in alto a sinistra, poi su `Aprire ed esportare`{.action} e infine su `importare/esportare`{.action}.
+>> - Clicca su `File`{.action} in alto a sinistra, poi su `Aprire ed esportare`{.action} e infine su `Importare/Esportare`{.action}.
 >>
 >> ![email](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
@@ -127,7 +127,7 @@ Attendi il completamento dell'operazione, che potrebbe richiedere da qualche min
 >>
 >> ![email](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - Se hai impostato una password sul tuo file di backup, inseriscilo e clicca su `OK`{.action}.
+>> - Se hai impostato una password sul tuo file di backup, inseriscila e clicca su `OK`{.action}.
 >>
 >> - Seleziona `Importa gli elementi nella cartella attiva`{.action} e clicca su `Termina`{.action}.
 >>
@@ -150,7 +150,7 @@ Attendi il completamento dell'operazione, che potrebbe richiedere da qualche min
 >>
 >> ![email](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> Visualizzi una finestra di progressione, clicca su `Continua`{.action} alla fine dell'operazione. Il file di backup è disponibile nella cartella selezionata precedentemente.
+>> Viene visualizzata una finestra di progressione, clicca su `Continua`{.action} alla fine dell'operazione. Il file di backup è disponibile nella cartella selezionata precedentemente.
 >>
 > **Importare**
 >>
@@ -166,7 +166,7 @@ Attendi il completamento dell'operazione, che potrebbe richiedere da qualche min
 >>
 >> ![email](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> Visualizzi una finestra di progressione, clicca su `Continua`{.action} alla fine dell'operazione. Il backup viene poi implementato sul tuo Outlook.
+>> Viene visualizzata una finestra di progressione, clicca su `Continua`{.action} alla fine dell'operazione. Il backup viene poi implementato sul tuo Outlook.
 
 ### Email su Mac OS
 
@@ -197,7 +197,7 @@ Attendi il completamento dell'operazione, che potrebbe richiedere da qualche min
 
 ### Thunderbird
 
-Al momento non esistono funzionalità native per esportare o importare un account e-mail da Thunderbird. È comunque possibile salvare un profilo Thunderbird. che contiene tutti gli account e le email in locale sul tuo computer. Questa guida ti mostra come salvare un profilo Thunderbird e reinserirlo su una nuova istanza di Thunderbird.
+Al momento non esistono funzionalità native per esportare o importare un account e-mail da Thunderbird. È comunque possibile salvare un profilo Thunderbird che contiene tutti gli account e le e-mail in locale sul tuo computer. Questa guida ti mostra come salvare un profilo Thunderbird e reinserirlo su una nuova istanza di Thunderbird.
 
 > [!tabs]
 > **Esportare**
@@ -227,7 +227,7 @@ Al momento non esistono funzionalità native per esportare o importare un accoun
 >>
 >> Per prima cosa è necessario avviare Thunderbird tramite il gestore dei profili.
 >>
->> - Su Windows, clicca sul menu `Start`{.action} e poi sul programma `Esegui`{.action}. Clicca su `thunderbird.exe -ProfileManager` e clicca su `OK`{.action}.
+>> - Su Windows, clicca sul menu `Start`{.action} e poi sul programma `Esegui`{.action}. Inserisci `thunderbird.exe -ProfileManager` e clicca su `OK`{.action}.
 >>
 >> ![email](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.it-it.md
@@ -20,7 +20,7 @@ updated: 2026-01-16
 ## Prerequisiti
 
 - Disporre di un servizio email OVHcloud, come [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/zimbra) o MX Plan (tramite l'offerta MX Plan o inclusa in un'offerta di [hosting Web OVHcloud](/links/web/hosting))
-- Disporre delle credenziali relative agli account email da migrare
+- Disporre delle credenziali relative agli account e-mail da migrare
 - Disporre delle credenziali relative agli account e-mail OVHcloud che ricevono i dati migrati (gli account di destinazione).
 
 <!-- CP-NAV-START:web-mx-plan -->
@@ -33,17 +33,17 @@ updated: 2026-01-16
 **MX Plan:**
 
 - **Link diretto:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo MX Plan service
+- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo servizio MX Plan
 
 **Email Pro:**
 
 - **Link diretto:** [Email Pro](/links/control-panel/web-email-pro)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua platform
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua piattaforma
 
 **Exchange:**
 
 - **Link diretto:** [Exchange](/links/control-panel/web-exchange)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua platform
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua piattaforma
 
 ---
 <!-- CP-NAV-END:web-exchange -->
@@ -53,21 +53,21 @@ updated: 2026-01-16
 ## Procedura
 
 > [!primary]
-> Per prima cosa, verifica che la migrazione automatica sia possibile utilizzando il nostro tool [OVHcloud Mail Migrator](/links/web/omm). Per effettuare questa operazione, consulta la guida [Migrare account email via OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).
+> Per prima cosa, verifica che la migrazione automatica sia possibile utilizzando il nostro tool [OVHcloud Mail Migrator](/links/web/omm). Per effettuare questa operazione, consulta la guida [Migrare account e-mail via OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).
 
 In questa guida abbiamo eseguito le operazioni sui 3 client di posta più utilizzati, **Outlook**, **Mail** su Mac OS e **Thunderbird**.
 
 Le seguenti istruzioni sono suddivise in due parti:
 
-- **L'esportazione**. per estrarre un backup completo del tuo account email e trasferirlo verso un'altra postazione, un client di posta o un altro account. Se è necessario spostare gli elementi da un indirizzo email verso un altro indirizzo configurato sullo stesso client di posta, è possibile copiare/incollare o trascinare/depositare l'uno verso l'altro. Ti consigliamo comunque di utilizzare il sistema di esportazione del software utilizzato.
+- **L'esportazione**. per estrarre un backup completo del tuo account e-mail e trasferirlo verso un'altra postazione, un client di posta o un altro account. Se è necessario spostare gli elementi da un indirizzo email verso un altro indirizzo configurato sullo stesso client di posta, è possibile copiare/incollare o trascinare/depositare l'uno verso l'altro. Ti consigliamo comunque di utilizzare il sistema di esportazione del software utilizzato.
 
 - **Importazione**. per permetterti di applicare un backup realizzato sulla tua nuova postazione o software. Verifica che il file di backup da importare sia compatibile con il client di posta utilizzato.
 
 ### Outlook
 
-Se disponi di un account email [Exchange OVHcloud](/links/web/emails-hosted-exchange), è possibile esportarlo direttamente in formato PST dallo Spazio Cliente.
+Se disponi di un account e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), è possibile esportarlo direttamente in formato PST dallo Spazio Cliente.
 
-Nella scheda `Account email`{.action}, clicca sul pulsante `...`{.action} a destra dell'account da esportare e poi su `Esporta in formato PST`{.action}.
+Una volta nella pagina del tuo servizio Exchange, nella scheda `Account e-mail`{.action}, clicca sul pulsante `...`{.action} a destra dell'account da esportare e poi su `Esporta in formato PST`{.action}.
 
 ![email](images/manager-export-pst01.png){.thumbnail .w-640}
 
@@ -80,28 +80,28 @@ Attendi il completamento dell'operazione, che potrebbe richiedere da qualche min
 > [!tabs]
 > **Esportare**
 >>
->> - Clicca su `file` in alto a sinistra, poi su `Aprire ed esportare` e infine su `importare/esportare`.
+>> - Clicca su `file`{.action} in alto a sinistra, poi su `Aprire ed esportare`{.action} e infine su `importare/esportare`{.action}.
 >>
 >> ![email](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Seleziona `Esporta dati verso un file` e clicca su `Seguente`.
+>> - Seleziona `Esporta dati verso un file`{.action} e clicca su `Seguente`{.action}.
 >>
 >> ![email](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Seleziona `File dati Outlook (.pst)` e clicca su `Seguente`.
+>> - Seleziona `File dati Outlook (.pst)`{.action} e clicca su `Seguente`{.action}.
 >>
 >> ![email](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
->> - Seleziona il nome dell'account email da esportare.
+>> - Seleziona il nome dell'account e-mail da esportare.
 >>
 >> > [!primary]
 >> > Potete esportare un solo account per volta.
 >>
->> Seleziona `Includi le sottocartelle` e clicca su `Seguente`.
+>> Seleziona `Includi le sottocartelle`{.action} e clicca su `Seguente`{.action}.
 >>
 >> ![email](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Scegli la cartella di destinazione del tuo backup e inserisci un nome per quest'ultimo cliccando su `Percorrere`. Seleziona l'opzione che preferisci e clicca su `Terminare`.
+>> - Scegli la cartella di destinazione del tuo backup e inserisci un nome per quest'ultimo cliccando su `Percorrere`{.action}. Seleziona l'opzione che preferisci e clicca su `Terminare`{.action}.
 >>
 >> ![email](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -111,42 +111,42 @@ Attendi il completamento dell'operazione, che potrebbe richiedere da qualche min
 >>
 > **Importare**
 >>
->> - Clicca su `file` in alto a sinistra, poi su `Aprire ed esportare` e infine su `importare/esportare`.
+>> - Clicca su `file`{.action} in alto a sinistra, poi su `Aprire ed esportare`{.action} e infine su `importare/esportare`{.action}.
 >>
 >> ![email](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Seleziona `Importa da un altro programma o file` e clicca su `Seguente`.
+>> - Seleziona `Importa da un altro programma o file`{.action} e clicca su `Seguente`{.action}.
 >>
 >> ![email](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Seleziona `File dati Outlook (.pst)` e clicca su `Seguente`.
+>> - Seleziona `File dati Outlook (.pst)`{.action} e clicca su `Seguente`{.action}.
 >>
 >> ![email](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Seleziona il file di backup cliccando su `Percorri`. Seleziona l'opzione che preferisci e clicca su `Terminare`.
+>> - Seleziona il file di backup cliccando su `Percorri`{.action}. Seleziona l'opzione che preferisci e clicca su `Terminare`{.action}.
 >>
 >> ![email](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - Se hai impostato una password sul tuo file di backup, inseriscilo e clicca su `OK`.
+>> - Se hai impostato una password sul tuo file di backup, inseriscilo e clicca su `OK`{.action}.
 >>
->> - Seleziona `Importa gli elementi nella cartella attiva` e clicca su `Termina`.
+>> - Seleziona `Importa gli elementi nella cartella attiva`{.action} e clicca su `Termina`{.action}.
 >>
->> L'importazione del tuo backup inizia
+>> L'importazione del tuo backup inizia.
 
 #### Mac OS
 
 > [!tabs]
 > **Esportare**
 >>
->> Nella scheda `Strumenti` della tua finestra Outlook, clicca su `Esporta`.
+>> Nella scheda `Strumenti`{.action} della tua finestra Outlook, clicca su `Esporta`{.action}.
 >>
 >> ![email](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> Dalla finestra "Esporta verso un file archivio (.olm)", seleziona gli elementi che vuoi aggiungere al tuo file di backup e clicca su `Continua`.
+>> Dalla finestra "Esporta verso un file archivio (.olm)", seleziona gli elementi che vuoi aggiungere al tuo file di backup e clicca su `Continua`{.action}.
 >>
 >> ![email](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Seleziona la cartella di destinazione per il tuo backup e clicca su `Salva`.
+>> Seleziona la cartella di destinazione per il tuo backup e clicca su `Salva`{.action}.
 >>
 >> ![email](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
@@ -154,15 +154,15 @@ Attendi il completamento dell'operazione, che potrebbe richiedere da qualche min
 >>
 > **Importare**
 >>
->> Nella scheda `Strumenti` della tua finestra Outlook, clicca su `Importa`.
+>> Nella scheda `Strumenti`{.action} della tua finestra Outlook, clicca su `Importa`{.action}.
 >>
 >> ![email](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Scegli il formato di backup che vuoi importare e clicca su `Continua`.
+>> Scegli il formato di backup che vuoi importare e clicca su `Continua`{.action}.
 >>
 >> ![email](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Seleziona il file di backup e clicca su `Importa`.
+>> Seleziona il file di backup e clicca su `Importa`{.action}.
 >>
 >> ![email](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
@@ -173,11 +173,11 @@ Attendi il completamento dell'operazione, che potrebbe richiedere da qualche min
 > [!tabs]
 > **Esportare**
 >>
->> Nella colonna di sinistra, seleziona uno o più account email. Clicca sulla `Casella lettere` nel menu orizzontale e poi su `Esporta la cassetta delle lettere`.
+>> Nella colonna di sinistra, seleziona uno o più account e-mail. Clicca sulla `Casella lettere`{.action} nel menu orizzontale e poi su `Esporta la cassetta delle lettere`{.action}.
 >>
 >> ![email](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Seleziona la cartella scelta o creane una nuova, poi clicca su `Scegli`.
+>> Seleziona la cartella scelta o creane una nuova, poi clicca su `Scegli`{.action}.
 >>
 >> ![email](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -185,28 +185,28 @@ Attendi il completamento dell'operazione, che potrebbe richiedere da qualche min
 >>
 > **Importare**
 >>
->> Clicca su `File` nel menu orizzontale e poi su `Importa cassette delle lettere`.
+>> Clicca su `File`{.action} nel menu orizzontale e poi su `Importa cassette delle lettere`{.action}.
 >>
 >> ![email](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Seleziona il file di backup in formato ".mbox" e clicca su `Continua`.
+>> Seleziona il file di backup in formato ".mbox" e clicca su `Continua`{.action}.
 >>
 >> ![email](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
->> Nella colonna di sinistra, le email importate sono contenute in un nuovo account email chiamato "Importazione". Le cartelle e i messaggi possono essere spostati dall'account "Importazione" verso i tuoi account email già configurati. Una volta terminati i trasferimenti, potrai eliminare l'account "Importazione".
+>> Nella colonna di sinistra, le email importate sono contenute in un nuovo account e-mail chiamato "Importazione". Le cartelle e i messaggi possono essere spostati dall'account "Importazione" verso i tuoi account e-mail già configurati. Una volta terminati i trasferimenti, potrai eliminare l'account "Importazione".
 
 ### Thunderbird
 
-Al momento non esistono funzionalità native per esportare o importare un account email da Thunderbird. È comunque possibile salvare un profilo Thunderbird. che contiene tutti gli account e le email in locale sul tuo computer. Questa guida ti mostra come salvare un profilo Thunderbird e reinserirlo su una nuova istanza di Thunderbird.
+Al momento non esistono funzionalità native per esportare o importare un account e-mail da Thunderbird. È comunque possibile salvare un profilo Thunderbird. che contiene tutti gli account e le email in locale sul tuo computer. Questa guida ti mostra come salvare un profilo Thunderbird e reinserirlo su una nuova istanza di Thunderbird.
 
 > [!tabs]
 > **Esportare**
 >>
->> Dalla finestra principale, clicca sul menu in alto a destra, poi su `Aiuto` e infine su `Informazioni di soccorso`.
+>> Dalla finestra principale, clicca sul menu in alto a destra, poi su `Aiuto`{.action} e infine su `Informazioni di soccorso`{.action}.
 >>
 >> ![email](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> Visualizzi una tabella. Identifica la linea `Directory del profilo` e clicca sul pulsante `Apri la cartella corrispondente`.
+>> Visualizzi una tabella. Identifica la linea `Directory del profilo`{.action} e clicca sul pulsante `Apri la cartella corrispondente`{.action}.
 >>
 >> ![email](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -221,21 +221,21 @@ Al momento non esistono funzionalità native per esportare o importare un accoun
 > **Importare**
 >>
 >> Anziché importare, si tratterà di un carico di profilo.
->> Se sull'istanza Thunderbird di destinazione sono già stati configurati account email, questi saranno presenti sul profilo A.
+>> Se sull'istanza Thunderbird di destinazione sono già stati configurati account e-mail, questi saranno presenti sul profilo A.
 >> Quando Thunderbird caricerà un nuovo profilo (profilo B), potrà caricare **solo** gli elementi di questo profilo B.
->> Per questo ti consigliamo di caricare il nuovo profilo (profilo B) e configurare gli account email provenienti dal profilo A.
+>> Per questo ti consigliamo di caricare il nuovo profilo (profilo B) e configurare gli account e-mail provenienti dal profilo A.
 >>
 >> Per prima cosa è necessario avviare Thunderbird tramite il gestore dei profili.
 >>
->> - Su Windows, clicca sul menu `Start` e poi sul programma `Esegui`. Clicca su `thunderbird.exe -ProfileManager` e clicca su `OK`.
+>> - Su Windows, clicca sul menu `Start`{.action} e poi sul programma `Esegui`{.action}. Clicca su `thunderbird.exe -ProfileManager` e clicca su `OK`{.action}.
 >>
 >> ![email](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
->> - Su Mac OS, avvia l'applicazione Terminal e inserisci la tua applicazione Thunderbird nella finestra del Terminal, aggiungendo alla linea `/Contents/MacOS/thunderbird-bin -ProfileManager`. Clicca sul tasto `Invio` (⏎) per confermare.
+>> - Su Mac OS, avvia l'applicazione Terminal e inserisci la tua applicazione Thunderbird nella finestra del Terminal, aggiungendo alla linea `/Contents/MacOS/thunderbird-bin -ProfileManager`. Clicca sul tasto `Invio`{.action} (⏎) per confermare.
 >>
 >> ![email](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> Visualizzi una tabella con tutti i profili disponibili. Clicca su `Crea un profilo` e poi su `Seguente` quando visualizzi il messaggio informativo.
+>> Visualizzi una tabella con tutti i profili disponibili. Clicca su `Crea un profilo`{.action} e poi su `Seguente`{.action} quando visualizzi il messaggio informativo.
 >>
 >> ![email](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -246,9 +246,9 @@ Al momento non esistono funzionalità native per esportare o importare un accoun
 >> > [!primary]
 >> > Ti consigliamo di copiare il backup del tuo profilo Thunderbird nella cartella dei profili di Thunderbird.
 >>
->> Clicca su `Seleziona una cartella...` per selezionare la cartella contenente il tuo backup. Clicca su `Fine` per creare il profilo con il tuo backup.
+>> Clicca su `Seleziona una cartella...`{.action} per selezionare la cartella contenente il tuo backup. Clicca su `Fine`{.action} per creare il profilo con il tuo backup.
 >>
->> Puoi trovare la finestra di scelta del tuo profilo con il tuo nuovo profilo selezionato. Clicca su `Avvia Thunderbird`, Thunderbird verrà lanciato con tutti gli elementi presenti nel tuo backup.
+>> Puoi trovare la finestra di scelta del tuo profilo con il tuo nuovo profilo selezionato. Clicca su `Avvia Thunderbird`{.action}, Thunderbird verrà lanciato con tutti gli elementi presenti nel tuo backup.
 
 ### Verifica l'importazione sul nuovo indirizzo email
 
@@ -263,6 +263,6 @@ Nella casella di ricezione e nella colonna di sinistra, troverai le cartelle e l
 
 ## Per saperne di più
 
-[Migrare un account email con OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm)
+[Migrare un account e-mail con OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm)
 
 Contatta la nostra [Community di utenti](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.it-it.md
@@ -33,17 +33,17 @@ updated: 2026-01-16
 **MX Plan:**
 
 - **Link diretto:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo servizio MX Plan
+- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo MX Plan service
 
 **Email Pro:**
 
 - **Link diretto:** [Email Pro](/links/control-panel/web-email-pro)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua piattaforma
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua platform
 
 **Exchange:**
 
 - **Link diretto:** [Exchange](/links/control-panel/web-exchange)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua piattaforma
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua platform
 
 ---
 <!-- CP-NAV-END:web-exchange -->
@@ -67,184 +67,188 @@ Le seguenti istruzioni sono suddivise in due parti:
 
 Se disponi di un account email [Exchange OVHcloud](/links/web/emails-hosted-exchange), è possibile esportarlo direttamente in formato PST dallo Spazio Cliente.
 
-1. Accedi allo [Spazio Cliente OVHcloud](/links/manager).
-1. Accedi alla sezione `Web Cloud`{.action}.
-1. Nella sezione `MICROSOFT`, clicca su `Exchange`{.action}.
-1. Seleziona la piattaforma interessata.
-1. Nella scheda `Account email`{.action}, clicca sul pulsante `...`{.action} a destra dell'account da esportare e poi su `Esporta in formato PST`{.action}.
+Nella scheda `Account email`{.action}, clicca sul pulsante `...`{.action} a destra dell'account da esportare e poi su `Esporta in formato PST`{.action}.
 
-![email](images/manager-export-pst01.png){.thumbnail}
+![email](images/manager-export-pst01.png){.thumbnail .w-640}
 
 Attendi il completamento dell'operazione, che potrebbe richiedere da qualche minuto a diverse ore, in base alla dimensione dell'esportazione. Al termine di questo processo, sarà sufficiente tornare al pulsante `Esporta in formato PST`{.action} per recuperare un link per scaricare il file.
 
-![email](images/manager-export-pst02.png){.thumbnail}
+![email](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Esporta da Windows
+#### Windows
 
-- Clicca su `file` in alto a sinistra, poi su `Aprire ed esportare` e infine su `importare/esportare`.
+> [!tabs]
+> **Esportare**
+>>
+>> - Clicca su `file` in alto a sinistra, poi su `Aprire ed esportare` e infine su `importare/esportare`.
+>>
+>> ![email](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Seleziona `Esporta dati verso un file` e clicca su `Seguente`.
+>>
+>> ![email](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Seleziona `File dati Outlook (.pst)` e clicca su `Seguente`.
+>>
+>> ![email](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Seleziona il nome dell'account email da esportare.
+>>
+>> > [!primary]
+>> > Potete esportare un solo account per volta.
+>>
+>> Seleziona `Includi le sottocartelle` e clicca su `Seguente`.
+>>
+>> ![email](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Scegli la cartella di destinazione del tuo backup e inserisci un nome per quest'ultimo cliccando su `Percorrere`. Seleziona l'opzione che preferisci e clicca su `Terminare`.
+>>
+>> ![email](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> L'esportazione del tuo file inizia. Durante la creazione di un file, ti verrà chiesto di definire una password. che è facoltativo.
+>>
+>> ![email](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Importare**
+>>
+>> - Clicca su `file` in alto a sinistra, poi su `Aprire ed esportare` e infine su `importare/esportare`.
+>>
+>> ![email](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Seleziona `Importa da un altro programma o file` e clicca su `Seguente`.
+>>
+>> ![email](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Seleziona `File dati Outlook (.pst)` e clicca su `Seguente`.
+>>
+>> ![email](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Seleziona il file di backup cliccando su `Percorri`. Seleziona l'opzione che preferisci e clicca su `Terminare`.
+>>
+>> ![email](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - Se hai impostato una password sul tuo file di backup, inseriscilo e clicca su `OK`.
+>>
+>> - Seleziona `Importa gli elementi nella cartella attiva` e clicca su `Termina`.
+>>
+>> L'importazione del tuo backup inizia
 
-![email](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Seleziona `Esporta dati verso un file` e clicca su `Seguente`.
-
-![email](images/outlook-export-win02.png){.thumbnail}
-
-- Seleziona `File dati Outlook (.pst)` e clicca su `Seguente`.
-
-![email](images/outlook-export-win03.png){.thumbnail}
-
-- Seleziona il nome dell'account email da esportare.
-
-> [!primary]
-> Potete esportare un solo account per volta.
-
-Seleziona `Includi le sottocartelle` e clicca su `Seguente`.
-
-![email](images/outlook-export-win04.png){.thumbnail}
-
-- Scegli la cartella di destinazione del tuo backup e inserisci un nome per quest'ultimo cliccando su `Percorrere`. Seleziona l'opzione che preferisci e clicca su `Terminare`.
-
-![email](images/outlook-export-win05.png){.thumbnail}
-
-L'esportazione del tuo file inizia. Durante la creazione di un file, ti verrà chiesto di definire una password. che è facoltativo.
-
-![email](images/outlook-export-win06.png){.thumbnail}
-
-#### Importa da Windows
-
-- Clicca su `file` in alto a sinistra, poi su `Aprire ed esportare` e infine su `importare/esportare`.
-
-![email](images/outlook-export-import-win.png){.thumbnail}
-
-- Seleziona `Importa da un altro programma o file` e clicca su `Seguente`.
-
-![email](images/outlook-import-win02.png){.thumbnail}
-
-- Seleziona `File dati Outlook (.pst)` e clicca su `Seguente`.
-
-![email](images/outlook-import-win03.png){.thumbnail}
-
-- Seleziona il file di backup cliccando su `Percorri`. Seleziona l'opzione che preferisci e clicca su `Terminare`.
-
-![email](images/outlook-import-win04.png){.thumbnail}
-
-- Se hai impostato una password sul tuo file di backup, inseriscilo e clicca su `OK`.
-
-- Seleziona `Importa gli elementi nella cartella attiva` e clicca su `Terminer`.
-
-L'importazione del tuo backup inizia
-
-#### Esporta da Mac OS
-
-Nella scheda `Strumenti` della tua finestra Outlook, clicca su `Esporta`.
-
-![email](images/outlook-export-mac01.png){.thumbnail}
-
-Dalla finestra "Esporta verso un file archivio (.olm)", seleziona gli elementi che vuoi aggiungere al tuo file di backup e clicca su `Continua`.
-
-![email](images/outlook-export-mac02.png){.thumbnail}
-
-Seleziona la cartella di destinazione per il tuo backup e clicca su `Salva`.
-
-![email](images/outlook-export-mac03.png){.thumbnail}
-
-Visualizzi una finestra di progressione, clicca su Continua` ` alla fine dell'operazione. Il file di backup è disponibile nella cartella selezionata precedentemente.
-
-#### Importa da Mac OS
-
-Nella scheda `Strumenti` della tua finestra Outlook, clicca su `Importa`.
-
-![email](images/outlook-import-mac01.png){.thumbnail}
-
-Scegli il formato di backup che vuoi importare e clicca su `Continua`.
-
-![email](images/outlook-import-mac02.png){.thumbnail}
-
-Seleziona il file di backup e clicca su `Importa`.
-
-![email](images/outlook-import-mac03.png){.thumbnail}
-
-Visualizzi una finestra di progressione, clicca su Continua` ` alla fine dell'operazione. Il backup viene poi implementato sul tuo Outlook.
+> [!tabs]
+> **Esportare**
+>>
+>> Nella scheda `Strumenti` della tua finestra Outlook, clicca su `Esporta`.
+>>
+>> ![email](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> Dalla finestra "Esporta verso un file archivio (.olm)", seleziona gli elementi che vuoi aggiungere al tuo file di backup e clicca su `Continua`.
+>>
+>> ![email](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Seleziona la cartella di destinazione per il tuo backup e clicca su `Salva`.
+>>
+>> ![email](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> Visualizzi una finestra di progressione, clicca su `Continua`{.action} alla fine dell'operazione. Il file di backup è disponibile nella cartella selezionata precedentemente.
+>>
+> **Importare**
+>>
+>> Nella scheda `Strumenti` della tua finestra Outlook, clicca su `Importa`.
+>>
+>> ![email](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Scegli il formato di backup che vuoi importare e clicca su `Continua`.
+>>
+>> ![email](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Seleziona il file di backup e clicca su `Importa`.
+>>
+>> ![email](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> Visualizzi una finestra di progressione, clicca su `Continua`{.action} alla fine dell'operazione. Il backup viene poi implementato sul tuo Outlook.
 
 ### Email su Mac OS
 
-#### Esportare
-
-Nella colonna di sinistra, seleziona uno o più account email. Clicca sulla `Casella lettere` nel menu orizzontale e poi su `Esporta la cassetta delle lettere`.
-
-![email](images/mail-export-mac01.png){.thumbnail}
-
-Seleziona la cartella scelta o creane una nuova, poi clicca su `Scegli`.
-
-![email](images/mail-export-mac02.png){.thumbnail}
-
-La tua esportazione è un file ".mbox".
-
-#### Importare
-
-Clicca su `File` nel menu orizzontale e poi su `Importa cassette delle lettere`.
-
-![email](images/mail-import-mac01.png){.thumbnail}
-
-Seleziona il file di backup in formato ".mbox" e clicca su `Continua`.
-
-![email](images/mail-import-mac02.png){.thumbnail}
-
-Nella colonna di sinistra, le email importate sono contenute in un nuovo account email chiamato "Importazione". Le cartelle e i messaggi possono essere spostati dall'account "Importazione" verso i tuoi account email già configurati. Una volta terminati i trasferimenti, potrai eliminare l'account "Importazione".
+> [!tabs]
+> **Esportare**
+>>
+>> Nella colonna di sinistra, seleziona uno o più account email. Clicca sulla `Casella lettere` nel menu orizzontale e poi su `Esporta la cassetta delle lettere`.
+>>
+>> ![email](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Seleziona la cartella scelta o creane una nuova, poi clicca su `Scegli`.
+>>
+>> ![email](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> La tua esportazione è un file ".mbox".
+>>
+> **Importare**
+>>
+>> Clicca su `File` nel menu orizzontale e poi su `Importa cassette delle lettere`.
+>>
+>> ![email](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Seleziona il file di backup in formato ".mbox" e clicca su `Continua`.
+>>
+>> ![email](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> Nella colonna di sinistra, le email importate sono contenute in un nuovo account email chiamato "Importazione". Le cartelle e i messaggi possono essere spostati dall'account "Importazione" verso i tuoi account email già configurati. Una volta terminati i trasferimenti, potrai eliminare l'account "Importazione".
 
 ### Thunderbird
 
 Al momento non esistono funzionalità native per esportare o importare un account email da Thunderbird. È comunque possibile salvare un profilo Thunderbird. che contiene tutti gli account e le email in locale sul tuo computer. Questa guida ti mostra come salvare un profilo Thunderbird e reinserirlo su una nuova istanza di Thunderbird.
 
-#### Esportare
-
-Dalla finestra principale, clicca sul menu in alto a destra, poi su `Aiuto` e infine su `Informazioni di soccorso`.
-
-![email](images/thunderbird_menu.png){.thumbnail}
-
-Visualizzi una tabella Identifica la linea `Directory del profilo` e clicca sul pulsante `Apri la cartella corrispondente`.
-
-![email](images/thunderbird_open_folder.png){.thumbnail}
-
-Verrai diretto nella cartella del profilo. Ricollegatevi a una cartella nell'arborescenza.
-
-![email](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Copia la cartella del profilo tramite un click con il tasto destro sul profilo e incolla la cartella nella cartella o supporto di tua scelta.
-
-![email](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importare
-
-Anziché importare, si tratterà di un carico di profilo.
-Se sull'istanza Thunderbird di destinazione sono già stati configurati account email, questi saranno presenti sul profilo A.
-Quando Thunderbird caricerà un nuovo profilo (profilo B), potrà caricare **solo** gli elementi di questo profilo B.
-Per questo ti consigliamo di caricare il nuovo profilo (profilo B) e configurare gli account email provenienti dal profilo A.
-
-Per prima cosa è necessario avviare Thunderbird tramite il provider.
-
-- Su Windows, clicca sul menu `Inizia` e poi sul programma `Esegui`. Clicca su `thunderbird.exe -ProfileManager` e clicca su `OK`.
-
-![email](images/thunderbird-run-profil.png){.thumbnail}
-
-- Su Mac OS, avvia l'applicazione Terminal e inserisci la tua applicazione Thunderbird nella finestra del Terminal, aggiungendo alla linea `/Contents/MacOS/thunderbird-bin-ProfileManager`. Clicca sul tasto `Invio` (⏎) per confermare.
-
-![email](images/thunderbird-terminal-profil.png){.thumbnail}
-
-Visualizzi una tabella con tutti i profili disponibili. Clicca su `Crea un profilo` e poi su `Seguente` quando visualizzi il messaggio informativo.
-
-![email](images/thunderbird-profil-create01.png){.thumbnail}
-
-Allo step successivo, assegna un nome al tuo profilo e identifica la cartella in cui verrà creato il profilo, sotto la frase "I tuoi parametri utente, preferenze e tutti i tuoi dati personali saranno registrati in":
-
-![email](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> Ti consigliamo di copiare il backup del tuo profilo Thunderbird nella cartella dei profili di Thunderbird.
-
-Clicca su `Seleziona una cartella...` per selezionare la cartella contenente il tuo backup. Clicca su `Terminer` per creare il profilo con il tuo backup.
-
-Puoi trovare la finestra di scelta del tuo profilo con il tuo nuovo profilo selezionato. Clicca su `Avvia Thunderbird`, Thunderbird verrà lanciato con tutti gli elementi presenti nel tuo backup.
+> [!tabs]
+> **Esportare**
+>>
+>> Dalla finestra principale, clicca sul menu in alto a destra, poi su `Aiuto` e infine su `Informazioni di soccorso`.
+>>
+>> ![email](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> Visualizzi una tabella. Identifica la linea `Directory del profilo` e clicca sul pulsante `Apri la cartella corrispondente`.
+>>
+>> ![email](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> Verrai diretto nella cartella del profilo. Risali di un livello nella struttura ad albero.
+>>
+>> ![email](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Copia la cartella del profilo tramite un click con il tasto destro sul profilo e incolla la cartella nella cartella o supporto di tua scelta.
+>>
+>> ![email](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Importare**
+>>
+>> Anziché importare, si tratterà di un carico di profilo.
+>> Se sull'istanza Thunderbird di destinazione sono già stati configurati account email, questi saranno presenti sul profilo A.
+>> Quando Thunderbird caricerà un nuovo profilo (profilo B), potrà caricare **solo** gli elementi di questo profilo B.
+>> Per questo ti consigliamo di caricare il nuovo profilo (profilo B) e configurare gli account email provenienti dal profilo A.
+>>
+>> Per prima cosa è necessario avviare Thunderbird tramite il gestore dei profili.
+>>
+>> - Su Windows, clicca sul menu `Start` e poi sul programma `Esegui`. Clicca su `thunderbird.exe -ProfileManager` e clicca su `OK`.
+>>
+>> ![email](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - Su Mac OS, avvia l'applicazione Terminal e inserisci la tua applicazione Thunderbird nella finestra del Terminal, aggiungendo alla linea `/Contents/MacOS/thunderbird-bin -ProfileManager`. Clicca sul tasto `Invio` (⏎) per confermare.
+>>
+>> ![email](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> Visualizzi una tabella con tutti i profili disponibili. Clicca su `Crea un profilo` e poi su `Seguente` quando visualizzi il messaggio informativo.
+>>
+>> ![email](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> Allo step successivo, assegna un nome al tuo profilo e identifica la cartella in cui verrà creato il profilo, sotto la frase "I tuoi parametri utente, preferenze e tutti i tuoi dati personali saranno registrati in":
+>>
+>> ![email](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > Ti consigliamo di copiare il backup del tuo profilo Thunderbird nella cartella dei profili di Thunderbird.
+>>
+>> Clicca su `Seleziona una cartella...` per selezionare la cartella contenente il tuo backup. Clicca su `Fine` per creare il profilo con il tuo backup.
+>>
+>> Puoi trovare la finestra di scelta del tuo profilo con il tuo nuovo profilo selezionato. Clicca su `Avvia Thunderbird`, Thunderbird verrà lanciato con tutti gli elementi presenti nel tuo backup.
 
 ### Verifica l'importazione sul nuovo indirizzo email
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pl-pl.md
@@ -38,7 +38,7 @@ updated: 2026-01-16
 **Email Pro:**
 
 - **Link bezpośredni:** [Email Pro](/links/control-panel/web-email-pro)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Email Pro`{.action} > Wybierz platformę
+- **Ścieżka nawigacji:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Wybierz platformę
 
 **Exchange:**
 
@@ -67,11 +67,11 @@ Poniższe instrukcje są podzielone na dwie części:
 
 Jeśli posiadasz konto e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), możesz je wyeksportować bezpośrednio w formacie PST w Panelu klienta.
 
-W karcie `Konta e-mail`{.action} kliknij przycisk `...`{.action} po prawej stronie konta e-mail, które chcesz wyeksportować, a następnie wybierz opcję `Eksportuj w formacie PST`{.action}.
+W karcie `Konta e-mail`{.action} kliknij przycisk `...`{.action} po prawej stronie konta e-mail, które chcesz wyeksportować, a następnie wybierz opcję `Eksportuj do pliku PST`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-Następnie należy poczekać na eksport, który może trwać od kilku minut do kilku godzin, w zależności od wielkości eksportu. Po zakończeniu operacji wystarczy powrócić do przycisku `Eksportuj w formacie PST`{.action}, aby pobrać link do pobrania pliku.
+Następnie należy poczekać na eksport, który może trwać od kilku minut do kilku godzin, w zależności od wielkości eksportu. Po zakończeniu operacji wystarczy powrócić do przycisku `Eksportuj do pliku PST`{.action}, aby pobrać link do pobrania pliku.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pl-pl.md
@@ -67,11 +67,11 @@ Poniższe instrukcje są podzielone na dwie części:
 
 Jeśli posiadasz konto e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), możesz je wyeksportować bezpośrednio w formacie PST w Panelu klienta.
 
-W karcie `Konta e-mail`{.action} kliknij przycisk `...`{.action} po prawej stronie konta e-mail, które chcesz wyeksportować, a następnie wybierz opcję `Eksportuj do pliku PST`{.action}.
+Po przejściu do strony usługi Exchange, w karcie `Konta e-mail`{.action} kliknij przycisk `...`{.action} po prawej stronie konta e-mail, które chcesz wyeksportować, a następnie wybierz opcję `Eksportuj w formacie PST`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-Następnie należy poczekać na eksport, który może trwać od kilku minut do kilku godzin, w zależności od wielkości eksportu. Po zakończeniu operacji wystarczy powrócić do przycisku `Eksportuj do pliku PST`{.action}, aby pobrać link do pobrania pliku.
+Następnie należy poczekać na eksport, który może trwać od kilku minut do kilku godzin, w zależności od wielkości eksportu. Po zakończeniu operacji wystarczy powrócić do przycisku `Eksportuj w formacie PST`{.action}, aby pobrać link do pobrania pliku.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
@@ -80,15 +80,15 @@ Następnie należy poczekać na eksport, który może trwać od kilku minut do k
 > [!tabs]
 > **Eksport**
 >>
->> - Kliknij `plik` w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`, a następnie wybierz `import/eksport`.
+>> - Kliknij `plik`{.action} w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`{.action}, a następnie wybierz `import/eksport`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Wybierz Eksportuj `dane do pliku`, po czym kliknij `Dalej`.
+>> - Wybierz Eksportuj `dane do pliku`{.action}, po czym kliknij `Dalej`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Wybierz `Plik danych Outlook (.pst)` i kliknij `Dalej`.
+>> - Wybierz `Plik danych Outlook (.pst)`{.action} i kliknij `Dalej`{.action}.
 >>
 >> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -97,11 +97,11 @@ Następnie należy poczekać na eksport, który może trwać od kilku minut do k
 >> > [!primary]
 >> > Możesz wyeksportować tylko jedno konto jednocześnie.
 >>
->> Zaznacz dobrze `Dodaj podkatalogi`, a następnie kliknij `Dalej`.
+>> Zaznacz dobrze `Dodaj podkatalogi`{.action}, a następnie kliknij `Dalej`{.action}.
 >>
 >> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Wybierz docelowy folder kopii zapasowej i podaj nazwę kopii zapasowej klikając `Przeglądaj`. Wybierz odpowiednią opcję i kliknij `Zakończ`.
+>> - Wybierz docelowy folder kopii zapasowej i podaj nazwę kopii zapasowej klikając `Przeglądaj`{.action}. Wybierz odpowiednią opcję i kliknij `Zakończ`{.action}.
 >>
 >> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -111,25 +111,25 @@ Następnie należy poczekać na eksport, który może trwać od kilku minut do k
 >>
 > **Import**
 >>
->> - Kliknij `plik` w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`, a następnie wybierz `import/eksport`.
+>> - Kliknij `plik`{.action} w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`{.action}, a następnie wybierz `import/eksport`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Wybierz Importuj `z innego programu lub pliku`, a następnie kliknij `Dalej`.
+>> - Wybierz Importuj `z innego programu lub pliku`{.action}, a następnie kliknij `Dalej`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Wybierz `Plik danych Outlook (.pst)` i kliknij `Dalej`.
+>> - Wybierz `Plik danych Outlook (.pst)`{.action} i kliknij `Dalej`{.action}.
 >>
 >> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Wybierz plik kopii zapasowej, klikając `Przeglądaj`. Wybierz odpowiednią opcję i kliknij `Zakończ`.
+>> - Wybierz plik kopii zapasowej, klikając `Przeglądaj`{.action}. Wybierz odpowiednią opcję i kliknij `Zakończ`{.action}.
 >>
 >> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - Jeśli ustaliłeś hasło do pliku kopii zapasowej, wprowadź je i kliknij `OK`.
+>> - Jeśli ustaliłeś hasło do pliku kopii zapasowej, wprowadź je i kliknij `OK`{.action}.
 >>
->> - Wybierz `Importuj elementy do aktywnego` folderu, a następnie kliknij `Zakończ`.
+>> - Wybierz `Importuj elementy do aktywnego`{.action} folderu, a następnie kliknij `Zakończ`{.action}.
 >>
 >> Rozpoczyna się import kopii zapasowej.
 
@@ -138,46 +138,46 @@ Następnie należy poczekać na eksport, który może trwać od kilku minut do k
 > [!tabs]
 > **Eksport**
 >>
->> W zakładce `Narzędzia` w oknie Outlook kliknij `Eksportuj`.
+>> W zakładce `Narzędzia`{.action} w oknie Outlook kliknij `Eksportuj`{.action}.
 >>
 >> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> W oknie "Eksport do pliku archiwum (.olm)" zaznacz elementy, które chcesz dodać do pliku kopii zapasowej, następnie kliknij `Dalej`.
+>> W oknie "Eksport do pliku archiwum (.olm)" zaznacz elementy, które chcesz dodać do pliku kopii zapasowej, następnie kliknij `Dalej`{.action}.
 >>
 >> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> Następnie wybierz docelowy folder dla kopii zapasowej, a następnie kliknij `Zapisz`.
+>> Następnie wybierz docelowy folder dla kopii zapasowej, a następnie kliknij `Zapisz`{.action}.
 >>
 >> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> Pojawi się okno postępu, kliknij `Dalej` po zakończeniu operacji. Twój plik kopii zapasowej znajdziesz w wybranym wcześniej katalogu.
+>> Pojawi się okno postępu, kliknij `Dalej`{.action} po zakończeniu operacji. Twój plik kopii zapasowej znajdziesz w wybranym wcześniej katalogu.
 >>
 > **Import**
 >>
->> W zakładce `Narzędzia` w oknie Outlook kliknij `Importuj`.
+>> W zakładce `Narzędzia`{.action} w oknie Outlook kliknij `Importuj`{.action}.
 >>
 >> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Wybierz format kopii zapasowej, którą chcesz importować, a następnie kliknij `Dalej`.
+>> Wybierz format kopii zapasowej, którą chcesz importować, a następnie kliknij `Dalej`{.action}.
 >>
 >> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Wybierz Twój plik kopii zapasowej, po czym kliknij `importuj`.
+>> Wybierz Twój plik kopii zapasowej, po czym kliknij `Importuj`{.action}.
 >>
 >> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> Pojawi się okno postępu, kliknij `Dalej` po zakończeniu operacji. Twoja kopia zapasowa jest wdrażana w programie Outlook.
+>> Pojawi się okno postępu, kliknij `Dalej`{.action} po zakończeniu operacji. Twoja kopia zapasowa jest wdrażana w programie Outlook.
 
 ### Mail na Mac OS
 
 > [!tabs]
 > **Eksport**
 >>
->> W kolumnie z lewej strony wybierz jedno lub kilka kont e-mail. Kliknij `Skrzynka na listy` w menu poziomym, a następnie kliknij `Eksportuj skrzynkę na listy`.
+>> W kolumnie z lewej strony wybierz jedno lub kilka kont e-mail. Kliknij `Skrzynka na listy`{.action} w menu poziomym, a następnie kliknij `Eksportuj skrzynkę na listy`{.action}.
 >>
 >> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Wybierz lub utwórz nowy folder, następnie kliknij `Wybierz`.
+>> Wybierz lub utwórz nowy folder, następnie kliknij `Wybierz`{.action}.
 >>
 >> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -185,11 +185,11 @@ Następnie należy poczekać na eksport, który może trwać od kilku minut do k
 >>
 > **Import**
 >>
->> Kliknij `Plik` w menu poziomym, a następnie kliknij `Importuj skrzynki na listy`.
+>> Kliknij `Plik`{.action} w menu poziomym, a następnie kliknij `Importuj skrzynki na listy`{.action}.
 >>
 >> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Wybierz plik kopii zapasowej w formacie.mbox, po czym kliknij `Dalej`.
+>> Wybierz plik kopii zapasowej w formacie.mbox, po czym kliknij `Dalej`{.action}.
 >>
 >> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -202,11 +202,11 @@ Aktualnie nie istnieje funkcjonalność umożliwiająca eksportowanie lub import
 > [!tabs]
 > **Eksport**
 >>
->> W oknie głównym kliknij menu w prawym górnym rogu, następnie `Pomoc`, a następnie `Informacje dotyczące rozwiązywania problemów`.
+>> W oknie głównym kliknij menu w prawym górnym rogu, następnie `Pomoc`{.action}, a następnie `Informacje dotyczące rozwiązywania problemów`{.action}.
 >>
 >> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> Pojawi się tabela. Wyszukaj linię `Katalog Profilowy` i kliknij przycisk `Otwórz odpowiedni` katalog.
+>> Pojawi się tabela. Wyszukaj linię `Katalog Profilowy`{.action} i kliknij przycisk `Otwórz odpowiedni katalog`{.action}.
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -227,7 +227,7 @@ Aktualnie nie istnieje funkcjonalność umożliwiająca eksportowanie lub import
 >>
 >> Najpierw należy uruchomić Thunderbird za pomocą menedżera profili.
 >>
->> - W systemie Windows przejdź do menu `Start`, a następnie do programu `Uruchom`. Wpisz `thunderbird.exe -ProfileManager` i kliknij `OK`.
+>> - W systemie Windows przejdź do menu `Start`{.action}, a następnie do programu `Uruchom`{.action}. Wpisz `thunderbird.exe -ProfileManager` i kliknij `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
@@ -235,7 +235,7 @@ Aktualnie nie istnieje funkcjonalność umożliwiająca eksportowanie lub import
 >>
 >> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> W następnym oknie wyświetlą się istniejące profile. Kliknij `Utwórz profil`, a następnie `Dalej`, gdy pojawi się komunikat informacyjny.
+>> W następnym oknie wyświetlą się istniejące profile. Kliknij `Utwórz profil`{.action}, a następnie `Dalej`{.action}, gdy pojawi się komunikat informacyjny.
 >>
 >> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -246,9 +246,9 @@ Aktualnie nie istnieje funkcjonalność umożliwiająca eksportowanie lub import
 >> > [!primary]
 >> > Zalecamy skopiowanie kopii zapasowej Twojego profilu Thunderbird do folderu z profilami Thunderbirda.
 >>
->> Kliknij `Wybierz katalog...` aby wybrać folder z kopią zapasową. Kliknij `Zakończ`, aby utworzyć profil z kopii zapasowej.
+>> Kliknij `Wybierz katalog...`{.action} aby wybrać folder z kopią zapasową. Kliknij `Zakończ`{.action}, aby utworzyć profil z kopii zapasowej.
 >>
->> Okno wyboru profilu znajdziesz w nowym, wybranym profilu. Kliknij `Uruchom Thunderbird`, Thunderbird zostanie uruchomiony z wszystkimi elementami, które posiadasz w kopii zapasowej.
+>> Okno wyboru profilu znajdziesz w nowym, wybranym profilu. Kliknij `Uruchom Thunderbird`{.action}, Thunderbird zostanie uruchomiony z wszystkimi elementami, które posiadasz w kopii zapasowej.
 
 ### Sprawdź import na nowy adres e-mail
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pl-pl.md
@@ -3,7 +3,6 @@ title: Ręczna migracja Twojego konta e-mail
 excerpt: Dowiedz się, jak ręcznie przenieść Twoje konto e-mail na inny adres e-mail
 updated: 2026-01-16
 ---
- 
 
 ## Wprowadzenie
 
@@ -20,7 +19,7 @@ updated: 2026-01-16
 
 ## Wymagania początkowe
 
-- Posiadanie usługi e-mail w OVHcloud, takiej jak oferta [Exchange](/links/web/emails-exchange), [E-mail Pro](/links/web/email-pro), [Zimbra](/links/web/zimbra) lub MX Plan (w postaci pakietu MX Plan lub w postaci pakietu [hostingowego OVHcloud](/links/web/hosting))
+- Posiadanie usługi e-mail w OVHcloud, takiej jak oferta [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/zimbra) lub MX Plan (w postaci pakietu MX Plan lub w postaci pakietu [hostingowego OVHcloud](/links/web/hosting))
 - Posiadanie danych dostępowych do kont e-mail, które chcesz przenieść (konta źródłowe)
 - Posiadanie danych dostępowych do kont e-mail OVHcloud, na które przeniesione zostaną dane (konta docelowe)
 
@@ -33,18 +32,18 @@ updated: 2026-01-16
 
 **MX Plan:**
 
-- **Bezpośredni link:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz swoją usługę MX Plan
+- **Link bezpośredni:** [MX Plan](/links/control-panel/web-mx-plan)
+- **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz usługę MX Plan
 
-**E-mail Pro:**
+**Email Pro:**
 
-- **Bezpośredni link:** [E-mail Pro](/links/control-panel/web-email-pro)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Wybierz swoją platformę
+- **Link bezpośredni:** [Email Pro](/links/control-panel/web-email-pro)
+- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Email Pro`{.action} > Wybierz platformę
 
 **Exchange:**
 
-- **Bezpośredni link:** [Exchange](/links/control-panel/web-exchange)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Exchange`{.action} > Wybierz swoją platformę
+- **Link bezpośredni:** [Exchange](/links/control-panel/web-exchange)
+- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Exchange`{.action} > Wybierz platformę
 
 ---
 <!-- CP-NAV-END:web-exchange -->
@@ -68,184 +67,188 @@ Poniższe instrukcje są podzielone na dwie części:
 
 Jeśli posiadasz konto e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), możesz je wyeksportować bezpośrednio w formacie PST w Panelu klienta.
 
-1. Zaloguj się do [Panelu klienta OVHcloud](/links/manager).
-1. Przejdź do sekcji `Web Cloud`{.action}.
-1. W sekcji `MICROSOFT` kliknij `Exchange`{.action}.
-1. Wybierz odpowiednią platformę.
-1. W karcie `Konta e-mail`{.action} kliknij przycisk `...`{.action} po prawej stronie konta e-mail, które chcesz wyeksportować, a następnie wybierz opcję `Eksportuj w formacie PST`{.action}.
+W karcie `Konta e-mail`{.action} kliknij przycisk `...`{.action} po prawej stronie konta e-mail, które chcesz wyeksportować, a następnie wybierz opcję `Eksportuj w formacie PST`{.action}.
 
-![emails](images/manager-export-pst01.png){.thumbnail}
+![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
 Następnie należy poczekać na eksport, który może trwać od kilku minut do kilku godzin, w zależności od wielkości eksportu. Po zakończeniu operacji wystarczy powrócić do przycisku `Eksportuj w formacie PST`{.action}, aby pobrać link do pobrania pliku.
 
-![emails](images/manager-export-pst02.png){.thumbnail}
+![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Eksport z systemu Windows
+#### Windows
 
-- Kliknij `plik` w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`, a następnie wybierz `import/eksport`.
+> [!tabs]
+> **Eksport**
+>>
+>> - Kliknij `plik` w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`, a następnie wybierz `import/eksport`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Wybierz Eksportuj `dane do pliku`, po czym kliknij `Dalej`.
+>>
+>> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Wybierz `Plik danych Outlook (.pst)` i kliknij `Dalej`.
+>>
+>> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Wybierz nazwę konta e-mail, które chcesz wyeksportować.
+>>
+>> > [!primary]
+>> > Możesz wyeksportować tylko jedno konto jednocześnie.
+>>
+>> Zaznacz dobrze `Dodaj podkatalogi`, a następnie kliknij `Dalej`.
+>>
+>> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Wybierz docelowy folder kopii zapasowej i podaj nazwę kopii zapasowej klikając `Przeglądaj`. Wybierz odpowiednią opcję i kliknij `Zakończ`.
+>>
+>> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> Rozpoczyna się eksport pliku. Podczas tworzenia pliku zostaniesz poproszony o określenie hasła. Jest on opcjonalny.
+>>
+>> ![emails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> - Kliknij `plik` w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`, a następnie wybierz `import/eksport`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Wybierz Importuj `z innego programu lub pliku`, a następnie kliknij `Dalej`.
+>>
+>> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Wybierz `Plik danych Outlook (.pst)` i kliknij `Dalej`.
+>>
+>> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Wybierz plik kopii zapasowej, klikając `Przeglądaj`. Wybierz odpowiednią opcję i kliknij `Zakończ`.
+>>
+>> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - Jeśli ustaliłeś hasło do pliku kopii zapasowej, wprowadź je i kliknij `OK`.
+>>
+>> - Wybierz `Importuj elementy do aktywnego` folderu, a następnie kliknij `Zakończ`.
+>>
+>> Rozpoczyna się import kopii zapasowej.
 
-![emails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Wybierz Eksportuj `dane do pliku`, po czym kliknij `Dalej`.
-
-![emails](images/outlook-export-win02.png){.thumbnail}
-
-- Wybierz `Plik danych Outlook (.pst)` i kliknij `Dalej`.
-
-![emails](images/outlook-export-win03.png){.thumbnail}
-
-- Wybierz nazwę konta e-mail, które chcesz wyeksportować.
-
-> [!primary]
-> Możesz wyeksportować tylko jedno konto jednocześnie.
-
-Zaznacz dobrze `Dodaj podkatalogi`, a następnie kliknij `Dalej`.
-
-![emails](images/outlook-export-win04.png){.thumbnail}
-
-- Wybierz docelowy folder kopii zapasowej i podaj nazwę kopii zapasowej klikając `Przeglądaj`. Wybierz odpowiednią opcję i kliknij `Zakończ`.
-
-![emails](images/outlook-export-win05.png){.thumbnail}
-
-Rozpoczyna się eksport pliku. Podczas tworzenia pliku zostaniesz poproszony o określenie hasła. Jest on opcjonalny.
-
-![emails](images/outlook-export-win06.png){.thumbnail}
-
-#### Import z systemu Windows
-
-- Kliknij `plik` w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`, a następnie wybierz `import/eksport`.
-
-![emails](images/outlook-export-import-win.png){.thumbnail}
-
-- Wybierz Importuj `z innego programu lub pliku`, a następnie kliknij `Dalej`.
-
-![emails](images/outlook-import-win02.png){.thumbnail}
-
-- Wybierz `Plik danych Outlook (.pst)` i kliknij `Dalej`.
-
-![emails](images/outlook-import-win03.png){.thumbnail}
-
-- Wybierz plik kopii zapasowej, klikając `Przeglądaj`. Wybierz odpowiednią opcję i kliknij `Zakończ`.
-
-![emails](images/outlook-import-win04.png){.thumbnail}
-
-- Jeśli ustaliłeś hasło do pliku kopii zapasowej, wprowadź je i kliknij `OK`.
-
-- Wybierz `Importuj elementy do aktywnego` folderu, a następnie kliknij `Zakończ`.
-
-Rozpoczyna się import kopii zapasowej.
-
-#### Eksportuj z systemu Mac OS
-
-W zakładce `Narzędzia` w oknie Outlook kliknij `Eksportuj`.
-
-![emails](images/outlook-export-mac01.png){.thumbnail}
-
-W oknie "Eksport do pliku archiwum (.olm)" zaznacz elementy, które chcesz dodać do pliku kopii zapasowej, następnie kliknij `Dalej`.
-
-![emails](images/outlook-export-mac02.png){.thumbnail}
-
-Następnie wybierz docelowy folder dla kopii zapasowej, a następnie kliknij `Zapisz`.
-
-![emails](images/outlook-export-mac03.png){.thumbnail}
-
-Pojawi się okno postępu, kliknij `Dalej` po zakończeniu operacji. Twój plik kopii zapasowej znajdziesz w wybranym wcześniej katalogu.
-
-#### Import z systemu Mac OS
-
-W zakładce `Narzędzia` w oknie Outlook kliknij `Importuj`.
-
-![emails](images/outlook-import-mac01.png){.thumbnail}
-
-Wybierz format kopii zapasowej, którą chcesz importować, a następnie kliknij `Dalej`.
-
-![emails](images/outlook-import-mac02.png){.thumbnail}
-
-Wybierz Twój plik kopii zapasowej, po czym kliknij `importuj`.
-
-![emails](images/outlook-import-mac03.png){.thumbnail}
-
-Pojawi się okno postępu, kliknij `Dalej` po zakończeniu operacji. Twoja kopia zapasowa jest wdrażana w programie Outlook.
+> [!tabs]
+> **Eksport**
+>>
+>> W zakładce `Narzędzia` w oknie Outlook kliknij `Eksportuj`.
+>>
+>> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> W oknie "Eksport do pliku archiwum (.olm)" zaznacz elementy, które chcesz dodać do pliku kopii zapasowej, następnie kliknij `Dalej`.
+>>
+>> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> Następnie wybierz docelowy folder dla kopii zapasowej, a następnie kliknij `Zapisz`.
+>>
+>> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> Pojawi się okno postępu, kliknij `Dalej` po zakończeniu operacji. Twój plik kopii zapasowej znajdziesz w wybranym wcześniej katalogu.
+>>
+> **Import**
+>>
+>> W zakładce `Narzędzia` w oknie Outlook kliknij `Importuj`.
+>>
+>> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Wybierz format kopii zapasowej, którą chcesz importować, a następnie kliknij `Dalej`.
+>>
+>> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Wybierz Twój plik kopii zapasowej, po czym kliknij `importuj`.
+>>
+>> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> Pojawi się okno postępu, kliknij `Dalej` po zakończeniu operacji. Twoja kopia zapasowa jest wdrażana w programie Outlook.
 
 ### Mail na Mac OS
 
-#### Eksport
-
-W kolumnie z lewej strony wybierz jedno lub kilka kont e-mail. Kliknij `Skrzynka na listy` w menu poziomym, a następnie kliknij `Eksportuj skrzynkę na listy`.
-
-![emails](images/mail-export-mac01.png){.thumbnail}
-
-Wybierz lub utwórz nowy folder, następnie kliknij `Wybierz`.
-
-![emails](images/mail-export-mac02.png){.thumbnail}
-
-Twój eksport to plik ".mbox".
-
-#### Import
-
-Kliknij `Plik` w menu poziomym, a następnie kliknij `Importuj skrzynki na listy`.
-
-![emails](images/mail-import-mac01.png){.thumbnail}
-
-Wybierz plik kopii zapasowej w formacie.mbox, po czym kliknij `Dalej`.
-
-![emails](images/mail-import-mac02.png){.thumbnail}
-
-Z lewej strony, importowane e-maile znajdują się na nowym koncie e-mail o nazwie "Import". Możesz przeciągnąć foldery i wiadomości z konta "Import" na Twoje skonfigurowane konta e-mail. Po zakończeniu transferu będziesz mógł usunąć konto "Import".
+> [!tabs]
+> **Eksport**
+>>
+>> W kolumnie z lewej strony wybierz jedno lub kilka kont e-mail. Kliknij `Skrzynka na listy` w menu poziomym, a następnie kliknij `Eksportuj skrzynkę na listy`.
+>>
+>> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Wybierz lub utwórz nowy folder, następnie kliknij `Wybierz`.
+>>
+>> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> Twój eksport to plik ".mbox".
+>>
+> **Import**
+>>
+>> Kliknij `Plik` w menu poziomym, a następnie kliknij `Importuj skrzynki na listy`.
+>>
+>> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Wybierz plik kopii zapasowej w formacie.mbox, po czym kliknij `Dalej`.
+>>
+>> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> Z lewej strony, importowane e-maile znajdują się na nowym koncie e-mail o nazwie "Import". Możesz przeciągnąć foldery i wiadomości z konta "Import" na Twoje skonfigurowane konta e-mail. Po zakończeniu transferu będziesz mógł usunąć konto "Import".
 
 ### Thunderbird
 
 Aktualnie nie istnieje funkcjonalność umożliwiająca eksportowanie lub importowanie konta e-mail z Thunderbird. Można jednak zapisać profil Thunderbirda. Zawiera ona wszystkie konta i e-maile znajdujące się lokalnie na Twoim komputerze. Zobaczymy, jak zapisać profil Thunderbird i ponownie włączyć go do nowej instancji Thunderbird.
 
-#### Eksport
-
-W oknie głównym kliknij menu w prawym górnym rogu, następnie `Pomoc`, a następnie `Informacje dotyczące rozwiązywania problemów`.
-
-![emails](images/thunderbird_menu.png){.thumbnail}
-
-Pojawi się tabela. Wyszukaj linię `Katalog Profilowy` i kliknij przycisk `Otwórz odpowiedni` katalog.
-
-![emails](images/thunderbird_open_folder.png){.thumbnail}
-
-Zostaniesz przekierowany do folderu profilu. Przejdź z folderu do drzewa.
-
-![emails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Skopiuj folder profilu za pomocą prawym przyciskiem myszy, a następnie wklej ten folder do wybranego folderu lub pomocy.
-
-![emails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Import
-
-Zamiast importowania, będzie tu o ładowanie profilu.
-Jeśli konta e-mail zostały już skonfigurowane w docelowej instancji Thunderbird, zostaną one wyświetlone w profilu A.
-Gdy Thunderbird załaduje nowy profil (profil B), może załadować **tylko** elementy tego profilu B.
-Dlatego zalecamy załadowanie najpierw nowego profilu (profil B), a następnie skonfigurowanie kont e-mail pochodzących z profilu A.
-
-Najpierw należy uruchomić Thunderbird za pomocą menedżera profili.
-
-- W systemie Windows przejdź do menu `Start`, a następnie do programu `Uruchom`. Wpisz `thunderbird.exe -ProfileManager` i kliknij `OK`.
-
-![emails](images/thunderbird-run-profil.png){.thumbnail}
-
-- W systemie Mac OS uruchom aplikację Terminal i przeciągnij i upuść aplikację Thunderbird w oknie terminala, dodając ją do linii `/Contents/MacOS/thunderbird-bin -ProfileManager`. Wpisz przycisk `Enter` ( ⏎), aby zatwierdzić.
-
-![emails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-W następnym oknie wyświetlą się istniejące profile. Kliknij `Utwórz profil`, a następnie `Dalej`, gdy pojawi się komunikat informacyjny.
-
-![emails](images/thunderbird-profil-create01.png){.thumbnail}
-
-Na następnym etapie nadaj nazwę profilowi i podaj folder, w którym utworzony zostanie profil, poniżej zdania "Twoje ustawienia użytkownika, preferencje i wszystkie dane osobowe będą zapisane w":
-
-![emails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> Zalecamy skopiowanie kopii zapasowej Twojego profilu Thunderbird do folderu z profilami Thunderbirda.
-
-Kliknij `Wybierz katalog...` aby wybrać folder z kopią zapasową. Kliknij `Zakończ`, aby utworzyć profil z kopii zapasowej.
-
-Okno wyboru profilu znajdziesz w nowym, wybranym profilu. Kliknij `Uruchom Thunderbird`, Thunderbird zostanie uruchomiony z wszystkimi elementami, które posiadasz w kopii zapasowej.
+> [!tabs]
+> **Eksport**
+>>
+>> W oknie głównym kliknij menu w prawym górnym rogu, następnie `Pomoc`, a następnie `Informacje dotyczące rozwiązywania problemów`.
+>>
+>> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> Pojawi się tabela. Wyszukaj linię `Katalog Profilowy` i kliknij przycisk `Otwórz odpowiedni` katalog.
+>>
+>> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> Zostaniesz przekierowany do folderu profilu. Przejdź z folderu do drzewa.
+>>
+>> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Skopiuj folder profilu za pomocą prawym przyciskiem myszy, a następnie wklej ten folder do wybranego folderu lub pomocy.
+>>
+>> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Import**
+>>
+>> Zamiast importowania, będzie tu o ładowanie profilu.
+>> Jeśli konta e-mail zostały już skonfigurowane w docelowej instancji Thunderbird, zostaną one wyświetlone w profilu A.
+>> Gdy Thunderbird załaduje nowy profil (profil B), może załadować **tylko** elementy tego profilu B.
+>> Dlatego zalecamy załadowanie najpierw nowego profilu (profil B), a następnie skonfigurowanie kont e-mail pochodzących z profilu A.
+>>
+>> Najpierw należy uruchomić Thunderbird za pomocą menedżera profili.
+>>
+>> - W systemie Windows przejdź do menu `Start`, a następnie do programu `Uruchom`. Wpisz `thunderbird.exe -ProfileManager` i kliknij `OK`.
+>>
+>> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - W systemie Mac OS uruchom aplikację Terminal i przeciągnij i upuść aplikację Thunderbird w oknie terminala, dodając ją do linii `/Contents/MacOS/thunderbird-bin -ProfileManager`. Wpisz przycisk `Enter` (⏎), aby zatwierdzić.
+>>
+>> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> W następnym oknie wyświetlą się istniejące profile. Kliknij `Utwórz profil`, a następnie `Dalej`, gdy pojawi się komunikat informacyjny.
+>>
+>> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> Na następnym etapie nadaj nazwę profilowi i podaj folder, w którym utworzony zostanie profil, poniżej zdania "Twoje ustawienia użytkownika, preferencje i wszystkie dane osobowe będą zapisane w":
+>>
+>> ![emails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > Zalecamy skopiowanie kopii zapasowej Twojego profilu Thunderbird do folderu z profilami Thunderbirda.
+>>
+>> Kliknij `Wybierz katalog...` aby wybrać folder z kopią zapasową. Kliknij `Zakończ`, aby utworzyć profil z kopii zapasowej.
+>>
+>> Okno wyboru profilu znajdziesz w nowym, wybranym profilu. Kliknij `Uruchom Thunderbird`, Thunderbird zostanie uruchomiony z wszystkimi elementami, które posiadasz w kopii zapasowej.
 
 ### Sprawdź import na nowy adres e-mail
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pl-pl.md
@@ -19,7 +19,7 @@ updated: 2026-01-16
 
 ## Wymagania początkowe
 
-- Posiadanie usługi e-mail w OVHcloud, takiej jak oferta [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro), [Zimbra](/links/web/zimbra) lub MX Plan (w postaci pakietu MX Plan lub w postaci pakietu [hostingowego OVHcloud](/links/web/hosting))
+- Posiadanie usługi e-mail w OVHcloud, takiej jak oferta [Exchange](/links/web/emails-exchange), [E-mail Pro](/links/web/email-pro), [Zimbra](/links/web/zimbra) lub MX Plan (w postaci pakietu MX Plan lub w postaci pakietu [hostingowego OVHcloud](/links/web/hosting))
 - Posiadanie danych dostępowych do kont e-mail, które chcesz przenieść (konta źródłowe)
 - Posiadanie danych dostępowych do kont e-mail OVHcloud, na które przeniesione zostaną dane (konta docelowe)
 
@@ -35,9 +35,9 @@ updated: 2026-01-16
 - **Link bezpośredni:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz usługę MX Plan
 
-**Email Pro:**
+**E-mail Pro:**
 
-- **Link bezpośredni:** [Email Pro](/links/control-panel/web-email-pro)
+- **Link bezpośredni:** [E-mail Pro](/links/control-panel/web-email-pro)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Wybierz platformę
 
 **Exchange:**
@@ -80,11 +80,11 @@ Następnie należy poczekać na eksport, który może trwać od kilku minut do k
 > [!tabs]
 > **Eksport**
 >>
->> - Kliknij `plik`{.action} w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`{.action}, a następnie wybierz `import/eksport`{.action}.
+>> - Kliknij `Plik`{.action} w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`{.action}, a następnie wybierz `Import/Eksport`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Wybierz Eksportuj `dane do pliku`{.action}, po czym kliknij `Dalej`{.action}.
+>> - Wybierz `Eksportuj dane do pliku`{.action}, po czym kliknij `Dalej`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
@@ -111,11 +111,11 @@ Następnie należy poczekać na eksport, który może trwać od kilku minut do k
 >>
 > **Import**
 >>
->> - Kliknij `plik`{.action} w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`{.action}, a następnie wybierz `import/eksport`{.action}.
+>> - Kliknij `Plik`{.action} w lewym górnym rogu, a następnie `Otwórz i wyeksportuj`{.action}, a następnie wybierz `Import/Eksport`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Wybierz Importuj `z innego programu lub pliku`{.action}, a następnie kliknij `Dalej`{.action}.
+>> - Wybierz `Importuj z innego programu lub pliku`{.action}, a następnie kliknij `Dalej`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
@@ -129,7 +129,7 @@ Następnie należy poczekać na eksport, który może trwać od kilku minut do k
 >>
 >> - Jeśli ustaliłeś hasło do pliku kopii zapasowej, wprowadź je i kliknij `OK`{.action}.
 >>
->> - Wybierz `Importuj elementy do aktywnego`{.action} folderu, a następnie kliknij `Zakończ`{.action}.
+>> - Wybierz `Importuj elementy do aktywnego folderu`{.action}, a następnie kliknij `Zakończ`{.action}.
 >>
 >> Rozpoczyna się import kopii zapasowej.
 
@@ -214,7 +214,7 @@ Aktualnie nie istnieje funkcjonalność umożliwiająca eksportowanie lub import
 >>
 >> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
 >>
->> Skopiuj folder profilu za pomocą prawym przyciskiem myszy, a następnie wklej ten folder do wybranego folderu lub pomocy.
+>> Skopiuj folder profilu za pomocą prawego przycisku myszy, a następnie wklej ten folder do wybranego folderu lub pomocy.
 >>
 >> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
 >>

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pt-pt.md
@@ -35,9 +35,9 @@ updated: 2026-01-16
 - **Ligação direta:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Caminho de navegação:** `Web Cloud`{.action} > `MX Plan`{.action} > Selecione o seu serviço MX Plan
 
-**Email Pro:**
+**E-mail Pro:**
 
-- **Ligação direta:** [Email Pro](/links/control-panel/web-email-pro)
+- **Ligação direta:** [E-mail Pro](/links/control-panel/web-email-pro)
 - **Caminho de navegação:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Selecione a sua plataforma
 
 **Exchange:**
@@ -80,7 +80,7 @@ De seguida, será necessário aguardar o tempo de exportação que pode levar al
 > [!tabs]
 > **Exportar**
 >>
->> - Clique em `ficheiro`{.action} no canto superior esquerdo, depois em `Abrir e exportar`{.action} e, por fim, em `importar/exportar`{.action}.
+>> - Clique em `Ficheiro`{.action} no canto superior esquerdo, depois em `Abrir e exportar`{.action} e, por fim, em `Importar/Exportar`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
@@ -111,7 +111,7 @@ De seguida, será necessário aguardar o tempo de exportação que pode levar al
 >>
 > **Importar**
 >>
->> - Clique em `ficheiro`{.action} no canto superior esquerdo, depois em `Abrir e exportar`{.action} e, por fim, em `importar/exportar`{.action}.
+>> - Clique em `Ficheiro`{.action} no canto superior esquerdo, depois em `Abrir e exportar`{.action} e, por fim, em `Importar/Exportar`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
@@ -210,7 +210,7 @@ Atualmente, não existe nenhuma funcionalidade nativa para exportar ou importar 
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
->> Será então gerido na pasta do perfil. Remova de uma pasta para a arborescência.
+>> Será então direcionado para a pasta do perfil. Suba um nível na árvore de pastas.
 >>
 >> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
 >>

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pt-pt.md
@@ -32,17 +32,17 @@ updated: 2026-01-16
 
 **MX Plan:**
 
-- **Link direto:** [MX Plan](/links/control-panel/web-mx-plan)
+- **Ligação direta:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Caminho de navegação:** `Web Cloud`{.action} > `MX Plan`{.action} > Selecione o seu serviço MX Plan
 
 **E-mail Pro:**
 
-- **Link direto:** [E-mail Pro](/links/control-panel/web-email-pro)
+- **Ligação direta:** [E-mail Pro](/links/control-panel/web-email-pro)
 - **Caminho de navegação:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Selecione a sua plataforma
 
 **Exchange:**
 
-- **Link direto:** [Exchange](/links/control-panel/web-exchange)
+- **Ligação direta:** [Exchange](/links/control-panel/web-exchange)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Exchange`{.action} > Selecione a sua plataforma
 
 ---
@@ -67,184 +67,188 @@ As instruções que se seguem dividem - se em duas partes:
 
 Se possui uma conta de e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), é possível exportá-la diretamente para o formato PST a partir da Área de Cliente.
 
-1. Aceda à [Área de Cliente OVHcloud](/links/manager).
-1. Aceda à secção `Web Cloud`{.action}.
-1. Na rubrica `MICROSOFT`, clique em `Exchange`{.action}.
-1. Selecione a plataforma em causa.
-1. No separador `Contas de e-mail`{.action}, clique no botão `...`{.action} à direita da conta de e-mail a exportar e, a seguir, em `Exportar no formato PST`{.action}.
+No separador `Contas de e-mail`{.action}, clique no botão `...`{.action} à direita da conta de e-mail a exportar e, a seguir, em `Exportar no formato PST`{.action}.
 
-![emails](images/manager-export-pst01.png){.thumbnail}
+![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
 De seguida, será necessário aguardar o tempo de exportação que pode levar alguns minutos a várias horas, consoante o tamanho da exportação. No final, basta voltar ao botão `Exportar em formato PST`{.action} para obter um link para descarregar o ficheiro.
 
-![emails](images/manager-export-pst02.png){.thumbnail}
+![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
-#### Exportar a partir do Windows
+#### Windows
 
-- Clique em `ficheiro` no canto superior esquerdo, depois em `Abrir e exportar` e, por fim, em `importar/exportar`.
+> [!tabs]
+> **Exportar**
+>>
+>> - Clique em `ficheiro` no canto superior esquerdo, depois em `Abrir e exportar` e, por fim, em `importar/exportar`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Selecione `Exportar dados para um ficheiro` e clique em `Seguinte`.
+>>
+>> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
+>>
+>> - Selecione `Ficheiro de dados Outlook (.pst)` e clique em `Seguinte`.
+>>
+>> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
+>>
+>> - Selecione o nome da conta de e-mail a exportar.
+>>
+>> > [!primary]
+>> > Só pode exportar uma conta de cada vez.
+>>
+>> Selecione bem `Incluir as sub-pastas` e clique em `Seguinte`.
+>>
+>> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
+>>
+>> - Escolha a pasta de destino do seu backup e introduza um nome para este ao clicar em `Percorrer`. Selecione a opção adequada e clique em `Terminar`.
+>>
+>> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
+>>
+>> A exportação do seu ficheiro começa. Ao criar um ficheiro, ser-lhe-á pedido que defina uma palavra-passe. É facultativo.
+>>
+>> ![emails](images/outlook-export-win06.png){.thumbnail .w-640}
+>>
+> **Importar**
+>>
+>> - Clique em `ficheiro` no canto superior esquerdo, depois em `Abrir e exportar` e, por fim, em `importar/exportar`.
+>>
+>> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
+>>
+>> - Selecione `Importar a partir de outro programa ou ficheiro` e clique em `Seguinte`.
+>>
+>> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
+>>
+>> - Selecione `Ficheiro de dados Outlook (.pst)` e clique em `Seguinte`.
+>>
+>> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
+>>
+>> - Escolha o seu ficheiro de backup clicando em `Percorrer`. Selecione a opção adequada e clique em `Terminar`.
+>>
+>> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
+>>
+>> - Se tiver definido uma palavra-passe no ficheiro de backup, introduza-a e clique em `OK`.
+>>
+>> - Selecione `Importar os elementos na pasta ativa` e clique em `Terminar`.
+>>
+>> A importação do seu backup inicia-se.
 
-![emails](images/outlook-export-import-win.png){.thumbnail}
+#### Mac OS
 
-- Selecione `Exportar dados para um ficheiro` e clique em `Seguinte`.
-
-![emails](images/outlook-export-win02.png){.thumbnail}
-
-- Selecione `Ficheiro de dados Outlook (.pst)` e clique em `Seguinte`.
-
-![emails](images/outlook-export-win03.png){.thumbnail}
-
-- Selecione o nome da conta de e-mail a exportar.
-
-> [!primary]
-> Só pode exportar uma conta de cada vez.
-
-Selecione bem `Incluir as sub-pastas` e clique em `Seguinte`.
-
-![emails](images/outlook-export-win04.png){.thumbnail}
-
-- Escolha a pasta de destino do seu backup e introduza um nome para este ao clicar em `Percorrer`. Selecione a opção adequada e clique em `Terminar`.
-
-![emails](images/outlook-export-win05.png){.thumbnail}
-
-A exportação do seu ficheiro começa. Ao criar um ficheiro, ser-lhe-á pedido que defina uma palavra-passe. É facultativo.
-
-![emails](images/outlook-export-win06.png){.thumbnail}
-
-#### Importar a partir do Windows
-
-- Clique em `ficheiro` no canto superior esquerdo, depois em `Abrir e exportar` e, por fim, em `importar/exportar`.
-
-![emails](images/outlook-export-import-win.png){.thumbnail}
-
-- Selecione `Importar a partir de outro programa ou ficheiro` e clique em `Seguinte`.
-
-![emails](images/outlook-import-win02.png){.thumbnail}
-
-- Selecione `Ficheiro de dados Outlook (.pst)` e clique em `Seguinte`.
-
-![emails](images/outlook-import-win03.png){.thumbnail}
-
-- Escolha o seu ficheiro de backup clicando em `Percorrer`. Selecione a opção adequada e clique em `Terminar`.
-
-![emails](images/outlook-import-win04.png){.thumbnail}
-
-- Se tiver definido uma palavra-passe no ficheiro de backup, introduza-a e clique em `OK`.
-
-- Selecione `Importar os elementos na pasta ativa` e clique em `Terminar`.
-
-A importação do seu backup inicia-se.
-
-#### Exportar a partir do Mac OS
-
-No separador `Ferramentas` da janela Outlook, clique em `Exportar`.
-
-![emails](images/outlook-export-mac01.png){.thumbnail}
-
-Na janela "Exportar para um ficheiro de arquivo (.olm)", selecione os elementos que deseja adicionar ao seu ficheiro de backup e clique em `Continuar`.
-
-![emails](images/outlook-export-mac02.png){.thumbnail}
-
-De seguida, selecione a pasta de destino para o seu backup e clique em `Registar`.
-
-![emails](images/outlook-export-mac03.png){.thumbnail}
-
-Aparecerá uma janela de progresso, clique em `Continuar` no final da operação. O seu ficheiro de backup será encontrado na pasta escolhida.
-
-#### Importar a partir do Mac OS
-
-No separador `Ferramentas` da janela Outlook, clique em `Importar`.
-
-![emails](images/outlook-import-mac01.png){.thumbnail}
-
-Escolha o formato de backup que vai importar e depois clique em `Continuar`.
-
-![emails](images/outlook-import-mac02.png){.thumbnail}
-
-Selecione o seu ficheiro de backup e clique em `importar`.
-
-![emails](images/outlook-import-mac03.png){.thumbnail}
-
-Aparecerá uma janela de progresso, clique em `Continuar` no final da operação. O seu backup é implementado no seu Outlook.
+> [!tabs]
+> **Exportar**
+>>
+>> No separador `Ferramentas` da janela Outlook, clique em `Exportar`.
+>>
+>> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
+>>
+>> Na janela "Exportar para um ficheiro de arquivo (.olm)", selecione os elementos que deseja adicionar ao seu ficheiro de backup e clique em `Continuar`.
+>>
+>> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
+>>
+>> De seguida, selecione a pasta de destino para o seu backup e clique em `Registar`.
+>>
+>> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
+>>
+>> Aparecerá uma janela de progresso, clique em `Continuar` no final da operação. O seu ficheiro de backup será encontrado na pasta escolhida.
+>>
+> **Importar**
+>>
+>> No separador `Ferramentas` da janela Outlook, clique em `Importar`.
+>>
+>> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
+>>
+>> Escolha o formato de backup que vai importar e depois clique em `Continuar`.
+>>
+>> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
+>>
+>> Selecione o seu ficheiro de backup e clique em `importar`.
+>>
+>> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
+>>
+>> Aparecerá uma janela de progresso, clique em `Continuar` no final da operação. O seu backup é implementado no seu Outlook.
 
 ### Mail no Mac OS
 
-#### Exportar
-
-Na coluna da esquerda, selecione uma ou várias contas de e-mail. Clique em `Caixa de correio` no menu horizontal e, a seguir, em `Exportar a caixa de correio`.
-
-![emails](images/mail-export-mac01.png){.thumbnail}
-
-Selecione a pasta à sua escolha ou crie uma nova pasta e clique em `Escolher`.
-
-![emails](images/mail-export-mac02.png){.thumbnail}
-
-A sua exportação é apresentada sob a forma de um ficheiro ".mbox".
-
-#### Importar
-
-Clique em `Ficheiro` no menu horizontal e, a seguir, em `Importar caixas de correio`.
-
-![emails](images/mail-import-mac01.png){.thumbnail}
-
-Selecione o seu ficheiro de backup no formato ".mbox" e depois clique em `Continuar`.
-
-![emails](images/mail-import-mac02.png){.thumbnail}
-
-Na coluna da esquerda, os e-mails importados encontram-se numa nova conta de e-mail denominada "Importação". Pode transferir as pastas e mensagens da conta "Importação" para as suas contas de e-mail já configuradas. Uma vez terminadas as transferências, poderá eliminar a conta "Importação".
+> [!tabs]
+> **Exportar**
+>>
+>> Na coluna da esquerda, selecione uma ou várias contas de e-mail. Clique em `Caixa de correio` no menu horizontal e, a seguir, em `Exportar a caixa de correio`.
+>>
+>> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
+>>
+>> Selecione a pasta à sua escolha ou crie uma nova pasta e clique em `Escolher`.
+>>
+>> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
+>>
+>> A sua exportação é apresentada sob a forma de um ficheiro ".mbox".
+>>
+> **Importar**
+>>
+>> Clique em `Ficheiro` no menu horizontal e, a seguir, em `Importar caixas de correio`.
+>>
+>> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
+>>
+>> Selecione o seu ficheiro de backup no formato ".mbox" e depois clique em `Continuar`.
+>>
+>> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
+>>
+>> Na coluna da esquerda, os e-mails importados encontram-se numa nova conta de e-mail denominada "Importação". Pode transferir as pastas e mensagens da conta "Importação" para as suas contas de e-mail já configuradas. Uma vez terminadas as transferências, poderá eliminar a conta "Importação".
 
 ### Thunderbird
 
 Atualmente, não existe nenhuma funcionalidade nativa para exportar ou importar uma conta de e-mail a partir do Thunderbird. No entanto, é possível guardar um perfil Thunderbird. que contém todas as contas e-mails no seu computador. Vamos ver como guardar um perfil Thunderbird e reintegrá-lo numa nova instância de Thunderbird.
 
-#### Exportar
-
-Na janela principal, clique no menu no canto superior direito, depois em `Ajuda` e, por fim, em `Informações de pronto-socorro`.
-
-![emails](images/thunderbird_menu.png){.thumbnail}
-
-Surge uma tabela. Identifique a linha `diretório do perfil` e clique no botão `Abrir a pasta correspondente`.
-
-![emails](images/thunderbird_open_folder.png){.thumbnail}
-
-Será então gerido na pasta do perfil. Remova de uma pasta para a arborescência.
-
-![emails](images/thunderbird_profil_folder1.png){.thumbnail}
-
-Copie a pasta do perfil através de um clique direito e cole-a na pasta ou no suporte à sua escolha.
-
-![emails](images/thunderbird_profil_folder2.png){.thumbnail}
-
-#### Importar
-
-Em vez de uma importação, tratar-se-á aqui de um carregamento de perfil.
-Se as contas de e-mail já tiverem sido configuradas na instância Thunderbird de destino, estarão presentes num perfil A.
-Quando Thunderbird carregar um novo perfil (perfil B), apenas poderá carregar **os** elementos desse perfil B.
-Assim, recomendamos que introduza primeiro o novo perfil (perfil B) e que configure as contas de e-mail do perfil A.
-
-Primeiro, deve iniciar o Thunderbird através do gestor de perfis.
-
-- No Windows, vá ao menu `Iniciar` e depois ao programa `Executar`. Neste último, introduza `thunderbird.exe -ProfileManager` e clique em `OK`.
-
-![emails](images/thunderbird-run-profil.png){.thumbnail}
-
-- No Mac OS, lance a aplicação Terminal e deslize-deponha a sua aplicação Thunderbird na janela do Terminal, adicionando à linha `/Contents/MacOS/thunderbird-bin-ProfileManager`. Introduza a tecla `Entrada` (⏎) para validar.
-
-![emails](images/thunderbird-terminal-profil.png){.thumbnail}
-
-A janela seguinte apresenta os perfis existentes. Clique em `Criar um perfil` e depois em `Seguinte` quando a mensagem de informação for apresentada.
-
-![emails](images/thunderbird-profil-create01.png){.thumbnail}
-
-Na etapa seguinte, dê um nome ao seu perfil e identifique a pasta na qual será criado o perfil, abaixo da frase "Os seus parâmetros de utilizador, preferências e todos os seus dados pessoais serão registados em":
-
-![emails](images/thunderbird-profil-create02.png){.thumbnail}
-
-> [!primary]
-> Sugerimos que copie o backup do seu perfil Thunderbird para a pasta dos perfis do Thunderbird.
-
-Clique em `Escolher uma pasta...` para selecionar a pasta que contém o seu backup. Clique em `Terminar` para criar o perfil com o seu backup.
-
-Poderá encontrar a janela de escolha do seu perfil com o seu novo perfil selecionado. Clique em `Iniciar Thunderbird`, Thunderbird será lançado com todos os elementos que tinha no seu backup.
+> [!tabs]
+> **Exportar**
+>>
+>> Na janela principal, clique no menu no canto superior direito, depois em `Ajuda` e, por fim, em `Informações de pronto-socorro`.
+>>
+>> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
+>>
+>> Surge uma tabela. Identifique a linha `diretório do perfil` e clique no botão `Abrir a pasta correspondente`.
+>>
+>> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
+>>
+>> Será então gerido na pasta do perfil. Remova de uma pasta para a arborescência.
+>>
+>> ![emails](images/thunderbird_profil_folder1.png){.thumbnail .w-640}
+>>
+>> Copie a pasta do perfil através de um clique direito e cole-a na pasta ou no suporte à sua escolha.
+>>
+>> ![emails](images/thunderbird_profil_folder2.png){.thumbnail .w-640}
+>>
+> **Importar**
+>>
+>> Em vez de uma importação, tratar-se-á aqui de um carregamento de perfil.
+>> Se as contas de e-mail já tiverem sido configuradas na instância Thunderbird de destino, estarão presentes num perfil A.
+>> Quando Thunderbird carregar um novo perfil (perfil B), apenas poderá carregar **os** elementos desse perfil B.
+>> Assim, recomendamos que introduza primeiro o novo perfil (perfil B) e que configure as contas de e-mail do perfil A.
+>>
+>> Primeiro, deve iniciar o Thunderbird através do gestor de perfis.
+>>
+>> - No Windows, vá ao menu `Iniciar` e depois ao programa `Executar`. Neste último, introduza `thunderbird.exe -ProfileManager` e clique em `OK`.
+>>
+>> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
+>>
+>> - No Mac OS, lance a aplicação Terminal e deslize-deponha a sua aplicação Thunderbird na janela do Terminal, adicionando à linha `/Contents/MacOS/thunderbird-bin -ProfileManager`. Introduza a tecla `Entrada` (⏎) para validar.
+>>
+>> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
+>>
+>> A janela seguinte apresenta os perfis existentes. Clique em `Criar um perfil` e depois em `Seguinte` quando a mensagem de informação for apresentada.
+>>
+>> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
+>>
+>> Na etapa seguinte, dê um nome ao seu perfil e identifique a pasta na qual será criado o perfil, abaixo da frase "Os seus parâmetros de utilizador, preferências e todos os seus dados pessoais serão registados em":
+>>
+>> ![emails](images/thunderbird-profil-create02.png){.thumbnail .w-640}
+>>
+>> > [!primary]
+>> > Sugerimos que copie o backup do seu perfil Thunderbird para a pasta dos perfis do Thunderbird.
+>>
+>> Clique em `Escolher uma pasta...` para selecionar a pasta que contém o seu backup. Clique em `Terminar` para criar o perfil com o seu backup.
+>>
+>> Poderá encontrar a janela de escolha do seu perfil com o seu novo perfil selecionado. Clique em `Iniciar Thunderbird`, Thunderbird será lançado com todos os elementos que tinha no seu backup.
 
 ### Verificar a importação para o novo endereço de e-mail
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pt-pt.md
@@ -35,9 +35,9 @@ updated: 2026-01-16
 - **Ligação direta:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Caminho de navegação:** `Web Cloud`{.action} > `MX Plan`{.action} > Selecione o seu serviço MX Plan
 
-**E-mail Pro:**
+**Email Pro:**
 
-- **Ligação direta:** [E-mail Pro](/links/control-panel/web-email-pro)
+- **Ligação direta:** [Email Pro](/links/control-panel/web-email-pro)
 - **Caminho de navegação:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Selecione a sua plataforma
 
 **Exchange:**
@@ -67,11 +67,11 @@ As instruções que se seguem dividem - se em duas partes:
 
 Se possui uma conta de e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), é possível exportá-la diretamente para o formato PST a partir da Área de Cliente.
 
-No separador `Contas de e-mail`{.action}, clique no botão `...`{.action} à direita da conta de e-mail a exportar e, a seguir, em `Exportar no formato PST`{.action}.
+No separador `Contas de e-mail`{.action}, clique no botão `...`{.action} à direita da conta de e-mail a exportar e, a seguir, em `Exportar em PST`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-De seguida, será necessário aguardar o tempo de exportação que pode levar alguns minutos a várias horas, consoante o tamanho da exportação. No final, basta voltar ao botão `Exportar em formato PST`{.action} para obter um link para descarregar o ficheiro.
+De seguida, será necessário aguardar o tempo de exportação que pode levar alguns minutos a várias horas, consoante o tamanho da exportação. No final, basta voltar ao botão `Exportar em PST`{.action} para obter um link para descarregar o ficheiro.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration/guide.pt-pt.md
@@ -67,11 +67,11 @@ As instruções que se seguem dividem - se em duas partes:
 
 Se possui uma conta de e-mail [Exchange OVHcloud](/links/web/emails-hosted-exchange), é possível exportá-la diretamente para o formato PST a partir da Área de Cliente.
 
-No separador `Contas de e-mail`{.action}, clique no botão `...`{.action} à direita da conta de e-mail a exportar e, a seguir, em `Exportar em PST`{.action}.
+Uma vez na página do serviço Exchange, no separador `Contas de e-mail`{.action}, clique no botão `...`{.action} à direita da conta de e-mail a exportar e, a seguir, em `Exportar para o formato PST`{.action}.
 
 ![emails](images/manager-export-pst01.png){.thumbnail .w-640}
 
-De seguida, será necessário aguardar o tempo de exportação que pode levar alguns minutos a várias horas, consoante o tamanho da exportação. No final, basta voltar ao botão `Exportar em PST`{.action} para obter um link para descarregar o ficheiro.
+De seguida, será necessário aguardar o tempo de exportação que pode levar alguns minutos a várias horas, consoante o tamanho da exportação. No final, basta voltar ao botão `Exportar para o formato PST`{.action} para obter um link para descarregar o ficheiro.
 
 ![emails](images/manager-export-pst02.png){.thumbnail .w-640}
 
@@ -80,15 +80,15 @@ De seguida, será necessário aguardar o tempo de exportação que pode levar al
 > [!tabs]
 > **Exportar**
 >>
->> - Clique em `ficheiro` no canto superior esquerdo, depois em `Abrir e exportar` e, por fim, em `importar/exportar`.
+>> - Clique em `ficheiro`{.action} no canto superior esquerdo, depois em `Abrir e exportar`{.action} e, por fim, em `importar/exportar`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Selecione `Exportar dados para um ficheiro` e clique em `Seguinte`.
+>> - Selecione `Exportar dados para um ficheiro`{.action} e clique em `Seguinte`{.action}.
 >>
 >> ![emails](images/outlook-export-win02.png){.thumbnail .w-640}
 >>
->> - Selecione `Ficheiro de dados Outlook (.pst)` e clique em `Seguinte`.
+>> - Selecione `Ficheiro de dados Outlook (.pst)`{.action} e clique em `Seguinte`{.action}.
 >>
 >> ![emails](images/outlook-export-win03.png){.thumbnail .w-640}
 >>
@@ -97,11 +97,11 @@ De seguida, será necessário aguardar o tempo de exportação que pode levar al
 >> > [!primary]
 >> > Só pode exportar uma conta de cada vez.
 >>
->> Selecione bem `Incluir as sub-pastas` e clique em `Seguinte`.
+>> Selecione bem `Incluir as sub-pastas`{.action} e clique em `Seguinte`{.action}.
 >>
 >> ![emails](images/outlook-export-win04.png){.thumbnail .w-640}
 >>
->> - Escolha a pasta de destino do seu backup e introduza um nome para este ao clicar em `Percorrer`. Selecione a opção adequada e clique em `Terminar`.
+>> - Escolha a pasta de destino do seu backup e introduza um nome para este ao clicar em `Percorrer`{.action}. Selecione a opção adequada e clique em `Terminar`{.action}.
 >>
 >> ![emails](images/outlook-export-win05.png){.thumbnail .w-640}
 >>
@@ -111,25 +111,25 @@ De seguida, será necessário aguardar o tempo de exportação que pode levar al
 >>
 > **Importar**
 >>
->> - Clique em `ficheiro` no canto superior esquerdo, depois em `Abrir e exportar` e, por fim, em `importar/exportar`.
+>> - Clique em `ficheiro`{.action} no canto superior esquerdo, depois em `Abrir e exportar`{.action} e, por fim, em `importar/exportar`{.action}.
 >>
 >> ![emails](images/outlook-export-import-win.png){.thumbnail .w-640}
 >>
->> - Selecione `Importar a partir de outro programa ou ficheiro` e clique em `Seguinte`.
+>> - Selecione `Importar a partir de outro programa ou ficheiro`{.action} e clique em `Seguinte`{.action}.
 >>
 >> ![emails](images/outlook-import-win02.png){.thumbnail .w-640}
 >>
->> - Selecione `Ficheiro de dados Outlook (.pst)` e clique em `Seguinte`.
+>> - Selecione `Ficheiro de dados Outlook (.pst)`{.action} e clique em `Seguinte`{.action}.
 >>
 >> ![emails](images/outlook-import-win03.png){.thumbnail .w-640}
 >>
->> - Escolha o seu ficheiro de backup clicando em `Percorrer`. Selecione a opção adequada e clique em `Terminar`.
+>> - Escolha o seu ficheiro de backup clicando em `Percorrer`{.action}. Selecione a opção adequada e clique em `Terminar`{.action}.
 >>
 >> ![emails](images/outlook-import-win04.png){.thumbnail .w-640}
 >>
->> - Se tiver definido uma palavra-passe no ficheiro de backup, introduza-a e clique em `OK`.
+>> - Se tiver definido uma palavra-passe no ficheiro de backup, introduza-a e clique em `OK`{.action}.
 >>
->> - Selecione `Importar os elementos na pasta ativa` e clique em `Terminar`.
+>> - Selecione `Importar os elementos na pasta ativa`{.action} e clique em `Terminar`{.action}.
 >>
 >> A importação do seu backup inicia-se.
 
@@ -138,46 +138,46 @@ De seguida, será necessário aguardar o tempo de exportação que pode levar al
 > [!tabs]
 > **Exportar**
 >>
->> No separador `Ferramentas` da janela Outlook, clique em `Exportar`.
+>> No separador `Ferramentas`{.action} da janela Outlook, clique em `Exportar`{.action}.
 >>
 >> ![emails](images/outlook-export-mac01.png){.thumbnail .w-640}
 >>
->> Na janela "Exportar para um ficheiro de arquivo (.olm)", selecione os elementos que deseja adicionar ao seu ficheiro de backup e clique em `Continuar`.
+>> Na janela "Exportar para um ficheiro de arquivo (.olm)", selecione os elementos que deseja adicionar ao seu ficheiro de backup e clique em `Continuar`{.action}.
 >>
 >> ![emails](images/outlook-export-mac02.png){.thumbnail .w-640}
 >>
->> De seguida, selecione a pasta de destino para o seu backup e clique em `Registar`.
+>> De seguida, selecione a pasta de destino para o seu backup e clique em `Registar`{.action}.
 >>
 >> ![emails](images/outlook-export-mac03.png){.thumbnail .w-640}
 >>
->> Aparecerá uma janela de progresso, clique em `Continuar` no final da operação. O seu ficheiro de backup será encontrado na pasta escolhida.
+>> Aparecerá uma janela de progresso, clique em `Continuar`{.action} no final da operação. O seu ficheiro de backup será encontrado na pasta escolhida.
 >>
 > **Importar**
 >>
->> No separador `Ferramentas` da janela Outlook, clique em `Importar`.
+>> No separador `Ferramentas`{.action} da janela Outlook, clique em `Importar`{.action}.
 >>
 >> ![emails](images/outlook-import-mac01.png){.thumbnail .w-640}
 >>
->> Escolha o formato de backup que vai importar e depois clique em `Continuar`.
+>> Escolha o formato de backup que vai importar e depois clique em `Continuar`{.action}.
 >>
 >> ![emails](images/outlook-import-mac02.png){.thumbnail .w-640}
 >>
->> Selecione o seu ficheiro de backup e clique em `importar`.
+>> Selecione o seu ficheiro de backup e clique em `Importar`{.action}.
 >>
 >> ![emails](images/outlook-import-mac03.png){.thumbnail .w-640}
 >>
->> Aparecerá uma janela de progresso, clique em `Continuar` no final da operação. O seu backup é implementado no seu Outlook.
+>> Aparecerá uma janela de progresso, clique em `Continuar`{.action} no final da operação. O seu backup é implementado no seu Outlook.
 
 ### Mail no Mac OS
 
 > [!tabs]
 > **Exportar**
 >>
->> Na coluna da esquerda, selecione uma ou várias contas de e-mail. Clique em `Caixa de correio` no menu horizontal e, a seguir, em `Exportar a caixa de correio`.
+>> Na coluna da esquerda, selecione uma ou várias contas de e-mail. Clique em `Caixa de correio`{.action} no menu horizontal e, a seguir, em `Exportar a caixa de correio`{.action}.
 >>
 >> ![emails](images/mail-export-mac01.png){.thumbnail .w-640}
 >>
->> Selecione a pasta à sua escolha ou crie uma nova pasta e clique em `Escolher`.
+>> Selecione a pasta à sua escolha ou crie uma nova pasta e clique em `Escolher`{.action}.
 >>
 >> ![emails](images/mail-export-mac02.png){.thumbnail .w-640}
 >>
@@ -185,11 +185,11 @@ De seguida, será necessário aguardar o tempo de exportação que pode levar al
 >>
 > **Importar**
 >>
->> Clique em `Ficheiro` no menu horizontal e, a seguir, em `Importar caixas de correio`.
+>> Clique em `Ficheiro`{.action} no menu horizontal e, a seguir, em `Importar caixas de correio`{.action}.
 >>
 >> ![emails](images/mail-import-mac01.png){.thumbnail .w-640}
 >>
->> Selecione o seu ficheiro de backup no formato ".mbox" e depois clique em `Continuar`.
+>> Selecione o seu ficheiro de backup no formato ".mbox" e depois clique em `Continuar`{.action}.
 >>
 >> ![emails](images/mail-import-mac02.png){.thumbnail .w-640}
 >>
@@ -202,11 +202,11 @@ Atualmente, não existe nenhuma funcionalidade nativa para exportar ou importar 
 > [!tabs]
 > **Exportar**
 >>
->> Na janela principal, clique no menu no canto superior direito, depois em `Ajuda` e, por fim, em `Informações de pronto-socorro`.
+>> Na janela principal, clique no menu no canto superior direito, depois em `Ajuda`{.action} e, por fim, em `Informações de pronto-socorro`{.action}.
 >>
 >> ![emails](images/thunderbird_menu.png){.thumbnail .w-640}
 >>
->> Surge uma tabela. Identifique a linha `diretório do perfil` e clique no botão `Abrir a pasta correspondente`.
+>> Surge uma tabela. Identifique a linha `diretório do perfil`{.action} e clique no botão `Abrir a pasta correspondente`{.action}.
 >>
 >> ![emails](images/thunderbird_open_folder.png){.thumbnail .w-640}
 >>
@@ -227,15 +227,15 @@ Atualmente, não existe nenhuma funcionalidade nativa para exportar ou importar 
 >>
 >> Primeiro, deve iniciar o Thunderbird através do gestor de perfis.
 >>
->> - No Windows, vá ao menu `Iniciar` e depois ao programa `Executar`. Neste último, introduza `thunderbird.exe -ProfileManager` e clique em `OK`.
+>> - No Windows, vá ao menu `Iniciar`{.action} e depois ao programa `Executar`{.action}. Neste último, introduza `thunderbird.exe -ProfileManager` e clique em `OK`{.action}.
 >>
 >> ![emails](images/thunderbird-run-profil.png){.thumbnail .w-640}
 >>
->> - No Mac OS, lance a aplicação Terminal e deslize-deponha a sua aplicação Thunderbird na janela do Terminal, adicionando à linha `/Contents/MacOS/thunderbird-bin -ProfileManager`. Introduza a tecla `Entrada` (⏎) para validar.
+>> - No Mac OS, lance a aplicação Terminal e deslize-deponha a sua aplicação Thunderbird na janela do Terminal, adicionando à linha `/Contents/MacOS/thunderbird-bin -ProfileManager`. Introduza a tecla `Entrada`{.action} (⏎) para validar.
 >>
 >> ![emails](images/thunderbird-terminal-profil.png){.thumbnail .w-640}
 >>
->> A janela seguinte apresenta os perfis existentes. Clique em `Criar um perfil` e depois em `Seguinte` quando a mensagem de informação for apresentada.
+>> A janela seguinte apresenta os perfis existentes. Clique em `Criar um perfil`{.action} e depois em `Seguinte`{.action} quando a mensagem de informação for apresentada.
 >>
 >> ![emails](images/thunderbird-profil-create01.png){.thumbnail .w-640}
 >>
@@ -246,9 +246,9 @@ Atualmente, não existe nenhuma funcionalidade nativa para exportar ou importar 
 >> > [!primary]
 >> > Sugerimos que copie o backup do seu perfil Thunderbird para a pasta dos perfis do Thunderbird.
 >>
->> Clique em `Escolher uma pasta...` para selecionar a pasta que contém o seu backup. Clique em `Terminar` para criar o perfil com o seu backup.
+>> Clique em `Escolher uma pasta...`{.action} para selecionar a pasta que contém o seu backup. Clique em `Terminar`{.action} para criar o perfil com o seu backup.
 >>
->> Poderá encontrar a janela de escolha do seu perfil com o seu novo perfil selecionado. Clique em `Iniciar Thunderbird`, Thunderbird será lançado com todos os elementos que tinha no seu backup.
+>> Poderá encontrar a janela de escolha do seu perfil com o seu novo perfil selecionado. Clique em `Iniciar Thunderbird`{.action}, Thunderbird será lançado com todos os elementos que tinha no seu backup.
 
 ### Verificar a importação para o novo endereço de e-mail
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
@@ -1,14 +1,14 @@
 ---
-title: 'E-Mail-Accounts von MX Plan zu E-Mail Pro, Exchange oder Zimbra migrieren'
-excerpt: 'Erfahren Sie hier, wie Sie einen MX Plan E-Mail-Account zu E-Mail Pro oder Exchange umziehen'
+title: 'E-Mail-Accounts von MX Plan zu Email Pro, Exchange oder Zimbra migrieren'
+excerpt: 'Erfahren Sie hier, wie Sie einen MX Plan E-Mail-Account zu Email Pro oder Exchange umziehen'
 updated: 2026-01-16
 ---
 
 ## Ziel
 
-OVHcloud bietet verschiedene E-Mail-Lösungen an: MX Plan (autonom oder in einem Webhosting-Angebot inbegriffen), Zimbra, E-Mail Pro und Exchange. Diese verfügen über individuelle Funktionen und können sich an verschiedene Einsatzzwecke anpassen. Ihre Bedürfnisse ändern sich? OVHcloud stellt Ihnen ein Migrationswerkzeug zur Verfügung, mit dem Sie von einer Lösung zur anderen wechseln können.
+OVHcloud bietet verschiedene E-Mail-Lösungen an: MX Plan (autonom oder in einem Webhosting-Angebot inbegriffen), Zimbra, Email Pro und Exchange. Diese verfügen über individuelle Funktionen und können sich an verschiedene Einsatzzwecke anpassen. Ihre Bedürfnisse ändern sich? OVHcloud stellt Ihnen ein Migrationswerkzeug zur Verfügung, mit dem Sie von einer Lösung zur anderen wechseln können.
 
-**Diese Anleitung erklärt, wie Sie einen E-Mail-Account von MX Plan zu E-Mail Pro oder Exchange migrieren.**
+**Diese Anleitung erklärt, wie Sie einen E-Mail-Account von MX Plan zu Email Pro, Exchange oder Zimbra migrieren.**
 
 > [!warning]
 >
@@ -18,7 +18,7 @@ OVHcloud bietet verschiedene E-Mail-Lösungen an: MX Plan (autonom oder in einem
 ## Voraussetzungen
 
 - Sie verfügen über einen MX Plan E-Mail-Account (als eigenständige Lösung oder als Teil eines [OVHcloud Webhosting Angebots](/links/web/hosting)).
-- Sie verfügen über einen [Exchange](/links/web/emails-hosted-exchange), [E-Mail Pro](/links/web/email-pro) Dienst mit mindestens einem unkonfigurierten Account (dieser wird als "@configureme.me" angezeigt) oder [Zimbra](/links/web/zimbra).
+- Sie verfügen über einen [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) Dienst mit mindestens einem unkonfigurierten Account (dieser wird als "@configureme.me" angezeigt) oder [Zimbra](/links/web/zimbra).
 - **Sie haben keine Weiterleitungen für die MX Plan E-Mail-Accounts aktiviert, die Sie migrieren möchten.**
 
 <!-- CP-NAV-START:web-mx-plan -->
@@ -26,21 +26,21 @@ OVHcloud bietet verschiedene E-Mail-Lösungen an: MX Plan (autonom oder in einem
 <!-- CP-NAV-START:web-exchange -->
 ---
 
-### Zugang zum OVHcloud Kundencenter
+### Zugriff auf das OVHcloud Kundencenter
 
 **MX Plan:**
 
-- **Direktlink:** [MX Plan](/links/control-panel/web-mx-plan)
+- **Direkter Link:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Navigationspfad:** `Web Cloud`{.action} > `MX Plan`{.action} > Wählen Sie Ihren MX Plan Dienst aus
 
-**E-Mail Pro:**
+**Email Pro:**
 
-- **Direktlink:** [E-Mail Pro](/links/control-panel/web-email-pro)
+- **Direkter Link:** [Email Pro](/links/control-panel/web-email-pro)
 - **Navigationspfad:** `Web Cloud`{.action} > `E-Mail Pro`{.action} > Wählen Sie Ihre Plattform aus
 
 **Exchange:**
 
-- **Direktlink:** [Exchange](/links/control-panel/web-exchange)
+- **Direkter Link:** [Exchange](/links/control-panel/web-exchange)
 - **Navigationspfad:** `Web Cloud`{.action} > `Exchange`{.action} > Wählen Sie Ihre Plattform aus
 
 ---
@@ -52,15 +52,15 @@ OVHcloud bietet verschiedene E-Mail-Lösungen an: MX Plan (autonom oder in einem
 
 ### Schritt 1: Ihr Projekt definieren
 
-Die E-Mail Pro und Exchange Lösungen verfügen über eine gemeinsame Basis für Funktionen. Je nach Verwendungszweck bestehen jedoch Unterschiede. Wenn Sie eine Exchange Account auswählen, verfügen Sie über alle kollaborativen Funktionen wie die Synchronisation des Kalenders und der Kontakte. Die E-Mail Pro Lösung bietet ebenfalls einige dieser Funktionen, diese sind jedoch auf die Verwendung über das Webmail beschränkt.
+Die Email Pro und Exchange Lösungen verfügen über eine gemeinsame Basis für Funktionen. Je nach Verwendungszweck bestehen jedoch Unterschiede. Wenn Sie eine Exchange Account auswählen, verfügen Sie über alle kollaborativen Funktionen wie die Synchronisation des Kalenders und der Kontakte. Die Email Pro Lösung bietet ebenfalls einige dieser Funktionen, diese sind jedoch auf die Verwendung über das Webmail beschränkt.
 
-Bevor Sie fortfahren, ist es wichtig zu wissen, auf welches Angebot Sie Ihren MX Plan E-Mail-Account migrieren möchten. Um Ihnen bei dieser Auswahl zu helfen können Sie die [Produktseite](/links/web/emails) konsultieren, die einen detaillierten Vergleich der Angebote bietet. Sie haben die Möglichkeit, die Lösungen zu kombinieren, um unter einem Domainnamen Accounts in E-Mail Pro und Exchange zu nutzen. Wenn Sie mehrere Accounts migrieren, empfehlen wir Ihnen die Erstellung eines Migrationsplans.
+Bevor Sie fortfahren, ist es wichtig zu wissen, auf welches Angebot Sie Ihren MX Plan E-Mail-Account migrieren möchten. Um Ihnen bei dieser Auswahl zu helfen können Sie die [Produktseite](/links/web/emails) konsultieren, die einen detaillierten Vergleich der Angebote bietet. Sie haben die Möglichkeit, die Lösungen zu kombinieren, um unter einem Domainnamen Accounts in Email Pro und Exchange zu nutzen. Wenn Sie mehrere Accounts migrieren, empfehlen wir Ihnen die Erstellung eines Migrationsplans.
 
-### Schritt 2: E-Mail Pro oder Exchange Accounts bestellen
+### Schritt 2: Email Pro oder Exchange Accounts bestellen
 
-Dieser Schritt ist optional, wenn Sie bereits über einen Exchange oder E-Mail Pro Dienst verfügen, auf den Sie diese Migration durchführen.
+Dieser Schritt ist optional, wenn Sie bereits über einen Exchange oder Email Pro Dienst verfügen, auf den Sie diese Migration durchführen.
 
-Andernfalls loggen Sie sich in Ihr [OVHcloud Kundencenter](/links/manager) ein und bestellen Sie E-Mail Pro oder Exchange. Folgen Sie den Konfigurationsschritten und warten Sie, bis der Dienst fertig installiert ist. Sie erhalten eine E-Mail, sobald der Vorgang abgeschlossen ist.
+Andernfalls bestellen Sie Email Pro oder Exchange. Folgen Sie den Konfigurationsschritten und warten Sie, bis der Dienst fertig installiert ist. Sie erhalten eine E-Mail, sobald der Vorgang abgeschlossen ist.
 
 > [!primary]
 >
@@ -74,23 +74,19 @@ Bevor Sie mit der Migration beginnen, müssen Sie die Version des MX Plan identi
 >
 > Die E-Mail-Technologie Ihrer MX Plan-Angebot kann je nach Aktivierungsdatum Ihres Angebots oder bei kürzlich erfolgter Migration variieren. Diese Technologie ist an der Oberfläche ihres Webmails zu erkennen. Um sie in Ihrem Kundencenter zu identifizieren, folgen Sie diesen Schritten:
 >
-> 1. Melden Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager) an.
-> 1. Gehen Sie in den Bereich `Web Cloud`{.action}.
-> 1. Klicken Sie auf `MX Plan`{.action}.
-> 1. Wählen Sie den betreffenden Domainnamen aus.
 > 1. Der Tab `Allgemeine Informationen`{.action} ist standardmäßig ausgewählt.
 > 1. Notieren Sie sich die genutzte Technologie unter der Bezeichnung **Webmail** im Feld `Abonnement`.
 >
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Manuelle Migration eines MX Plan-Angebots zu Exchange, E-Mail Pro oder Zimbra  <a name="all-mxplan"></a>
+#### 3.1 Manuelle Migration eines MX Plan-Angebots zu Exchange, Email Pro oder Zimbra  <a name="all-mxplan"></a>
 
 > [!warning]
 >
 > Dieser Abschnitt betrifft alle MX Plan-Dienste, die die Webmail-Technologie Roundcube, Zimbra oder OWA nutzen.
 >
-> Wenn Sie jedoch einen MX Plan-Dienst mit Roundcube Webmail zu einer OVHcloud E-Mail Pro- oder Exchange-Plattform migrieren möchten, folgen Sie dem Abschnitt [Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder E-Mail Pro](#roundcube-mxplan).
+> Wenn Sie jedoch einen MX Plan-Dienst mit Roundcube Webmail zu einer OVHcloud Email Pro- oder Exchange-Plattform migrieren möchten, folgen Sie dem Abschnitt [Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder Email Pro](#roundcube-mxplan).
 
 > [!warning]
 >
@@ -100,8 +96,7 @@ Bevor Sie mit der Migration beginnen, müssen Sie die Version des MX Plan identi
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
-> Weitere Informationen zum Hinzufügen eines Domainnamens finden Sie in den Hilfen zu [E-Mail Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config), [Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) oder [Zimbra-Leitfaden](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra).
-.
+> Weitere Informationen zum Hinzufügen eines Domainnamens finden Sie in den Hilfen zu [Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config), [Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) oder [Zimbra-Leitfaden](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra).
 
 Die Migration Ihres MX Plan erfolgt in 3 Schritten: **Umbenennen**, **Erstellen** und **Migrieren**.
 
@@ -117,9 +112,9 @@ Klicken Sie im Tab `E-Mails`{.action} auf den Button `...`{.action} und dann auf
 >
 > Die Änderung des Accounts ist nicht sofort aktiv. Bitte warten Sie bis zum Abschluss der Operation, bevor Sie zum nächsten Schritt übergehen.
 
-2\. **Erstellen** Ihres E-Mail-Adresse auf dem neuen Account Ihrer E-Mail Pro oder Exchange Plattform (Sie erstellen *john.smith@mydomain.ovh* auf Ihrer neuen Plattform).
+2\. **Erstellen** Ihres E-Mail-Adresse auf dem neuen Account Ihrer Email Pro oder Exchange Plattform (Sie erstellen *john.smith@mydomain.ovh* auf Ihrer neuen Plattform).
 
-Klicken Sie im Tab `E-Mail-Accounts`{.action} Ihrer E-Mail Pro oder Exchange Plattform auf den Button `...`{.action} und dann auf `Ändern`{.action}.
+Klicken Sie im Tab `E-Mail-Accounts`{.action} Ihrer Email Pro oder Exchange Plattform auf den Button `...`{.action} und dann auf `Ändern`{.action}.
 
 ![Exchange](images/mxplan-migration-configure-account02.png){.thumbnail}
 
@@ -137,7 +132,7 @@ Sie können den ursprünglichen Account nach dieser Migration mit dem vorläufig
 
 Wenn Sie ihn löschen möchten, gehen Sie in den Tab `E-Mails`{.action} Ihres MX Plans, klicken Sie auf `...`{.action} und dann auf `Konto löschen`{.action}.
 
-#### 3.2 Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder E-Mail Pro <a name="roundcube-mxplan"></a>
+#### 3.2 Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder Email Pro <a name="roundcube-mxplan"></a>
 
 > [!warning]
 >
@@ -145,7 +140,7 @@ Wenn Sie ihn löschen möchten, gehen Sie in den Tab `E-Mails`{.action} Ihres MX
 
 > [!primary]
 >
-> Ihr OVHcloud Kunden-Account muss als Administrator-Kontakt **und** technischer Kontakt des zu migrierenden MX Plans, **und** des E-Mail Pro oder Exchange Dienstes, auf den Sie migrieren, eingetragen sein.
+> Ihr OVHcloud Kunden-Account muss als Administrator-Kontakt **und** technischer Kontakt des zu migrierenden MX Plans, **und** des Email Pro oder Exchange Dienstes, auf den Sie migrieren, eingetragen sein.
 >
 > Weitere Informationen zu den Änderungen der Kontakte finden Sie in unserer Anleitung zur [Verwaltung der Kontakte Ihrer Dienstleistungen](/pages/account_and_service_management/account_information/managing_contacts).
 >
@@ -153,7 +148,7 @@ Wenn Sie ihn löschen möchten, gehen Sie in den Tab `E-Mails`{.action} Ihres MX
 Die Migration kann über zwei Interfaces durchgeführt werden:<br>
 
 - **Der Konfigurationsassistent von Hosted Exchange**: Zu verwenden, wenn ein Hosted Exchange Dienst besteht, der noch unkonfiguriert ist.
-- **Im Bereich für MX Plan**: Möglich, sobald Sie über einen E-Mail Pro oder Exchange Dienst (bereits konfiguriert oder nicht konfiguriert) und einen MX Plan Account verfügen, den Sie migrieren möchten.
+- **Im Bereich für MX Plan**: Möglich, sobald Sie über einen Email Pro oder Exchange Dienst (bereits konfiguriert oder nicht konfiguriert) und einen MX Plan Account verfügen, den Sie migrieren möchten.
 
 > Zur Erinnerung: Vergewissern Sie sich vor Beginn der Migration, dass keine **Weiterleitung** oder **Auto-Antworten** für Ihren MX Plan eingerichtet sind.
 >
@@ -170,7 +165,7 @@ Wenn Sie bereit sind, folgen Sie der Anleitung entsprechend dem gewählten Inter
 
 ##### **Migration mit Exchange Konfigurationsassistent**
 
-Wählen Sie im [OVHcloud Kundencenter](/links/manager) Ihren Exchange Dienst aus. Der Assistent sollte erscheinen, um Ihnen bei der Konfiguration Ihres neuen Exchange Dienstes zu helfen. Während dieses Vorgangs können Sie die zu migrierenden MX Plan E-Mail-Accounts auswählen.
+Der Assistent sollte erscheinen, um Ihnen bei der Konfiguration Ihres neuen Exchange Dienstes zu helfen. Während dieses Vorgangs können Sie die zu migrierenden MX Plan E-Mail-Accounts auswählen.
 
 Wenn der Konfigurationsassistent nicht startet, werden stattdessen die allgemeinen Informationen zum Exchange Dienst angezeigt. In diesem Fall müssen Sie Ihre Accounts über das MX Plan Interface migrieren.
 
@@ -192,13 +187,13 @@ Bestätigen Sie anschließend das Passwort des Quell-Accounts (die Adresse, die 
 
 In diesem Schritt müssen Ihre E-Mail-Accounts bereits migriert und funktionsfähig sein. Aus Sicherheitsgründen bitten wir Sie, die korrekte Konfiguration Ihres Domainnamens in Ihrem Kundencenter zu überprüfen.
 
-Dazu wählen Sie den betreffenden E-Mail Pro-, Exchange- oder Zimbra-Dienst aus und gehen Sie auf den Tab `Zugeordnete Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform. Überprüfen Sie den Abschnitt oder die Spalte `Diagnose`{.action}.
+Dazu wählen Sie den betreffenden Email Pro-, Exchange- oder Zimbra-Dienst aus und gehen Sie auf den Tab `Zugeordnete Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform. Überprüfen Sie den Abschnitt oder die Spalte `Diagnose`{.action}.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 
 > [!primary]
 >
-> Wenn Sie gerade die Migration durchgeführt oder einen DNS-Eintrag Ihres Domainnamens geändert haben, kann es einige Stunden dauern, bis die [OVHcloud Kundencenter](/links/manager) aktualisiert wird.
+> Wenn Sie gerade die Migration durchgeführt oder einen DNS-Eintrag Ihres Domainnamens geändert haben, kann es einige Stunden dauern, bis das [OVHcloud Kundencenter](/links/manager) aktualisiert wird.
 >
 
 Um die Konfiguration zu ändern, klicken Sie auf das rote Symbol und führen Sie den gewünschten Vorgang durch. Eine Propagationszeit von 4 bis maximal 24 Stunden ist abzuwarten, bis die Änderung voll wirksam ist.
@@ -207,7 +202,7 @@ Um die Konfiguration zu ändern, klicken Sie auf das rote Symbol und führen Sie
 
 Verwenden Sie nun Ihre migrierten E-Mail-Accounts. OVHcloud stellt dazu eine Online-Anwendung (*Web App*) zur Verfügung, die über [Webmail](/links/web/email) erreichbar ist. Geben Sie dort die Login-Daten für Ihre E-Mail-Adresse ein.
 
-Wenn Sie einen der migrierten Accounts auf einem E-Mail-Client (wie Outlook) eingerichtet haben, müssen Sie diesen erneut konfigurieren. Die Verbindungsdaten zum OVHcloud Server haben sich nach der Migration geändert. Weitere Informationen finden Sie in den jeweiligen Anleitungen zu [E-Mail Pro](/products/web-cloud-email-collaborative-solutions-email-pro) und [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Auch wenn Sie den Account nicht sofort neu konfigurieren können, ist der Zugriff über die Online-Anwendung weiterhin möglich.
+Wenn Sie einen der migrierten Accounts auf einem E-Mail-Client (wie Outlook) eingerichtet haben, müssen Sie diesen erneut konfigurieren. Die Verbindungsdaten zum OVHcloud Server haben sich nach der Migration geändert. Weitere Informationen finden Sie in den jeweiligen Anleitungen zu [Email Pro](/products/web-cloud-email-collaborative-solutions-email-pro) und [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Auch wenn Sie den Account nicht sofort neu konfigurieren können, ist der Zugriff über die Online-Anwendung weiterhin möglich.
 
 ### Organisation der Inhalte Ihrer E-Mail-Accounts nach einer Migration <a name="content-after-migration"></a>
 
@@ -227,7 +222,7 @@ Sie können auch Ihre E-Mail-Accounts manuell auf Ihr neues OVHcloud E-Mail-Ange
 
 [Verwaltung der Kontakte Ihrer Dienste](/pages/account_and_service_management/account_information/managing_contacts)
 
-[Erste Schritte mit dem E-Mail Pro-Angebot](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config).
+[Erste Schritte mit dem Email Pro-Angebot](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config).
 
 [Erste Schritte mit dem Exchange-Angebot](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted).
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
@@ -1,6 +1,6 @@
 ---
 title: 'E-Mail-Accounts von MX Plan zu Email Pro, Exchange oder Zimbra migrieren'
-excerpt: 'Erfahren Sie hier, wie Sie einen MX Plan E-Mail-Account zu Email Pro oder Exchange umziehen'
+excerpt: 'Erfahren Sie hier, wie Sie einen MX Plan E-Mail-Account zu Email Pro, Exchange oder Zimbra umziehen'
 updated: 2026-01-16
 ---
 
@@ -112,7 +112,7 @@ Klicken Sie im Tab `E-Mails`{.action} auf den Button `...`{.action} und dann auf
 >
 > Die Änderung des Accounts ist nicht sofort aktiv. Bitte warten Sie bis zum Abschluss der Operation, bevor Sie zum nächsten Schritt übergehen.
 
-2\. **Erstellen** Ihres E-Mail-Adresse auf dem neuen Account Ihrer Email Pro oder Exchange Plattform (Sie erstellen *john.smith@mydomain.ovh* auf Ihrer neuen Plattform).
+2\. **Erstellen** Ihrer E-Mail-Adresse auf dem neuen Account Ihrer Email Pro oder Exchange Plattform (Sie erstellen *john.smith@mydomain.ovh* auf Ihrer neuen Plattform).
 
 Klicken Sie im Tab `E-Mail-Accounts`{.action} Ihrer Email Pro oder Exchange Plattform auf den Button `...`{.action} und dann auf `Ändern`{.action}.
 
@@ -126,7 +126,7 @@ Weitere Informationen zu OMM finden Sie in unserer Anleitung [E-Mail-Accounts ü
 
 Die Migrationsdauer hängt davon ab, wie viele Inhalte auf Ihren neuen Account migriert werden sollen. Dieser kann von einigen Minuten bis zu mehreren Stunden variieren.
 
-Überprüfen Sie nach der Migration, ob alle Elemente vorhanden sind, indem Sie sich im Webmail anmelden: [Webmail](/links/web/email).
+Überprüfen Sie nach der Migration, ob alle Elemente vorhanden sind, indem Sie sich am [Webmail OVHcloud](/links/web/email) anmelden.
 
 Sie können den ursprünglichen Account nach dieser Migration mit dem vorläufigen Namen beibehalten oder löschen.
 
@@ -171,7 +171,7 @@ Wenn der Konfigurationsassistent nicht startet, werden stattdessen die allgemein
 
 ##### **Migration über das MX Plan Interface**
 
-Um die Migration über dieses Interface durchzuführen, gehen Sie im Bereich `E-Mails`{.action} Ihres OVHcloud Kundencenters. Wählen Sie dann den Dienst mit dem Domainnamen Ihrer E-Mail-Adressen aus. Klicken Sie auf den Tab `E-Mails`{.action}. Klicken Sie auf `...`{.action} in der Zeile des betreffenden E-Mail-Accounts (auch als Quell-Account bezeichnet) und dann auf `Account überführen`{.action}.
+Um die Migration über dieses Interface durchzuführen, wählen Sie im Bereich [MX Plan](/links/control-panel/web-mx-plan) Ihres OVHcloud Kundencenters die betreffende Domain aus. Klicken Sie im Tab `E-Mails`{.action} auf `...`{.action} in der Zeile des betreffenden E-Mail-Accounts (auch als Quell-Account bezeichnet) und dann auf `Account überführen`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 
@@ -222,9 +222,9 @@ Sie können auch Ihre E-Mail-Accounts manuell auf Ihr neues OVHcloud E-Mail-Ange
 
 [Verwaltung der Kontakte Ihrer Dienste](/pages/account_and_service_management/account_information/managing_contacts)
 
-[Erste Schritte mit dem Email Pro-Angebot](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config).
+[Erste Schritte mit dem Email Pro-Angebot](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 
-[Erste Schritte mit dem Exchange-Angebot](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted).
+[Erste Schritte mit dem Exchange-Angebot](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
 [Erste Schritte mit dem Zimbra-Angebot](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
@@ -1,14 +1,14 @@
 ---
-title: 'E-Mail-Accounts von MX Plan zu Email Pro, Exchange oder Zimbra migrieren'
-excerpt: 'Erfahren Sie hier, wie Sie einen MX Plan E-Mail-Account zu Email Pro, Exchange oder Zimbra umziehen'
+title: 'E-Mail-Accounts von MX Plan zu E-Mail Pro, Exchange oder Zimbra migrieren'
+excerpt: 'Erfahren Sie hier, wie Sie einen MX Plan E-Mail-Account zu E-Mail Pro, Exchange oder Zimbra umziehen'
 updated: 2026-01-16
 ---
 
 ## Ziel
 
-OVHcloud bietet verschiedene E-Mail-Lösungen an: MX Plan (autonom oder in einem Webhosting-Angebot inbegriffen), Zimbra, Email Pro und Exchange. Diese verfügen über individuelle Funktionen und können sich an verschiedene Einsatzzwecke anpassen. Ihre Bedürfnisse ändern sich? OVHcloud stellt Ihnen ein Migrationswerkzeug zur Verfügung, mit dem Sie von einer Lösung zur anderen wechseln können.
+OVHcloud bietet verschiedene E-Mail-Lösungen an: MX Plan (autonom oder in einem Webhosting-Angebot inbegriffen), Zimbra, E-Mail Pro und Exchange. Diese verfügen über individuelle Funktionen und können sich an verschiedene Einsatzzwecke anpassen. Ihre Bedürfnisse ändern sich? OVHcloud stellt Ihnen ein Migrationswerkzeug zur Verfügung, mit dem Sie von einer Lösung zur anderen wechseln können.
 
-**Diese Anleitung erklärt, wie Sie einen E-Mail-Account von MX Plan zu Email Pro, Exchange oder Zimbra migrieren.**
+**Diese Anleitung erklärt, wie Sie einen E-Mail-Account von MX Plan zu E-Mail Pro, Exchange oder Zimbra migrieren.**
 
 > [!warning]
 >
@@ -18,7 +18,7 @@ OVHcloud bietet verschiedene E-Mail-Lösungen an: MX Plan (autonom oder in einem
 ## Voraussetzungen
 
 - Sie verfügen über einen MX Plan E-Mail-Account (als eigenständige Lösung oder als Teil eines [OVHcloud Webhosting Angebots](/links/web/hosting)).
-- Sie verfügen über einen [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) Dienst mit mindestens einem unkonfigurierten Account (dieser wird als "@configureme.me" angezeigt) oder [Zimbra](/links/web/zimbra).
+- Sie verfügen über einen [Exchange](/links/web/emails-hosted-exchange), [E-Mail Pro](/links/web/email-pro) Dienst mit mindestens einem unkonfigurierten Account (dieser wird als "@configureme.me" angezeigt) oder [Zimbra](/links/web/zimbra).
 - **Sie haben keine Weiterleitungen für die MX Plan E-Mail-Accounts aktiviert, die Sie migrieren möchten.**
 
 <!-- CP-NAV-START:web-mx-plan -->
@@ -33,9 +33,9 @@ OVHcloud bietet verschiedene E-Mail-Lösungen an: MX Plan (autonom oder in einem
 - **Direkter Link:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Navigationspfad:** `Web Cloud`{.action} > `MX Plan`{.action} > Wählen Sie Ihren MX Plan Dienst aus
 
-**Email Pro:**
+**E-Mail Pro:**
 
-- **Direkter Link:** [Email Pro](/links/control-panel/web-email-pro)
+- **Direkter Link:** [E-Mail Pro](/links/control-panel/web-email-pro)
 - **Navigationspfad:** `Web Cloud`{.action} > `E-Mail Pro`{.action} > Wählen Sie Ihre Plattform aus
 
 **Exchange:**
@@ -52,15 +52,15 @@ OVHcloud bietet verschiedene E-Mail-Lösungen an: MX Plan (autonom oder in einem
 
 ### Schritt 1: Ihr Projekt definieren
 
-Die Email Pro und Exchange Lösungen verfügen über eine gemeinsame Basis für Funktionen. Je nach Verwendungszweck bestehen jedoch Unterschiede. Wenn Sie eine Exchange Account auswählen, verfügen Sie über alle kollaborativen Funktionen wie die Synchronisation des Kalenders und der Kontakte. Die Email Pro Lösung bietet ebenfalls einige dieser Funktionen, diese sind jedoch auf die Verwendung über das Webmail beschränkt.
+Die E-Mail Pro und Exchange Lösungen verfügen über eine gemeinsame Basis für Funktionen. Je nach Verwendungszweck bestehen jedoch Unterschiede. Wenn Sie eine Exchange Account auswählen, verfügen Sie über alle kollaborativen Funktionen wie die Synchronisation des Kalenders und der Kontakte. Die E-Mail Pro Lösung bietet ebenfalls einige dieser Funktionen, diese sind jedoch auf die Verwendung über das Webmail beschränkt.
 
-Bevor Sie fortfahren, ist es wichtig zu wissen, auf welches Angebot Sie Ihren MX Plan E-Mail-Account migrieren möchten. Um Ihnen bei dieser Auswahl zu helfen können Sie die [Produktseite](/links/web/emails) konsultieren, die einen detaillierten Vergleich der Angebote bietet. Sie haben die Möglichkeit, die Lösungen zu kombinieren, um unter einem Domainnamen Accounts in Email Pro und Exchange zu nutzen. Wenn Sie mehrere Accounts migrieren, empfehlen wir Ihnen die Erstellung eines Migrationsplans.
+Bevor Sie fortfahren, ist es wichtig zu wissen, auf welches Angebot Sie Ihren MX Plan E-Mail-Account migrieren möchten. Um Ihnen bei dieser Auswahl zu helfen können Sie die [Produktseite](/links/web/emails) konsultieren, die einen detaillierten Vergleich der Angebote bietet. Sie haben die Möglichkeit, die Lösungen zu kombinieren, um unter einem Domainnamen Accounts in E-Mail Pro und Exchange zu nutzen. Wenn Sie mehrere Accounts migrieren, empfehlen wir Ihnen die Erstellung eines Migrationsplans.
 
-### Schritt 2: Email Pro oder Exchange Accounts bestellen
+### Schritt 2: E-Mail Pro oder Exchange Accounts bestellen
 
-Dieser Schritt ist optional, wenn Sie bereits über einen Exchange oder Email Pro Dienst verfügen, auf den Sie diese Migration durchführen.
+Dieser Schritt ist optional, wenn Sie bereits über einen Exchange oder E-Mail Pro Dienst verfügen, auf den Sie diese Migration durchführen.
 
-Andernfalls bestellen Sie Email Pro oder Exchange. Folgen Sie den Konfigurationsschritten und warten Sie, bis der Dienst fertig installiert ist. Sie erhalten eine E-Mail, sobald der Vorgang abgeschlossen ist.
+Andernfalls bestellen Sie E-Mail Pro oder Exchange. Folgen Sie den Konfigurationsschritten und warten Sie, bis der Dienst fertig installiert ist. Sie erhalten eine E-Mail, sobald der Vorgang abgeschlossen ist.
 
 > [!primary]
 >
@@ -80,13 +80,13 @@ Bevor Sie mit der Migration beginnen, müssen Sie die Version des MX Plan identi
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Manuelle Migration eines MX Plan-Angebots zu Exchange, Email Pro oder Zimbra  <a name="all-mxplan"></a>
+#### 3.1 Manuelle Migration eines MX Plan-Angebots zu Exchange, E-Mail Pro oder Zimbra  <a name="all-mxplan"></a>
 
 > [!warning]
 >
 > Dieser Abschnitt betrifft alle MX Plan-Dienste, die die Webmail-Technologie Roundcube, Zimbra oder OWA nutzen.
 >
-> Wenn Sie jedoch einen MX Plan-Dienst mit Roundcube Webmail zu einer OVHcloud Email Pro- oder Exchange-Plattform migrieren möchten, folgen Sie dem Abschnitt [Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder Email Pro](#roundcube-mxplan).
+> Wenn Sie jedoch einen MX Plan-Dienst mit Roundcube Webmail zu einer OVHcloud E-Mail Pro- oder Exchange-Plattform migrieren möchten, folgen Sie dem Abschnitt [Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder E-Mail Pro](#roundcube-mxplan).
 
 > [!warning]
 >
@@ -96,7 +96,7 @@ Bevor Sie mit der Migration beginnen, müssen Sie die Version des MX Plan identi
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
-> Weitere Informationen zum Hinzufügen eines Domainnamens finden Sie in den Hilfen zu [Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config), [Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) oder [Zimbra-Leitfaden](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra).
+> Weitere Informationen zum Hinzufügen eines Domainnamens finden Sie in den Hilfen zu [E-Mail Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config), [Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) oder [Zimbra-Leitfaden](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra).
 
 Die Migration Ihres MX Plan erfolgt in 3 Schritten: **Umbenennen**, **Erstellen** und **Migrieren**.
 
@@ -112,9 +112,9 @@ Klicken Sie im Tab `E-Mails`{.action} auf den Button `...`{.action} und dann auf
 >
 > Die Änderung des Accounts ist nicht sofort aktiv. Bitte warten Sie bis zum Abschluss der Operation, bevor Sie zum nächsten Schritt übergehen.
 
-2\. **Erstellen** Ihrer E-Mail-Adresse auf dem neuen Account Ihrer Email Pro oder Exchange Plattform (Sie erstellen *john.smith@mydomain.ovh* auf Ihrer neuen Plattform).
+2\. **Erstellen** Ihrer E-Mail-Adresse auf dem neuen Account Ihrer E-Mail Pro oder Exchange Plattform (Sie erstellen *john.smith@mydomain.ovh* auf Ihrer neuen Plattform).
 
-Klicken Sie im Tab `E-Mail-Accounts`{.action} Ihrer Email Pro oder Exchange Plattform auf den Button `...`{.action} und dann auf `Ändern`{.action}.
+Klicken Sie im Tab `E-Mail-Accounts`{.action} Ihrer E-Mail Pro oder Exchange Plattform auf den Button `...`{.action} und dann auf `Ändern`{.action}.
 
 ![Exchange](images/mxplan-migration-configure-account02.png){.thumbnail}
 
@@ -132,7 +132,7 @@ Sie können den ursprünglichen Account nach dieser Migration mit dem vorläufig
 
 Wenn Sie ihn löschen möchten, gehen Sie in den Tab `E-Mails`{.action} Ihres MX Plans, klicken Sie auf `...`{.action} und dann auf `Konto löschen`{.action}.
 
-#### 3.2 Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder Email Pro <a name="roundcube-mxplan"></a>
+#### 3.2 Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder E-Mail Pro <a name="roundcube-mxplan"></a>
 
 > [!warning]
 >
@@ -140,7 +140,7 @@ Wenn Sie ihn löschen möchten, gehen Sie in den Tab `E-Mails`{.action} Ihres MX
 
 > [!primary]
 >
-> Ihr OVHcloud Kunden-Account muss als Administrator-Kontakt **und** technischer Kontakt des zu migrierenden MX Plans, **und** des Email Pro oder Exchange Dienstes, auf den Sie migrieren, eingetragen sein.
+> Ihr OVHcloud Kunden-Account muss als Administrator-Kontakt **und** technischer Kontakt des zu migrierenden MX Plans, **und** des E-Mail Pro oder Exchange Dienstes, auf den Sie migrieren, eingetragen sein.
 >
 > Weitere Informationen zu den Änderungen der Kontakte finden Sie in unserer Anleitung zur [Verwaltung der Kontakte Ihrer Dienstleistungen](/pages/account_and_service_management/account_information/managing_contacts).
 >
@@ -148,7 +148,7 @@ Wenn Sie ihn löschen möchten, gehen Sie in den Tab `E-Mails`{.action} Ihres MX
 Die Migration kann über zwei Interfaces durchgeführt werden:<br>
 
 - **Der Konfigurationsassistent von Hosted Exchange**: Zu verwenden, wenn ein Hosted Exchange Dienst besteht, der noch unkonfiguriert ist.
-- **Im Bereich für MX Plan**: Möglich, sobald Sie über einen Email Pro oder Exchange Dienst (bereits konfiguriert oder nicht konfiguriert) und einen MX Plan Account verfügen, den Sie migrieren möchten.
+- **Im Bereich für MX Plan**: Möglich, sobald Sie über einen E-Mail Pro oder Exchange Dienst (bereits konfiguriert oder nicht konfiguriert) und einen MX Plan Account verfügen, den Sie migrieren möchten.
 
 > Zur Erinnerung: Vergewissern Sie sich vor Beginn der Migration, dass keine **Weiterleitung** oder **Auto-Antworten** für Ihren MX Plan eingerichtet sind.
 >
@@ -187,7 +187,7 @@ Bestätigen Sie anschließend das Passwort des Quell-Accounts (die Adresse, die 
 
 In diesem Schritt müssen Ihre E-Mail-Accounts bereits migriert und funktionsfähig sein. Aus Sicherheitsgründen bitten wir Sie, die korrekte Konfiguration Ihres Domainnamens in Ihrem Kundencenter zu überprüfen.
 
-Dazu wählen Sie den betreffenden Email Pro-, Exchange- oder Zimbra-Dienst aus und gehen Sie auf den Tab `Assoziierte Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform. Überprüfen Sie den Abschnitt oder die Spalte `Diagnose`{.action}.
+Dazu wählen Sie den betreffenden E-Mail Pro-, Exchange- oder Zimbra-Dienst aus und gehen Sie auf den Tab `Assoziierte Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform. Überprüfen Sie den Abschnitt oder die Spalte `Diagnose`{.action}.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 
@@ -202,7 +202,7 @@ Um die Konfiguration zu ändern, klicken Sie auf das rote Symbol und führen Sie
 
 Verwenden Sie nun Ihre migrierten E-Mail-Accounts. OVHcloud stellt dazu eine Online-Anwendung (*Web App*) zur Verfügung, die über [Webmail](/links/web/email) erreichbar ist. Geben Sie dort die Login-Daten für Ihre E-Mail-Adresse ein.
 
-Wenn Sie einen der migrierten Accounts auf einem E-Mail-Client (wie Outlook) eingerichtet haben, müssen Sie diesen erneut konfigurieren. Die Verbindungsdaten zum OVHcloud Server haben sich nach der Migration geändert. Weitere Informationen finden Sie in den jeweiligen Anleitungen zu [Email Pro](/products/web-cloud-email-collaborative-solutions-email-pro) und [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Auch wenn Sie den Account nicht sofort neu konfigurieren können, ist der Zugriff über die Online-Anwendung weiterhin möglich.
+Wenn Sie einen der migrierten Accounts auf einem E-Mail-Client (wie Outlook) eingerichtet haben, müssen Sie diesen erneut konfigurieren. Die Verbindungsdaten zum OVHcloud Server haben sich nach der Migration geändert. Weitere Informationen finden Sie in den jeweiligen Anleitungen zu [E-Mail Pro](/products/web-cloud-email-collaborative-solutions-email-pro) und [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Auch wenn Sie den Account nicht sofort neu konfigurieren können, ist der Zugriff über die Online-Anwendung weiterhin möglich.
 
 ### Organisation der Inhalte Ihrer E-Mail-Accounts nach einer Migration <a name="content-after-migration"></a>
 
@@ -222,7 +222,7 @@ Sie können auch Ihre E-Mail-Accounts manuell auf Ihr neues OVHcloud E-Mail-Ange
 
 [Verwaltung der Kontakte Ihrer Dienste](/pages/account_and_service_management/account_information/managing_contacts)
 
-[Erste Schritte mit dem Email Pro-Angebot](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
+[Erste Schritte mit dem E-Mail Pro-Angebot](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 
 [Erste Schritte mit dem Exchange-Angebot](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
@@ -92,7 +92,7 @@ Bevor Sie mit der Migration beginnen, müssen Sie die Version des MX Plan identi
 >
 > Wenn Sie Ihr neues E-Mail Angebot gerade erst bestellt haben, fügen Sie zuerst den Domainnamen zu Ihrem E-Mail-Dienst hinzu, bevor Sie mit der Migration beginnen. <br> - *Um beispielsweise den Account "myemail@mydomain.ovh" zu migrieren, müssen Sie die Domain "mydomain.ovh" zu Ihrem Dienst hinzufügen.*
 >
-> Wählen Sie den Tab `Zugeordnete Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform aus und klicken Sie auf `Domain hinzufügen`{.action}. Sobald der Domainname hinzugefügt wurde, stellen Sie sicher, dass die Bezeichnung `OK` oder `Aktiv`{.action} in der Spalte `Status` angezeigt wird.
+> Wählen Sie den Tab `Assoziierte Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform aus und klicken Sie auf `Domain hinzufügen`{.action}. Sobald der Domainname hinzugefügt wurde, stellen Sie sicher, dass die Bezeichnung `OK` oder `Aktiv`{.action} in der Spalte `Status` angezeigt wird.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
@@ -187,7 +187,7 @@ Bestätigen Sie anschließend das Passwort des Quell-Accounts (die Adresse, die 
 
 In diesem Schritt müssen Ihre E-Mail-Accounts bereits migriert und funktionsfähig sein. Aus Sicherheitsgründen bitten wir Sie, die korrekte Konfiguration Ihres Domainnamens in Ihrem Kundencenter zu überprüfen.
 
-Dazu wählen Sie den betreffenden Email Pro-, Exchange- oder Zimbra-Dienst aus und gehen Sie auf den Tab `Zugeordnete Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform. Überprüfen Sie den Abschnitt oder die Spalte `Diagnose`{.action}.
+Dazu wählen Sie den betreffenden Email Pro-, Exchange- oder Zimbra-Dienst aus und gehen Sie auf den Tab `Assoziierte Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform. Überprüfen Sie den Abschnitt oder die Spalte `Diagnose`{.action}.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
@@ -171,7 +171,7 @@ Wenn der Konfigurationsassistent nicht startet, werden stattdessen die allgemein
 
 ##### **Migration über das MX Plan Interface**
 
-Um die Migration über dieses Interface durchzuführen, gehen Sie im Bereich `E-Mails`{.action} zum Tab "E-Mails". Wählen Sie dann den Dienst mit dem Domainnamen Ihrer E-Mail-Adressen aus. Klicken Sie auf `...`{.action} in der Zeile des betreffenden E-Mail-Accounts (auch als Quell-Account bezeichnet) und dann auf `Account überführen`{.action}.
+Um die Migration über dieses Interface durchzuführen, gehen Sie im Bereich `E-Mails`{.action} Ihres OVHcloud Kundencenters. Wählen Sie dann den Dienst mit dem Domainnamen Ihrer E-Mail-Adressen aus. Klicken Sie auf den Tab `E-Mails`{.action}. Klicken Sie auf `...`{.action} in der Zeile des betreffenden E-Mail-Accounts (auch als Quell-Account bezeichnet) und dann auf `Account überführen`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
@@ -152,7 +152,7 @@ For more information on OMM, please read our guide on [Migrating email accounts 
 
 The migration time depends on the amount of content to migrate to your new account. This may vary from a few minutes to several hours.
 
-Check that you can find your items after the migration by logging into [Webmail OVHcloud](/links/web/email).
+Check that you can find your items after the migration by logging into the [OVHcloud webmail](/links/web/email).
 
 You can keep or delete the original account with the temporary name after this migration.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
@@ -48,7 +48,7 @@ If you need to migrate multiple accounts, we recommend that you set up a migrati
 
 This step is optional if you already have an Exchange service to which you are migrating.
 
-Log in to your [OVHcloud Control Panel](/links/manager), then order the Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
+Order the Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
 
 > [!primary]
 >
@@ -58,11 +58,6 @@ Log in to your [OVHcloud Control Panel](/links/manager), then order the Exchange
 ### Step 3: Carrying out the migration
 
 Before starting your migration, you will need to identify the version of the MX Plan you are migrating from.
-
-1. Log in to your [OVHcloud Control Panel](/links/manager).
-1. Open the `Web Cloud`{.action} section.
-1. Click `MX Plan`{.action}.
-1. Select the domain concerned.
 
 Please refer to the table below.
 
@@ -99,7 +94,7 @@ Once you are ready, follow the steps below, depending on the interface you have 
 
 ##### **Migration with the Exchange configuration assistant**
 
-To access it, select the relevant service in the [OVHcloud Control Panel](/links/manager) . The wizard should appear to help you configure your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
+The wizard should appear to help you configure your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
 
 If the configuration wizard does not appear, the general information for the Exchange service will appear instead. In this case, you will need to migrate your accounts via the MX Plan interface.
 
@@ -184,7 +179,7 @@ Now, you can start using your migrated email addresses. To do this, OVHcloud off
 
 If you have configured one of the migrated accounts on an email client (such as Outlook), you must set it up again. The login details for the OVHcloud server have changed following the migration. To help you make changes, please read the relevant guides in the [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan) guide section. Even if you are unable to reconfigure the account immediately, access via the online application is still possible.
 
-### Organise the content of your email addresses following a migration <a name=`content-after-migration`></a>
+### Organise the content of your email addresses following a migration <a name="content-after-migration"></a>
 
 When you first log in to your new email account, the migrated content may be partially hidden. To view all items, from the webmail, click on the chevron next to the `Inbox` to reveal the subfolders. The migrated content of your old email account should appear.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
@@ -140,7 +140,7 @@ In the `Email accounts`{.action} tab for your MX Plan platform, click the `...`{
 
 2\. **Create** your email address on the new account on your Exchange platform (using the previous example, you will create *john.smith@mydomain.ovh* on your new platform).
 
-In the `Email accounts`{.action} tab for your Exchange platform, click the `...`{.action} button, then `Modify`{.action}.
+In the `Email accounts`{.action} tab for your Exchange platform, click the `...`{.action} button, then `Edit`{.action}.
 
 ![Exchange](images/mxplan-migration-configure-account02.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
@@ -48,7 +48,7 @@ If you need to migrate multiple accounts, we recommend that you set up a migrati
 
 This step is optional if you already have an Exchange service to which you are migrating.
 
-Order the Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
+Order the Exchange service you want. Follow the steps, then wait for the service to be installed. You will receive a confirmation email once it is complete.
 
 > [!primary]
 >
@@ -94,13 +94,13 @@ Once you are ready, follow the steps below, depending on the interface you have 
 
 ##### **Migration with the Exchange configuration assistant**
 
-The wizard should appear to help you configure your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
+A wizard will guide you through configuring your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
 
 If the configuration wizard does not appear, the general information for the Exchange service will appear instead. In this case, you will need to migrate your accounts via the MX Plan interface.
 
 ##### **Migration from the MX Plan interface**
 
-To migrate from this interface, go to the `Emails`{.action} section of the OVHcloud Control Panel. Then choose the service with the domain name of your email addresses. Click on the `Emails`{.action} tab. Click on `...`{.action} next to the relevant email account (also called the source account), then `Migrate account`{.action}.
+To carry out the migration from this interface, go to the [MX Plan](/links/control-panel/web-mx-plan) section of your OVHcloud Control Panel and select the relevant domain. In the `Emails`{.action} tab, click on `...`{.action} next to the relevant email account (also called the source account), then `Migrate account`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 
@@ -152,7 +152,7 @@ For more information on OMM, please read our guide on [Migrating email accounts 
 
 The migration time depends on the amount of content to migrate to your new account. This may vary from a few minutes to several hours.
 
-Check that you can find your items after the migration, by logging into OVHcloud [webmail](/links/web/email).
+Check that you can find your items after the migration by logging into [Webmail OVHcloud](/links/web/email).
 
 You can keep or delete the original account with the temporary name after this migration.
 
@@ -193,6 +193,6 @@ You can also manually migrate your email addresses to your new OVHcloud email so
 
 ## Go further
 
-[Exchange guides](/products/web-cloud-email-collaborative-solutions-mx-plan).
+[Exchange guides](/products/web-cloud-email-collaborative-solutions-mx-plan)
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
@@ -100,7 +100,7 @@ If the configuration wizard does not appear, the general information for the Exc
 
 ##### **Migration from the MX Plan interface**
 
-To migrate from this interface, go to the `Emails`{.action} section of the OVHcloud Control Panel. Then choose the service with the domain name of your email addresses. Click on `...`{.action} next to the relevant email account (also called the source account), then `Migrate account`{.action}.
+To migrate from this interface, go to the `Emails`{.action} section of the OVHcloud Control Panel. Then choose the service with the domain name of your email addresses. Click on the `Emails`{.action} tab. Click on `...`{.action} next to the relevant email account (also called the source account), then `Migrate account`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-gb.md
@@ -60,7 +60,7 @@ It is important to choose the solution you would like to migrate your MX Plan em
 
 This step is optional if you already have an Exchange or Email Pro service to which you are migrating.
 
-Order the Email Pro or Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
+Order the Email Pro or Exchange service you want. Follow the steps, then wait for the service to be installed. You will receive a confirmation email once it is complete.
 
 > [!primary]
 >
@@ -125,7 +125,7 @@ For more information on OMM, please read our guide on [Migrating email accounts 
 
 The migration time depends on the amount of content to migrate to your new account. This may vary from a few minutes to several hours.
 
-Check that you can find your items after the migration, by logging into OVHcloud [webmail](/links/web/email).
+Check that you can find your items after the migration by logging into [Webmail OVHcloud](/links/web/email).
 
 You can keep or delete the original account with the temporary name after this migration.
 
@@ -162,13 +162,13 @@ Once you are ready, follow the steps below, depending on the interface you have 
 
 ##### **Migration with the Exchange configuration assistant**
 
-The wizard should appear to help you configure your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
+A wizard will guide you through configuring your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
 
 If the configuration wizard does not appear, the general information for the Exchange service will appear instead. In this case, you will need to migrate your accounts via the MX Plan interface.
 
 ##### **Migration from the MX Plan interface**
 
-To carry out the migration from this interface, go to the `Emails`{.action} section of your OVHcloud control panel. Then select the service bearing the domain name of your email addresses. Click on the `Emails`{.action} tab. Click on `...`{.action} on the line of the concerned email account (also called the source account) then on `Migrate the account`{.action}.
+To carry out the migration from this interface, go to the [MX Plan](/links/control-panel/web-mx-plan) section of your OVHcloud Control Panel and select the relevant domain. In the `Emails`{.action} tab, click on `...`{.action} on the line of the concerned email account (also called the source account), then on `Migrate account`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-gb.md
@@ -168,7 +168,7 @@ If the configuration wizard does not appear, the general information for the Exc
 
 ##### **Migration from the MX Plan interface**
 
-To carry out the migration from this interface, go to the `Emails`{.action} section of your OVHcloud control panel. Then select the service bearing the domain name of your email addresses. Click on `...`{.action} on the line of the concerned email account (also called the source account) then on `Migrate the account`{.action}.
+To carry out the migration from this interface, go to the `Emails`{.action} section of your OVHcloud control panel. Then select the service bearing the domain name of your email addresses. Click on the `Emails`{.action} tab. Click on `...`{.action} on the line of the concerned email account (also called the source account) then on `Migrate the account`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-gb.md
@@ -1,5 +1,5 @@
 ---
-title: 'Migrating an MX Plan email account to an Email Pro, Exchange account or Zimbra'
+title: 'Migrating an MX Plan email account to an Email Pro, Exchange or Zimbra account'
 excerpt: 'Find out how to migrate an MX Plan email address to an Email Pro, Exchange or Zimbra account'
 updated: 2026-01-16
 ---
@@ -60,7 +60,7 @@ It is important to choose the solution you would like to migrate your MX Plan em
 
 This step is optional if you already have an Exchange or Email Pro service to which you are migrating.
 
-Order the Email Pro or Exchange service you want. Follow the steps, then wait for the service to be installed. You will receive a confirmation email once it is complete.
+Order the Email Pro or Exchange service you want. Follow the steps, then wait for the service to be installed. You will receive a confirmation email once the installation is complete.
 
 > [!primary]
 >
@@ -125,7 +125,7 @@ For more information on OMM, please read our guide on [Migrating email accounts 
 
 The migration time depends on the amount of content to migrate to your new account. This may vary from a few minutes to several hours.
 
-Check that you can find your items after the migration by logging into [Webmail OVHcloud](/links/web/email).
+Check that you can find your items after the migration by logging into the [OVHcloud webmail](/links/web/email).
 
 You can keep or delete the original account with the temporary name after this migration.
 
@@ -168,7 +168,7 @@ If the configuration wizard does not appear, the general information for the Exc
 
 ##### **Migration from the MX Plan interface**
 
-To carry out the migration from this interface, go to the [MX Plan](/links/control-panel/web-mx-plan) section of your OVHcloud Control Panel and select the relevant domain. In the `Emails`{.action} tab, click on `...`{.action} on the line of the concerned email account (also called the source account), then on `Migrate account`{.action}.
+To migrate from this interface, go to the [MX Plan](/links/control-panel/web-mx-plan) section of your OVHcloud Control Panel and select the relevant domain. In the `Emails`{.action} tab, click on `...`{.action} on the line of the relevant email account (also called the source account), then on `Migrate account`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 
@@ -184,7 +184,7 @@ Finally, confirm the password for the source email account (the one you want to 
 
 At this stage, your email addresses should already be migrated and functional. For security reasons, we invite you to make sure that the configuration of your domain is correct by consulting your control panel.
 
-To do this, select the concerned Email Pro, Exchange or Zimbra service, then go to the `Associated Domains`{.action} or `Domain`{.action} tab on your platform. Check the `Diagnostic`{.action} section or column.
+To do this, select the relevant Email Pro, Exchange or Zimbra service, then go to the `Associated Domains`{.action} or `Domain`{.action} tab on your platform. Check the `Diagnostic`{.action} section or column.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-gb.md
@@ -8,7 +8,7 @@ updated: 2026-01-16
 
 OVHcloud offers several email solutions: MX Plan (standalone or included in a Web Hosting plan), Zimbra, Email Pro and Exchange. They have their individual features, and can be adapted to suit a number of uses. Are your needs changing? OVHcloud offers a migration tool you can use to switch from one solution to another.
 
-**Find out how to migrate an MX Plan email account to an Email Pro or Exchange account.**
+**Find out how to migrate an MX Plan email account to an Email Pro, Exchange or Zimbra account.**
 
 > [!warning]
 >
@@ -60,7 +60,7 @@ It is important to choose the solution you would like to migrate your MX Plan em
 
 This step is optional if you already have an Exchange or Email Pro service to which you are migrating.
 
-Log in to your [OVHcloud Control Panel](/links/manager), then order the Email Pro or Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
+Order the Email Pro or Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
 
 > [!primary]
 >
@@ -74,10 +74,6 @@ Before starting your migration, you will need to identify the version of the MX 
 >
 > The email technology of your MX Plan offer may vary depending on the date of activation of your offer or if a migration has recently taken place. This technology is particularly distinguished by the interface of its webmail. To identify it from your control panel, follow these steps:
 >
-> 1. Log in to your [OVHcloud control panel](/links/manager).
-> 1. Go to the `Web Cloud`{.action} section.
-> 1. Click on `MX Plan`{.action}.
-> 1. Select the concerned domain.
 > 1. The `General information`{.action} tab is selected by default.
 > 1. Note the technology used under the mention **Webmail** in the `Subscription` box.
 >
@@ -87,7 +83,7 @@ Before starting your migration, you will need to identify the version of the MX 
 
 > [!warning]
 >
-> This section concerns all MX Plan services using the Rouncube, Zimbra or OWA webmail technology.
+> This section concerns all MX Plan services using the Roundcube, Zimbra or OWA webmail technology.
 >
 > However, if you want to migrate an MX Plan service using the Roundcube webmail to an OVHcloud Email Pro or Exchange platform, follow the section "[Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro](#roundcube-mxplan)" of this guide.
 
@@ -107,7 +103,7 @@ Your MX Plan migration will be done in 3 main steps: **Renaming**, **Creating** 
 
 1\. **Rename** the MX Plan account to be migrated with a temporary name (example: to migrate the MX plan account *john.smith@mydomain.ovh*, rename it to *john.smith01@mydomain.ovh*).
 
-In the `Email accounts`{.action} tab for your MX Plan platform, click the `...`{.action} button, then `Edit`{.action}.
+In the `Email accounts`{.action} tab for your MX Plan platform, click the `...`{.action} button, then `Modify the account`{.action}.
 
 ![Exchange](images/mxplan-migration-configure-account01.png){.thumbnail}
 
@@ -117,7 +113,7 @@ In the `Email accounts`{.action} tab for your MX Plan platform, click the `...`{
 
 2\. **Create** your email address on the new account on your Email Pro or Exchange platform (using the previous example, you will create *john.smith@mydomain.ovh* on your new platform).
 
-In the `Email accounts`{.action} tab for your Email Pro or Exchange platform, click the `...`{.action} button, then `Modify`{.action}.
+In the `Email accounts`{.action} tab for your Email Pro or Exchange platform, click the `...`{.action} button, then `Edit`{.action}.
 
 ![Exchange](images/mxplan-migration-configure-account02.png){.thumbnail}
 
@@ -133,13 +129,13 @@ Check that you can find your items after the migration, by logging into OVHcloud
 
 You can keep or delete the original account with the temporary name after this migration.
 
-If you want to delete it, go to the `Email accounts`{.action} tab in your MX Plan, click on the `...`{.action} button, then `Disable account`{.action}.
+If you want to delete it, go to the `Email accounts`{.action} tab in your MX Plan, click on the `...`{.action} button, then `Reset this account`{.action}.
 
 #### 3.2 Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro <a name="roundcube-mxplan"></a>
 
 > [!warning]
 >
-> This section concerns only MX Plan services using the Rouncube webmail technology.
+> This section concerns only MX Plan services using the Roundcube webmail technology.
 
 > [!primary]
 >
@@ -166,7 +162,7 @@ Once you are ready, follow the steps below, depending on the interface you have 
 
 ##### **Migration with the Exchange configuration assistant**
 
-To access it, select the relevant service in the [OVHcloud Control Panel](/links/manager). The wizard should appear to help you configure your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
+The wizard should appear to help you configure your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
 
 If the configuration wizard does not appear, the general information for the Exchange service will appear instead. In this case, you will need to migrate your accounts via the MX Plan interface.
 
@@ -204,7 +200,7 @@ Now, you can start using your migrated email accounts. To do this, OVHcloud offe
 
 If you have configured one of the migrated accounts on an email client (such as Outlook), you must set it up again. The login details for the OVHcloud server have changed following the migration. To help you make changes, please read the respective guides in the [Email Pro](/products/web-cloud-email-collaborative-solutions-email-pro) and [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan) guide sections. Even if you are unable to reconfigure the account immediately, access via the online application is still possible.
 
-### Organise the contents of your email accounts following a migration <a name=`content-after-migration`></a>
+### Organise the contents of your email accounts following a migration <a name="content-after-migration"></a>
 
 When you first log in to your new email account, the migrated content may be partially hidden. To view all items in the webmail, click on the arrow symbol next to the `Inbox` to reveal the subfolders. The migrated content of your old email account should appear.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ie.md
@@ -60,7 +60,7 @@ It is important to choose the solution you would like to migrate your MX Plan em
 
 This step is optional if you already have an Exchange or Email Pro service to which you are migrating.
 
-Order the Email Pro or Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
+Order the Email Pro or Exchange service you want. Follow the steps, then wait for the service to be installed. You will receive a confirmation email once it is complete.
 
 > [!primary]
 >
@@ -125,7 +125,7 @@ For more information on OMM, please read our guide on [Migrating email accounts 
 
 The migration time depends on the amount of content to migrate to your new account. This may vary from a few minutes to several hours.
 
-Check that you can find your items after the migration, by logging into OVHcloud [webmail](/links/web/email).
+Check that you can find your items after the migration by logging into [Webmail OVHcloud](/links/web/email).
 
 You can keep or delete the original account with the temporary name after this migration.
 
@@ -162,13 +162,13 @@ Once you are ready, follow the steps below, depending on the interface you have 
 
 ##### **Migration with the Exchange configuration assistant**
 
-The wizard should appear to help you configure your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
+A wizard will guide you through configuring your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
 
 If the configuration wizard does not appear, the general information for the Exchange service will appear instead. In this case, you will need to migrate your accounts via the MX Plan interface.
 
 ##### **Migration from the MX Plan interface**
 
-To carry out the migration from this interface, go to the `Emails`{.action} section of your OVHcloud control panel. Then select the service bearing the domain name of your email addresses. Click on the `Emails`{.action} tab. Click on `...`{.action} on the line of the concerned email account (also called the source account) then on `Migrate the account`{.action}.
+To carry out the migration from this interface, go to the [MX Plan](/links/control-panel/web-mx-plan) section of your OVHcloud Control Panel and select the relevant domain. In the `Emails`{.action} tab, click on `...`{.action} on the line of the concerned email account (also called the source account), then on `Migrate account`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ie.md
@@ -168,7 +168,7 @@ If the configuration wizard does not appear, the general information for the Exc
 
 ##### **Migration from the MX Plan interface**
 
-To carry out the migration from this interface, go to the `Emails`{.action} section of your OVHcloud control panel. Then select the service bearing the domain name of your email addresses. Click on `...`{.action} on the line of the concerned email account (also called the source account) then on `Migrate the account`{.action}.
+To carry out the migration from this interface, go to the `Emails`{.action} section of your OVHcloud control panel. Then select the service bearing the domain name of your email addresses. Click on the `Emails`{.action} tab. Click on `...`{.action} on the line of the concerned email account (also called the source account) then on `Migrate the account`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ie.md
@@ -1,5 +1,5 @@
 ---
-title: 'Migrating an MX Plan email account to an Email Pro, Exchange account or Zimbra'
+title: 'Migrating an MX Plan email account to an Email Pro, Exchange or Zimbra account'
 excerpt: 'Find out how to migrate an MX Plan email address to an Email Pro, Exchange or Zimbra account'
 updated: 2026-01-16
 ---
@@ -125,7 +125,7 @@ For more information on OMM, please read our guide on [Migrating email accounts 
 
 The migration time depends on the amount of content to migrate to your new account. This may vary from a few minutes to several hours.
 
-Check that you can find your items after the migration by logging into [Webmail OVHcloud](/links/web/email).
+Check that you can find your items after the migration by logging into the [OVHcloud webmail](/links/web/email).
 
 You can keep or delete the original account with the temporary name after this migration.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ie.md
@@ -8,7 +8,7 @@ updated: 2026-01-16
 
 OVHcloud offers several email solutions: MX Plan (standalone or included in a Web Hosting plan), Zimbra, Email Pro and Exchange. They have their individual features, and can be adapted to suit a number of uses. Are your needs changing? OVHcloud offers a migration tool you can use to switch from one solution to another.
 
-**Find out how to migrate an MX Plan email account to an Email Pro or Exchange account.**
+**Find out how to migrate an MX Plan email account to an Email Pro, Exchange or Zimbra account.**
 
 > [!warning]
 >
@@ -60,7 +60,7 @@ It is important to choose the solution you would like to migrate your MX Plan em
 
 This step is optional if you already have an Exchange or Email Pro service to which you are migrating.
 
-Log in to your [OVHcloud Control Panel](/links/manager), then order the Email Pro or Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
+Order the Email Pro or Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
 
 > [!primary]
 >
@@ -74,10 +74,6 @@ Before starting your migration, you will need to identify the version of the MX 
 >
 > The email technology of your MX Plan offer may vary depending on the date of activation of your offer or if a migration has recently taken place. This technology is particularly distinguished by the interface of its webmail. To identify it from your control panel, follow these steps:
 >
-> 1. Log in to your [OVHcloud control panel](/links/manager).
-> 1. Go to the `Web Cloud`{.action} section.
-> 1. Click on `MX Plan`{.action}.
-> 1. Select the concerned domain.
 > 1. The `General information`{.action} tab is selected by default.
 > 1. Note the technology used under the mention **Webmail** in the `Subscription` box.
 >
@@ -87,7 +83,7 @@ Before starting your migration, you will need to identify the version of the MX 
 
 > [!warning]
 >
-> This section concerns all MX Plan services using the Rouncube, Zimbra or OWA webmail technology.
+> This section concerns all MX Plan services using the Roundcube, Zimbra or OWA webmail technology.
 >
 > However, if you want to migrate an MX Plan service using the Roundcube webmail to an OVHcloud Email Pro or Exchange platform, follow the section "[Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro](#roundcube-mxplan)" of this guide.
 
@@ -107,7 +103,7 @@ Your MX Plan migration will be done in 3 main steps: **Renaming**, **Creating** 
 
 1\. **Rename** the MX Plan account to be migrated with a temporary name (example: to migrate the MX plan account *john.smith@mydomain.ovh*, rename it to *john.smith01@mydomain.ovh*).
 
-In the `Email accounts`{.action} tab for your MX Plan platform, click the `...`{.action} button, then `Edit`{.action}.
+In the `Email accounts`{.action} tab for your MX Plan platform, click the `...`{.action} button, then `Modify the account`{.action}.
 
 ![Exchange](images/mxplan-migration-configure-account01.png){.thumbnail}
 
@@ -117,7 +113,7 @@ In the `Email accounts`{.action} tab for your MX Plan platform, click the `...`{
 
 2\. **Create** your email address on the new account on your Email Pro or Exchange platform (using the previous example, you will create *john.smith@mydomain.ovh* on your new platform).
 
-In the `Email accounts`{.action} tab for your Email Pro or Exchange platform, click the `...`{.action} button, then `Modify`{.action}.
+In the `Email accounts`{.action} tab for your Email Pro or Exchange platform, click the `...`{.action} button, then `Edit`{.action}.
 
 ![Exchange](images/mxplan-migration-configure-account02.png){.thumbnail}
 
@@ -133,13 +129,13 @@ Check that you can find your items after the migration, by logging into OVHcloud
 
 You can keep or delete the original account with the temporary name after this migration.
 
-If you want to delete it, go to the `Email accounts`{.action} tab in your MX Plan, click on the `...`{.action} button, then `Disable account`{.action}.
+If you want to delete it, go to the `Email accounts`{.action} tab in your MX Plan, click on the `...`{.action} button, then `Reset this account`{.action}.
 
 #### 3.2 Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro <a name="roundcube-mxplan"></a>
 
 > [!warning]
 >
-> This section concerns only MX Plan services using the Rouncube webmail technology.
+> This section concerns only MX Plan services using the Roundcube webmail technology.
 
 > [!primary]
 >
@@ -166,7 +162,7 @@ Once you are ready, follow the steps below, depending on the interface you have 
 
 ##### **Migration with the Exchange configuration assistant**
 
-To access it, select the relevant service in the [OVHcloud Control Panel](/links/manager). The wizard should appear to help you configure your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
+The wizard should appear to help you configure your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
 
 If the configuration wizard does not appear, the general information for the Exchange service will appear instead. In this case, you will need to migrate your accounts via the MX Plan interface.
 
@@ -204,7 +200,7 @@ Now, you can start using your migrated email accounts. To do this, OVHcloud offe
 
 If you have configured one of the migrated accounts on an email client (such as Outlook), you must set it up again. The login details for the OVHcloud server have changed following the migration. To help you make changes, please read the respective guides in the [Email Pro](/products/web-cloud-email-collaborative-solutions-email-pro) and [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan) guide sections. Even if you are unable to reconfigure the account immediately, access via the online application is still possible.
 
-### Organise the contents of your email accounts following a migration <a name=`content-after-migration`></a>
+### Organise the contents of your email accounts following a migration <a name="content-after-migration"></a>
 
 When you first log in to your new email account, the migrated content may be partially hidden. To view all items in the webmail, click on the arrow symbol next to the `Inbox` to reveal the subfolders. The migrated content of your old email account should appear.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-us.md
@@ -53,7 +53,7 @@ If you need to migrate multiple accounts, we recommend that you set up a migrati
 
 This step is optional if you already have an Exchange service to which you are migrating.
 
-Log in to your [OVHcloud Control Panel](/links/manager), then order the Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
+Order the Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
 
 > [!primary]
 >
@@ -62,11 +62,6 @@ Log in to your [OVHcloud Control Panel](/links/manager), then order the Exchange
 ### Step 3: Carrying out the migration
 
 Before starting your migration, you will need to identify the version of the MX Plan you are migrating from.
-
-1. Log in to your [OVHcloud Control Panel](/links/manager).
-1. Open the `Web Cloud`{.action} section.
-1. Click `MX Plan`{.action}.
-1. Select the domain concerned.
 
 > [!warning]
 >
@@ -133,7 +128,7 @@ Now, you can start using your migrated email addresses. To do this, OVHcloud off
 
 If you have configured one of the migrated accounts on an email client (such as Outlook), you must set it up again. The login details for the OVHcloud server have changed following the migration. To help you make changes, please read the relevant guides in the [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan) guide section. Even if you are unable to reconfigure the account immediately, access via the online application is still possible.
 
-### Organise the content of your email addresses following a migration <a name=`content-after-migration`></a>
+### Organise the content of your email addresses following a migration <a name="content-after-migration"></a>
 
 When you first log in to your new email account, the migrated content may be partially hidden. To view all items, from the webmail, click on the chevron next to the `Inbox` to reveal the subfolders. The migrated content of your old email account should appear.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-us.md
@@ -53,7 +53,7 @@ If you need to migrate multiple accounts, we recommend that you set up a migrati
 
 This step is optional if you already have an Exchange service to which you are migrating.
 
-Order the Exchange service you want. Follow the steps, then wait until the service is actually installed. An email will be sent to you as soon as it is complete.
+Order the Exchange service you want. Follow the steps, then wait for the service to be installed. You will receive a confirmation email once it is complete.
 
 > [!primary]
 >
@@ -142,6 +142,6 @@ You can also manually migrate your email addresses to your new OVHcloud email so
 
 ## Go further
 
-[Exchange guides](/products/web-cloud-email-collaborative-solutions-mx-plan).
+[Exchange guides](/products/web-cloud-email-collaborative-solutions-mx-plan)
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-es.md
@@ -8,7 +8,7 @@ updated: 2026-01-16
 
 OVHcloud ofrece varias soluciones de correo electrónico: MX Plan (vendido solo o incluido en un plan de hosting), Zimbra, Email Pro y Exchange. Estas disfrutan de funcionalidades propias y pueden adaptarse a varios usos. ¿Sus necesidades evolucionan? OVHcloud pone a su disposición una herramienta de migración que le permitirá cambiar de una solución a otra.
 
-**Esta guía explica cómo migrar una cuenta MX Plan a una cuenta Email Pro o Exchange.**
+**Esta guía explica cómo migrar una cuenta MX Plan a una cuenta Email Pro, Exchange o Zimbra.**
 
 > [!warning]
 >
@@ -60,7 +60,7 @@ Por lo tanto, es importante conocer a qué solución quiere migrar sus direccion
 
 Este paso es opcional si ya tiene un servicio Exchange o Email Pro al que quiere realizar la migración.
 
-En caso contrario, conéctese al [área de cliente de OVHcloud](/links/manager) y contrate el servicio Email Pro o Exchange que desee. Siga los pasos que se indican y espere a que se instale el servicio. Recibirá un mensaje de correo electrónico cuando haya finalizado la operación.
+En caso contrario, contrate el servicio Email Pro o Exchange que desee. Siga los pasos que se indican y espere a que se instale el servicio. Recibirá un mensaje de correo electrónico cuando haya finalizado la operación.
 
 > [!primary]
 >
@@ -75,10 +75,6 @@ Antes de realizar la migración, deberá identificar la versión del MX Plan des
 >
 > La tecnología de correo de su oferta MX Plan puede variar según la fecha de activación de su oferta o si ha tenido lugar recientemente una migración. Esta tecnología se distingue especialmente por la interfaz de su webmail. Para identificarla desde su área de cliente, siga estos pasos:
 >
-> 1. Inicie sesión en su [área de cliente de OVHcloud](/links/manager).
-> 1. Vaya a la sección `Web Cloud`{.action}.
-> 1. Haga clic en `MX Plan`{.action}.
-> 1. Seleccione el dominio correspondiente.
 > 1. El apartado `Información general`{.action} se selecciona por defecto.
 > 1. Anote la tecnología utilizada bajo la mención **Webmail** en el recuadro `Suscripción`.
 >
@@ -89,7 +85,7 @@ Antes de realizar la migración, deberá identificar la versión del MX Plan des
 
 > [!warning]
 >
-> Esta sección se aplica a todos los servicios MX Plan que utilizan la tecnología de webmail Rouncube, Zimbra u OWA.
+> Esta sección se aplica a todos los servicios MX Plan que utilizan la tecnología de webmail Roundcube, Zimbra u OWA.
 >
 > Sin embargo, si desea migrar un servicio MX Plan que utilice el webmail Roundcube a una plataforma Email Pro o Exchange OVHcloud, siga la sección "[Migración automática de una oferta MX Plan Roundcube a Exchange o Email Pro](#roundcube-mxplan)" de esta guía.
 
@@ -141,7 +137,7 @@ Si quiere eliminarlo, abra la pestaña `Cuentas de correo`{.action} de su MX Pla
 
 > [!warning]
 >
-> Esta sección se aplica únicamente a los servicios MX Plan que utilizan la tecnología de webmail Rouncube.
+> Esta sección se aplica únicamente a los servicios MX Plan que utilizan la tecnología de webmail Roundcube.
 
 > [!primary]
 >
@@ -170,7 +166,7 @@ Continúe leyendo esta guía en la interfaz seleccionada. Le recordamos que el t
 
 ##### **Migración desde el asistente de configuración de Exchange**
 
-Para ello, seleccione el servicio en el [área de cliente de OVHcloud](/links/manager) El asistente aparecerá para ayudarle a configurar su nuevo servicio Exchange. Durante este proceso, podrá seleccionar las cuentas MX Plan que quiera migrar.
+El asistente aparecerá para ayudarle a configurar su nuevo servicio Exchange. Durante este proceso, podrá seleccionar las cuentas MX Plan que quiera migrar.
 
 Si no aparece el asistente de configuración, la información general del servicio Exchange se mostrará en su lugar. En ese caso, deberá realizar la migración de sus cuentas a través de la interfaz MX Plan.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-es.md
@@ -127,7 +127,7 @@ Para más información sobre OMM, consulte nuestra guía [Migrar cuentas de corr
 
 El tiempo de migración dependerá de cuánto contenido quiera migrar a la nueva cuenta. Éste puede variar desde unos minutos hasta varias horas.
 
-Una vez realizada la migración, compruebe que los elementos que contiene se encuentren conectándose al webmail en la dirección [Webmail](/links/web/email)
+Una vez realizada la migración, compruebe que encuentra todos sus elementos conectándose al [Webmail OVHcloud](/links/web/email).
 
 Una vez realizada la migración, puede conservar o eliminar la cuenta original con el nombre provisional.
 
@@ -172,7 +172,7 @@ Si no aparece el asistente de configuración, la información general del servic
 
 ##### **Migración desde la interfaz MX Plan**
 
-Para realizar la migración desde esta interfaz, acceda a la sección `Correo electrónico`{.action} del área de cliente de OVHcloud. Seleccione el servicio con el nombre de dominio de sus direcciones de correo. Haga clic en la pestaña `Emails`{.action}. Haga clic en `...`{.action} en la línea de la cuenta de correo correspondiente (también llamada cuenta de origen) y seleccione `Migrar la cuenta`{.action}.
+Para realizar la migración desde esta interfaz, acceda a la sección [MX Plan](/links/control-panel/web-mx-plan) de su área de cliente de OVHcloud y seleccione el dominio correspondiente. En la pestaña `Correo electrónico`{.action}, haga clic en `...`{.action} en la línea de la cuenta de correo correspondiente (también llamada cuenta de origen) y seleccione `Migrar la cuenta`{.action}.
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-es.md
@@ -172,7 +172,7 @@ Si no aparece el asistente de configuración, la información general del servic
 
 ##### **Migración desde la interfaz MX Plan**
 
-Para realizar la migración desde esta interfaz, acceda a la sección `Correo electrónico`{.action} del área de cliente de OVHcloud. Seleccione el servicio con el nombre de dominio de sus direcciones de correo. Haga clic en `...`{.action} en la línea de la cuenta de correo correspondiente (también llamada cuenta de origen) y seleccione `Migrar la cuenta`{.action}.
+Para realizar la migración desde esta interfaz, acceda a la sección `Correo electrónico`{.action} del área de cliente de OVHcloud. Seleccione el servicio con el nombre de dominio de sus direcciones de correo. Haga clic en la pestaña `Emails`{.action}. Haga clic en `...`{.action} en la línea de la cuenta de correo correspondiente (también llamada cuenta de origen) y seleccione `Migrar la cuenta`{.action}.
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-us.md
@@ -44,17 +44,17 @@ OVHcloud ofrece varias soluciones de correo electrónico: MX Plan (incluido en u
 
 ## Procedimiento
 
-### Étape 1 : delimitador de tu proyecto
+### Etapa 1: delimitar su proyecto
 
 Con una dirección Exchange, puede utilizar funciones colaborativas, calendarios y sincronización de contactos. Consulte la [página de ofertas de Exchange](/links/web/emails-hosted-exchange) para obtener una lista detallada de funciones.
 
-Si vous devez migrer plusieurs comptes, nous vous conseillons de mettre en place un plan de migración.
+Si necesita migrar varias cuentas, le recomendamos que establezca un plan de migración.
 
 ### Etapa 2 : contratar sus cuentas Exchange
 
 Este paso es opcional si ya tiene un servicio Exchange al que quiere realizar la migración.
 
-En caso contrario, conéctese al [área de cliente de OVHcloud](/links/manager) y contrate el servicio Exchange que desee. Siga los pasos que se indican y espere a que se instale el servicio. Recibirá un mensaje de correo electrónico cuando haya finalizado la operación.
+En caso contrario, contrate el servicio Exchange que desee. Siga los pasos que se indican y espere a que se instale el servicio. Recibirá un mensaje de correo electrónico cuando haya finalizado la operación.
 
 > [!primary]
 >
@@ -63,11 +63,6 @@ En caso contrario, conéctese al [área de cliente de OVHcloud](/links/manager) 
 ### Etapa 3 : Realizar la migración
 
 Antes de realizar la migración, deberá identificar la versión del MX Plan desde el que migrará.
-
-1. Conéctese a su [área de cliente de OVHcloud](/links/manager).
-1. Acceda al apartado `Web Cloud`{.action}.
-1. Haga clic en `MX Plan`{.action}.
-1. Seleccione el dominio.
 
 > [!warning]
 >

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-us.md
@@ -102,7 +102,7 @@ Para más información sobre OMM, consulte nuestra guía [Migrar cuentas de corr
 
 El tiempo de migración dependerá de cuánto contenido quiera migrar a la nueva cuenta. Éste puede variar desde unos minutos hasta varias horas.
 
-Una vez realizada la migración, compruebe que los elementos que contiene se encuentren conectándose al webmail en la dirección [Webmail](/links/web/email)
+Una vez realizada la migración, compruebe que encuentra todos sus elementos conectándose al [Webmail OVHcloud](/links/web/email).
 
 Una vez realizada la migración, puede conservar o eliminar la cuenta original con el nombre provisional.
 
@@ -145,6 +145,6 @@ También puede migrar manualmente sus direcciones de correo a su nueva solución
 
 ## Más información
 
-[Guías Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan).
+[Guías Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan)
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
@@ -166,7 +166,7 @@ Si l'assistant de configuration ne s'affiche pas, les informations générales d
 
 ##### **Migration depuis l'interface MX Plan**
 
-Pour réaliser la migration depuis cette interface, rendez-vous dans la section `E-mails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur l'onglet `Emails`{.action}. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
+Pour réaliser la migration depuis cette interface, rendez-vous dans la section `Emails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur l'onglet `Emails`{.action}. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
@@ -170,7 +170,7 @@ Pour réaliser la migration depuis cette interface, rendez-vous dans la section 
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail .w-640}
 
-Dans la fenêtre qui s'affiche, sélectionnez le service de destination (celui vers lequel vous souhaitez migrer l'adresse) puis cliquez sur `Suivant`{.action}. S'il possède au minimum un compte « libre » (c'est-à-dire encore non paramétré), la migration s'effectuera vers l'un de ces comptes. Dès lors, prenez connaissance des informations qui s'affichent, validez-les, puis cliquez sur `Suivant`{.action} afin de poursuivre la manipulation.
+Dans la fenêtre qui s'affiche, sélectionnez le service de destination (celui vers lequel vous souhaitez migrer l'adresse) puis cliquez sur `Suivant`{.action}. S'il possède au minimum un compte « libre » (c'est-à-dire encore non paramétré), la migration s'effectuera vers l'un de ces comptes. Dès lors, prenez connaissance des informations qui s'affichent, validez-les, puis cliquez sur `Suivant`{.action} pour poursuivre l'opération.
 
 Si vous ne possédez pas de compte « libre », un bouton `Commander des comptes`{.action} apparaîtra. Suivez les étapes, puis patientez le temps que les comptes soient installés pour effectuer de nouveau la manipulation.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
@@ -121,7 +121,7 @@ Pour plus d'informations sur OMM, consultez notre guide [Migrer des comptes e-ma
 
 Le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
-Après la migration, vérifiez que vous retrouvez vos éléments en vous connectant au [Webmail](/links/web/email).
+Après la migration, vérifiez que vous retrouvez vos éléments en vous connectant au [Webmail OVHcloud](/links/web/email).
 
 Vous pouvez conserver ou supprimer le compte d'origine avec le nom provisoire après cette migration.
 
@@ -160,13 +160,13 @@ Une fois que vous êtes prêt, poursuivez la lecture de cette documentation selo
 
 ##### **Migration depuis l'assistant de configuration Exchange**
 
-L'assistant devrait apparaître afin de vous aider à configurer votre nouveau service Exchange. Durant ce processus, vous pourrez sélectionner les comptes e-mails MX Plan à migrer.
+L'assistant s'affiche pour vous aider à configurer votre nouveau service Exchange. Durant ce processus, vous pouvez sélectionner les comptes e-mail MX Plan à migrer.
 
 Si l'assistant de configuration ne s'affiche pas, les informations générales du service Exchange apparaîtront à la place. Dans ce cas, vous devrez réaliser la migration de vos comptes via l'interface MX Plan.
 
 ##### **Migration depuis l'interface MX Plan**
 
-Pour réaliser la migration depuis cette interface, rendez-vous dans la section `Emails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur l'onglet `Emails`{.action}. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
+Pour réaliser la migration depuis cette interface, rendez-vous dans la section [MX Plan](/links/control-panel/web-mx-plan) de votre espace client OVHcloud et sélectionnez le domaine concerné. Dans l'onglet `Emails`{.action}, cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source), puis sur `Migrer le compte`{.action}.
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail .w-640}
 
@@ -183,7 +183,7 @@ Confirmez enfin le mot de passe de l'adresse e-mail source (celle que vous voule
 
 À cette étape, vos adresses e-mail doivent déjà être migrées et fonctionnelles. Par sécurité, nous vous invitons à vous assurer que la configuration de votre domaine est correcte en consultant votre espace client.
 
-Pour cela, sélectionnez le service Exchange concerné, puis rendez-vous sur l'onglet `Domaines associés`{.action} ou `Domaine`{.action} sur votre plateforme. Vérifiez la rubrique ou la colonne `Diagnostic`{.action}.
+Pour cela, sélectionnez le service Exchange concerné, puis rendez-vous sur l'onglet `Domaines associés`{.action} ou `Domaine`{.action} sur votre plateforme. Vérifiez la rubrique ou la colonne `Diagnostics`{.action}.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail .w-640}
 
@@ -216,7 +216,7 @@ Vous pouvez également migrer manuellement vos adresses e-mail vers votre nouvel
 
 ## Aller plus loin
 
-[Gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts).
+[Gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts)
 
 [Premiers pas avec l'offre Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
@@ -44,57 +44,64 @@ OVHcloud propose plusieurs solutions e-mail : MX Plan (vendu seul ou compris dan
 
 ## En pratique
 
-### Étape 1 : délimiter votre projet
+### Étape 1 : Délimiter votre projet
 
-Avec une adresse Exchange, vous pouvez utiliser des fonctionnalités collaboratives, telles que les calendriers et la synchronisation des contacts. Veuillez consulter la [page de l'offre Exchange](/links/web/emails-hosted-exchange) pour obtenir une liste détaillée des fonctionnalités.
+En choisissant une adresse Exchange, vous disposez de la totalité des fonctions collaboratives, comme la synchronisation du calendrier et des contacts.
 
-Si vous devez migrer plusieurs comptes, nous vous conseillons de mettre en place un plan de migration.
+Avant de poursuivre, assurez-vous de disposer d'un service Exchange. Par ailleurs, si vous devez migrer plusieurs comptes, nous vous conseillons de mettre en place un plan de migration.
 
-### Étape 2 : commander vos comptes Exchange
+### Étape 2 : Commander votre compte Exchange
 
 Cette étape est facultative si vous disposez déjà d'un service Exchange vers lequel vous effectuez cette migration.
 
-Dans le cas contraire, connectez-vous à votre [espace client OVHcloud](/links/manager), puis commandez le service Exchange de votre choix. Suivez les différentes étapes, puis patientez jusqu'à l'installation du service. Un e-mail vous sera envoyé dès la fin de celle-ci.
+Dans le cas contraire, commandez le service Exchange de votre choix. Suivez les différentes étapes, puis patientez jusqu'à l'installation du service. Un e-mail vous sera envoyé dès la fin de celle-ci.
 
 > [!primary]
 >
 > Une fois le compte commandé, laissez-le sous la forme « @configureme.me » dans un premier temps. En effet, il sera renommé lors de la migration.
+>
 
 ### Étape 3 : Réaliser la migration
 
 Avant de débuter votre migration, il vous faudra identifier la version du MX Plan depuis lequel vous migrez.
 
-1. Connectez-vous à votre [espace client OVHcloud](/links/manager).
-1. Rendez-vous dans la partie `Web Cloud`{.action}.
-1. Cliquez sur `MX Plan`{.action}.
-1. Sélectionnez le domaine concerné.
+> [!primary]
+>
+> La technologie e-mail de votre offre MX Plan peut varier selon la date d'activation de votre offre ou si une migration a récemment eu lieu. Cette technologie se distingue notamment par l'interface de son webmail. Pour l'identifier depuis votre espace client, suivez ces étapes :
+>
+> 1. L'onglet `Informations générales`{.action} est sélectionné par défaut.
+> 1. Relevez la technologie utilisée sous la mention **Webmail** dans l'encadré `Abonnement`.
+>
+> ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
+>
 
-Poursuivez selon la version que vous possédez en vous référant au tableau ci-dessous.
+#### 3.1 Migration manuelle d'une offre MX Plan vers Exchange  <a name="all-mxplan"></a>
 
-|Version historique de l'offre MX Plan|Nouvelle version de l'offre MX Plan|
-|---|---|
-|![email](images/mxplan-starter-legacy-step1.png){.thumbnail}<br> Votre offre se situe dans le cadre « Abonnement »|![email](images/mxplan-starter-new-step1.png){.thumbnail}<br>Vous retrouvez une `Référence serveur` dans le cadre « Résumé » commençant par "mxplan-"|
-|Poursuivre vers « [Version historique de l'offre MX Plan](#VersionHistoriqueMxplan) »|Poursuivre vers « [Nouvelle version de l'offre MX Plan](#NouvelleVersionMxplan) »|
+> [!warning]
+>
+> Cette partie concerne l'ensemble des services MX Plan utilisant la technologie webmail Roundcube ou OWA.
+>
+> Néanmoins, si vous souhaitez migrer un service MX Plan utilisant le webmail Roundcube vers une plateforme Exchange OVHcloud, suivez la partie « [Migration automatique d'une offre MX Plan Roundcube vers Exchange](#roundcube-mxplan) » de ce guide.
 
 > [!warning]
 >
 > Si vous venez de commander votre nouvelle offre e-mail, ajoutez d'abord le nom de domaine à votre plateforme e-mail, avant de commencer votre migration. <br> - *Par exemple, pour migrer le compte « myemail@mydomain.ovh », vous devez ajouter le nom de domaine « mydomain.ovh » à votre plateforme.*
 >
->Sélectionnez l’onglet `Domaines associés`{.action} sur votre plateforme, puis cliquez sur `Ajouter un domaine`{.action}. Une fois le nom de domaine ajouté, assurez-vous que la mention `OK` est bien présente dans la colonne `Statut`.
+> Sélectionnez l'onglet `Domaines associés`{.action} ou `Domaine`{.action} sur votre plateforme, puis cliquez sur `Ajouter un domaine`{.action}. Une fois le nom de domaine ajouté, assurez-vous que la mention `OK` ou `Actif`{.action} est bien présente dans la colonne `Statut`.
 >
-> ![exchange](images/account_migration_adddomain.png){.thumbnail}
+> ![exchange](images/account_migration_adddomain.png){.thumbnail .w-640}
 >
 > Pour plus de détails sur l'ajout d'un nom de domaine, suivez [le guide Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain).
 
-La migration de votre MX Plan se fera en 3 grandes étapes, **Renommer**,**Créer** et **Migrer**.
+La migration de votre MX Plan se fera en 3 grandes étapes, **Renommer**, **Créer** et **Migrer**.
 
-![exchange](images/mxplan-migration-configure-account.gif){.thumbnail}
+![exchange](images/mxplan-migration-configure-account.gif){.thumbnail .w-640}
 
-1\. **Renommez** le compte MX Plan à migrer avec un nom provisoire ( exemple: pour migrer le compte MX plan *john.smith@mydomain.ovh*, renommez celui-ci en *john.smith01@mydomain.ovh*).
+1\. **Renommez** le compte MX Plan à migrer avec un nom provisoire (par exemple : pour migrer le compte MX plan *john.smith@mydomain.ovh*, renommez celui-ci en *john.smith01@mydomain.ovh*).
 
 Dans l'onglet `Comptes e-mail`{.action} de votre plateforme MX Plan, cliquez sur le bouton `...`{.action} puis sur `Modifier`{.action}.
 
-![exchange](images/mxplan-migration-configure-account01.png){.thumbnail}
+![exchange](images/mxplan-migration-configure-account01.png){.thumbnail .w-640}
 
 > [!primary]
 >
@@ -104,48 +111,100 @@ Dans l'onglet `Comptes e-mail`{.action} de votre plateforme MX Plan, cliquez sur
 
 Dans l'onglet `Comptes e-mail`{.action} de votre plateforme Exchange, cliquez sur le bouton `...`{.action} puis sur `Modifier`{.action}.
 
-![exchange](images/mxplan-migration-configure-account02.png){.thumbnail}
+![exchange](images/mxplan-migration-configure-account02.png){.thumbnail .w-640}
 
 3\. **Migrez** le compte MX Plan vers le compte de votre nouvelle plateforme à l'aide de notre outil [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Pour plus d'informations sur OMM, consultez notre guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).
 
-![exchange](images/mxplan-migration-configure-account03.png){.thumbnail}
+![exchange](images/mxplan-migration-configure-account03.png){.thumbnail .w-640}
 
 Le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
-Vérifiez, après la migration, que vous retrouvez vos éléments en vous connectant au webmail à l'adresse [Webmail](/links/web/email)
+Après la migration, vérifiez que vous retrouvez vos éléments en vous connectant au [Webmail](/links/web/email).
 
 Vous pouvez conserver ou supprimer le compte d'origine avec le nom provisoire après cette migration.
 
 Si vous souhaitez le supprimer, dirigez-vous dans l'onglet `Comptes e-mail`{.action} de votre MX Plan, cliquez sur le bouton `...`{.action} puis sur `Réinitialiser ce compte`{.action}.
 
-### Étape 4 : vérifier ou modifier la configuration de votre domaine
+#### 3.2 Migration automatique d'une offre MX Plan Roundcube vers Exchange <a name="roundcube-mxplan"></a>
 
-À cette étape, vos adresses e-mail doivent déjà être migrées et fonctionnelles. Par sécurité, nous vous invitons à vous assurer que la configuration de votre domaine est correcte en consultant votre espace client.
-
-Pour cela, sélectionnez le service Exchange concerné, puis rendez-vous sur l'onglet `Domaines associés`{.action}. Dans le tableau qui s'affiche, la colonne « Diagnostic » vous permettra de voir si la configuration DNS est correcte : une pastille rouge apparaît si la configuration doit être modifiée.
+> [!warning]
+>
+> Cette partie concerne uniquement les services MX Plan utilisant la technologie webmail Roundcube.
 
 > [!primary]
 >
-> Si vous venez juste de réaliser la migration ou de modifier un enregistrement DNS de votre domaine, il se peut que l’affichage dans l’[espace client OVHcloud](/links/manager) nécessite quelques heures pour se mettre à jour.
+> Votre compte OVHcloud doit préalablement être contact administrateur **et** contact technique du service MX plan à migrer, **ainsi que** du service Exchange vers lequel vous migrez.
+>
+> Pour plus d'information sur les changements de contacts, consultez notre guide pour [gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts).
 >
 
-Pour modifier la configuration, cliquez sur la pastille rouge et réalisez la manipulation demandée. Cette dernière nécessite un temps de propagation de 4 à 24 heures maximum avant d’être pleinement effective.
+La migration peut être effectuée depuis deux interfaces :<br>
 
-![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
+- **celle de l'assistant de configuration Hosted Exchange**, uniquement si vous venez de commander un service Hosted Exchange et que vous n'avez encore rien paramétré sur ce dernier ;
+- **celle du MX Plan**, dès que vous êtes en possession d'un service Exchange (déjà configuré ou non) et d'une adresse MX Plan que vous souhaitez migrer.
 
-### Étape 5 : utiliser vos adresses e-mail migrées
+> Pour rappel, avant de débuter la migration, assurez-vous qu'aucune **redirection** ou qu'aucun **répondeur** ne soient paramétrés sur votre MX Plan.
+>
+> ![email](images/mxplan-legacy-redirect.png){.thumbnail .w-640}
 
-Il ne vous reste plus qu’à utiliser vos adresses e-mail migrées. Pour cela, OVHcloud met à disposition un applicatif en ligne (_web app_) accessible à l’adresse [Webmail](/links/web/email). Vous devez y renseigner les identifiants relatifs à votre adresse e-mail.
+Une fois que vous êtes prêt, poursuivez la lecture de cette documentation selon l'interface sélectionnée. Nous vous rappelons que le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
-Si vous avez configuré l'un des comptes migrés sur un client de messagerie (comme Outlook), vous devez de nouveau le paramétrer. Les informations de connexion au serveur OVHcloud ont changé suite à la migration. Pour vous aider dans vos manipulations, consultez notre documentation [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Si vous n'êtes pas en mesure de reconfigurer le compte dans l'immédiat, l'accès via l'applicatif en ligne est toujours possible.
+> [!warning]
+>
+> Une fois la migration confirmée, vous ne pourrez plus accéder à votre ancienne adresse e-mail MX Plan ni annuler le processus de migration. Nous vous conseillons vivement de réaliser cette opération à un horaire propice.
+>
+> Même si vous ne pourrez plus accéder à votre adresse e-mail actuelle, les messages déjà réceptionnés ainsi que ceux reçus ne seront pas perdus. Tous seront immédiatement accessibles depuis votre nouveau compte.
+>
+
+##### **Migration depuis l'assistant de configuration Exchange**
+
+L'assistant devrait apparaître afin de vous aider à configurer votre nouveau service Exchange. Durant ce processus, vous pourrez sélectionner les comptes e-mails MX Plan à migrer.
+
+Si l'assistant de configuration ne s'affiche pas, les informations générales du service Exchange apparaîtront à la place. Dans ce cas, vous devrez réaliser la migration de vos comptes via l'interface MX Plan.
+
+##### **Migration depuis l'interface MX Plan**
+
+Pour réaliser la migration depuis cette interface, rendez-vous dans la section `E-mails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
+
+![exchange](images/access_the_migration_tool.png){.thumbnail .w-640}
+
+Dans la fenêtre qui s'affiche, sélectionnez le service de destination (celui vers lequel vous souhaitez migrer l'adresse) puis cliquez sur `Suivant`{.action}. S'il possède au minimum un compte « libre » (c'est-à-dire encore non paramétré), la migration s'effectuera vers l'un de ces comptes. Dès lors, prenez connaissance des informations qui s'affichent, validez-les, puis cliquez sur `Suivant`{.action} afin de poursuivre la manipulation.
+
+Si vous ne possédez pas de compte « libre », un bouton `Commander des comptes`{.action} apparaîtra. Suivez les étapes, puis patientez le temps que les comptes soient installés pour effectuer de nouveau la manipulation.
+
+Confirmez enfin le mot de passe de l'adresse e-mail source (celle que vous voulez migrer), puis cliquez sur `Migrer`{.action}. Cette manipulation sera à répéter autant de fois que nécessaire pour la migration d'autres comptes.
+
+![exchange](images/account_migration_steps.png){.thumbnail .w-640}
+
+
+### Étape 4 : Vérifier ou modifier la configuration de votre domaine
+
+À cette étape, vos adresses e-mail doivent déjà être migrées et fonctionnelles. Par sécurité, nous vous invitons à vous assurer que la configuration de votre domaine est correcte en consultant votre espace client.
+
+Pour cela, sélectionnez le service Exchange concerné, puis rendez-vous sur l'onglet `Domaines associés`{.action} ou `Domaine`{.action} sur votre plateforme. Vérifiez la rubrique ou la colonne `Diagnostic`{.action}.
+
+![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail .w-640}
+
+> [!primary]
+>
+> Si vous venez juste de réaliser la migration ou de modifier un enregistrement DNS de votre domaine, il se peut que l'affichage dans l'[espace client OVHcloud](/links/manager) nécessite quelques heures pour se mettre à jour.
+>
+
+Pour modifier la configuration, cliquez sur la pastille rouge et réalisez la manipulation demandée. Cette dernière nécessite un temps de propagation de 4 à 24 heures maximum avant d'être pleinement effective.
+
+### Étape 5 : Utiliser vos adresses e-mail migrées
+
+Il ne vous reste plus qu'à utiliser vos adresses e-mail migrées. Pour cela, OVHcloud met à disposition un applicatif en ligne (_web app_) accessible à l'adresse [Webmail](/links/web/email). Vous devez y renseigner les identifiants relatifs à votre adresse e-mail.
+
+Si vous avez configuré l'un des comptes migrés sur un client de messagerie (comme Outlook), vous devez de nouveau le paramétrer. Les informations de connexion au serveur OVHcloud ont changé suite à la migration. Pour vous aider dans vos manipulations, consultez notre documentation depuis la section des guides consacrée à [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Si vous n'êtes pas en mesure de reconfigurer le compte dans l'immédiat, l'accès via l'applicatif en ligne est toujours possible.
 
 ### Organisation du contenu de vos adresses e-mail suite à une migration <a name="content-after-migration"></a>
 
 Lorsque vous vous connectez pour la première fois sur votre nouveau compte e-mail, le contenu migré peut être partiellement caché. Pour afficher l'ensemble des éléments, depuis le webmail, cliquez sur le chevron à côté de la `Boîte de réception` pour révéler les sous-dossiers. Le contenu migré de votre ancien compte e-mail devrait apparaitre.
 
-![exchange](images/owa_migrate_content.png){.thumbnail}
+![exchange](images/owa_migrate_content.png){.thumbnail .w-640}
 
 Les dossiers par défaut, comme « éléments envoyés » ou « corbeille » apparaissent en anglais (« Sent items » et « Trash »), à l'exception des dossiers que vous avez créés.
 
@@ -157,6 +216,8 @@ Vous pouvez également migrer manuellement vos adresses e-mail vers votre nouvel
 
 ## Aller plus loin
 
-[Guides Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan).
+[Gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts).
+
+[Premiers pas avec l'offre Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
@@ -166,7 +166,7 @@ Si l'assistant de configuration ne s'affiche pas, les informations générales d
 
 ##### **Migration depuis l'interface MX Plan**
 
-Pour réaliser la migration depuis cette interface, rendez-vous dans la section `E-mails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
+Pour réaliser la migration depuis cette interface, rendez-vous dans la section `E-mails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur l'onglet `Emails`{.action}. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
@@ -178,7 +178,7 @@ Pour réaliser la migration depuis cette interface, rendez-vous dans la section 
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail .w-640}
 
-Dans la fenêtre qui s'affiche, sélectionnez le service de destination (celui vers lequel vous souhaitez migrer l'adresse) puis cliquez sur `Suivant`{.action}. S'il possède au minimum un compte « libre » (c'est-à-dire encore non paramétré), la migration s'effectuera vers l'un de ces comptes. Dès lors, prenez connaissance des informations qui s'affichent, validez-les, puis cliquez sur `Suivant`{.action} afin de poursuivre la manipulation.
+Dans la fenêtre qui s'affiche, sélectionnez le service de destination (celui vers lequel vous souhaitez migrer l'adresse) puis cliquez sur `Suivant`{.action}. S'il possède au minimum un compte « libre » (c'est-à-dire encore non paramétré), la migration s'effectuera vers l'un de ces comptes. Dès lors, prenez connaissance des informations qui s'affichent, validez-les, puis cliquez sur `Suivant`{.action} pour poursuivre l'opération.
 
 Si vous ne possédez pas de compte « libre », un bouton `Commander des comptes`{.action} apparaîtra. Suivez les étapes, puis patientez le temps que les comptes soient installés pour effectuer de nouveau la manipulation.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
@@ -129,7 +129,7 @@ Pour plus d'informations sur OMM, consultez notre guide [Migrer des comptes e-ma
 
 Le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
-Après la migration, vérifiez que vous retrouvez vos éléments en vous connectant au [Webmail](/links/web/email).
+Après la migration, vérifiez que vous retrouvez vos éléments en vous connectant au [Webmail OVHcloud](/links/web/email).
 
 Vous pouvez conserver ou supprimer le compte d'origine avec le nom provisoire après cette migration.
 
@@ -168,13 +168,13 @@ Une fois que vous êtes prêt, poursuivez la lecture de cette documentation selo
 
 ##### **Migration depuis l'assistant de configuration Exchange**
 
-L'assistant devrait apparaître afin de vous aider à configurer votre nouveau service Exchange. Durant ce processus, vous pourrez sélectionner les comptes e-mails MX Plan à migrer.
+L'assistant s'affiche pour vous aider à configurer votre nouveau service Exchange. Durant ce processus, vous pouvez sélectionner les comptes e-mail MX Plan à migrer.
 
 Si l'assistant de configuration ne s'affiche pas, les informations générales du service Exchange apparaîtront à la place. Dans ce cas, vous devrez réaliser la migration de vos comptes via l'interface MX Plan.
 
 ##### **Migration depuis l'interface MX Plan**
 
-Pour réaliser la migration depuis cette interface, rendez-vous dans la section `Emails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur l'onglet `Emails`{.action}. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
+Pour réaliser la migration depuis cette interface, rendez-vous dans la section [MX Plan](/links/control-panel/web-mx-plan) de votre espace client OVHcloud et sélectionnez le domaine concerné. Dans l'onglet `Emails`{.action}, cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source), puis sur `Migrer le compte`{.action}.
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail .w-640}
 
@@ -191,7 +191,7 @@ Confirmez enfin le mot de passe de l'adresse e-mail source (celle que vous voule
 
 À cette étape, vos adresses e-mail doivent déjà être migrées et fonctionnelles. Par sécurité, nous vous invitons à vous assurer que la configuration de votre domaine est correcte en consultant votre espace client.
 
-Pour cela, sélectionnez le service Email Pro, Exchange ou Zimbra concerné, puis rendez-vous sur l'onglet `Domaines associés`{.action} ou `Domaine`{.action} sur votre plateforme. Vérifiez la rubrique ou la colonne `Diagnostic`{.action}.
+Pour cela, sélectionnez le service Email Pro, Exchange ou Zimbra concerné, puis rendez-vous sur l'onglet `Domaines associés`{.action} ou `Domaine`{.action} sur votre plateforme. Vérifiez la rubrique ou la colonne `Diagnostics`{.action}.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail .w-640}
 
@@ -224,7 +224,7 @@ Vous pouvez également migrer manuellement vos adresses e-mail vers votre nouvel
 
 ## Aller plus loin
 
-[Gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts).
+[Gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts)
 
 [Premiers pas avec l'offre Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
@@ -174,7 +174,7 @@ Si l'assistant de configuration ne s'affiche pas, les informations générales d
 
 ##### **Migration depuis l'interface MX Plan**
 
-Pour réaliser la migration depuis cette interface, rendez-vous dans la section `E-mails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
+Pour réaliser la migration depuis cette interface, rendez-vous dans la section `E-mails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur l'onglet `Emails`{.action}. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
@@ -174,7 +174,7 @@ Si l'assistant de configuration ne s'affiche pas, les informations générales d
 
 ##### **Migration depuis l'interface MX Plan**
 
-Pour réaliser la migration depuis cette interface, rendez-vous dans la section `E-mails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur l'onglet `Emails`{.action}. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
+Pour réaliser la migration depuis cette interface, rendez-vous dans la section `Emails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur l'onglet `Emails`{.action}. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail .w-640}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
@@ -8,7 +8,7 @@ updated: 2026-01-16
 
 OVHcloud propose plusieurs solutions e-mail : MX Plan (vendu seul ou compris dans une offre d'hébergement web), Email Pro, Exchange et Zimbra. Celles-ci bénéficient de fonctionnalités propres et peuvent s'adapter à plusieurs usages. Vos besoins évoluent ? OVHcloud met à votre disposition un outil de migration vous permettant de passer d'une solution à une autre.
 
-**Découvrez comment migrer une adresse e-mail MX Plan vers un compte Email Pro ou Exchange.**
+**Découvrez comment migrer une adresse e-mail MX Plan vers un compte Email Pro, Exchange ou Zimbra.**
 
 <iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/0JLLoBBvsCc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
@@ -62,7 +62,7 @@ Avant de poursuivre, il est donc important de savoir vers quelle offre vous souh
 
 Cette étape est facultative si vous disposez déjà d'un service Exchange ou Email Pro vers lequel vous effectuez cette migration.
 
-Dans le cas contraire, connectez-vous à votre [espace client OVHcloud](/links/manager), puis commandez le service Email Pro ou Exchange de votre choix. Suivez les différentes étapes, puis patientez jusqu'à l'installation du service. Un e-mail vous sera envoyé dès la fin de celle-ci.
+Dans le cas contraire, commandez le service Email Pro ou Exchange de votre choix. Suivez les différentes étapes, puis patientez jusqu'à l'installation du service. Un e-mail vous sera envoyé dès la fin de celle-ci.
 
 > [!primary]
 >
@@ -75,14 +75,10 @@ Avant de débuter votre migration, il vous faudra identifier la version du MX Pl
 
 > [!primary]
 >
-> La technologie e-mail de votre offre MX Plan peut varier selon la date d’activation de votre offre ou si une migration a récemment eu lieu. Cette technologie se distingue notamment par l’interface de son webmail. Pour l'identifier depuis votre espace client, suivez ces étapes :
+> La technologie e-mail de votre offre MX Plan peut varier selon la date d’activation de votre offre ou si une migration a récemment eu lieu. Cette technologie se distingue notamment par l’interface de son webmail. Pour l’identifier depuis votre espace client, suivez ces étapes :
 >
-> 1. Connectez-vous à votre [espace client OVHcloud](/links/manager).
-> 1. Rendez-vous dans la partie `Web Cloud`{.action}.
-> 1. Cliquez sur `MX Plan`{.action}.
-> 1. Sélectionnez le domaine concerné.
-> 1. L'onglet `Informations générales`{.action} est sélectionné par défaut.
-> 1. Relevez la technologie utilisée sous la mention **Webmail** dans l'encadré `Abonnement`.
+> 1. L’onglet `Informations générales`{.action} est sélectionné par défaut.
+> 1. Relevez la technologie utilisée sous la mention **Webmail** dans l’encadré `Abonnement`.
 >
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
@@ -91,7 +87,7 @@ Avant de débuter votre migration, il vous faudra identifier la version du MX Pl
 
 > [!warning]
 >
-> Cette partie concerne l'ensemble des services MX Plan utilisant la technologie webmail Rouncube, Zimbra ou OWA.
+> Cette partie concerne l'ensemble des services MX Plan utilisant la technologie webmail Roundcube, Zimbra ou OWA.
 >
 > Néanmoins, si vous souhaitez migrer un service MX Plan utilisant le webmail Roundcube vers une plateforme Email Pro ou Exchange OVHcloud, suivez la partie « [Migration automatique d'une offre MX Plan Roundcube vers Exchange ou Email Pro](#roundcube-mxplan) » de ce guide.
 
@@ -101,19 +97,19 @@ Avant de débuter votre migration, il vous faudra identifier la version du MX Pl
 >
 > Sélectionnez l’onglet `Domaines associés`{.action} ou `Domaine`{.action} sur votre plateforme, puis cliquez sur `Ajouter un domaine`{.action}. Une fois le nom de domaine ajouté, assurez-vous que la mention `OK` ou `Actif`{.action} est bien présente dans la colonne `Statut`.
 >
-> ![exchange](images/account_migration_adddomain.png){.thumbnail}
+> ![exchange](images/account_migration_adddomain.png){.thumbnail .w-640}
 >
 > Pour plus de détails sur l'ajout d'un nom de domaine, suivez [le guide Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config), [le guide Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) ou [le guide Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra).
 
-La migration de votre MX Plan se fera en 3 grandes étapes, **Renommer**,**Créer** et **Migrer**.
+La migration de votre MX Plan se fera en 3 grandes étapes, **Renommer**, **Créer** et **Migrer**.
 
-![exchange](images/mxplan-migration-configure-account.gif){.thumbnail}
+![exchange](images/mxplan-migration-configure-account.gif){.thumbnail .w-640}
 
 1\. **Renommez** le compte MX Plan à migrer avec un nom provisoire (par exemple : pour migrer le compte MX plan *john.smith@mydomain.ovh*, renommez celui-ci en *john.smith01@mydomain.ovh*).
 
 Dans l'onglet `Comptes e-mail`{.action} de votre plateforme MX Plan, cliquez sur le bouton `...`{.action} puis sur `Modifier`{.action}.
 
-![exchange](images/mxplan-migration-configure-account01.png){.thumbnail}
+![exchange](images/mxplan-migration-configure-account01.png){.thumbnail .w-640}
 
 > [!primary]
 >
@@ -123,17 +119,17 @@ Dans l'onglet `Comptes e-mail`{.action} de votre plateforme MX Plan, cliquez sur
 
 Dans l'onglet `Comptes e-mail`{.action} de votre plateforme Email Pro ou Exchange, cliquez sur le bouton `...`{.action} puis sur `Modifier`{.action}.
 
-![exchange](images/mxplan-migration-configure-account02.png){.thumbnail}
+![exchange](images/mxplan-migration-configure-account02.png){.thumbnail .w-640}
 
 3\. **Migrez** le compte MX Plan vers le compte de votre nouvelle plateforme à l'aide de notre outil [OMM](/links/web/omm) (OVHcloud Mail Migrator).
 
 Pour plus d'informations sur OMM, consultez notre guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).
 
-![exchange](images/mxplan-migration-configure-account03.png){.thumbnail}
+![exchange](images/mxplan-migration-configure-account03.png){.thumbnail .w-640}
 
 Le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
-Vérifiez, après la migration, que vous retrouvez vos éléments en vous connectant au webmail à l'adresse [Webmail](/links/web/email)
+Après la migration, vérifiez que vous retrouvez vos éléments en vous connectant au [Webmail](/links/web/email).
 
 Vous pouvez conserver ou supprimer le compte d'origine avec le nom provisoire après cette migration.
 
@@ -143,7 +139,7 @@ Si vous souhaitez le supprimer, dirigez-vous dans l'onglet `Comptes e-mail`{.act
 
 > [!warning]
 >
-> Cette partie concerne uniquement les services MX Plan utilisant la technologie webmail Rouncube.
+> Cette partie concerne uniquement les services MX Plan utilisant la technologie webmail Roundcube.
 
 > [!primary]
 >
@@ -159,7 +155,7 @@ La migration peut être effectuée depuis deux interfaces :<br>
 
 > Pour rappel, avant de débuter la migration, assurez-vous qu'aucune **redirection** ou qu'aucun **répondeur** ne soient paramétrés sur votre MX Plan.
 >
-> ![email](images/mxplan-legacy-redirect.png){.thumbnail}
+> ![email](images/mxplan-legacy-redirect.png){.thumbnail .w-640}
 
 Une fois que vous êtes prêt, poursuivez la lecture de cette documentation selon l'interface sélectionnée. Nous vous rappelons que le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
@@ -172,7 +168,7 @@ Une fois que vous êtes prêt, poursuivez la lecture de cette documentation selo
 
 ##### **Migration depuis l'assistant de configuration Exchange**
 
-Pour y accéder, sélectionnez dans [l'espace client OVHcloud](/links/manager) le service concerné. L'assistant devrait apparaître afin de vous aider à configurer votre nouveau service Exchange. Durant ce processus, vous pourrez sélectionner les comptes e-mails MX Plan à migrer.
+L'assistant devrait apparaître afin de vous aider à configurer votre nouveau service Exchange. Durant ce processus, vous pourrez sélectionner les comptes e-mails MX Plan à migrer.
 
 Si l'assistant de configuration ne s'affiche pas, les informations générales du service Exchange apparaîtront à la place. Dans ce cas, vous devrez réaliser la migration de vos comptes via l'interface MX Plan.
 
@@ -180,7 +176,7 @@ Si l'assistant de configuration ne s'affiche pas, les informations générales d
 
 Pour réaliser la migration depuis cette interface, rendez-vous dans la section `E-mails`{.action} de votre espace client OVHcloud. Choisissez alors le service portant le nom de domaine de vos adresses e-mail. Cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source) puis sur `Migrer le compte`{.action}.
 
-![exchange](images/access_the_migration_tool.png){.thumbnail}
+![exchange](images/access_the_migration_tool.png){.thumbnail .w-640}
 
 Dans la fenêtre qui s'affiche, sélectionnez le service de destination (celui vers lequel vous souhaitez migrer l'adresse) puis cliquez sur `Suivant`{.action}. S'il possède au minimum un compte « libre » (c'est-à-dire encore non paramétré), la migration s'effectuera vers l'un de ces comptes. Dès lors, prenez connaissance des informations qui s'affichent, validez-les, puis cliquez sur `Suivant`{.action} afin de poursuivre la manipulation.
 
@@ -188,7 +184,7 @@ Si vous ne possédez pas de compte « libre », un bouton `Commander des comptes
 
 Confirmez enfin le mot de passe de l'adresse e-mail source (celle que vous voulez migrer), puis cliquez sur `Migrer`{.action}. Cette manipulation sera à répéter autant de fois que nécessaire pour la migration d'autres comptes.
 
-![exchange](images/account_migration_steps.png){.thumbnail}
+![exchange](images/account_migration_steps.png){.thumbnail .w-640}
 
 
 ### Étape 4 : Vérifier ou modifier la configuration de votre domaine
@@ -197,7 +193,7 @@ Confirmez enfin le mot de passe de l'adresse e-mail source (celle que vous voule
 
 Pour cela, sélectionnez le service Email Pro, Exchange ou Zimbra concerné, puis rendez-vous sur l'onglet `Domaines associés`{.action} ou `Domaine`{.action} sur votre plateforme. Vérifiez la rubrique ou la colonne `Diagnostic`{.action}.
 
-![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
+![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail .w-640}
 
 > [!primary]
 >
@@ -216,7 +212,7 @@ Si vous avez configuré l'un des comptes migrés sur un client de messagerie (co
 
 Lorsque vous vous connectez pour la première fois sur votre nouveau compte e-mail, le contenu migré peut être partiellement caché. Pour afficher l'ensemble des éléments, depuis le webmail, cliquez sur le chevron à côté de la `Boîte de réception` pour révéler les sous-dossiers. Le contenu migré de votre ancien compte e-mail devrait apparaitre.
 
-![exchange](images/owa_migrate_content.png){.thumbnail}
+![exchange](images/owa_migrate_content.png){.thumbnail .w-640}
 
 Les dossiers par défaut, comme « éléments envoyés » ou « corbeille » apparaissent en anglais (« Sent items » et « Trash »), à l'exception des dossiers que vous avez créés.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.it-it.md
@@ -8,7 +8,7 @@ updated: 2026-01-16
 
 OVHcloud propone diverse soluzioni email: MX Plan (venduto da solo o incluso in un'offerta di hosting Web), Zimbra, Email Pro  ed Exchange. che possono usufruire di funzionalità proprie e adattarsi a diversi utilizzi. Le tue necessità si evolvono? OVHcloud mette a tua disposizione uno strumento di migrazione che ti permette di passare da una soluzione a un'altra.
 
-**Questa guida ti mostra come migrare un indirizzo email MX Plan verso un account Email Pro o Exchange.**
+**Questa guida ti mostra come migrare un indirizzo email MX Plan verso un account Email Pro, Exchange o Zimbra.**
 
 > [!warning]
 >
@@ -31,17 +31,17 @@ OVHcloud propone diverse soluzioni email: MX Plan (venduto da solo o incluso in 
 **MX Plan:**
 
 - **Link diretto:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo servizio MX Plan
+- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo MX Plan service
 
 **Email Pro:**
 
 - **Link diretto:** [Email Pro](/links/control-panel/web-email-pro)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua piattaforma
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua platform
 
 **Exchange:**
 
 - **Link diretto:** [Exchange](/links/control-panel/web-exchange)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua piattaforma
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua platform
 
 ---
 <!-- CP-NAV-END:web-exchange -->
@@ -60,7 +60,7 @@ Prima di proseguire, è importante sapere verso quale offerta vuoi migrare i tuo
 
 Questo step è facoltativo se disponi già di un servizio Exchange o Email Pro verso cui effettuare la migrazione.
 
-In caso contrario, accedi allo [Spazio Cliente OVHcloud](/links/manager) e ordina il servizio Email Pro o Exchange di tua scelta. Segui gli step e attendi fino all'installazione del servizio. Riceverai un'email al termine dell'operazione.
+In caso contrario, ordina il servizio Email Pro o Exchange di tua scelta. Segui gli step e attendi fino all'installazione del servizio. Riceverai un'email al termine dell'operazione.
 
 > [!primary]
 >
@@ -75,11 +75,7 @@ Prima di avviare la migrazione, dovrai identificare la versione del MX Plan dal 
 >
 > La tecnologia e-mail della vostra offerta MX Plan può variare in base alla data di attivazione della vostra offerta o se una migrazione è avvenuta di recente. Questa tecnologia si distingue in particolare per l'interfaccia del suo webmail. Per identificarla dal vostro Spazio Cliente, seguite questi passaggi:
 >
-> 1. Accedete al vostro [Spazio Cliente OVHcloud](/links/manager).
-> 1. Recatevi nella sezione `Web Cloud`{.action}.
-> 1. Cliccate su `MX Plan`{.action}.
-> 1. Selezionate il dominio interessato.
-> 1. L'onghetto `Informazioni generali`{.action} è selezionato per default.
+> 1. La scheda `Informazioni generali`{.action} è selezionata per impostazione predefinita.
 > 1. Individuate la tecnologia utilizzata sotto la dicitura **Webmail** nell'area `Abbonamento`.
 >
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
@@ -103,7 +99,7 @@ Prima di avviare la migrazione, dovrai identificare la versione del MX Plan dal 
 >
 > Per ulteriori dettagli sull'aggiunta di un nome di dominio, seguite [la guida Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config), [la guida Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) o [la guida Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra).
 
-La migrazione del tuo MX Plan avverrà in 3 step, **Rinommer**, **Creare** e **Migrare**.
+La migrazione del tuo MX Plan avverrà in 3 step, **Rinominare**, **Creare** e **Migrare**.
 
 ![exchange](images/mxplan-migration-configure-account.gif){.thumbnail}
 
@@ -139,9 +135,9 @@ Per eliminarlo, seleziona la scheda `Account email`{.action} del tuo MX Plan, cl
 
 #### 3.2 Migrazione automatica di un'offerta MX Plan Roundcube verso Exchange o Email Pro <a name="roundcube-mxplan"></a>
 
- [!warning]
+> [!warning]
 >
-> Questa parte riguarda esclusivamente i servizi MX Plan che utilizzano la tecnologia webmail Rouncube.
+> Questa parte riguarda esclusivamente i servizi MX Plan che utilizzano la tecnologia webmail Roundcube.
 
 > [!primary]
 >
@@ -170,7 +166,7 @@ Quando tutto è pronto, prosegui nella lettura di questa guida utilizzando l'int
 
 ##### **Migrazione dall'assistente di configurazione Exchange**
 
-Nello [Spazio Cliente OVHcloud](/links/manager) è possibile selezionare il servizio. L'assistente dovrebbe apparire per aiutarti a configurare il tuo nuovo servizio Exchange. Durante questo processo, è possibile selezionare gli account email MX Plan da migrare.
+L'assistente dovrebbe apparire per aiutarti a configurare il tuo nuovo servizio Exchange. Durante questo processo, è possibile selezionare gli account email MX Plan da migrare.
 
 Se l'assistente di configurazione non compare, visualizzi le informazioni generali del servizio Exchange. In questo caso, sarà necessario effettuare la migrazione dei tuoi account tramite l'interfaccia MX Plan.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.it-it.md
@@ -1,6 +1,6 @@
 ---
-title: Migrare un indirizzo email MX Plan verso un account Email Pro o Exchange
-excerpt: Come migrare un indirizzo email MX Plan verso un account Email Pro o Exchange
+title: Migrare un indirizzo email MX Plan verso un account Email Pro, Exchange o Zimbra
+excerpt: Come migrare un indirizzo email MX Plan verso un account Email Pro, Exchange o Zimbra
 updated: 2026-01-16
 ---
 
@@ -31,17 +31,17 @@ OVHcloud propone diverse soluzioni email: MX Plan (venduto da solo o incluso in 
 **MX Plan:**
 
 - **Link diretto:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo MX Plan service
+- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo servizio MX Plan
 
 **Email Pro:**
 
 - **Link diretto:** [Email Pro](/links/control-panel/web-email-pro)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua platform
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua piattaforma
 
 **Exchange:**
 
 - **Link diretto:** [Exchange](/links/control-panel/web-exchange)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua platform
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua piattaforma
 
 ---
 <!-- CP-NAV-END:web-exchange -->
@@ -85,7 +85,7 @@ Prima di avviare la migrazione, dovrai identificare la versione del MX Plan dal 
 
 > [!warning]
 >
-> Questa parte riguarda tutti i servizi MX Plan che utilizzano la tecnologia webmail Rouncube, Zimbra o OWA.
+> Questa parte riguarda tutti i servizi MX Plan che utilizzano la tecnologia webmail Roundcube, Zimbra o OWA.
 >
 > Tuttavia, se desiderate migrare un servizio MX Plan che utilizza il webmail Roundcube verso una piattaforma Email Pro o Exchange OVHcloud, seguite la parte "[Migrazione automatica di un'offerta MX Plan Roundcube verso Exchange o Email Pro](#roundcube-mxplan)" di questa guida.
 
@@ -127,7 +127,7 @@ Per maggiori informazioni su OMM, consulta la guida [Migrare account email via O
 
 Il tempo di migrazione dipende dalla quantità di contenuto da migrare verso il nuovo account. che può variare da pochi minuti a diverse ore.
 
-Una volta completata la migrazione, verifica di trovare i tuoi elementi accedendo alla Webmail all'indirizzo [Webmail](/links/web/email)
+Una volta completata la migrazione, verifica di trovare i tuoi elementi accedendo alla [Webmail OVHcloud](/links/web/email).
 
 Dopo la migrazione è possibile conservare o eliminare l'account di origine.
 
@@ -172,7 +172,7 @@ Se l'assistente di configurazione non compare, visualizzi le informazioni genera
 
 ##### **Migrazione dall'interfaccia MX Plan**
 
-Per effettuare la migrazione da questa interfaccia, accedi alla sezione `Email`{.action} del tuo Spazio Cliente OVHcloud. A questo punto scegli il servizio con il dominio dei tuoi indirizzi email. Clicca sulla scheda `Email`{.action}. Clicca su `...`{.action} sulla riga dell'account email interessato (chiamato anche account sorgente) e poi su `Migra l'account`{.action}.
+Per effettuare la migrazione da questa interfaccia, accedi alla sezione [MX Plan](/links/control-panel/web-mx-plan) del tuo Spazio Cliente OVHcloud e seleziona il dominio interessato. Nella scheda `Email`{.action}, clicca su `...`{.action} sulla riga dell'account email interessato (chiamato anche account sorgente) e poi su `Migra l'account`{.action}.
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.it-it.md
@@ -172,7 +172,7 @@ Se l'assistente di configurazione non compare, visualizzi le informazioni genera
 
 ##### **Migrazione dall'interfaccia MX Plan**
 
-Per effettuare la migrazione da questa interfaccia, accedi alla sezione `Email`{.action} del tuo Spazio Cliente OVHcloud. A questo punto scegli il servizio con il dominio dei tuoi indirizzi email. Clicca su `...`{.action} sulla riga dell'account email interessato (chiamato anche account sorgente) e poi su `Migra l'account`{.action}.
+Per effettuare la migrazione da questa interfaccia, accedi alla sezione `Email`{.action} del tuo Spazio Cliente OVHcloud. A questo punto scegli il servizio con il dominio dei tuoi indirizzi email. Clicca sulla scheda `Email`{.action}. Clicca su `...`{.action} sulla riga dell'account email interessato (chiamato anche account sorgente) e poi su `Migra l'account`{.action}.
 
 ![exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
@@ -1,14 +1,14 @@
 ---
-title: 'Migrowanie adresu e-mail MX Plan do konta E-mail Pro, Exchange lub Zimbra'
-excerpt: 'Dowiedz się, jak przeprowadzić migrację adresu e-mail MX Plan do konta E-mail Pro, Exchange lub Zimbra'
+title: 'Migrowanie adresu e-mail MX Plan do konta Email Pro, Exchange lub Zimbra'
+excerpt: 'Dowiedz się, jak przeprowadzić migrację adresu e-mail MX Plan do konta Email Pro, Exchange lub Zimbra'
 updated: 2026-01-16
 ---
 
 ## Wprowadzenie
 
-OVHcloud oferuje kilka rozwiązań poczty elektronicznej: MX Plan (sprzedawany samodzielnie lub zawarty w ofercie hostingu), Zimbra, E-mail Pro i Exchange. Korzystają one z własnych funkcji i mogą być dostosowane do wielu zastosowań. Twoje potrzeby zmieniają się? OVHcloud udostępnia Ci narzędzie migracji umożliwiające przejście z jednego rozwiązania na drugie.
+OVHcloud oferuje kilka rozwiązań poczty elektronicznej: MX Plan (sprzedawany samodzielnie lub zawarty w ofercie hostingu), Zimbra, Email Pro i Exchange. Korzystają one z własnych funkcji i mogą być dostosowane do wielu zastosowań. Twoje potrzeby zmieniają się? OVHcloud udostępnia Ci narzędzie migracji umożliwiające przejście z jednego rozwiązania na drugie.
 
-**Dowiedz się, jak przenieść konto e-mail MX Plan na konto E-mail Pro lub Exchange.**
+**Dowiedz się, jak przenieść konto e-mail MX Plan na konto Email Pro, Exchange lub Zimbra.**
 
 > [!warning]
 >
@@ -18,7 +18,7 @@ OVHcloud oferuje kilka rozwiązań poczty elektronicznej: MX Plan (sprzedawany s
 ## Wymagania początkowe
 
 - Posiadanie konta e-mail MX Plan (w ramach pakietu MX Plan lub zawartego w pakiecie [hostingowym OVHcloud](/links/web/hosting)).
-- Posiadanie usługi [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) z co najmniej jednym niezakonfigurowanym kontem (które będzie miało postać "@configureme.me") lub [Zimbra](/links/web/zimbra).
+- Posiadanie usługi [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) z co najmniej jednym niezakonfigurowanym kontem (które będzie miało postać "@configureme.me") lub [Zimbra](/links/web/zimbra).
 - **Nie skonfigurowałeś przekierowania na adres e-mail MX Plan, który chcesz przenieść**.
 
 <!-- CP-NAV-START:web-mx-plan -->
@@ -30,18 +30,18 @@ OVHcloud oferuje kilka rozwiązań poczty elektronicznej: MX Plan (sprzedawany s
 
 **MX Plan:**
 
-- **Bezpośredni link:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz swoją usługę MX Plan
+- **Link bezpośredni:** [MX Plan](/links/control-panel/web-mx-plan)
+- **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz usługę MX Plan
 
-**E-mail Pro:**
+**Email Pro:**
 
-- **Bezpośredni link:** [E-mail Pro](/links/control-panel/web-email-pro)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Wybierz swoją platformę
+- **Link bezpośredni:** [Email Pro](/links/control-panel/web-email-pro)
+- **Ścieżka nawigacji:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Wybierz platformę
 
 **Exchange:**
 
-- **Bezpośredni link:** [Exchange](/links/control-panel/web-exchange)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Exchange`{.action} > Wybierz swoją platformę
+- **Link bezpośredni:** [Exchange](/links/control-panel/web-exchange)
+- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Exchange`{.action} > Wybierz platformę
 
 ---
 <!-- CP-NAV-END:web-exchange -->
@@ -52,15 +52,15 @@ OVHcloud oferuje kilka rozwiązań poczty elektronicznej: MX Plan (sprzedawany s
 
 ### Etap 1: Określenie ram projektu
 
-Rozwiązania E-mail Pro i Exchange mają wspólną bazę funkcjonalności. Niemniej jednak nadal występują różnice w zależności od zastosowania. Wybierając adres Exchange, dysponujesz wszystkimi funkcjami do pracy zespołowej, takimi jak synchronizacja kalendarza i kontaktów. Niektóre z nich są dostępne w ofercie E-mail Pro, ale są one ograniczone do korzystania wyłącznie z poczty webmail.
+Rozwiązania Email Pro i Exchange mają wspólną bazę funkcjonalności. Niemniej jednak nadal występują różnice w zależności od zastosowania. Wybierając adres Exchange, dysponujesz wszystkimi funkcjami do pracy zespołowej, takimi jak synchronizacja kalendarza i kontaktów. Niektóre z nich są dostępne w ofercie Email Pro, ale są one ograniczone do korzystania wyłącznie z poczty webmail.
 
-Zanim przejdziesz dalej, ważne jest, aby wiedzieć, na jaką ofertę chcesz przenieść Twoje konta e-mail MX Plan. Aby pomóc w wyborze tej opcji, zapoznaj się ze stroną firmowych [rozwiązań poczty elektronicznej OVHcloud](/links/web/emails), na której znajdziesz szczegółowe porównanie ofert. Możesz łączyć rozwiązania i używać dla tej samej domeny jednego lub kilku kont E-mail Pro i Exchange. Jeśli chcesz migrować kilka kont, zalecamy wdrożenie planu migracji.
+Zanim przejdziesz dalej, ważne jest, aby wiedzieć, na jaką ofertę chcesz przenieść Twoje konta e-mail MX Plan. Aby pomóc w wyborze tej opcji, zapoznaj się ze stroną firmowych [rozwiązań poczty elektronicznej OVHcloud](/links/web/emails), na której znajdziesz szczegółowe porównanie ofert. Możesz łączyć rozwiązania i używać dla tej samej domeny jednego lub kilku kont Email Pro i Exchange. Jeśli chcesz migrować kilka kont, zalecamy wdrożenie planu migracji.
 
-### Etap 2: Zamów konta E-mail Pro lub Exchange
+### Etap 2: Zamów konta Email Pro lub Exchange
 
-Ten etap jest opcjonalny, jeśli posiadasz już usługę Exchange lub E-mail Pro, do której chcesz przeprowadzić migrację.
+Ten etap jest opcjonalny, jeśli posiadasz już usługę Exchange lub Email Pro, do której chcesz przeprowadzić migrację.
 
-W przeciwnym razie zaloguj się do [Panelu klienta OVHcloud](/links/manager) i zamów usługę E-mail Pro lub Exchange. Postępuj zgodnie z kolejnymi instrukcjami, następnie zaczekaj aż usługa zostanie zainstalowana. Otrzymasz e-mail z końcem abonamentu.
+W przeciwnym razie zamów usługę Email Pro lub Exchange. Postępuj zgodnie z kolejnymi instrukcjami, następnie zaczekaj aż usługa zostanie zainstalowana. Otrzymasz e-mail z końcem abonamentu.
 
 > [!primary]
 >
@@ -75,23 +75,19 @@ Przed rozpoczęciem migracji określ wersję programu MX Plan, z której chcesz 
 >
 > Technologia e-maila oferty MX Plan może się różnić w zależności od daty aktywacji oferty lub jeśli niedawno miała miejsce migracja. Ta technologia różni się m.in. wyglądem interfejsu webmaila. Aby ją zidentyfikować w panelu klienta, wykonaj poniższe kroki:
 >
-> 1. Zaloguj się do [Panelu klienta OVHcloud](/links/manager).
-> 1. Przejdź do sekcji `Web Cloud`{.action}.
-> 1. Kliknij `MX Plan`{.action}.
-> 1. Wybierz odpowiedni domenę.
 > 1. Zazwyczaj wybrany jest zakładka `Informacje ogólne`{.action}.
 > 1. Zanotuj technologię używaną pod hasłem **Webmail** w sekcji `Abonament`.
 >
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Ręczna migracja oferty MX Plan do Exchange, E-mail Pro lub Zimbra  <a name="all-mxplan"></a>
+#### 3.1 Ręczna migracja oferty MX Plan do Exchange, Email Pro lub Zimbra  <a name="all-mxplan"></a>
 
 > [!warning]
 >
-> Ta sekcja dotyczy wszystkich usług MX Plan korzystających z technologii webmaila Rouncube, Zimbra lub OWA.
+> Ta sekcja dotyczy wszystkich usług MX Plan korzystających z technologii webmaila Roundcube, Zimbra lub OWA.
 >
-> Jednak jeśli chcesz przenieść usługę MX Plan korzystającą z webmaila Roundcube do platformy E-mail Pro lub Exchange OVHcloud, przejdź do sekcji "[Automatyczna migracja oferty MX Plan Roundcube do Exchange lub E-mail Pro](#roundcube-mxplan)" tego przewodnika.
+> Jednak jeśli chcesz przenieść usługę MX Plan korzystającą z webmaila Roundcube do platformy Email Pro lub Exchange OVHcloud, przejdź do sekcji "[Automatyczna migracja oferty MX Plan Roundcube do Exchange lub Email Pro](#roundcube-mxplan)" tego przewodnika.
 
 > [!warning]
 >
@@ -101,7 +97,7 @@ Przed rozpoczęciem migracji określ wersję programu MX Plan, z której chcesz 
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
-> Aby uzyskać więcej informacji na temat dodania domeny, sprawdź [przewodnik E-mail Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config) lub [przewodnik Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain).
+> Aby uzyskać więcej informacji na temat dodania domeny, sprawdź [przewodnik Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config) lub [przewodnik Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain).
 
 Migracja MX Plan przebiega 3 etapach. **Zmień nazwę**, **Utwórz** i **Migracja**.
 
@@ -117,9 +113,9 @@ W zakładce `Konta e-mail`{.action} na Twojej platformie MX Plan kliknij przycis
 >
 > Modyfikacja konta nie jest natychmiastowa. Prosimy o cierpliwość do końca operacji, zanim przejdziesz do kolejnego etapu.
 
-2\. **Utwórz** konto e-mail na nowym koncie w Twojej platformie E-mail Pro lub Exchange (w powyższym przykładzie utworzysz zatem *john.smith@mydomain.ovh* na nowej platformie).
+2\. **Utwórz** konto e-mail na nowym koncie w Twojej platformie Email Pro lub Exchange (w powyższym przykładzie utworzysz zatem *john.smith@mydomain.ovh* na nowej platformie).
 
-W zakładce `Konta e-mail`{.action} na Twojej platformie E-mail Pro lub Exchange kliknij przycisk `...`{.action}, a następnie `Zmień`{.action}.
+W zakładce `Konta e-mail`{.action} na Twojej platformie Email Pro lub Exchange kliknij przycisk `...`{.action}, a następnie `Zmień`{.action}.
 
 ![Exchange](images/mxplan-migration-configure-account02.png){.thumbnail}
 
@@ -137,15 +133,15 @@ Po przeprowadzeniu migracji możesz zachować lub usunąć konto źródłowe, u�
 
 Jeśli chcesz go usunąć, przejdź do zakładki `Konta e-mail`{.action} MX Plan, kliknij przycisk `...`{.action}, a następnie  `Zresetuj to konto`{.action}.
 
-#### 3.2 Automatyczna migracja oferty MX Plan Roundcube do Exchange lub E-mail Pro <a name="roundcube-mxplan"></a>
+#### 3.2 Automatyczna migracja oferty MX Plan Roundcube do Exchange lub Email Pro <a name="roundcube-mxplan"></a>
 
 > [!warning]
 >
-> Ta sekcja dotyczy wyłącznie usług MX Plan korzystających z technologii webmaila Rouncube.
+> Ta sekcja dotyczy wyłącznie usług MX Plan korzystających z technologii webmaila Roundcube.
 
 > [!primary]
 >
-> Twoje konto OVHcloud musi być wcześniej kontaktem administratora **i** kontakt techniczny usługi MX Plan, którą chcesz przenieść, **oraz** usługi E-mail Pro lub Exchange, do której możesz się przenieść.
+> Twoje konto OVHcloud musi być wcześniej kontaktem administratora **i** kontakt techniczny usługi MX Plan, którą chcesz przenieść, **oraz** usługi Email Pro lub Exchange, do której możesz się przenieść.
 >
 > Aby uzyskać więcej informacji na temat zmian kontaktów, zapoznaj się z naszym przewodnikiem dotyczącym [zarządzania kontaktami swoich usług](/pages/account_and_service_management/account_information/managing_contacts).
 >
@@ -153,7 +149,7 @@ Jeśli chcesz go usunąć, przejdź do zakładki `Konta e-mail`{.action} MX Plan
 Migracja może zostać przeprowadzona z dwóch interfejsów:<br>
 
 - **adres asystenta konfiguracji Hosted Exchange**, tylko jeśli zamówiłeś usługę Hosted Exchange i nie skonfigurowałeś jeszcze usługi Hosted Exchange;
-- **adres MX Plan**, jeśli posiadasz usługę E-mail Pro lub Exchange (skonfigurowaną lub nie) oraz adres MX Plan, który chcesz przenieść.
+- **adres MX Plan**, jeśli posiadasz usługę Email Pro lub Exchange (skonfigurowaną lub nie) oraz adres MX Plan, który chcesz przenieść.
 
 > Przypominamy, że przed rozpoczęciem migracji upewnij się, że na serwerze MX Plan nie ma **przekierowania** lub żadna **autoresponder**.
 >
@@ -170,7 +166,7 @@ Kiedy wszystko jest gotowe, przejdź do opisu operacji w wybranym interfejsie. P
 
 ##### **Migracja z poziomu asystenta konfiguracji Exchange**
 
-Aby się do niego zalogować, wybierz w [Panelu klienta](/links/manager) odpowiednią usługę. Należy pojawić się asystent, który pomoże Ci w skonfigurowaniu nowej usługi Exchange. Podczas tego procesu będziesz mógł wybrać konta e-mail MX Plan, które chcesz przenieść.
+Asystent powinien pojawić się, aby pomóc Ci w skonfigurowaniu nowej usługi Exchange. Podczas tego procesu będziesz mógł wybrać konta e-mail MX Plan, które chcesz przenieść.
 
 Jeśli asystent konfiguracji nie wyświetla się, wyświetlą się ogólne informacje o usłudze Exchange. W takim przypadku będziesz musiał przeprowadzić migrację Twoich kont za pomocą interfejsu MX Plan.
 
@@ -192,7 +188,7 @@ Następnie potwierdź hasło do źródłowego konta e-mail (które chcesz przeni
 
 Na tym etapie Twoje konta e-mail muszą być migrowane i działać. Ze względów bezpieczeństwa sprawdź, czy konfiguracja Twojej domeny jest poprawna, sprawdzając w Panelu klienta.
 
-W tym celu wybierz odpowiednią usługę E-mail Pro lub Exchange, następnie przejdź do zakładki Powiązane `domeny`{.action}. W tabeli, która się wyświetla, w kolumnie "Diagnostyka" możesz sprawdzić, czy konfiguracja DNS jest prawidłowa: czerwony przycisk pojawia się, jeśli konfiguracja wymaga zmiany.
+W tym celu wybierz odpowiednią usługę Email Pro lub Exchange, następnie przejdź do zakładki Powiązane `domeny`{.action}. W tabeli, która się wyświetla, w kolumnie "Diagnostyka" możesz sprawdzić, czy konfiguracja DNS jest prawidłowa: czerwony przycisk pojawia się, jeśli konfiguracja wymaga zmiany.
 
 > [!primary]
 >
@@ -207,7 +203,7 @@ Aby zmienić konfigurację, kliknij czerwony przycisk i wykonaj żądaną operac
 
 Teraz możesz korzystać z migrowanych kont e-mail. W tym celu OVHcloud udostępnia aplikację online (_web app_) dostępną pod adresem [Webmail](/links/web/email). Wpisz dane dostępowe do Twojego konta e-mail.
 
-Jeśli skonfigurowałeś jedno z kont przeniesionych na klienta poczty elektronicznej (np. Outlook), należy ponownie skonfigurować to konto. Dane do logowania do serwera OVHcloud zmieniły się po migracji. Aby pomóc Ci w przeprowadzeniu operacji, zapoznaj się z naszą dokumentacją w sekcjach przewodników dotyczących [E-mail Pro](/products/web-cloud-email-collaborative-solutions-email-pro) i [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Jeśli nie jesteś w stanie zmienić konfiguracji konta w tej chwili, dostęp przez aplikację online jest zawsze możliwy.
+Jeśli skonfigurowałeś jedno z kont przeniesionych na klienta poczty elektronicznej (np. Outlook), należy ponownie skonfigurować to konto. Dane do logowania do serwera OVHcloud zmieniły się po migracji. Aby pomóc Ci w przeprowadzeniu operacji, zapoznaj się z naszą dokumentacją w sekcjach przewodników dotyczących [Email Pro](/products/web-cloud-email-collaborative-solutions-email-pro) i [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Jeśli nie jesteś w stanie zmienić konfiguracji konta w tej chwili, dostęp przez aplikację online jest zawsze możliwy.
 
 ### Organizacja zawartości Twoich kont e-mail po migracji <a name="content-after-migration"></a>
 
@@ -227,7 +223,7 @@ Możesz również ręcznie przenieść Twoje konta e-mail do nowej usługi e-mai
 
 [Zarządzanie kontaktami swoich usług](/pages/account_and_service_management/account_information/managing_contacts)
 
-[Przewodniki E-mail Pro](/products/web-cloud-email-collaborative-solutions-email-pro)
+[Przewodniki Email Pro](/products/web-cloud-email-collaborative-solutions-email-pro)
 
 [Przewodniki Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
@@ -93,7 +93,7 @@ Przed rozpoczęciem migracji określ wersję programu MX Plan, z której chcesz 
 >
 > Jeśli właśnie zamówiłeś nową ofertę e-mail, przed rozpoczęciem migracji dodaj najpierw nazwę domeny do platformy e-mail. <br> - *Na przykład, aby przenieść konto "myemail@mydomain.ovh", należy dodać do swojej platformy nazwę domeny "mydomain.ovh".*
 >
-> Wybierz kartę `Przypisane domeny`{.action} lub `Domeny`{.action} na swojej platformie, a następnie kliknij `Dodaj domenę`{.action}. Po dodaniu nazwy domeny upewnij się, że w kolumnie `Statut` znajduje się oznaczenie `OK` lub `Aktywny`{.action}.
+> Wybierz kartę `Przypisane domeny`{.action} lub `Domena`{.action} na swojej platformie, a następnie kliknij `Dodaj domenę`{.action}. Po dodaniu nazwy domeny upewnij się, że w kolumnie `Status` znajduje się oznaczenie `OK` lub `Aktywny`{.action}.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
@@ -127,7 +127,7 @@ Aby uzyskać więcej informacji na temat narzędzia OMM, zapoznaj się z naszym 
 
 Czas migracji zależy od ilości treści, które chcesz przenieść na nowe konto. Może się on różnić od kilku minut do kilku godzin.
 
-Po przeprowadzeniu migracji sprawdź, czy Twoje dane znajdują się na stronie WWW pod adresem [Webmail](/links/web/email)
+Po przeprowadzeniu migracji sprawdź, czy odnajdujesz swoje elementy, logując się do [Webmail OVHcloud](/links/web/email).
 
 Po przeprowadzeniu migracji możesz zachować lub usunąć konto źródłowe, używając tymczasowej nazwy.
 
@@ -172,7 +172,7 @@ Jeśli asystent konfiguracji nie wyświetla się, wyświetlą się ogólne infor
 
 ##### **Migracja z poziomu interfejsu MX Plan**
 
-Aby przeprowadzić migrację w tym interfejsie, przejdź do sekcji `E-maile`{.action} Panelu klienta OVHcloud. Wybierz usługę noszącą nazwę domeny Twoich kont e-mail. Kliknij kartę `E-maile`{.action}. Kliknij logo w kształcie koła zębatego na linii odpowiedniego konta e-mail (zwane również kontem źródłowym), a następnie kliknij `Przeprowadź migrację konta`{.action}.
+Aby przeprowadzić migrację w tym interfejsie, przejdź do sekcji [MX Plan](/links/control-panel/web-mx-plan) Panelu klienta OVHcloud i wybierz odpowiednią domenę. W karcie `E-maile`{.action} kliknij logo w kształcie koła zębatego na linii odpowiedniego konta e-mail (zwane również kontem źródłowym), a następnie kliknij `Przeprowadź migrację konta`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
@@ -172,7 +172,7 @@ Jeśli asystent konfiguracji nie wyświetla się, wyświetlą się ogólne infor
 
 ##### **Migracja z poziomu interfejsu MX Plan**
 
-Aby przeprowadzić migrację w tym interfejsie, przejdź do sekcji `E-maile`{.action} Panelu klienta OVHcloud. Wybierz usługę noszącą nazwę domeny Twoich kont e-mail. Kliknij logo w kształcie koła zębatego na linii odpowiedniego konta e-mail (zwane również kontem źródłowym), a następnie kliknij `Przeprowadź migrację konta`{.action}.
+Aby przeprowadzić migrację w tym interfejsie, przejdź do sekcji `E-maile`{.action} Panelu klienta OVHcloud. Wybierz usługę noszącą nazwę domeny Twoich kont e-mail. Kliknij kartę `E-maile`{.action}. Kliknij logo w kształcie koła zębatego na linii odpowiedniego konta e-mail (zwane również kontem źródłowym), a następnie kliknij `Przeprowadź migrację konta`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
@@ -93,7 +93,7 @@ Przed rozpoczęciem migracji określ wersję programu MX Plan, z której chcesz 
 >
 > Jeśli właśnie zamówiłeś nową ofertę e-mail, przed rozpoczęciem migracji dodaj najpierw nazwę domeny do platformy e-mail. <br> - *Na przykład, aby przenieść konto "myemail@mydomain.ovh", należy dodać do swojej platformy nazwę domeny "mydomain.ovh".*
 >
-> Wybierz kartę `Powiązane domeny`{.action} lub `Domeny`{.action} na swojej platformie, a następnie kliknij `Dodaj domenę`{.action}. Po dodaniu nazwy domeny upewnij się, że w kolumnie `Statut` znajduje się oznaczenie `OK` lub `Aktywny`{.action}.
+> Wybierz kartę `Przypisane domeny`{.action} lub `Domeny`{.action} na swojej platformie, a następnie kliknij `Dodaj domenę`{.action}. Po dodaniu nazwy domeny upewnij się, że w kolumnie `Statut` znajduje się oznaczenie `OK` lub `Aktywny`{.action}.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
@@ -1,14 +1,14 @@
 ---
-title: 'Migrowanie adresu e-mail MX Plan do konta Email Pro, Exchange lub Zimbra'
-excerpt: 'Dowiedz się, jak przeprowadzić migrację adresu e-mail MX Plan do konta Email Pro, Exchange lub Zimbra'
+title: 'Migrowanie adresu e-mail MX Plan do konta E-mail Pro, Exchange lub Zimbra'
+excerpt: 'Dowiedz się, jak przeprowadzić migrację adresu e-mail MX Plan do konta E-mail Pro, Exchange lub Zimbra'
 updated: 2026-01-16
 ---
 
 ## Wprowadzenie
 
-OVHcloud oferuje kilka rozwiązań poczty elektronicznej: MX Plan (sprzedawany samodzielnie lub zawarty w ofercie hostingu), Zimbra, Email Pro i Exchange. Korzystają one z własnych funkcji i mogą być dostosowane do wielu zastosowań. Twoje potrzeby zmieniają się? OVHcloud udostępnia Ci narzędzie migracji umożliwiające przejście z jednego rozwiązania na drugie.
+OVHcloud oferuje kilka rozwiązań poczty elektronicznej: MX Plan (sprzedawany samodzielnie lub zawarty w ofercie hostingu), Zimbra, E-mail Pro i Exchange. Korzystają one z własnych funkcji i mogą być dostosowane do wielu zastosowań. Twoje potrzeby zmieniają się? OVHcloud udostępnia Ci narzędzie migracji umożliwiające przejście z jednego rozwiązania na drugie.
 
-**Dowiedz się, jak przenieść konto e-mail MX Plan na konto Email Pro, Exchange lub Zimbra.**
+**Dowiedz się, jak przenieść konto e-mail MX Plan na konto E-mail Pro, Exchange lub Zimbra.**
 
 > [!warning]
 >
@@ -18,7 +18,7 @@ OVHcloud oferuje kilka rozwiązań poczty elektronicznej: MX Plan (sprzedawany s
 ## Wymagania początkowe
 
 - Posiadanie konta e-mail MX Plan (w ramach pakietu MX Plan lub zawartego w pakiecie [hostingowym OVHcloud](/links/web/hosting)).
-- Posiadanie usługi [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) z co najmniej jednym niezakonfigurowanym kontem (które będzie miało postać "@configureme.me") lub [Zimbra](/links/web/zimbra).
+- Posiadanie usługi [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) z co najmniej jednym niezakonfigurowanym kontem (które będzie miało postać "@configureme.me") lub [Zimbra](/links/web/zimbra).
 - **Nie skonfigurowałeś przekierowania na adres e-mail MX Plan, który chcesz przenieść**.
 
 <!-- CP-NAV-START:web-mx-plan -->
@@ -33,9 +33,9 @@ OVHcloud oferuje kilka rozwiązań poczty elektronicznej: MX Plan (sprzedawany s
 - **Link bezpośredni:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz usługę MX Plan
 
-**Email Pro:**
+**E-mail Pro:**
 
-- **Link bezpośredni:** [Email Pro](/links/control-panel/web-email-pro)
+- **Link bezpośredni:** [E-mail Pro](/links/control-panel/web-email-pro)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Wybierz platformę
 
 **Exchange:**
@@ -52,15 +52,15 @@ OVHcloud oferuje kilka rozwiązań poczty elektronicznej: MX Plan (sprzedawany s
 
 ### Etap 1: Określenie ram projektu
 
-Rozwiązania Email Pro i Exchange mają wspólną bazę funkcjonalności. Niemniej jednak nadal występują różnice w zależności od zastosowania. Wybierając adres Exchange, dysponujesz wszystkimi funkcjami do pracy zespołowej, takimi jak synchronizacja kalendarza i kontaktów. Niektóre z nich są dostępne w ofercie Email Pro, ale są one ograniczone do korzystania wyłącznie z poczty webmail.
+Rozwiązania E-mail Pro i Exchange mają wspólną bazę funkcjonalności. Niemniej jednak nadal występują różnice w zależności od zastosowania. Wybierając adres Exchange, dysponujesz wszystkimi funkcjami do pracy zespołowej, takimi jak synchronizacja kalendarza i kontaktów. Niektóre z nich są dostępne w ofercie E-mail Pro, ale są one ograniczone do korzystania wyłącznie z poczty webmail.
 
-Zanim przejdziesz dalej, ważne jest, aby wiedzieć, na jaką ofertę chcesz przenieść Twoje konta e-mail MX Plan. Aby pomóc w wyborze tej opcji, zapoznaj się ze stroną firmowych [rozwiązań poczty elektronicznej OVHcloud](/links/web/emails), na której znajdziesz szczegółowe porównanie ofert. Możesz łączyć rozwiązania i używać dla tej samej domeny jednego lub kilku kont Email Pro i Exchange. Jeśli chcesz migrować kilka kont, zalecamy wdrożenie planu migracji.
+Zanim przejdziesz dalej, ważne jest, aby wiedzieć, na jaką ofertę chcesz przenieść Twoje konta e-mail MX Plan. Aby pomóc w wyborze tej opcji, zapoznaj się ze stroną firmowych [rozwiązań poczty elektronicznej OVHcloud](/links/web/emails), na której znajdziesz szczegółowe porównanie ofert. Możesz łączyć rozwiązania i używać dla tej samej domeny jednego lub kilku kont E-mail Pro i Exchange. Jeśli chcesz migrować kilka kont, zalecamy wdrożenie planu migracji.
 
-### Etap 2: Zamów konta Email Pro lub Exchange
+### Etap 2: Zamów konta E-mail Pro lub Exchange
 
-Ten etap jest opcjonalny, jeśli posiadasz już usługę Exchange lub Email Pro, do której chcesz przeprowadzić migrację.
+Ten etap jest opcjonalny, jeśli posiadasz już usługę Exchange lub E-mail Pro, do której chcesz przeprowadzić migrację.
 
-W przeciwnym razie zamów usługę Email Pro lub Exchange. Postępuj zgodnie z kolejnymi instrukcjami, następnie zaczekaj aż usługa zostanie zainstalowana. Otrzymasz e-mail z końcem abonamentu.
+W przeciwnym razie zamów usługę E-mail Pro lub Exchange. Postępuj zgodnie z kolejnymi instrukcjami, następnie zaczekaj aż usługa zostanie zainstalowana. Otrzymasz e-mail z końcem abonamentu.
 
 > [!primary]
 >
@@ -81,13 +81,13 @@ Przed rozpoczęciem migracji określ wersję programu MX Plan, z której chcesz 
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Ręczna migracja oferty MX Plan do Exchange, Email Pro lub Zimbra  <a name="all-mxplan"></a>
+#### 3.1 Ręczna migracja oferty MX Plan do Exchange, E-mail Pro lub Zimbra  <a name="all-mxplan"></a>
 
 > [!warning]
 >
 > Ta sekcja dotyczy wszystkich usług MX Plan korzystających z technologii webmaila Roundcube, Zimbra lub OWA.
 >
-> Jednak jeśli chcesz przenieść usługę MX Plan korzystającą z webmaila Roundcube do platformy Email Pro lub Exchange OVHcloud, przejdź do sekcji "[Automatyczna migracja oferty MX Plan Roundcube do Exchange lub Email Pro](#roundcube-mxplan)" tego przewodnika.
+> Jednak jeśli chcesz przenieść usługę MX Plan korzystającą z webmaila Roundcube do platformy E-mail Pro lub Exchange OVHcloud, przejdź do sekcji "[Automatyczna migracja oferty MX Plan Roundcube do Exchange lub E-mail Pro](#roundcube-mxplan)" tego przewodnika.
 
 > [!warning]
 >
@@ -97,7 +97,7 @@ Przed rozpoczęciem migracji określ wersję programu MX Plan, z której chcesz 
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
-> Aby uzyskać więcej informacji na temat dodania domeny, sprawdź [przewodnik Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config) lub [przewodnik Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain).
+> Aby uzyskać więcej informacji na temat dodania domeny, sprawdź [przewodnik E-mail Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config) lub [przewodnik Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain).
 
 Migracja MX Plan przebiega 3 etapach. **Zmień nazwę**, **Utwórz** i **Migracja**.
 
@@ -113,9 +113,9 @@ W zakładce `Konta e-mail`{.action} na Twojej platformie MX Plan kliknij przycis
 >
 > Modyfikacja konta nie jest natychmiastowa. Prosimy o cierpliwość do końca operacji, zanim przejdziesz do kolejnego etapu.
 
-2\. **Utwórz** konto e-mail na nowym koncie w Twojej platformie Email Pro lub Exchange (w powyższym przykładzie utworzysz zatem *john.smith@mydomain.ovh* na nowej platformie).
+2\. **Utwórz** konto e-mail na nowym koncie w Twojej platformie E-mail Pro lub Exchange (w powyższym przykładzie utworzysz zatem *john.smith@mydomain.ovh* na nowej platformie).
 
-W zakładce `Konta e-mail`{.action} na Twojej platformie Email Pro lub Exchange kliknij przycisk `...`{.action}, a następnie `Zmień`{.action}.
+W zakładce `Konta e-mail`{.action} na Twojej platformie E-mail Pro lub Exchange kliknij przycisk `...`{.action}, a następnie `Zmień`{.action}.
 
 ![Exchange](images/mxplan-migration-configure-account02.png){.thumbnail}
 
@@ -133,7 +133,7 @@ Po przeprowadzeniu migracji możesz zachować lub usunąć konto źródłowe, u�
 
 Jeśli chcesz go usunąć, przejdź do zakładki `Konta e-mail`{.action} MX Plan, kliknij przycisk `...`{.action}, a następnie  `Zresetuj to konto`{.action}.
 
-#### 3.2 Automatyczna migracja oferty MX Plan Roundcube do Exchange lub Email Pro <a name="roundcube-mxplan"></a>
+#### 3.2 Automatyczna migracja oferty MX Plan Roundcube do Exchange lub E-mail Pro <a name="roundcube-mxplan"></a>
 
 > [!warning]
 >
@@ -141,7 +141,7 @@ Jeśli chcesz go usunąć, przejdź do zakładki `Konta e-mail`{.action} MX Plan
 
 > [!primary]
 >
-> Twoje konto OVHcloud musi być wcześniej kontaktem administratora **i** kontakt techniczny usługi MX Plan, którą chcesz przenieść, **oraz** usługi Email Pro lub Exchange, do której możesz się przenieść.
+> Twoje konto OVHcloud musi być wcześniej kontaktem administratora **i** kontakt techniczny usługi MX Plan, którą chcesz przenieść, **oraz** usługi E-mail Pro lub Exchange, do której możesz się przenieść.
 >
 > Aby uzyskać więcej informacji na temat zmian kontaktów, zapoznaj się z naszym przewodnikiem dotyczącym [zarządzania kontaktami swoich usług](/pages/account_and_service_management/account_information/managing_contacts).
 >
@@ -149,7 +149,7 @@ Jeśli chcesz go usunąć, przejdź do zakładki `Konta e-mail`{.action} MX Plan
 Migracja może zostać przeprowadzona z dwóch interfejsów:<br>
 
 - **adres asystenta konfiguracji Hosted Exchange**, tylko jeśli zamówiłeś usługę Hosted Exchange i nie skonfigurowałeś jeszcze usługi Hosted Exchange;
-- **adres MX Plan**, jeśli posiadasz usługę Email Pro lub Exchange (skonfigurowaną lub nie) oraz adres MX Plan, który chcesz przenieść.
+- **adres MX Plan**, jeśli posiadasz usługę E-mail Pro lub Exchange (skonfigurowaną lub nie) oraz adres MX Plan, który chcesz przenieść.
 
 > Przypominamy, że przed rozpoczęciem migracji upewnij się, że na serwerze MX Plan nie ma **przekierowania** lub żadna **autoresponder**.
 >
@@ -188,7 +188,7 @@ Następnie potwierdź hasło do źródłowego konta e-mail (które chcesz przeni
 
 Na tym etapie Twoje konta e-mail muszą być migrowane i działać. Ze względów bezpieczeństwa sprawdź, czy konfiguracja Twojej domeny jest poprawna, sprawdzając w Panelu klienta.
 
-W tym celu wybierz odpowiednią usługę Email Pro lub Exchange, następnie przejdź do zakładki Powiązane `domeny`{.action}. W tabeli, która się wyświetla, w kolumnie "Diagnostyka" możesz sprawdzić, czy konfiguracja DNS jest prawidłowa: czerwony przycisk pojawia się, jeśli konfiguracja wymaga zmiany.
+W tym celu wybierz odpowiednią usługę E-mail Pro lub Exchange, następnie przejdź do zakładki Powiązane `domeny`{.action}. W tabeli, która się wyświetla, w kolumnie "Diagnostyka" możesz sprawdzić, czy konfiguracja DNS jest prawidłowa: czerwony przycisk pojawia się, jeśli konfiguracja wymaga zmiany.
 
 > [!primary]
 >
@@ -203,7 +203,7 @@ Aby zmienić konfigurację, kliknij czerwony przycisk i wykonaj żądaną operac
 
 Teraz możesz korzystać z migrowanych kont e-mail. W tym celu OVHcloud udostępnia aplikację online (_web app_) dostępną pod adresem [Webmail](/links/web/email). Wpisz dane dostępowe do Twojego konta e-mail.
 
-Jeśli skonfigurowałeś jedno z kont przeniesionych na klienta poczty elektronicznej (np. Outlook), należy ponownie skonfigurować to konto. Dane do logowania do serwera OVHcloud zmieniły się po migracji. Aby pomóc Ci w przeprowadzeniu operacji, zapoznaj się z naszą dokumentacją w sekcjach przewodników dotyczących [Email Pro](/products/web-cloud-email-collaborative-solutions-email-pro) i [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Jeśli nie jesteś w stanie zmienić konfiguracji konta w tej chwili, dostęp przez aplikację online jest zawsze możliwy.
+Jeśli skonfigurowałeś jedno z kont przeniesionych na klienta poczty elektronicznej (np. Outlook), należy ponownie skonfigurować to konto. Dane do logowania do serwera OVHcloud zmieniły się po migracji. Aby pomóc Ci w przeprowadzeniu operacji, zapoznaj się z naszą dokumentacją w sekcjach przewodników dotyczących [E-mail Pro](/products/web-cloud-email-collaborative-solutions-email-pro) i [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Jeśli nie jesteś w stanie zmienić konfiguracji konta w tej chwili, dostęp przez aplikację online jest zawsze możliwy.
 
 ### Organizacja zawartości Twoich kont e-mail po migracji <a name="content-after-migration"></a>
 
@@ -223,7 +223,7 @@ Możesz również ręcznie przenieść Twoje konta e-mail do nowej usługi e-mai
 
 [Zarządzanie kontaktami swoich usług](/pages/account_and_service_management/account_information/managing_contacts)
 
-[Przewodniki Email Pro](/products/web-cloud-email-collaborative-solutions-email-pro)
+[Przewodniki E-mail Pro](/products/web-cloud-email-collaborative-solutions-email-pro)
 
 [Przewodniki Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
@@ -172,7 +172,7 @@ Se o assistente de configuração não for apresentado, aparecerão as informaç
 
 ##### **Migração a partir da interface MX Plan**
 
-Para realizar a migração a partir desta interface, aceda à secção `E-mails`{.action} da Área de Cliente OVHcloud. De seguida, selecione o serviço que tem o nome de domínio dos seus endereços de e-mail. Clique no ícone em forma de engrenagem na linha da conta de e-mail em causa (também designada conta de origem) e, a seguir, em `Migrar conta`{.action}.
+Para realizar a migração a partir desta interface, aceda à secção `E-mails`{.action} da Área de Cliente OVHcloud. De seguida, selecione o serviço que tem o nome de domínio dos seus endereços de e-mail. Clique no separador `E-mails`{.action}. Clique no ícone em forma de engrenagem na linha da conta de e-mail em causa (também designada conta de origem) e, a seguir, em `Migrar conta`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
@@ -1,14 +1,14 @@
 ---
-title: 'Migrar um endereço de e-mail MX Plan para uma conta de E-mail Pro, Exchange ou Zimbra'
-excerpt: 'Descubra como migrar um endereço de e-mail MX Plan para uma conta de E-mail Pro, Exchange ou Zimbra'
+title: 'Migrar um endereço de e-mail MX Plan para uma conta de Email Pro, Exchange ou Zimbra'
+excerpt: 'Descubra como migrar um endereço de e-mail MX Plan para uma conta de Email Pro, Exchange ou Zimbra'
 updated: 2026-01-16
 ---
 
 ## Objetivo
 
-A OVHcloud oferece várias soluções de e-mail: MX Plan (vendido isoladamente ou incluído numa oferta de alojamento web), Zimbra, E-mail Pro e Exchange. Estas beneficiam de funcionalidades próprias e podem adaptar-se a várias utilizações. As suas necessidades evoluem? A OVHcloud oferece-lhe uma ferramenta de migração que lhe permite passar de uma solução para outra.
+A OVHcloud oferece várias soluções de e-mail: MX Plan (vendido isoladamente ou incluído numa oferta de alojamento web), Zimbra, Email Pro e Exchange. Estas beneficiam de funcionalidades próprias e podem adaptar-se a várias utilizações. As suas necessidades evoluem? A OVHcloud oferece-lhe uma ferramenta de migração que lhe permite passar de uma solução para outra.
 
-**Saiba como migrar um endereço de e-mail MX Plan para uma conta E-mail Pro ou Exchange.**
+**Saiba como migrar um endereço de e-mail MX Plan para uma conta Email Pro, Exchange ou Zimbra.**
 
 > [!warning]
 >
@@ -18,7 +18,7 @@ A OVHcloud oferece várias soluções de e-mail: MX Plan (vendido isoladamente o
 ## Requisitos
 
 - Ter um endereço de e-mail MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web da OVHcloud](/links/web/hosting)).
-- Dispor de um serviço [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) com pelo menos uma conta não configurada (que aparecerá na forma "@configureme.me") ou [Zimbra](/links/web/zimbra).
+- Dispor de um serviço [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) com pelo menos uma conta não configurada (que aparecerá na forma "@configureme.me") ou [Zimbra](/links/web/zimbra).
 - **Não ter configurado um reencaminhamento para o endereço de e-mail MX Plan que pretende migrar.**
 
 <!-- CP-NAV-START:web-mx-plan -->
@@ -30,17 +30,17 @@ A OVHcloud oferece várias soluções de e-mail: MX Plan (vendido isoladamente o
 
 **MX Plan:**
 
-- **Link direto:** [MX Plan](/links/control-panel/web-mx-plan)
+- **Ligação direta:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Caminho de navegação:** `Web Cloud`{.action} > `MX Plan`{.action} > Selecione o seu serviço MX Plan
 
-**E-mail Pro:**
+**Email Pro:**
 
-- **Link direto:** [E-mail Pro](/links/control-panel/web-email-pro)
+- **Ligação direta:** [Email Pro](/links/control-panel/web-email-pro)
 - **Caminho de navegação:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Selecione a sua plataforma
 
 **Exchange:**
 
-- **Link direto:** [Exchange](/links/control-panel/web-exchange)
+- **Ligação direta:** [Exchange](/links/control-panel/web-exchange)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Exchange`{.action} > Selecione a sua plataforma
 
 ---
@@ -52,15 +52,15 @@ A OVHcloud oferece várias soluções de e-mail: MX Plan (vendido isoladamente o
 
 ### Etapa 1: Definir o projeto
 
-As soluções E-mail Pro e Exchange dispõem de uma base de funcionalidades comum. No entanto, subsistem diferenças consoante os casos de utilização. Ao escolher um endereço Exchange, dispõe da totalidade das funções colaborativas, como a sincronização do calendário e dos contactos. A solução E-mail Pro, por sua vez, propõe algumas, mas estas estão limitadas a uma utilização apenas através de um webmail.
+As soluções Email Pro e Exchange dispõem de uma base de funcionalidades comum. No entanto, subsistem diferenças consoante os casos de utilização. Ao escolher um endereço Exchange, dispõe da totalidade das funções colaborativas, como a sincronização do calendário e dos contactos. A solução Email Pro, por sua vez, propõe algumas, mas estas estão limitadas a uma utilização apenas através de um webmail.
 
-Antes de continuar, é importante saber para que oferta deseja migrar os seus endereços de e-mail MX Plan. Para o ajudar nesta escolha, consulte a página das [soluções de e-mails profissionais da OVHcloud](/links/web/emails) que propõe uma comparação pormenorizada das ofertas. Tem a possibilidade de acumular as soluções e de utilizar para um mesmo nome de domínio uma ou várias contas E-mail Pro e Exchange. Além disso, se tiver de migrar várias contas, recomendamos que execute um plano de migração.
+Antes de continuar, é importante saber para que oferta deseja migrar os seus endereços de e-mail MX Plan. Para o ajudar nesta escolha, consulte a página das [soluções de e-mails profissionais da OVHcloud](/links/web/emails) que propõe uma comparação pormenorizada das ofertas. Tem a possibilidade de acumular as soluções e de utilizar para um mesmo nome de domínio uma ou várias contas Email Pro e Exchange. Além disso, se tiver de migrar várias contas, recomendamos que execute um plano de migração.
 
-### Etapa 2: Encomendar as suas contas E-mail Pro ou Exchange
+### Etapa 2: Encomendar as suas contas Email Pro ou Exchange
 
-Esta etapa é facultativa se já dispõe de um serviço Exchange ou E-mail Pro para o qual está a migrar.
+Esta etapa é facultativa se já dispõe de um serviço Exchange ou Email Pro para o qual está a migrar.
 
-Caso contrário, aceda à [Área de Cliente OVHcloud](/links/manager) e encomende o serviço E-mail Pro ou Exchange à sua escolha. Siga os passos indicados e aguarde até que o serviço esteja instalado. Receberá um e-mail no final desta operação.
+Caso contrário, encomende o serviço Email Pro ou Exchange à sua escolha. Siga os passos indicados e aguarde até que o serviço esteja instalado. Receberá um e-mail no final desta operação.
 
 > [!primary]
 >
@@ -75,25 +75,21 @@ Antes de iniciar a migração, terá de identificar a versão do MX Plan a parti
 >
 > A tecnologia de e-mail da sua oferta MX Plan pode variar consoante a data de ativação da sua oferta ou se uma migração ocorreu recentemente. Esta tecnologia distingue-se, nomeadamente, pela interface do seu webmail. Para a identificar a partir do seu Área de Cliente OVHcloud, siga estes passos:
 >
-> 1. Faça login no seu [Área de Cliente OVHcloud](/links/manager).
-> 1. Dirija-se à secção `Web Cloud`{.action}.
-> 1. Clique em `MX Plan`{.action}.
-> 1. Selecione o domínio em questão.
 > 1. O separador `Informações gerais`{.action} está selecionado por defeito.
 > 1. Registe a tecnologia utilizada sob a menção **Webmail** no quadro `Subscrição`.
 >
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Migração manual de uma oferta MX Plan para Exchange, E-mail Pro ou Zimbra  <a name="all-mxplan"></a>
+#### 3.1 Migração manual de uma oferta MX Plan para Exchange, Email Pro ou Zimbra  <a name="all-mxplan"></a>
 
 > [!warning]
 >
-> Esta secção aplica-se a todos os serviços MX Plan que utilizam a tecnologia webmail Rouncube, Zimbra ou OWA.
+> Esta secção aplica-se a todos os serviços MX Plan que utilizam a tecnologia webmail Roundcube, Zimbra ou OWA.
 >
-> No entanto, se pretender migrar um serviço MX Plan que utiliza o webmail Roundcube para uma plataforma E-mail Pro ou Exchange OVHcloud, siga a secção "[Migração automática de uma oferta MX Plan Roundcube para Exchange ou E-mail Pro](#roundcube-mxplan)" deste guia.
+> No entanto, se pretender migrar um serviço MX Plan que utiliza o webmail Roundcube para uma plataforma Email Pro ou Exchange OVHcloud, siga a secção "[Migração automática de uma oferta MX Plan Roundcube para Exchange ou Email Pro](#roundcube-mxplan)" deste guia.
 
-[!warning]
+> [!warning]
 >
 > Se acabou de encomendar a sua nova oferta de e-mail, adicione o domínio à sua plataforma de e-mail antes de começar a migração. <br> - *Por exemplo, para migrar a conta "myemail@mydomain.ovh", deve adicionar o nome de domínio "mydomain.ovh" à sua plataforma.*
 >
@@ -101,7 +97,7 @@ Antes de iniciar a migração, terá de identificar a versão do MX Plan a parti
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
-> Para mais detalhes sobre a adição de um nome de domínio, siga [o guia E-mail Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config), [o guia Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) ou [o guia Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra).
+> Para mais detalhes sobre a adição de um nome de domínio, siga [o guia Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config), [o guia Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) ou [o guia Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra).
 
 A migração do seu MX Plan far-se-á em 3 grandes etapas, **Renomear**, **Criar** e **Migrar**.
 
@@ -117,9 +113,9 @@ No separador `Contas de e-mail`{.action} da plataforma MX Plan, clique no botão
 >
 > A alteração da conta não é imediata. Aguarde até ao fim da operação antes de avançar para a etapa seguinte.
 
-2\. **Crie** o seu endereço de e-mail na nova conta da sua plataforma E-mail Pro ou Exchange (tomando o exemplo anterior, vai criar *john.smith@mydomain.ovh* na sua nova plataforma).
+2\. **Crie** o seu endereço de e-mail na nova conta da sua plataforma Email Pro ou Exchange (tomando o exemplo anterior, vai criar *john.smith@mydomain.ovh* na sua nova plataforma).
 
-No separador `Contas de e-mail`{.action} da plataforma E-mail Pro ou Exchange, clique no botão `...`{.action} e depois em `Alterar`{.action}.
+No separador `Contas de e-mail`{.action} da plataforma Email Pro ou Exchange, clique no botão `...`{.action} e depois em `Alterar`{.action}.
 
 ![Exchange](images/mxplan-migration-configure-account02.png){.thumbnail}
 
@@ -137,15 +133,15 @@ Pode conservar ou eliminar a conta de origem com o nome provisório após esta m
 
 Se pretender eliminá-lo, aceda ao separador `Contas de e-mail`{.action} do MX Plan e clique no botão `...`{.action} e em `Reinicializar esta conta`{.action}.
 
-#### 3.2 Migração automática de uma oferta MX Plan Roundcube para Exchange ou E-mail Pro <a name="roundcube-mxplan"></a>
+#### 3.2 Migração automática de uma oferta MX Plan Roundcube para Exchange ou Email Pro <a name="roundcube-mxplan"></a>
 
 > [!warning]
 >
-> Esta secção aplica-se apenas aos serviços MX Plan que utilizam a tecnologia webmail Rouncube.
+> Esta secção aplica-se apenas aos serviços MX Plan que utilizam a tecnologia webmail Roundcube.
 
 > [!primary]
 >
-> A sua conta OVHcloud deve ter um contacto com o administrador **e** contacto técnico do serviço MX plan a migrar, **bem como** do serviço E-mail Pro ou Exchange para o qual migra.
+> A sua conta OVHcloud deve ter um contacto com o administrador **e** contacto técnico do serviço MX plan a migrar, **bem como** do serviço Email Pro ou Exchange para o qual migra.
 >
 > Para mais informações sobre as alterações de contactos, consulte o nosso guia para [gerir os contactos dos seus serviços](/pages/account_and_service_management/account_information/managing_contacts).
 >
@@ -153,7 +149,7 @@ Se pretender eliminá-lo, aceda ao separador `Contas de e-mail`{.action} do MX P
 A migração pode ser efetuada a partir de duas interfaces:<br>
 
 - **o do assistente de configuração Hosted Exchange**, apenas se encomendou um serviço Hosted Exchange e ainda não o configurou;
-- **do MX Plan**, quando tiver um serviço E-mail Pro ou Exchange (configurado ou não) e um endereço MX Plan que pretende migrar.
+- **do MX Plan**, quando tiver um serviço Email Pro ou Exchange (configurado ou não) e um endereço MX Plan que pretende migrar.
 
 > Lembre-se de que antes de iniciar a migração, certifique-se de que nenhum *reencaminhamento* ou que nenhum **atendedor automático* está configurado no seu MX Plan.
 >
@@ -170,7 +166,7 @@ Quando estiver pronto, continue a ler este manual em função da interface selec
 
 ##### **Migração a partir do assistente de configuração Exchange**
 
-Para aceder, selecione na [Área de Cliente OVHcloud](/links/manager) o serviço em questão. O assistente deverá aparecer para o ajudar a configurar o seu novo serviço Exchange. Durante este processo, poderá selecionar as contas de e-mail MX Plan a migrar.
+O assistente deverá aparecer para o ajudar a configurar o seu novo serviço Exchange. Durante este processo, poderá selecionar as contas de e-mail MX Plan a migrar.
 
 Se o assistente de configuração não for apresentado, aparecerão as informações gerais do serviço Exchange. Neste caso, deverá realizar a migração das suas contas através da interface MX Plan.
 
@@ -192,7 +188,7 @@ Por fim, confirme a palavra-passe do endereço de e-mail original (aquela que pr
 
 Nesta etapa, os seus endereços de e-mail já devem ser migrados e funcionais. Por questões de segurança, sugerimos que verifique se a configuração do seu domínio está correta ao consultar a Área de Cliente.
 
-Para isso, selecione o serviço E-mail Pro ou Exchange em questão e aceda ao separador `Domínios associados`{.action}. Na tabela que vai aparecer, a coluna "Diagnóstico" irá permitir-lhe ver se a configuração DNS está correta: se a configuração tiver de ser alterada, aparecerá uma etiqueta vermelha.
+Para isso, selecione o serviço Email Pro ou Exchange em questão e aceda ao separador `Domínios associados`{.action}. Na tabela que vai aparecer, a coluna "Diagnóstico" irá permitir-lhe ver se a configuração DNS está correta: se a configuração tiver de ser alterada, aparecerá uma etiqueta vermelha.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 
@@ -207,7 +203,7 @@ Para alterar a configuração, clique na etiqueta vermelha e execute a operaçã
 
 Só precisa de utilizar os seus endereços de e-mail migrados. Para isso, a OVHcloud disponibiliza uma aplicação online (_web app_) acessível no endereço [Webmail](/links/web/email). Introduza os dados de acesso relativos ao seu endereço de e-mail.
 
-Se configurou uma das contas migradas num cliente de e-mail (como o Outlook), deve configurá-la novamente. As informações de ligação ao servidor OVHcloud foram alteradas após a migração. Para o ajudar nas suas operações, consulte o nosso manual através das secções dos guias [E-mail Pro](/products/web-cloud-email-collaborative-solutions-email-pro) e [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Se não consegue reconfigurar a conta de forma imediata, o acesso através da aplicação online é sempre possível.
+Se configurou uma das contas migradas num cliente de e-mail (como o Outlook), deve configurá-la novamente. As informações de ligação ao servidor OVHcloud foram alteradas após a migração. Para o ajudar nas suas operações, consulte o nosso manual através das secções dos guias [Email Pro](/products/web-cloud-email-collaborative-solutions-email-pro) e [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Se não consegue reconfigurar a conta de forma imediata, o acesso através da aplicação online é sempre possível.
 
 ## Organização do conteúdo dos seus endereços de e-mail na sequência de uma migração <a name="content-after-migration"></a>
 
@@ -227,7 +223,7 @@ Também pode migrar manualmente os seus endereços de e-mail para a nova oferta 
 
 [Como gerir os contactos (gestores) dos serviços OVHcloud](/pages/account_and_service_management/account_information/managing_contacts)
 
-[Primeiros passos com a oferta E-mail Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
+[Primeiros passos com a oferta Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 
 [Primeiros passos com a oferta Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
@@ -1,14 +1,14 @@
 ---
-title: 'Migrar um endereço de e-mail MX Plan para uma conta de Email Pro, Exchange ou Zimbra'
-excerpt: 'Descubra como migrar um endereço de e-mail MX Plan para uma conta de Email Pro, Exchange ou Zimbra'
+title: 'Migrar um endereço de e-mail MX Plan para uma conta de E-mail Pro, Exchange ou Zimbra'
+excerpt: 'Descubra como migrar um endereço de e-mail MX Plan para uma conta de E-mail Pro, Exchange ou Zimbra'
 updated: 2026-01-16
 ---
 
 ## Objetivo
 
-A OVHcloud oferece várias soluções de e-mail: MX Plan (vendido isoladamente ou incluído numa oferta de alojamento web), Zimbra, Email Pro e Exchange. Estas beneficiam de funcionalidades próprias e podem adaptar-se a várias utilizações. As suas necessidades evoluem? A OVHcloud oferece-lhe uma ferramenta de migração que lhe permite passar de uma solução para outra.
+A OVHcloud oferece várias soluções de e-mail: MX Plan (vendido isoladamente ou incluído numa oferta de alojamento web), Zimbra, E-mail Pro e Exchange. Estas beneficiam de funcionalidades próprias e podem adaptar-se a várias utilizações. As suas necessidades evoluem? A OVHcloud oferece-lhe uma ferramenta de migração que lhe permite passar de uma solução para outra.
 
-**Saiba como migrar um endereço de e-mail MX Plan para uma conta Email Pro, Exchange ou Zimbra.**
+**Saiba como migrar um endereço de e-mail MX Plan para uma conta E-mail Pro, Exchange ou Zimbra.**
 
 > [!warning]
 >
@@ -18,7 +18,7 @@ A OVHcloud oferece várias soluções de e-mail: MX Plan (vendido isoladamente o
 ## Requisitos
 
 - Ter um endereço de e-mail MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web da OVHcloud](/links/web/hosting)).
-- Dispor de um serviço [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) com pelo menos uma conta não configurada (que aparecerá na forma "@configureme.me") ou [Zimbra](/links/web/zimbra).
+- Dispor de um serviço [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) com pelo menos uma conta não configurada (que aparecerá na forma "@configureme.me") ou [Zimbra](/links/web/zimbra).
 - **Não ter configurado um reencaminhamento para o endereço de e-mail MX Plan que pretende migrar.**
 
 <!-- CP-NAV-START:web-mx-plan -->
@@ -33,9 +33,9 @@ A OVHcloud oferece várias soluções de e-mail: MX Plan (vendido isoladamente o
 - **Ligação direta:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Caminho de navegação:** `Web Cloud`{.action} > `MX Plan`{.action} > Selecione o seu serviço MX Plan
 
-**Email Pro:**
+**E-mail Pro:**
 
-- **Ligação direta:** [Email Pro](/links/control-panel/web-email-pro)
+- **Ligação direta:** [E-mail Pro](/links/control-panel/web-email-pro)
 - **Caminho de navegação:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Selecione a sua plataforma
 
 **Exchange:**
@@ -52,15 +52,15 @@ A OVHcloud oferece várias soluções de e-mail: MX Plan (vendido isoladamente o
 
 ### Etapa 1: Definir o projeto
 
-As soluções Email Pro e Exchange dispõem de uma base de funcionalidades comum. No entanto, subsistem diferenças consoante os casos de utilização. Ao escolher um endereço Exchange, dispõe da totalidade das funções colaborativas, como a sincronização do calendário e dos contactos. A solução Email Pro, por sua vez, propõe algumas, mas estas estão limitadas a uma utilização apenas através de um webmail.
+As soluções E-mail Pro e Exchange dispõem de uma base de funcionalidades comum. No entanto, subsistem diferenças consoante os casos de utilização. Ao escolher um endereço Exchange, dispõe da totalidade das funções colaborativas, como a sincronização do calendário e dos contactos. A solução E-mail Pro, por sua vez, propõe algumas, mas estas estão limitadas a uma utilização apenas através de um webmail.
 
-Antes de continuar, é importante saber para que oferta deseja migrar os seus endereços de e-mail MX Plan. Para o ajudar nesta escolha, consulte a página das [soluções de e-mails profissionais da OVHcloud](/links/web/emails) que propõe uma comparação pormenorizada das ofertas. Tem a possibilidade de acumular as soluções e de utilizar para um mesmo nome de domínio uma ou várias contas Email Pro e Exchange. Além disso, se tiver de migrar várias contas, recomendamos que execute um plano de migração.
+Antes de continuar, é importante saber para que oferta deseja migrar os seus endereços de e-mail MX Plan. Para o ajudar nesta escolha, consulte a página das [soluções de e-mails profissionais da OVHcloud](/links/web/emails) que propõe uma comparação pormenorizada das ofertas. Tem a possibilidade de acumular as soluções e de utilizar para um mesmo nome de domínio uma ou várias contas E-mail Pro e Exchange. Além disso, se tiver de migrar várias contas, recomendamos que execute um plano de migração.
 
-### Etapa 2: Encomendar as suas contas Email Pro ou Exchange
+### Etapa 2: Encomendar as suas contas E-mail Pro ou Exchange
 
-Esta etapa é facultativa se já dispõe de um serviço Exchange ou Email Pro para o qual está a migrar.
+Esta etapa é facultativa se já dispõe de um serviço Exchange ou E-mail Pro para o qual está a migrar.
 
-Caso contrário, encomende o serviço Email Pro ou Exchange à sua escolha. Siga os passos indicados e aguarde até que o serviço esteja instalado. Receberá um e-mail no final desta operação.
+Caso contrário, encomende o serviço E-mail Pro ou Exchange à sua escolha. Siga os passos indicados e aguarde até que o serviço esteja instalado. Receberá um e-mail no final desta operação.
 
 > [!primary]
 >
@@ -81,13 +81,13 @@ Antes de iniciar a migração, terá de identificar a versão do MX Plan a parti
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Migração manual de uma oferta MX Plan para Exchange, Email Pro ou Zimbra  <a name="all-mxplan"></a>
+#### 3.1 Migração manual de uma oferta MX Plan para Exchange, E-mail Pro ou Zimbra  <a name="all-mxplan"></a>
 
 > [!warning]
 >
 > Esta secção aplica-se a todos os serviços MX Plan que utilizam a tecnologia webmail Roundcube, Zimbra ou OWA.
 >
-> No entanto, se pretender migrar um serviço MX Plan que utiliza o webmail Roundcube para uma plataforma Email Pro ou Exchange OVHcloud, siga a secção "[Migração automática de uma oferta MX Plan Roundcube para Exchange ou Email Pro](#roundcube-mxplan)" deste guia.
+> No entanto, se pretender migrar um serviço MX Plan que utiliza o webmail Roundcube para uma plataforma E-mail Pro ou Exchange OVHcloud, siga a secção "[Migração automática de uma oferta MX Plan Roundcube para Exchange ou E-mail Pro](#roundcube-mxplan)" deste guia.
 
 > [!warning]
 >
@@ -97,7 +97,7 @@ Antes de iniciar a migração, terá de identificar a versão do MX Plan a parti
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
-> Para mais detalhes sobre a adição de um nome de domínio, siga [o guia Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config), [o guia Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) ou [o guia Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra).
+> Para mais detalhes sobre a adição de um nome de domínio, siga [o guia E-mail Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config), [o guia Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) ou [o guia Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra).
 
 A migração do seu MX Plan far-se-á em 3 grandes etapas, **Renomear**, **Criar** e **Migrar**.
 
@@ -113,9 +113,9 @@ No separador `Contas de e-mail`{.action} da plataforma MX Plan, clique no botão
 >
 > A alteração da conta não é imediata. Aguarde até ao fim da operação antes de avançar para a etapa seguinte.
 
-2\. **Crie** o seu endereço de e-mail na nova conta da sua plataforma Email Pro ou Exchange (tomando o exemplo anterior, vai criar *john.smith@mydomain.ovh* na sua nova plataforma).
+2\. **Crie** o seu endereço de e-mail na nova conta da sua plataforma E-mail Pro ou Exchange (tomando o exemplo anterior, vai criar *john.smith@mydomain.ovh* na sua nova plataforma).
 
-No separador `Contas de e-mail`{.action} da plataforma Email Pro ou Exchange, clique no botão `...`{.action} e depois em `Alterar`{.action}.
+No separador `Contas de e-mail`{.action} da plataforma E-mail Pro ou Exchange, clique no botão `...`{.action} e depois em `Alterar`{.action}.
 
 ![Exchange](images/mxplan-migration-configure-account02.png){.thumbnail}
 
@@ -133,7 +133,7 @@ Pode conservar ou eliminar a conta de origem com o nome provisório após esta m
 
 Se pretender eliminá-lo, aceda ao separador `Contas de e-mail`{.action} do MX Plan e clique no botão `...`{.action} e em `Reinicializar esta conta`{.action}.
 
-#### 3.2 Migração automática de uma oferta MX Plan Roundcube para Exchange ou Email Pro <a name="roundcube-mxplan"></a>
+#### 3.2 Migração automática de uma oferta MX Plan Roundcube para Exchange ou E-mail Pro <a name="roundcube-mxplan"></a>
 
 > [!warning]
 >
@@ -141,7 +141,7 @@ Se pretender eliminá-lo, aceda ao separador `Contas de e-mail`{.action} do MX P
 
 > [!primary]
 >
-> A sua conta OVHcloud deve ter um contacto com o administrador **e** contacto técnico do serviço MX plan a migrar, **bem como** do serviço Email Pro ou Exchange para o qual migra.
+> A sua conta OVHcloud deve ter um contacto com o administrador **e** contacto técnico do serviço MX plan a migrar, **bem como** do serviço E-mail Pro ou Exchange para o qual migra.
 >
 > Para mais informações sobre as alterações de contactos, consulte o nosso guia para [gerir os contactos dos seus serviços](/pages/account_and_service_management/account_information/managing_contacts).
 >
@@ -149,7 +149,7 @@ Se pretender eliminá-lo, aceda ao separador `Contas de e-mail`{.action} do MX P
 A migração pode ser efetuada a partir de duas interfaces:<br>
 
 - **o do assistente de configuração Hosted Exchange**, apenas se encomendou um serviço Hosted Exchange e ainda não o configurou;
-- **do MX Plan**, quando tiver um serviço Email Pro ou Exchange (configurado ou não) e um endereço MX Plan que pretende migrar.
+- **do MX Plan**, quando tiver um serviço E-mail Pro ou Exchange (configurado ou não) e um endereço MX Plan que pretende migrar.
 
 > Lembre-se de que antes de iniciar a migração, certifique-se de que nenhum *reencaminhamento* ou que nenhum *atendedor automático* está configurado no seu MX Plan.
 >
@@ -188,7 +188,7 @@ Por fim, confirme a palavra-passe do endereço de e-mail original (aquela que pr
 
 Nesta etapa, os seus endereços de e-mail já devem ser migrados e funcionais. Por questões de segurança, sugerimos que verifique se a configuração do seu domínio está correta ao consultar a Área de Cliente.
 
-Para isso, selecione o serviço Email Pro ou Exchange em questão e aceda ao separador `Domínios associados`{.action}. Na tabela que vai aparecer, a coluna "Diagnóstico" irá permitir-lhe ver se a configuração DNS está correta: se a configuração tiver de ser alterada, aparecerá uma etiqueta vermelha.
+Para isso, selecione o serviço E-mail Pro ou Exchange em questão e aceda ao separador `Domínios associados`{.action}. Na tabela que vai aparecer, a coluna "Diagnóstico" irá permitir-lhe ver se a configuração DNS está correta: se a configuração tiver de ser alterada, aparecerá uma etiqueta vermelha.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 
@@ -203,7 +203,7 @@ Para alterar a configuração, clique na etiqueta vermelha e execute a operaçã
 
 Só precisa de utilizar os seus endereços de e-mail migrados. Para isso, a OVHcloud disponibiliza uma aplicação online (_web app_) acessível no endereço [Webmail](/links/web/email). Introduza os dados de acesso relativos ao seu endereço de e-mail.
 
-Se configurou uma das contas migradas num cliente de e-mail (como o Outlook), deve configurá-la novamente. As informações de ligação ao servidor OVHcloud foram alteradas após a migração. Para o ajudar nas suas operações, consulte o nosso manual através das secções dos guias [Email Pro](/products/web-cloud-email-collaborative-solutions-email-pro) e [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Se não consegue reconfigurar a conta de forma imediata, o acesso através da aplicação online é sempre possível.
+Se configurou uma das contas migradas num cliente de e-mail (como o Outlook), deve configurá-la novamente. As informações de ligação ao servidor OVHcloud foram alteradas após a migração. Para o ajudar nas suas operações, consulte o nosso manual através das secções dos guias [E-mail Pro](/products/web-cloud-email-collaborative-solutions-email-pro) e [Hosted Exchange](/products/web-cloud-email-collaborative-solutions-mx-plan). Se não consegue reconfigurar a conta de forma imediata, o acesso através da aplicação online é sempre possível.
 
 ## Organização do conteúdo dos seus endereços de e-mail na sequência de uma migração <a name="content-after-migration"></a>
 
@@ -223,7 +223,7 @@ Também pode migrar manualmente os seus endereços de e-mail para a nova oferta 
 
 [Como gerir os contactos (gestores) dos serviços OVHcloud](/pages/account_and_service_management/account_information/managing_contacts)
 
-[Primeiros passos com a oferta Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
+[Primeiros passos com a oferta E-mail Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 
 [Primeiros passos com a oferta Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
@@ -93,7 +93,7 @@ Antes de iniciar a migração, terá de identificar a versão do MX Plan a parti
 >
 > Se acabou de encomendar a sua nova oferta de e-mail, adicione o domínio à sua plataforma de e-mail antes de começar a migração. <br> - *Por exemplo, para migrar a conta "myemail@mydomain.ovh", deve adicionar o nome de domínio "mydomain.ovh" à sua plataforma.*
 >
->Selecione o separador `Domínios associados`{.action} na sua plataforma, e clique em `Adicionar um domínio`{.action}. Uma vez adicionado o domínio, certifique-se de que a menção `OK` está na coluna `Estatuto`.
+>Selecione o separador `Domínios associados`{.action} na sua plataforma, e clique em `Adicionar domínio`{.action}. Uma vez adicionado o domínio, certifique-se de que a menção `OK` está na coluna `Estatuto`.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
@@ -93,7 +93,7 @@ Antes de iniciar a migração, terá de identificar a versão do MX Plan a parti
 >
 > Se acabou de encomendar a sua nova oferta de e-mail, adicione o domínio à sua plataforma de e-mail antes de começar a migração. <br> - *Por exemplo, para migrar a conta "myemail@mydomain.ovh", deve adicionar o nome de domínio "mydomain.ovh" à sua plataforma.*
 >
->Selecione o separador `Domínios associados`{.action} na sua plataforma, e clique em `Adicionar domínio`{.action}. Uma vez adicionado o domínio, certifique-se de que a menção `OK` está na coluna `Estatuto`.
+> Selecione o separador `Domínios associados`{.action} na sua plataforma, e clique em `Adicionar domínio`{.action}. Uma vez adicionado o domínio, certifique-se de que a menção `OK` está na coluna `Estado`.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
@@ -127,7 +127,7 @@ Para mais informações sobre OMM, consulte o nosso guia [Migrar contas de e-mai
 
 O tempo de migração depende da quantidade de conteúdo a migrar para a sua nova conta. Pode variar de alguns minutos a várias horas.
 
-Após a migração, verifique que encontra os seus elementos ao aceder ao webmail no endereço [Webmail](/links/web/email)
+Após a migração, verifique que encontra os seus elementos ao aceder ao [Webmail OVHcloud](/links/web/email).
 
 Pode conservar ou eliminar a conta de origem com o nome provisório após esta migração.
 
@@ -151,7 +151,7 @@ A migração pode ser efetuada a partir de duas interfaces:<br>
 - **o do assistente de configuração Hosted Exchange**, apenas se encomendou um serviço Hosted Exchange e ainda não o configurou;
 - **do MX Plan**, quando tiver um serviço Email Pro ou Exchange (configurado ou não) e um endereço MX Plan que pretende migrar.
 
-> Lembre-se de que antes de iniciar a migração, certifique-se de que nenhum *reencaminhamento* ou que nenhum **atendedor automático* está configurado no seu MX Plan.
+> Lembre-se de que antes de iniciar a migração, certifique-se de que nenhum *reencaminhamento* ou que nenhum *atendedor automático* está configurado no seu MX Plan.
 >
 > ![email](images/mxplan-legacy-redirect.png){.thumbnail}
 
@@ -172,7 +172,7 @@ Se o assistente de configuração não for apresentado, aparecerão as informaç
 
 ##### **Migração a partir da interface MX Plan**
 
-Para realizar a migração a partir desta interface, aceda à secção `E-mails`{.action} da Área de Cliente OVHcloud. De seguida, selecione o serviço que tem o nome de domínio dos seus endereços de e-mail. Clique no separador `E-mails`{.action}. Clique no ícone em forma de engrenagem na linha da conta de e-mail em causa (também designada conta de origem) e, a seguir, em `Migrar conta`{.action}.
+Para realizar a migração a partir desta interface, aceda à secção [MX Plan](/links/control-panel/web-mx-plan) da sua Área de Cliente OVHcloud e selecione o domínio em causa. No separador `E-mails`{.action}, clique no ícone em forma de engrenagem na linha da conta de e-mail em causa (também designada conta de origem) e, a seguir, em `Migrar conta`{.action}.
 
 ![Exchange](images/access_the_migration_tool.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.de-de.md
@@ -17,7 +17,7 @@ updated: 2025-11-25
 
 [OVHcloud Mail Migrator](/links/web/omm) ist ein von OVHcloud entwickeltes Tool, das den Bedarf nach Reversibilität abdeckt. Sie können damit E-Mail-Accounts auf Ihre OVHcloud E-Mail-Accounts oder einen externen E-Mail-Dienst migrieren. Dabei können verschiedene Inhalte wie E-Mails, Kontakte, Kalender und Aufgaben übertragen werden, sofern diese mit Ihren E-Mail-Accounts kompatibel sind.
 
-**Diese Anleitung erklärt, wie Sie Ihre E-Mail--Accounts mit unserem OVHcloud Mail Migrator-Tool zu OVHcloud migrieren können.**
+**Diese Anleitung erklärt, wie Sie Ihre E-Mail-Accounts mit unserem OVHcloud Mail Migrator-Tool zu OVHcloud migrieren können.**
 
 ## Voraussetzungen
 
@@ -27,7 +27,7 @@ updated: 2025-11-25
 
 ## In der praktischen Anwendung
 
-Um auf OMM zuzugreifen, verwenden Sie die Adresse: <omm.ovhcloud.com>
+Um auf OMM zuzugreifen, verwenden Sie die Adresse: <https://omm.ovhcloud.com/>
 
 ![omm](images/omm-01.png){.thumbnail .w-600}
 
@@ -71,7 +71,7 @@ Eine neue Seite wird angezeigt, auf der Sie die Zugangsdaten für den Quell-Acco
 
 Bevor Sie Ihre Migration starten, ist es wichtig, die 3 Arten von Accounts zu kennen, die migriert werden können und wohin Sie migrieren können:
 
-- **OVHcloud**: Die `Auto detection` wird empfohlen, wenn Sie einen Account migrieren müssen, der auf einem E-Mail-Dienst bei OVHcloud gehostet wird. Wenn Sie viele OVHcloud E-Mail-Accounts haben, wählen Sie aus den Angeboten `MX Plan`, `E-Mail Pro`, `Exchange` und `Zimbra`. Sie werden aufgefordert, sich zum Ihrem OVHcloud Kunden-Account anzumelden. Weitere Informationen finden Sie im Abschnitt "[Über eine Anmeldung beim OVHcloud Kunden-Account migrieren](#sso-migration)".
+- **OVHcloud**: Die `Auto detection` wird empfohlen, wenn Sie einen Account migrieren müssen, der auf einem E-Mail-Dienst bei OVHcloud gehostet wird. Wenn Sie viele OVHcloud E-Mail-Accounts haben, wählen Sie aus den Angeboten `MX Plan`, `Email Pro`, `Exchange` und `Zimbra`. Sie werden aufgefordert, sich zum Ihrem OVHcloud Kunden-Account anzumelden. Weitere Informationen finden Sie im Abschnitt "[Über eine Anmeldung beim OVHcloud Kunden-Account migrieren](#sso-migration)".
 - **Others**: E-Mail-Dienste, die außerhalb von OVHcloud abgeschlossen wurden. Eine nicht erschöpfende Liste der von OMM unterstützten E-Mail-Dienste wird angezeigt. Wenn Ihr E-Mail-Account-Typ nicht aufgelistet ist, verwenden Sie die Protokolle `IMAP` oder `POP`, die mit den meisten E-Mail-Servern kompatibel sind.
 - **Importing files**: Es ist möglich, den Inhalt von PST-, ICS-, CSV- und XML-Dateien über OMM zu einem Ziel-E-Mail-Account zu migrieren. Wenn diese Funktion ausgewählt wird, genügt es, Ihre Datei in das Feld zu ziehen oder über den Button `Browse your files`{.action} Ihre Dateien zu durchsuchen.
 
@@ -100,7 +100,7 @@ Füllen Sie die Informationen entsprechend des Accounttyps aus:
     - **Service** *(je nach Typ)*: Wählen Sie den Dienst aus, der mit dem Ziel-E-Mail-Account verbunden ist.
     - **Advanced settings** > **Delegation account ID** *(je nach Typ)*: Wenn der zu migrierende E-Mail-Account ein geteilter Account ist, müssen Sie die E-Mail-Adresse des Administrator-Accounts des Delegation-Accounts eingeben.
 - **Start of Transfers**: Sie können die Migration unmittelbar über `Immediately` starten oder `Later` ankreuzen, um die Migration zu verschieben. Eine verschobene Migration ermöglicht es, Datum und Uhrzeit des Starts zu definieren.
-- **Data to transfer**: Abhängig vom Typ des zu migrierenden E-Mail-Accounts und des Ziel-Accountss zeigt Ihnen dieser Abschnitt die verschiedenen Arten von Daten an, die bei der Migration unterstützt werden. Dies hängt vom Quell-Account und vom Ziel-Accounts ab.
+- **Data to transfer**: Abhängig vom Typ des zu migrierenden E-Mail-Accounts und des Ziel-Accounts zeigt Ihnen dieser Abschnitt die verschiedenen Arten von Daten an, die bei der Migration unterstützt werden. Dies hängt vom Quell-Account und vom Ziel-Accounts ab.
 
 ![omm](images/omm-create-migration-04.png){.thumbnail .w-600}
 
@@ -115,7 +115,7 @@ Sobald die Parameter der Quell- und Ziel-Accounts ausgefüllt sind, klicken Sie 
 
 ### Über eine Anmeldung beim OVHcloud Kunden-Account migrieren <a name="sso-migration"></a>
 
-Bei einer Migration zu oder von einem OVHcloud Kunden-Account können Sie unserere Angebote `MX Plan`, `E-Mail Pro`, `Exchange` und `Zimbra` auswählen.
+Bei einer Migration zu oder von einem OVHcloud Kunden-Account können Sie unsere Angebote `MX Plan`, `Email Pro`, `Exchange` und `Zimbra` auswählen.
 
 ![omm](images/omm-migration-sso-00.png){.thumbnail .w-300}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.de-de.md
@@ -71,7 +71,7 @@ Eine neue Seite wird angezeigt, auf der Sie die Zugangsdaten für den Quell-Acco
 
 Bevor Sie Ihre Migration starten, ist es wichtig, die 3 Arten von Accounts zu kennen, die migriert werden können und wohin Sie migrieren können:
 
-- **OVHcloud**: Die `Auto detection` wird empfohlen, wenn Sie einen Account migrieren müssen, der auf einem E-Mail-Dienst bei OVHcloud gehostet wird. Wenn Sie viele OVHcloud E-Mail-Accounts haben, wählen Sie aus den Angeboten `MX Plan`, `Email Pro`, `Exchange` und `Zimbra`. Sie werden aufgefordert, sich zum Ihrem OVHcloud Kunden-Account anzumelden. Weitere Informationen finden Sie im Abschnitt "[Über eine Anmeldung beim OVHcloud Kunden-Account migrieren](#sso-migration)".
+- **OVHcloud**: Die `Auto detection` wird empfohlen, wenn Sie einen Account migrieren müssen, der auf einem E-Mail-Dienst bei OVHcloud gehostet wird. Wenn Sie viele OVHcloud E-Mail-Accounts haben, wählen Sie aus den Angeboten `MX Plan`, `E-Mail Pro`, `Exchange` und `Zimbra`. Sie werden aufgefordert, sich zum Ihrem OVHcloud Kunden-Account anzumelden. Weitere Informationen finden Sie im Abschnitt "[Über eine Anmeldung beim OVHcloud Kunden-Account migrieren](#sso-migration)".
 - **Others**: E-Mail-Dienste, die außerhalb von OVHcloud abgeschlossen wurden. Eine nicht erschöpfende Liste der von OMM unterstützten E-Mail-Dienste wird angezeigt. Wenn Ihr E-Mail-Account-Typ nicht aufgelistet ist, verwenden Sie die Protokolle `IMAP` oder `POP`, die mit den meisten E-Mail-Servern kompatibel sind.
 - **Importing files**: Es ist möglich, den Inhalt von PST-, ICS-, CSV- und XML-Dateien über OMM zu einem Ziel-E-Mail-Account zu migrieren. Wenn diese Funktion ausgewählt wird, genügt es, Ihre Datei in das Feld zu ziehen oder über den Button `Browse your files`{.action} Ihre Dateien zu durchsuchen.
 
@@ -115,7 +115,7 @@ Sobald die Parameter der Quell- und Ziel-Accounts ausgefüllt sind, klicken Sie 
 
 ### Über eine Anmeldung beim OVHcloud Kunden-Account migrieren <a name="sso-migration"></a>
 
-Bei einer Migration zu oder von einem OVHcloud Kunden-Account können Sie unsere Angebote `MX Plan`, `Email Pro`, `Exchange` und `Zimbra` auswählen.
+Bei einer Migration zu oder von einem OVHcloud Kunden-Account können Sie unsere Angebote `MX Plan`, `E-Mail Pro`, `Exchange` und `Zimbra` auswählen.
 
 ![omm](images/omm-migration-sso-00.png){.thumbnail .w-300}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.de-de.md
@@ -100,7 +100,7 @@ Füllen Sie die Informationen entsprechend des Accounttyps aus:
     - **Service** *(je nach Typ)*: Wählen Sie den Dienst aus, der mit dem Ziel-E-Mail-Account verbunden ist.
     - **Advanced settings** > **Delegation account ID** *(je nach Typ)*: Wenn der zu migrierende E-Mail-Account ein geteilter Account ist, müssen Sie die E-Mail-Adresse des Administrator-Accounts des Delegation-Accounts eingeben.
 - **Start of Transfers**: Sie können die Migration unmittelbar über `Immediately` starten oder `Later` ankreuzen, um die Migration zu verschieben. Eine verschobene Migration ermöglicht es, Datum und Uhrzeit des Starts zu definieren.
-- **Data to transfer**: Abhängig vom Typ des zu migrierenden E-Mail-Accounts und des Ziel-Accounts zeigt Ihnen dieser Abschnitt die verschiedenen Arten von Daten an, die bei der Migration unterstützt werden. Dies hängt vom Quell-Account und vom Ziel-Accounts ab.
+- **Data to transfer**: Abhängig vom Typ des zu migrierenden E-Mail-Accounts und des Ziel-Accounts zeigt Ihnen dieser Abschnitt die verschiedenen Arten von Daten an, die bei der Migration unterstützt werden. Dies hängt vom Quell-Account und vom Ziel-Account ab.
 
 ![omm](images/omm-create-migration-04.png){.thumbnail .w-600}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-ca.md
@@ -21,7 +21,7 @@ updated: 2025-11-25
 
 ## Requirements
 
-- An external email service or one from OVHcloud, such as an [Exchange](/links/web/emails-exchange) offer, or MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](/links/web/hosting)).
+- An external email service or one from OVHcloud, such as an [Exchange](/links/web/emails-exchange) offer, or MX Plan (via the MX Plan offer alone or included in an [OVHcloud web hosting offer](/links/web/hosting)).
 - Login details for the email accounts you want to migrate (the source accounts).
 - Login details for the destination email accounts.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-ca.md
@@ -21,7 +21,7 @@ updated: 2025-11-25
 
 ## Requirements
 
-- An external email service or one from OVHcloud, such as a [Zimbra](/links/web/zimbra), [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro) offer, or MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](/links/web/hosting)).
+- An external email service or one from OVHcloud, such as an [Exchange](/links/web/emails-exchange) offer, or MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](/links/web/hosting)).
 - Login details for the email accounts you want to migrate (the source accounts).
 - Login details for the destination email accounts.
 
@@ -71,7 +71,7 @@ On the new page that appears, enter the connection information of the source acc
 
 Before starting your migration, it is important to know the 3 types of accounts that can be migrated and where you can migrate to:
 
-- **OVHcloud**: The `Autodetect` option is recommended if you need to migrate an account hosted on one of the OVHcloud email offers. If you have a large number of OVHcloud email accounts, select one of the following offers: `MX plan`, `Email Pro`, `Exchange` or `Zimbra`. You will be asked to connect to the OVHcloud account associated with the offer concerned by the migration. For more information, see the section "[Migrate via a connection to the OVHcloud customer account](#sso-migration)".
+- **OVHcloud**: The `Autodetect` option is recommended if you need to migrate an account hosted on one of the OVHcloud email offers. If you have a large number of OVHcloud email accounts, select one of the following offers: `MX plan` or `Exchange`. You will be asked to connect to the OVHcloud account associated with the offer concerned by the migration. For more information, see the section "[Migrate via a connection to the OVHcloud customer account](#sso-migration)".
 - **Others**: They refer to email services outside of OVHcloud. You will find a non-exhaustive list of email services supported by OMM. If the type of service of your email account is not listed, use the `IMAP` or `POP` protocols, which are compatible with most email servers.
 - **Importing files**: It is possible to migrate the content of PST, ICS, CSV, and XML rules files via OMM to a destination email account. When this function is selected, simply drag and drop your document into the designated area or browse your files using the `Browse your files`{.action} button.
 
@@ -117,7 +117,7 @@ Once the source and destination account settings are completed, click on:
 
 ### Migrate via a connection to the OVHcloud customer account <a name="sso-migration"></a>
 
-When migrating to or from an OVHcloud account, you can select one of our offers `MX plan`, `Email Pro`, `Exchange` or `Zimbra`.
+When migrating to or from an OVHcloud account, you can select one of our offers `MX plan` or `Exchange`.
 
 ![omm](images/omm-migration-sso-00.png){.thumbnail .w-300}
 
@@ -153,7 +153,7 @@ When you select one of these offers, follow the steps below:
 >>
 >> - You will now be able to select your services and accounts using drop-down menus. This facilitates the search for items and avoids typing errors. It is nevertheless necessary to enter the password associated with the selected email account.
 >>
->> Example with a Zimbra service:
+>> Example with an Exchange service:
 >>
 >> ![omm](images/omm-migration-sso-04.png){.thumbnail .w-600}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-gb.md
@@ -15,7 +15,7 @@ updated: 2025-11-25
 
 ## Objective
 
-[OVHcloud Mail Migrator](/links/web/omm) is a tool created by OVHcloud to meet the need for reversibility. It allows you to migrate your email accounts to OVHcloud email addresses or to an external email service. The process supports different types of content, such as emails, contacts, calendars and tasks, as long as these are compatible with your email addresses.
+[OVHcloud Mail Migrator](/links/web/omm) is a tool created by OVHcloud to meet the need for reversibility. It allows you to migrate your email accounts to OVHcloud email addresses or an external email service. The process supports different types of content, such as emails, contacts, calendars and tasks, as long as these are compatible with your email addresses.
 
 **Find out how to migrate your email accounts to OVHcloud using our OVHcloud Mail Migrator tool.**
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-gb.md
@@ -15,7 +15,7 @@ updated: 2025-11-25
 
 ## Objective
 
-[OVHcloud Mail Migrator](/links/web/omm) is a tool created by OVHcloud to meet the need for reversibility. It allows you to migrate your email accounts to your OVHcloud email addresses or an external email service. The process supports different types of content, such as emails, contacts, calendars and tasks, as long as these are compatible with your email addresses.
+[OVHcloud Mail Migrator](/links/web/omm) is a tool created by OVHcloud to meet the need for reversibility. It allows you to migrate your email accounts to OVHcloud email addresses or to an external email service. The process supports different types of content, such as emails, contacts, calendars and tasks, as long as these are compatible with your email addresses.
 
 **Find out how to migrate your email accounts to OVHcloud using our OVHcloud Mail Migrator tool.**
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-us.md
@@ -21,7 +21,7 @@ updated: 2025-11-25
 
 ## Requirements
 
-- An external email service or one from OVHcloud, such as an [Exchange](/links/web/emails-exchange) offer, or MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](/links/web/hosting)).
+- An external email service or one from OVHcloud, such as an [Exchange](/links/web/emails-exchange) offer, or MX Plan (via the MX Plan offer alone or included in an [OVHcloud web hosting offer](/links/web/hosting)).
 - Login details for the email accounts you want to migrate (the source accounts).
 - Login details for the destination email accounts.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-us.md
@@ -21,7 +21,7 @@ updated: 2025-11-25
 
 ## Requirements
 
-- An external email service or one from OVHcloud, such as a [Zimbra](/links/web/zimbra), [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro) offer, or MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](/links/web/hosting)).
+- An external email service or one from OVHcloud, such as an [Exchange](/links/web/emails-exchange) offer, or MX Plan (via the MX Plan offer alone or included in a [OVHcloud web hosting offer](/links/web/hosting)).
 - Login details for the email accounts you want to migrate (the source accounts).
 - Login details for the destination email accounts.
 
@@ -71,7 +71,7 @@ On the new page that appears, enter the connection information of the source acc
 
 Before starting your migration, it is important to know the 3 types of accounts that can be migrated and where you can migrate to:
 
-- **OVHcloud**: The `Autodetect` option is recommended if you need to migrate an account hosted on one of the OVHcloud email offers. If you have a large number of OVHcloud email accounts, select one of the following offers: `MX plan`, `Email Pro`, `Exchange` or `Zimbra`. You will be asked to connect to the OVHcloud account associated with the offer concerned by the migration. For more information, see the section "[Migrate via a connection to the OVHcloud customer account](#sso-migration)".
+- **OVHcloud**: The `Autodetect` option is recommended if you need to migrate an account hosted on one of the OVHcloud email offers. If you have a large number of OVHcloud email accounts, select one of the following offers: `MX plan` or `Exchange`. You will be asked to connect to the OVHcloud account associated with the offer concerned by the migration. For more information, see the section "[Migrate via a connection to the OVHcloud customer account](#sso-migration)".
 - **Others**: They refer to email services outside of OVHcloud. You will find a non-exhaustive list of email services supported by OMM. If the type of service of your email account is not listed, use the `IMAP` or `POP` protocols, which are compatible with most email servers.
 - **Importing files**: It is possible to migrate the content of PST, ICS, CSV, and XML rules files via OMM to a destination email account. When this function is selected, simply drag and drop your document into the designated area or browse your files using the `Browse your files`{.action} button.
 
@@ -117,7 +117,7 @@ Once the source and destination account settings are completed, click on:
 
 ### Migrate via a connection to the OVHcloud customer account <a name="sso-migration"></a>
 
-When migrating to or from an OVHcloud account, you can select one of our offers `MX plan`, `Email Pro`, `Exchange` or `Zimbra`.
+When migrating to or from an OVHcloud account, you can select one of our offers `MX plan` or `Exchange`.
 
 ![omm](images/omm-migration-sso-00.png){.thumbnail .w-300}
 
@@ -153,7 +153,7 @@ When you select one of these offers, follow the steps below:
 >>
 >> - You will now be able to select your services and accounts using drop-down menus. This facilitates the search for items and avoids typing errors. It is nevertheless necessary to enter the password associated with the selected email account.
 >>
->> Example with a Zimbra service:
+>> Example with an Exchange service:
 >>
 >> ![omm](images/omm-migration-sso-04.png){.thumbnail .w-600}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.es-es.md
@@ -108,7 +108,7 @@ Complete las informaciones según el tipo de cuenta:
 
 > [!warning]
 >
-> Si migra una cuenta que dispone de funcionalidades que la cuenta de destino no posee, **deberá guardar por sus propios medios los elementos que no puedan ser migrados por OMM**. Para ayudarle, consulte nuestro guía "[Migrar manualmente su dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)".
+> Si migra una cuenta que dispone de funcionalidades que la cuenta de destino no posee, **deberá guardar por sus propios medios los elementos que no puedan ser migrados por OMM**. Para ayudarle, consulte nuestra guía "[Migrar manualmente su dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)".
 
 Una vez completados los parámetros de las cuentas de origen y de destino, haga clic en:
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.es-us.md
@@ -21,7 +21,7 @@ updated: 2025-11-25
 
 ## Requisitos
 
-- Tener un servicio de correo electrónico externo o en OVHcloud, como una oferta [Zimbra](/links/web/zimbra), [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro) o MX Plan (a través de la oferta MX Plan sola o incluida en una oferta de [alojamiento web de OVHcloud](/links/web/hosting)).
+- Tener un servicio de correo electrónico externo o en OVHcloud, como una oferta [Exchange](/links/web/emails-exchange) o MX Plan (a través de la oferta MX Plan sola o incluida en una oferta de [alojamiento web de OVHcloud](/links/web/hosting)).
 - Tener los identificadores relacionados con las cuentas de correo electrónico que desea migrar (las cuentas de correo electrónico de origen).
 - Tener los identificadores relacionados con las cuentas de correo electrónico de destino.
 
@@ -71,7 +71,7 @@ En la nueva página que aparece, introduzca las informaciones de conexión de la
 
 Antes de comenzar su migración, es importante conocer bien los 3 tipos de cuentas que se pueden migrar y hacia las que puede migrar:
 
-- **OVHcloud**: El `Autodetect` se recomienda si debe migrar una cuenta alojada en una de las ofertas de correo electrónico de OVHcloud. Si posee un gran número de cuentas de correo electrónico de OVHcloud, seleccione una de las siguientes ofertas: `MX plan`, `Email Pro`, `Exchange` o `Zimbra`. Se le pedirá que se conecte a la cuenta de OVHcloud asociada a la oferta concernida por la migración. Para más información, consulte la sección "[Migrar mediante una conexión a la cuenta cliente de OVHcloud](#sso-migration)".
+- **OVHcloud**: El `Autodetect` se recomienda si debe migrar una cuenta alojada en una de las ofertas de correo electrónico de OVHcloud. Si posee un gran número de cuentas de correo electrónico de OVHcloud, seleccione una de las siguientes ofertas: `MX plan` o `Exchange`. Se le pedirá que se conecte a la cuenta de OVHcloud asociada a la oferta concernida por la migración. Para más información, consulte la sección "[Migrar mediante una conexión a la cuenta cliente de OVHcloud](#sso-migration)".
 - **Others**: Se trata de servicios de correo electrónico contratados fuera de OVHcloud. Una lista no exhaustiva de servicios de correo electrónico compatibles con OMM está disponible. Si el tipo de servicio de su cuenta de correo electrónico no aparece en esta lista, utilice los protocolos `IMAP` o `POP`, compatibles con la mayoría de los servidores de correo electrónico.
 - **Importing files**: Es posible migrar el contenido de archivos PST, ICS, CSV y XML Rules a través de OMM a una cuenta de correo electrónico de destino. Cuando se selecciona esta función, basta con arrastrar y soltar su documento en la zona correspondiente o navegar por su terminal mediante el botón `Browse your files`{.action}.
 
@@ -117,7 +117,7 @@ Una vez completados los parámetros de las cuentas de origen y de destino, haga 
 
 ### Migrar mediante una conexión a la cuenta cliente de OVHcloud <a name="sso-migration"></a>
 
-Durante una migración hacia o desde una cuenta de OVHcloud, es posible seleccionar una de nuestras ofertas `MX plan`, `Email Pro`, `Exchange` o `Zimbra`.
+Durante una migración hacia o desde una cuenta de OVHcloud, es posible seleccionar una de nuestras ofertas `MX plan` o `Exchange`.
 
 ![omm](images/omm-migration-sso-00.png){.thumbnail .w-300}
 
@@ -153,7 +153,7 @@ Cuando seleccione una de estas ofertas, siga los pasos siguientes:
 >>
 >> - Ahora podrá seleccionar sus servicios y cuentas mediante menús desplegables. Esto facilita la búsqueda de los elementos y evita errores de escritura. Es, sin embargo, necesario introducir la contraseña asociada a la cuenta de correo electrónico seleccionada.
 >>
->> Ejemplo con un servicio Zimbra:
+>> Ejemplo con un servicio Exchange:
 >>
 >> ![omm](images/omm-migration-sso-04.png){.thumbnail .w-600}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.es-us.md
@@ -108,7 +108,7 @@ Complete las informaciones según el tipo de cuenta:
 
 > [!warning]
 >
-> Si migra una cuenta que dispone de funcionalidades que la cuenta de destino no posee, **deberá guardar por sus propios medios los elementos que no puedan ser migrados por OMM**. Para ayudarle, consulte nuestro guía "[Migrar manualmente su dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)".
+> Si migra una cuenta que dispone de funcionalidades que la cuenta de destino no posee, **deberá guardar por sus propios medios los elementos que no puedan ser migrados por OMM**. Para ayudarle, consulte nuestra guía "[Migrar manualmente su dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)".
 
 Una vez completados los parámetros de las cuentas de origen y de destino, haga clic en:
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.fr-ca.md
@@ -21,7 +21,7 @@ updated: 2025-11-25
 
 ## Prérequis
 
-- Disposer d'un service e-mail externe ou chez OVHcloud, tel qu'une offre [Zimbra](/links/web/zimbra), [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro) ou MX Plan (via l'offre MX Plan seule ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)).
+- Disposer d'un service e-mail externe ou chez OVHcloud, tel qu'une offre [Exchange](/links/web/emails-exchange) ou MX Plan (via l'offre MX Plan seule ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)).
 - Disposer des identifiants relatifs aux comptes e-mail que vous souhaitez migrer (les comptes e-mail source).
 - Disposer des identifiants relatifs aux comptes e-mail de destination.
 
@@ -33,7 +33,7 @@ Pour accéder à OMM, rendez-vous sur l'adresse <https://omm.ovhcloud.com/>.
 
 ### Créer un projet de migration <a name="create-project"></a>
 
-Avant de lancer une migration, il est nécessaire de créer un projet. Ce projet vous permettra de lancer une ou plusieurs migrations et des les suivre.
+Avant de lancer une migration, il est nécessaire de créer un projet. Ce projet vous permettra de lancer une ou plusieurs migrations et de les suivre.
 
 Cliquez sur `Nouvelle migration`{.action} pour débuter la création de votre projet.
 
@@ -69,9 +69,9 @@ Vous êtes maintenant sur la page d'accueil du projet qui vous permettra de lanc
 
 Sur la nouvelle page qui s’affiche, renseignez les informations de connexion du compte source et du compte de destination afin de planifier la migration ou de la lancer immédiatement. Pour rappel, le contenu du **compte source** sera migré vers le **compte de destination**.
 
-Avant de commencer votre migration, il est important de bien connaître les 3 types de comptes que l'on peut migrer et vers lesquels vous pouvez migrer:
+Avant de commencer votre migration, il est important de bien connaître les 3 types de comptes que l'on peut migrer et vers lesquels vous pouvez migrer :
 
-- **OVHcloud** : L'`Autodétection` est conseillée si vous devez migrer un compte hébergé sur l'une des offres e-mail OVHcloud. Si vous possédez un grand nombre de comptes e-mail OVHcloud, sélectionnez l'une des offres suivantes : `MX plan`, `Email Pro`, `Exchange` ou `Zimbra`. Il vous sera demandé de vous connecter au compte OVHcloud associé à l'offre concernée par la migration. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
+- **OVHcloud** : L'`Autodétection` est conseillée si vous devez migrer un compte hébergé sur l'une des offres e-mail OVHcloud. Si vous possédez un grand nombre de comptes e-mail OVHcloud, sélectionnez l'une des offres suivantes : `MX plan` ou `Exchange`. Il vous sera demandé de vous connecter au compte OVHcloud associé à l'offre concernée par la migration. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
 - **Autres** : Il s'agit de services e-mail souscrits hors OVHcloud. Une liste non exhaustive de services e-mail pris en charge par OMM est disponible. Si le type de service de votre compte e-mail n'y figure pas, utilisez les protocoles `IMAP` ou `POP`, compatibles avec la plupart des serveurs e-mail.
 - **Importation de fichiers** : Il est possible de migrer le contenu de fichiers PST, ICS, CSV et XML Rules via OMM vers un compte e-mail de destination. Lorsque cette fonction est sélectionnée, il suffit de glisser-déposer votre document dans la zone prévue à cet effet ou de parcourir votre terminal via le bouton `Parcourir vos fichiers`{.action}.
 
@@ -82,7 +82,7 @@ Complétez les informations selon le type de compte :
 - **Compte source**
     - **Type de compte** : Sélectionnez le type de compte source.
     - **E-mail** : Saisissez l'adresse e-mail du compte source.
-    - **Mot de passe** : Saisissez le mot de passe au compte source.
+    - **Mot de passe** : Saisissez le mot de passe du compte source.
     - **URL du serveur** / **Domaine du serveur** *(selon le type)* : Renseignez le nom d'hôte du serveur e-mail associé au compte e-mail que vous souhaitez migrer.
     - **Identifiant OVHcloud** *(selon le type)* : Ce champ est automatiquement rempli lorsque vous êtes connecté à un compte OVHcloud. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
     - **Organization** *(selon le type)* : Sélectionnez l'organisation associée au compte e-mail source.
@@ -108,7 +108,7 @@ Complétez les informations selon le type de compte :
 
 > [!warning]
 >
-> Si vous migrez un compte disposant de fonctionnalités que le compte destination ne possède pas, **il vous sera nécessaire de sauvegarder par vos moyens les éléments qui ne pourront pas être migrés par OMM**. Pour vous aider, Référez-vous à notre guide « [Migrer manuellement votre adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration) ».
+> Si vous migrez un compte disposant de fonctionnalités que le compte destination ne possède pas, **il vous sera nécessaire de sauvegarder par vos moyens les éléments qui ne pourront pas être migrés par OMM**. Pour vous aider, référez-vous à notre guide « [Migrer manuellement votre adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration) ».
 
 Une fois les paramètres des comptes source et destination complétés, cliquez sur :
 
@@ -117,7 +117,7 @@ Une fois les paramètres des comptes source et destination complétés, cliquez 
 
 ### Migrer via une connexion au compte client OVHcloud <a name="sso-migration"></a>
 
-Lors d'une migration vers ou depuis un compte OVHcloud, il est possible de sélectionner l'une de nos offres `MX plan`, `Email Pro`, `Exchange` ou `Zimbra`.
+Lors d'une migration vers ou depuis un compte OVHcloud, il est possible de sélectionner l'une de nos offres `MX plan` ou `Exchange`.
 
 ![omm](images/omm-migration-sso-00.png){.thumbnail .w-300}
 
@@ -145,7 +145,7 @@ Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
 >>
 > **Étape 3**
 >>
->> - Une nouvelle fenêtre s'affiche. Elle vous permet d'autoriser OMM à accéder aux fonctions de votre espace client, et de lister les offres et comptes e-mail présents. Par défaut, la validité (Validity) de ces droits est de 24 heures (1 day). Définissez la durée de validité qui vous convient, puis cliquez sur `Authorize`{.action}.
+>> - Une nouvelle fenêtre s'affiche. Elle vous permet d'autoriser OMM à accéder aux fonctions de votre espace client, et de lister les offres et comptes e-mail présents. Par défaut, la validité de ces droits est de 24 heures. Définissez la durée de validité qui vous convient, puis cliquez sur `Authorize`{.action}.
 >>
 >> ![omm](images/omm-migration-sso-03.png){.thumbnail .w-600}
 >>
@@ -153,7 +153,7 @@ Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
 >>
 >> - Vous serez à présent en mesure de sélectionner vos services et comptes à l'aide de menus déroulants. Cela facilite la recherche des éléments et permet d'éviter les erreurs de saisie. Il est toutefois nécessaire de saisir le mot de passe associé au compte e-mail sélectionné.
 >>
->> Exemple avec un service Zimbra :
+>> Exemple avec un service Exchange :
 >>
 >> ![omm](images/omm-migration-sso-04.png){.thumbnail .w-600}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.fr-ca.md
@@ -69,7 +69,7 @@ Vous êtes maintenant sur la page d'accueil du projet qui vous permettra de lanc
 
 Sur la nouvelle page qui s’affiche, renseignez les informations de connexion du compte source et du compte de destination afin de planifier la migration ou de la lancer immédiatement. Pour rappel, le contenu du **compte source** sera migré vers le **compte de destination**.
 
-Avant de commencer votre migration, il est important de bien connaître les 3 types de comptes que l'on peut migrer et vers lesquels vous pouvez migrer :
+Avant de commencer votre migration, il est important de bien connaître les 3 types de comptes que l'on peut migrer et vers lesquels vous pouvez migrer :
 
 - **OVHcloud** : L'`Autodétection` est conseillée si vous devez migrer un compte hébergé sur l'une des offres e-mail OVHcloud. Si vous possédez un grand nombre de comptes e-mail OVHcloud, sélectionnez l'une des offres suivantes : `MX plan` ou `Exchange`. Il vous sera demandé de vous connecter au compte OVHcloud associé à l'offre concernée par la migration. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
 - **Autres** : Il s'agit de services e-mail souscrits hors OVHcloud. Une liste non exhaustive de services e-mail pris en charge par OMM est disponible. Si le type de service de votre compte e-mail n'y figure pas, utilisez les protocoles `IMAP` ou `POP`, compatibles avec la plupart des serveurs e-mail.
@@ -117,7 +117,7 @@ Une fois les paramètres des comptes source et destination complétés, cliquez 
 
 ### Migrer via une connexion au compte client OVHcloud <a name="sso-migration"></a>
 
-Lors d'une migration vers ou depuis un compte OVHcloud, il est possible de sélectionner l'une de nos offres `MX plan` ou `Exchange`.
+Lors d'une migration vers ou depuis un compte OVHcloud, vous pouvez sélectionner l'une de nos offres `MX plan` ou `Exchange`.
 
 ![omm](images/omm-migration-sso-00.png){.thumbnail .w-300}
 
@@ -153,7 +153,7 @@ Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
 >>
 >> - Vous serez à présent en mesure de sélectionner vos services et comptes à l'aide de menus déroulants. Cela facilite la recherche des éléments et permet d'éviter les erreurs de saisie. Il est toutefois nécessaire de saisir le mot de passe associé au compte e-mail sélectionné.
 >>
->> Exemple avec un service Exchange :
+>> Exemple avec un service Exchange :
 >>
 >> ![omm](images/omm-migration-sso-04.png){.thumbnail .w-600}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.fr-fr.md
@@ -33,7 +33,7 @@ Pour accéder à OMM, rendez-vous sur l'adresse <https://omm.ovhcloud.com/>.
 
 ### Créer un projet de migration <a name="create-project"></a>
 
-Avant de lancer une migration, il est nécessaire de créer un projet. Ce projet vous permettra de lancer une ou plusieurs migrations et des les suivre.
+Avant de lancer une migration, il est nécessaire de créer un projet. Ce projet vous permettra de lancer une ou plusieurs migrations et de les suivre.
 
 Cliquez sur `Nouvelle migration`{.action} pour débuter la création de votre projet.
 
@@ -69,7 +69,7 @@ Vous êtes maintenant sur la page d'accueil du projet qui vous permettra de lanc
 
 Sur la nouvelle page qui s’affiche, renseignez les informations de connexion du compte source et du compte de destination afin de planifier la migration ou de la lancer immédiatement. Pour rappel, le contenu du **compte source** sera migré vers le **compte de destination**.
 
-Avant de commencer votre migration, il est important de bien connaître les 3 types de comptes que l'on peut migrer et vers lesquels vous pouvez migrer:
+Avant de commencer votre migration, il est important de bien connaître les 3 types de comptes que l'on peut migrer et vers lesquels vous pouvez migrer :
 
 - **OVHcloud** : L'`Autodétection` est conseillée si vous devez migrer un compte hébergé sur l'une des offres e-mail OVHcloud. Si vous possédez un grand nombre de comptes e-mail OVHcloud, sélectionnez l'une des offres suivantes : `MX plan`, `Email Pro`, `Exchange` ou `Zimbra`. Il vous sera demandé de vous connecter au compte OVHcloud associé à l'offre concernée par la migration. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
 - **Autres** : Il s'agit de services e-mail souscrits hors OVHcloud. Une liste non exhaustive de services e-mail pris en charge par OMM est disponible. Si le type de service de votre compte e-mail n'y figure pas, utilisez les protocoles `IMAP` ou `POP`, compatibles avec la plupart des serveurs e-mail.
@@ -82,7 +82,7 @@ Complétez les informations selon le type de compte :
 - **Compte source**
     - **Type de compte** : Sélectionnez le type de compte source.
     - **E-mail** : Saisissez l'adresse e-mail du compte source.
-    - **Mot de passe** : Saisissez le mot de passe au compte source.
+    - **Mot de passe** : Saisissez le mot de passe du compte source.
     - **URL du serveur** / **Domaine du serveur** *(selon le type)* : Renseignez le nom d'hôte du serveur e-mail associé au compte e-mail que vous souhaitez migrer.
     - **Identifiant OVHcloud** *(selon le type)* : Ce champ est automatiquement rempli lorsque vous êtes connecté à un compte OVHcloud. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
     - **Organization** *(selon le type)* : Sélectionnez l'organisation associée au compte e-mail source.
@@ -108,7 +108,7 @@ Complétez les informations selon le type de compte :
 
 > [!warning]
 >
-> Si vous migrez un compte disposant de fonctionnalités que le compte destination ne possède pas, **il vous sera nécessaire de sauvegarder par vos moyens les éléments qui ne pourront pas être migrés par OMM**. Pour vous aider, Référez-vous à notre guide « [Migrer manuellement votre adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration) ».
+> Si vous migrez un compte disposant de fonctionnalités que le compte destination ne possède pas, **il vous sera nécessaire de sauvegarder par vos moyens les éléments qui ne pourront pas être migrés par OMM**. Pour vous aider, référez-vous à notre guide « [Migrer manuellement votre adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration) ».
 
 Une fois les paramètres des comptes source et destination complétés, cliquez sur :
 
@@ -145,7 +145,7 @@ Lorsque vous sélectionnez l'une de ces offres, suivez les étapes ci-dessous :
 >>
 > **Étape 3**
 >>
->> - Une nouvelle fenêtre s'affiche. Elle vous permet d'autoriser OMM à accéder aux fonctions de votre espace client, et de lister les offres et comptes e-mail présents. Par défaut, la validité (Validity) de ces droits est de 24 heures (1 day). Définissez la durée de validité qui vous convient, puis cliquez sur `Authorize`{.action}.
+>> - Une nouvelle fenêtre s'affiche. Elle vous permet d'autoriser OMM à accéder aux fonctions de votre espace client, et de lister les offres et comptes e-mail présents. Par défaut, la validité de ces droits est de 24 heures. Définissez la durée de validité qui vous convient, puis cliquez sur `Authorize`{.action}.
 >>
 >> ![omm](images/omm-migration-sso-03.png){.thumbnail .w-600}
 >>

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.fr-fr.md
@@ -69,7 +69,7 @@ Vous êtes maintenant sur la page d'accueil du projet qui vous permettra de lanc
 
 Sur la nouvelle page qui s’affiche, renseignez les informations de connexion du compte source et du compte de destination afin de planifier la migration ou de la lancer immédiatement. Pour rappel, le contenu du **compte source** sera migré vers le **compte de destination**.
 
-Avant de commencer votre migration, il est important de bien connaître les 3 types de comptes que l'on peut migrer et vers lesquels vous pouvez migrer :
+Avant de commencer votre migration, il est important de bien connaître les 3 types de comptes que l'on peut migrer et vers lesquels vous pouvez migrer :
 
 - **OVHcloud** : L'`Autodétection` est conseillée si vous devez migrer un compte hébergé sur l'une des offres e-mail OVHcloud. Si vous possédez un grand nombre de comptes e-mail OVHcloud, sélectionnez l'une des offres suivantes : `MX plan`, `Email Pro`, `Exchange` ou `Zimbra`. Il vous sera demandé de vous connecter au compte OVHcloud associé à l'offre concernée par la migration. Pour plus d'informations, consultez la rubrique « [Migrer via une connexion au compte client OVHcloud](#sso-migration) ».
 - **Autres** : Il s'agit de services e-mail souscrits hors OVHcloud. Une liste non exhaustive de services e-mail pris en charge par OMM est disponible. Si le type de service de votre compte e-mail n'y figure pas, utilisez les protocoles `IMAP` ou `POP`, compatibles avec la plupart des serveurs e-mail.
@@ -117,7 +117,7 @@ Une fois les paramètres des comptes source et destination complétés, cliquez 
 
 ### Migrer via une connexion au compte client OVHcloud <a name="sso-migration"></a>
 
-Lors d'une migration vers ou depuis un compte OVHcloud, il est possible de sélectionner l'une de nos offres `MX plan`, `Email Pro`, `Exchange` ou `Zimbra`.
+Lors d'une migration vers ou depuis un compte OVHcloud, vous pouvez sélectionner l'une de nos offres `MX plan`, `Email Pro`, `Exchange` ou `Zimbra`.
 
 ![omm](images/omm-migration-sso-00.png){.thumbnail .w-300}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.pl-pl.md
@@ -21,7 +21,7 @@ updated: 2025-11-25
 
 ## Wymagania początkowe
 
-- Posiadaj zewnętrzny serwis poczty e-mail lub jeden z oferowanych przez OVHcloud, takich jak [Zimbra](/links/web/zimbra), [Exchange](/links/web/emails-exchange), [E-mail Pro](/links/web/email-pro) lub MX Plan (za pośrednictwem oferty MX Plan lub uwzględniony w ofercie [OVHcloud Hosting](/links/web/hosting)).
+- Posiadaj zewnętrzny serwis poczty e-mail lub jeden z oferowanych przez OVHcloud, takich jak [Zimbra](/links/web/zimbra), [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro) lub MX Plan (za pośrednictwem oferty MX Plan lub uwzględniony w ofercie [OVHcloud Hosting](/links/web/hosting)).
 - Posiadaj dane logowania do kont e-mailowych, które chcesz przenieść (konta źródłowe).
 - Posiadaj dane logowania do kont e-mailowych docelowych.
 
@@ -71,7 +71,7 @@ Na nowej stronie, która się pojawi, wprowadź dane logowania konta źródłowe
 
 Przed rozpoczęciem migracji ważne jest, aby wiedzieć o trzech typach kont, które można przenieść i gdzie można je przenieść:
 
-- **OVHcloud**: Opcja `Autodetect` jest zalecana, jeśli musisz przenieść konto hostowane na jednej z ofert poczty e-mail OVHcloud. Jeśli masz dużą liczbę kont poczty e-mail OVHcloud, wybierz jedną z poniższych ofert: `MX plan`, `E-mail Pro`, `Exchange` lub `Zimbra`. Będziesz musiał zalogować się do konta OVHcloud powiązanego z ofertą dotyczącą migracji. Aby uzyskać więcej informacji, zobacz sekcję "[Migrowanie za pomocą połączenia z kontem klienta OVHcloud](#sso-migration)".
+- **OVHcloud**: Opcja `Autodetect` jest zalecana, jeśli musisz przenieść konto hostowane na jednej z ofert poczty e-mail OVHcloud. Jeśli masz dużą liczbę kont poczty e-mail OVHcloud, wybierz jedną z poniższych ofert: `MX plan`, `Email Pro`, `Exchange` lub `Zimbra`. Będziesz musiał zalogować się do konta OVHcloud powiązanego z ofertą dotyczącą migracji. Aby uzyskać więcej informacji, zobacz sekcję "[Migrowanie za pomocą połączenia z kontem klienta OVHcloud](#sso-migration)".
 - **Others**: Są to usługi poczty e-mail subskrybowane poza OVHcloud. Dostępna jest niekompletna lista usług poczty e-mail obsługiwanych przez OMM. Jeśli typ usługi Twojego konta e-mail nie znajduje się na liście, użyj protokołów `IMAP` lub `POP`, kompatybilnych z większością serwerów poczty e-mail.
 - **Importing files**: Możliwe jest przeniesienie zawartości plików PST, ICS, CSV i XML Rules przez OMM do konta poczty e-mail docelowego. Gdy ta funkcja zostanie wybrana, po prostu przeciągnij i upuść swój dokument do wyznaczonej strefy lub przejdź do terminala za pomocą przycisku `Browse your files`{.action}.
 
@@ -117,7 +117,7 @@ Po uzupełnieniu ustawień konta źródłowego i docelowego kliknij:
 
 ### Migrowanie za pomocą połączenia z kontem klienta OVHcloud <a name="sso-migration"></a>
 
-Przy migracji do lub z konta OVHcloud możesz wybrać jedną z naszych ofert `MX plan`, `E-mail Pro`, `Exchange` lub `Zimbra`.
+Przy migracji do lub z konta OVHcloud możesz wybrać jedną z naszych ofert `MX plan`, `Email Pro`, `Exchange` lub `Zimbra`.
 
 ![omm](images/omm-migration-sso-00.png){.thumbnail .w-300}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.pl-pl.md
@@ -21,7 +21,7 @@ updated: 2025-11-25
 
 ## Wymagania początkowe
 
-- Posiadaj zewnętrzny serwis poczty e-mail lub jeden z oferowanych przez OVHcloud, takich jak [Zimbra](/links/web/zimbra), [Exchange](/links/web/emails-exchange), [Email Pro](/links/web/email-pro) lub MX Plan (za pośrednictwem oferty MX Plan lub uwzględniony w ofercie [OVHcloud Hosting](/links/web/hosting)).
+- Posiadaj zewnętrzny serwis poczty e-mail lub jeden z oferowanych przez OVHcloud, takich jak [Zimbra](/links/web/zimbra), [Exchange](/links/web/emails-exchange), [E-mail Pro](/links/web/email-pro) lub MX Plan (za pośrednictwem oferty MX Plan lub uwzględniony w ofercie [OVHcloud Hosting](/links/web/hosting)).
 - Posiadaj dane logowania do kont e-mailowych, które chcesz przenieść (konta źródłowe).
 - Posiadaj dane logowania do kont e-mailowych docelowych.
 
@@ -71,7 +71,7 @@ Na nowej stronie, która się pojawi, wprowadź dane logowania konta źródłowe
 
 Przed rozpoczęciem migracji ważne jest, aby wiedzieć o trzech typach kont, które można przenieść i gdzie można je przenieść:
 
-- **OVHcloud**: Opcja `Autodetect` jest zalecana, jeśli musisz przenieść konto hostowane na jednej z ofert poczty e-mail OVHcloud. Jeśli masz dużą liczbę kont poczty e-mail OVHcloud, wybierz jedną z poniższych ofert: `MX plan`, `Email Pro`, `Exchange` lub `Zimbra`. Będziesz musiał zalogować się do konta OVHcloud powiązanego z ofertą dotyczącą migracji. Aby uzyskać więcej informacji, zobacz sekcję "[Migrowanie za pomocą połączenia z kontem klienta OVHcloud](#sso-migration)".
+- **OVHcloud**: Opcja `Autodetect` jest zalecana, jeśli musisz przenieść konto hostowane na jednej z ofert poczty e-mail OVHcloud. Jeśli masz dużą liczbę kont poczty e-mail OVHcloud, wybierz jedną z poniższych ofert: `MX plan`, `E-mail Pro`, `Exchange` lub `Zimbra`. Będziesz musiał zalogować się do konta OVHcloud powiązanego z ofertą dotyczącą migracji. Aby uzyskać więcej informacji, zobacz sekcję "[Migrowanie za pomocą połączenia z kontem klienta OVHcloud](#sso-migration)".
 - **Others**: Są to usługi poczty e-mail subskrybowane poza OVHcloud. Dostępna jest niekompletna lista usług poczty e-mail obsługiwanych przez OMM. Jeśli typ usługi Twojego konta e-mail nie znajduje się na liście, użyj protokołów `IMAP` lub `POP`, kompatybilnych z większością serwerów poczty e-mail.
 - **Importing files**: Możliwe jest przeniesienie zawartości plików PST, ICS, CSV i XML Rules przez OMM do konta poczty e-mail docelowego. Gdy ta funkcja zostanie wybrana, po prostu przeciągnij i upuść swój dokument do wyznaczonej strefy lub przejdź do terminala za pomocą przycisku `Browse your files`{.action}.
 
@@ -117,7 +117,7 @@ Po uzupełnieniu ustawień konta źródłowego i docelowego kliknij:
 
 ### Migrowanie za pomocą połączenia z kontem klienta OVHcloud <a name="sso-migration"></a>
 
-Przy migracji do lub z konta OVHcloud możesz wybrać jedną z naszych ofert `MX plan`, `Email Pro`, `Exchange` lub `Zimbra`.
+Przy migracji do lub z konta OVHcloud możesz wybrać jedną z naszych ofert `MX plan`, `E-mail Pro`, `Exchange` lub `Zimbra`.
 
 ![omm](images/omm-migration-sso-00.png){.thumbnail .w-300}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.de-de.md
@@ -24,6 +24,7 @@ Sie möchten Ihre E-Mail-Adressen von einer Exchange- oder E-Mail Pro-Plattform 
 
 - Sie haben eine "**Quell-Plattform**" mit bereits eingerichteten [Exchange](/links/web/emails-hosted-exchange) oder [E-Mail Pro](/links/web/email-pro) oder [Zimbra](/links/web/zimbra) Accounts.
 - Sie verfügen über eine "**Ziel-Plattform**": [Exchange](/links/web/emails-hosted-exchange), [E-Mail Pro](/links/web/email-pro) oder MX Plan (über das MX Plan Angebot oder in einem [OVHcloud Webhosting](/links/web/hosting) enthalten). Diese Plattform muss unkonfigurierte oder verfügbare Accounts haben, um die zu migrierenden E-Mail-Accounts zu empfangen.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-email-pro -->
 <!-- CP-NAV-START:web-exchange -->
@@ -33,17 +34,17 @@ Sie möchten Ihre E-Mail-Adressen von einer Exchange- oder E-Mail Pro-Plattform 
 
 **MX Plan:**
 
-- **Direktlink:** [MX Plan](/links/control-panel/web-mx-plan)
+- **Direkter Link:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Navigationspfad:** `Web Cloud`{.action} > `MX Plan`{.action} > Wählen Sie Ihren MX Plan Dienst aus
 
 **E-Mail Pro:**
 
-- **Direktlink:** [E-Mail Pro](/links/control-panel/web-email-pro)
+- **Direkter Link:** [E-Mail Pro](/links/control-panel/web-email-pro)
 - **Navigationspfad:** `Web Cloud`{.action} > `E-Mail Pro`{.action} > Wählen Sie Ihre Plattform aus
 
 **Exchange:**
 
-- **Direktlink:** [Exchange](/links/control-panel/web-exchange)
+- **Direkter Link:** [Exchange](/links/control-panel/web-exchange)
 - **Navigationspfad:** `Web Cloud`{.action} > `Exchange`{.action} > Wählen Sie Ihre Plattform aus
 
 ---
@@ -114,7 +115,7 @@ Weitere Informationen zu OMM finden Sie in unserer Anleitung "[E-Mail-Accounts �
 
 Die Migrationsdauer hängt davon ab, wie viele Daten auf Ihren neuen Account migriert werden sollen. Dies kann von einigen Minuten bis zu mehreren Stunden variieren.
 
-Überprüfen Sie nach der Migration, ob alle Ihre Elemente vorhanden sind, indem Sie sich im Webmail einloggen:[Webmail](/links/web/email).
+Überprüfen Sie nach der Migration, ob alle Ihre Elemente vorhanden sind, indem Sie sich im Webmail einloggen: [Webmail](/links/web/email).
 
 Nach der Migration können Sie den ursprünglichen Account mit dem geänderten Namen beibehalten oder löschen.
 
@@ -139,7 +140,7 @@ Um die Konfiguration zu ändern, klicken Sie auf das rote Feld und führen Sie d
 
 ### Migrierte E-Mail-Adressen verwenden
 
-Sie können nun Ihre migrierten E-Mail-Adressen verwenden. OVHcloud stellt dazu einen Web-Client (*Wep App*) zur Verfügung, der über [Webmail](/links/web/email) erreichbar ist. Geben Sie dort die Login-Daten für Ihre E-Mail-Adresse ein.
+Sie können nun Ihre migrierten E-Mail-Adressen verwenden. OVHcloud stellt dazu einen Web-Client (*Web App*) zur Verfügung, der über [Webmail](/links/web/email) erreichbar ist. Geben Sie dort die Login-Daten für Ihre E-Mail-Adresse ein.
 
 Wenn Sie einen der migrierten Accounts auf einem lokalen E-Mail-Client eingerichtet haben (Outlook, Thunderbird, etc.), muss er erneut konfiguriert werden. Die Verbindungsdaten zum OVHcloud Server haben sich nach der Migration geändert.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.de-de.md
@@ -37,9 +37,9 @@ Sie möchten Ihre E-Mail-Adressen von einer Exchange- oder E-Mail Pro-Plattform 
 - **Direkter Link:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Navigationspfad:** `Web Cloud`{.action} > `MX Plan`{.action} > Wählen Sie Ihren MX Plan Dienst aus
 
-**Email Pro:**
+**E-Mail Pro:**
 
-- **Direkter Link:** [Email Pro](/links/control-panel/web-email-pro)
+- **Direkter Link:** [E-Mail Pro](/links/control-panel/web-email-pro)
 - **Navigationspfad:** `Web Cloud`{.action} > `E-Mail Pro`{.action} > Wählen Sie Ihre Plattform aus
 
 **Exchange:**
@@ -153,9 +153,9 @@ Wenn Sie einen der migrierten Accounts auf einem lokalen E-Mail-Client eingerich
 
 [Verwaltung der Kontakte Ihrer Dienste](/pages/account_and_service_management/account_information/managing_contacts)
 
-[Erste Schritte mit dem E-Mail Pro-Angebot](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config).
+[Erste Schritte mit dem E-Mail Pro-Angebot](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 
-[Erste Schritte mit dem Exchange-Angebot](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted).
+[Erste Schritte mit dem Exchange-Angebot](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
 [Erste Schritte mit dem Zimbra-Angebot](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.de-de.md
@@ -37,9 +37,9 @@ Sie möchten Ihre E-Mail-Adressen von einer Exchange- oder E-Mail Pro-Plattform 
 - **Direkter Link:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Navigationspfad:** `Web Cloud`{.action} > `MX Plan`{.action} > Wählen Sie Ihren MX Plan Dienst aus
 
-**E-Mail Pro:**
+**Email Pro:**
 
-- **Direkter Link:** [E-Mail Pro](/links/control-panel/web-email-pro)
+- **Direkter Link:** [Email Pro](/links/control-panel/web-email-pro)
 - **Navigationspfad:** `Web Cloud`{.action} > `E-Mail Pro`{.action} > Wählen Sie Ihre Plattform aus
 
 **Exchange:**
@@ -60,7 +60,7 @@ Sie möchten Ihre E-Mail-Adressen von einer Exchange- oder E-Mail Pro-Plattform 
 >
 > Vor Beginn der Migration, wenn Sie Ihr neues E-Mail-Angebot bestellt haben, fügen Sie zunächst den Domainnamen zu Ihrer E-Mail-Plattform hinzu. Wenn Sie zu einer MX Plan-Plattform migrieren, ist der angeschlossene Domainname nicht wählbar. Sie können direkt zum [nächsten Schritt](#accountsmigration) übergehen.
 >
-> Wählen Sie den Tab `Zugeordnete Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform aus und klicken Sie auf `Domain hinzufügen`{.action}. Nachdem der Domainname hinzugefügt wurde, stellen Sie sicher, dass die Bezeichnung `OK` oder `Aktiv`{.action} in der Spalte `Status` angezeigt wird.
+> Wählen Sie den Tab `Assoziierte Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform aus und klicken Sie auf `Domain hinzufügen`{.action}. Nachdem der Domainname hinzugefügt wurde, stellen Sie sicher, dass die Bezeichnung `OK` oder `Aktiv`{.action} in der Spalte `Status` angezeigt wird.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
@@ -125,7 +125,7 @@ Um ihn zu löschen, gehen Sie zum Tab `E-Mail-Accounts`{.action} Ihrer Quell-Pla
 
 Ihre E-Mail-Adressen sollten bereits migriert und funktionsfähig sein. Aus Sicherheitsgründen bitten wir Sie, die korrekte Konfiguration Ihrer Domain in Ihrem Kundencenter zu überprüfen.
 
-Wählen Sie den betreffenden E-Mail Pro-, Exchange- oder Zimbra-Service aus und gehen Sie zum Tab `Zugeordnete Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform. Überprüfen Sie den Abschnitt oder die Spalte `Diagnose`{.action}.
+Wählen Sie den betreffenden E-Mail Pro-, Exchange- oder Zimbra-Service aus und gehen Sie zum Tab `Assoziierte Domains`{.action} oder `Domain`{.action} auf Ihrer Plattform. Überprüfen Sie den Abschnitt oder die Spalte `Diagnose`{.action}.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-ca.md
@@ -53,7 +53,7 @@ You want to migrate your email addresses on an Exchange platform to another Exch
 >
 > Before starting your migration, if you have just ordered your new email offer, first add the domain name to your email platform. If you are migrating to an MX Plan platform, the attached domain name being "fixed", you can directly proceed to the [next step](#accountsmigration).
 >
-> Select the `Associated Domains`{.action} or `Domain`{.action} tab on your platform, then click on `Add a domain`{.action}. Once the domain name is added, make sure the `OK` or `Active`{.action} mention is present in the `Status` column.
+> Select the `Associated domains`{.action} or `Domain`{.action} tab on your platform, then click on `Add a domain`{.action}. Once the domain name is added, make sure the `OK` or `Active`{.action} mention is present in the `Status` column.
 >
 > ![email-migration](images/migration_platform02.png){.thumbnail}
 >
@@ -75,7 +75,7 @@ Your email accounts will be migrated in 3 main steps: **Rename** the original em
 
 Rename the email account to be migrated with a provisional name (example: to migrate the email account *john.smith@mydomain.ovh*, rename it to *john.smith01@mydomain.ovh*).
 
-In the `Email accounts`{.action} tab for your email platform, click on the `...`{.action} button, then `Modify`{.action}.
+In the `Email accounts`{.action} tab for your email platform, click on the `...`{.action} button, then `Edit`{.action}.
 
 ![email-migration](images/migration_platform04.png){.thumbnail}
 
@@ -83,7 +83,7 @@ In the `Email accounts`{.action} tab for your email platform, click on the `...`
 
 Re-create your email address on the new account for your Exchange or MX Plan platform. (Using the previous example, you will create *john.smith@mydomain.ovh* on your new platform.)
 
-In the `Email accounts`{.action} tab for your platform, click on the `...`{.action} button, to the right of the target email account, then `Modify`{.action}.
+In the `Email accounts`{.action} tab for your platform, click on the `...`{.action} button, to the right of the target email account, then `Edit`{.action}.
 
 ![email-migration](images/migration_platform05.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-ca.md
@@ -24,6 +24,7 @@ You want to migrate your email addresses on an Exchange platform to another Exch
 
 - a "**source**" platform with configured [Exchange](/links/web/emails-hosted-exchange) accounts
 - a "**destination**" platform with [Exchange](/links/web/emails-hosted-exchange) or MX Plan accounts (via the MX Plan solution or included in [OVHcloud Web Hosting plans](/links/web/hosting)). This platform must have unconfigured accounts or be available to host the email accounts that need to be migrated.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-exchange -->
 ---

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-gb.md
@@ -24,6 +24,7 @@ You want to migrate your email addresses on an Exchange or Email Pro platform to
 
 - A **"source"** platform with configured [Exchange](/links/web/emails-hosted-exchange) or [Email Pro](/links/web/email-pro) accounts or [Zimbra](/links/web/zimbra).
 - A "**destination**" platform with [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) or MX Plan accounts (via the MX Plan solution or included in [OVHcloud Web Hosting plans](/links/web/hosting)). This platform must have unconfigured accounts or be available to host the email accounts that need to be migrated.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-email-pro -->
 <!-- CP-NAV-START:web-exchange -->
@@ -82,7 +83,7 @@ Your email accounts will be migrated in 3 main steps: **Rename** the original em
 
 Rename the email account to be migrated with a provisional name (example: to migrate the email account *john.smith@mydomain.ovh*, rename it to *john.smith01@mydomain.ovh*).
 
-In the `Email accounts`{.action} tab for your email platform, click on the `...`{.action} button, then `Modify`{.action}.
+In the `Email accounts`{.action} tab for your email platform, click on the `...`{.action} button, then `Edit`{.action}.
 
 ![email-migration](images/migration_platform04.png){.thumbnail}
 
@@ -90,7 +91,7 @@ In the `Email accounts`{.action} tab for your email platform, click on the `...`
 
 Re-create your email address on the new account for your Email Pro, Exchange or MX Plan platform. (Using the previous example, you will create *john.smith@mydomain.ovh* on your new platform.)
 
-In the `Email accounts`{.action} tab for your platform, click on the `...`{.action} button, to the right of the target email account, then `Modify`{.action}.
+In the `Email accounts`{.action} tab for your platform, click on the `...`{.action} button, to the right of the target email account, then `Edit`{.action}.
 
 ![email-migration](images/migration_platform05.png){.thumbnail}
 
@@ -133,8 +134,6 @@ To do this, select the relevant Email Pro, Exchange or Zimbra service, then go t
 > If you have just migrated or modified a DNS record for your domain, it may take a few hours to be updated when you go to the [OVHcloud Control Panel](/links/manager).
 
 To modify the configuration, click on the red box and carry out the requested operation. It can take between 4 and a maximum of 24 hours for DNS changes to propagate fully.
-
-![email-migration](images/check_the_dns_records_associated_domains.png){.thumbnail}
 
 ### Use your migrated email addresses
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-gb.md
@@ -60,7 +60,7 @@ You want to migrate your email addresses on an Exchange or Email Pro platform to
 >
 > Before starting your migration, if you have just ordered your new email offer, first add the domain name to your email platform. If you are migrating to an MX Plan platform, the attached domain name being "fixed", you can directly proceed to the [next step](#accountsmigration).
 >
-> Select the `Associated Domains`{.action} or `Domain`{.action} tab on your platform, then click on `Add a domain`{.action}. Once the domain name is added, make sure the `OK` or `Active`{.action} mention is present in the `Status` column.
+> Select the `Associated domains`{.action} or `Domain`{.action} tab on your platform, then click on `Add a domain`{.action}. Once the domain name is added, make sure the `OK` or `Active`{.action} mention is present in the `Status` column.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
@@ -125,7 +125,7 @@ If you would like to delete it, go to the `Email accounts`{.action} tab on your 
 
 At this stage, your email addresses should already be migrated and functional. For security reasons, please ensure that your domain is correctly configured in your Control Panel.
 
-To do this, select the relevant Email Pro, Exchange or Zimbra service, then go to the `Associated Domains`{.action} or `Domain`{.action} tab on your platform. Check the `Diagnostics`{.action} section or column.
+To do this, select the relevant Email Pro, Exchange or Zimbra service, then go to the `Associated domains`{.action} or `Domain`{.action} tab on your platform. Check the `Diagnostics`{.action} section or column.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-ie.md
@@ -24,6 +24,7 @@ You want to migrate your email addresses on an Exchange or Email Pro platform to
 
 - A **"source"** platform with configured [Exchange](/links/web/emails-hosted-exchange) or [Email Pro](/links/web/email-pro) accounts or [Zimbra](/links/web/zimbra).
 - A "**destination**" platform with [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) or MX Plan accounts (via the MX Plan solution or included in [OVHcloud Web Hosting plans](/links/web/hosting)). This platform must have unconfigured accounts or be available to host the email accounts that need to be migrated.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-email-pro -->
 <!-- CP-NAV-START:web-exchange -->
@@ -82,7 +83,7 @@ Your email accounts will be migrated in 3 main steps: **Rename** the original em
 
 Rename the email account to be migrated with a provisional name (example: to migrate the email account *john.smith@mydomain.ovh*, rename it to *john.smith01@mydomain.ovh*).
 
-In the `Email accounts`{.action} tab for your email platform, click on the `...`{.action} button, then `Modify`{.action}.
+In the `Email accounts`{.action} tab for your email platform, click on the `...`{.action} button, then `Edit`{.action}.
 
 ![email-migration](images/migration_platform04.png){.thumbnail}
 
@@ -90,7 +91,7 @@ In the `Email accounts`{.action} tab for your email platform, click on the `...`
 
 Re-create your email address on the new account for your Email Pro, Exchange or MX Plan platform. (Using the previous example, you will create *john.smith@mydomain.ovh* on your new platform.)
 
-In the `Email accounts`{.action} tab for your platform, click on the `...`{.action} button, to the right of the target email account, then `Modify`{.action}.
+In the `Email accounts`{.action} tab for your platform, click on the `...`{.action} button, to the right of the target email account, then `Edit`{.action}.
 
 ![email-migration](images/migration_platform05.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-ie.md
@@ -60,7 +60,7 @@ You want to migrate your email addresses on an Exchange or Email Pro platform to
 >
 > Before starting your migration, if you have just ordered your new email offer, first add the domain name to your email platform. If you are migrating to an MX Plan platform, the attached domain name being "fixed", you can directly proceed to the [next step](#accountsmigration).
 >
-> Select the `Associated Domains`{.action} or `Domain`{.action} tab on your platform, then click on `Add a domain`{.action}. Once the domain name is added, make sure the `OK` or `Active`{.action} mention is present in the `Status` column.
+> Select the `Associated domains`{.action} or `Domain`{.action} tab on your platform, then click on `Add a domain`{.action}. Once the domain name is added, make sure the `OK` or `Active`{.action} mention is present in the `Status` column.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
@@ -125,7 +125,7 @@ If you would like to delete it, go to the `Email accounts`{.action} tab on your 
 
 At this stage, your email addresses should already be migrated and functional. For security reasons, please ensure that your domain is correctly configured in your Control Panel.
 
-To do this, select the relevant Email Pro, Exchange or Zimbra service, then go to the `Associated Domains`{.action} or `Domain`{.action} tab on your platform. Check the `Diagnostics`{.action} section or column.
+To do this, select the relevant Email Pro, Exchange or Zimbra service, then go to the `Associated domains`{.action} or `Domain`{.action} tab on your platform. Check the `Diagnostics`{.action} section or column.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-us.md
@@ -53,7 +53,7 @@ You want to migrate your email addresses on an Exchange platform to another Exch
 >
 > Before starting your migration, if you have just ordered your new email offer, first add the domain name to your email platform. If you are migrating to an MX Plan platform, the attached domain name being "fixed", you can directly proceed to the [next step](#accountsmigration).
 >
-> Select the `Associated Domains`{.action} or `Domain`{.action} tab on your platform, then click on `Add a domain`{.action}. Once the domain name is added, make sure the `OK` or `Active`{.action} mention is present in the `Status` column.
+> Select the `Associated domains`{.action} or `Domain`{.action} tab on your platform, then click on `Add a domain`{.action}. Once the domain name is added, make sure the `OK` or `Active`{.action} mention is present in the `Status` column.
 >
 > ![email-migration](images/migration_platform02.png){.thumbnail}
 >
@@ -75,7 +75,7 @@ Your email accounts will be migrated in 3 main steps: **Rename** the original em
 
 Rename the email account to be migrated with a provisional name (example: to migrate the email account *john.smith@mydomain.ovh*, rename it to *john.smith01@mydomain.ovh*).
 
-In the `Email accounts`{.action} tab for your email platform, click on the `...`{.action} button, then `Modify`{.action}.
+In the `Email accounts`{.action} tab for your email platform, click on the `...`{.action} button, then `Edit`{.action}.
 
 ![email-migration](images/migration_platform04.png){.thumbnail}
 
@@ -83,7 +83,7 @@ In the `Email accounts`{.action} tab for your email platform, click on the `...`
 
 Re-create your email address on the new account for your Exchange or MX Plan platform. (Using the previous example, you will create *john.smith@mydomain.ovh* on your new platform.)
 
-In the `Email accounts`{.action} tab for your platform, click on the `...`{.action} button, to the right of the target email account, then `Modify`{.action}.
+In the `Email accounts`{.action} tab for your platform, click on the `...`{.action} button, to the right of the target email account, then `Edit`{.action}.
 
 ![email-migration](images/migration_platform05.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.en-us.md
@@ -24,6 +24,7 @@ You want to migrate your email addresses on an Exchange platform to another Exch
 
 - a "**source**" platform with configured [Exchange](/links/web/emails-hosted-exchange) accounts
 - a "**destination**" platform with [Exchange](/links/web/emails-hosted-exchange) or MX Plan accounts (via the MX Plan solution or included in [OVHcloud Web Hosting plans](/links/web/hosting)). This platform must have unconfigured accounts or be available to host the email accounts that need to be migrated.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-exchange -->
 ---

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.es-es.md
@@ -6,7 +6,7 @@ updated: 2026-01-16
 
 ## Objetivo
 
-Si quiere migrar sus direcciones de correo electrónico a una plataforma Exchange o Email Pro a otra plataforma Exchange, Email Pro, MX Plan o Zimbra, Esta guía explica cómo realizar la migración en dos fases:
+Si quiere migrar sus direcciones de correo electrónico a una plataforma Exchange o Email Pro a otra plataforma Exchange, Email Pro, MX Plan o Zimbra, esta guía explica cómo realizar la migración en dos fases:
 
 1. **Configurar la plataforma de destino**.
 2. **Migrar las cuentas de correo** de su plataforma actual a la nueva.
@@ -24,6 +24,7 @@ Si quiere migrar sus direcciones de correo electrónico a una plataforma Exchang
 
 - Disponer de una plataforma **"fuente"** con cuentas configuradas de [Exchange](/links/web/emails-hosted-exchange) o [Email Pro](/links/web/email-pro) o [Zimbra](/links/web/zimbra).
 - Disponer de una plataforma de **"destino"** con cuentas [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](/links/web/hosting)). Esta plataforma debe disponer de cuentas no configuradas o disponibles para recibir las direcciones de correo que deban migrarse.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-email-pro -->
 <!-- CP-NAV-START:web-exchange -->

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.es-us.md
@@ -25,6 +25,7 @@ Si quiere migrar sus direcciones de correo electrónico a una plataforma Exchang
 
 - Tener una plataforma **"source"** con cuentas [Exchange](/links/web/emails-hosted-exchange)  configuradas.
 - Disponer de una plataforma de **"destino"** con cuentas [Exchange](/links/web/emails-hosted-exchange) o MX Plan (a través de la solución MX Plan o incluida en un plan de [hosting de OVHcloud](/links/web/hosting)). Esta plataforma debe disponer de cuentas no configuradas o disponibles para recibir las direcciones de correo que deban migrarse.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-exchange -->
 ---

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.es-us.md
@@ -141,8 +141,8 @@ Si ha configurado una de las cuentas migradas en un cliente de correo (p.ej.: Ou
 
 ## Más información
 
-[Gestionar los contactos de los servicios](/pages/account_and_service_management/account_information/managing_contacts).
+[Gestionar los contactos de los servicios](/pages/account_and_service_management/account_information/managing_contacts)
 
-[Guides Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
+[Guides Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange)
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.fr-ca.md
@@ -24,6 +24,7 @@ Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange
 
 - Disposer d'une plateforme **«source»** avec des comptes [Exchange](/links/web/emails-hosted-exchange)  configurés.
 - Disposer d'une plateforme de **«destination»** avec des comptes [Exchange](/links/web/emails-hosted-exchange) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)). Cette plateforme doit disposer de comptes non configurés ou disponibles pour accueillir les adresses e-mail qui doivent être migrées.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-exchange -->
 ---

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.fr-ca.md
@@ -80,7 +80,7 @@ Dans l'onglet `Comptes e-mail`{.action} de votre plateforme e-mail, cliquez sur 
 
 #### Créer
 
-Créez votre adresse e-mail sur le nouveau compte de votre plateforme Exchange ou MX Plan ( en prenant l'exemple précédent, vous allez donc créer *john.smith@mydomain.ovh* sur votre nouvelle plateforme)
+Créez votre adresse e-mail sur le nouveau compte de votre plateforme Exchange ou MX Plan ( en prenant l'exemple précédent, vous allez donc créer *john.smith@mydomain.ovh* sur votre nouvelle plateforme).
 
 Dans l'onglet `Comptes e-mail`{.action} de votre plateforme, cliquez sur le bouton `...`{.action}, à droite du compte e-mail de destination, puis sur `Modifier`{.action}.
 
@@ -139,8 +139,8 @@ Si vous avez configuré l'un des comptes migrés sur un client de messagerie (ex
 
 ## Aller plus loin
 
-[Gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts).
+[Gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts)
 
-[Guides Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
+[Guides Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange)
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.fr-fr.md
@@ -6,12 +6,12 @@ updated: 2026-01-16
 
 ## Objectif
 
-Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange ou Email Pro vers une autre plateforme Exchange, Email Pro ou MX Plan. Vous trouverez dans ce guide un processus de migration en deux phases :
+Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange ou Email Pro vers une autre plateforme Exchange, Email Pro, MX Plan ou Zimbra. Vous trouverez dans ce guide un processus de migration en deux phases :
 
 1. **Configurer la plateforme de destination**.
 2. **Migrer les comptes e-mail** de votre plateforme actuelle vers la nouvelle.
 
-![email-migration](images/migration_platform01.gif){.thumbnail}
+![email-migration](images/migration_platform01.gif){.thumbnail .w-640}
 
 > [!primary]
 >
@@ -24,6 +24,7 @@ Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange
 
 - Disposer d'une plateforme **«source»** avec des comptes [Exchange](/links/web/emails-hosted-exchange) ou [Email Pro](/links/web/email-pro) configurés ou [Zimbra](/links/web/zimbra).
 - Disposer d'une plateforme de **«destination»** avec des comptes [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) ou MX Plan (via l'offre MX Plan ou incluse dans une offre d'[hébergement web OVHcloud](/links/web/hosting)). Cette plateforme doit disposer de comptes non configurés ou disponibles pour accueillir les adresses e-mail qui doivent être migrées.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-email-pro -->
 <!-- CP-NAV-START:web-exchange -->
@@ -61,7 +62,7 @@ Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange
 >
 > Sélectionnez l’onglet `Domaines associés`{.action} ou `Domaine`{.action} sur votre plateforme, puis cliquez sur `Ajouter un domaine`{.action}. Une fois le nom de domaine ajouté, assurez-vous que la mention `OK` ou `Actif`{.action} est bien présente dans la colonne `Statut`.
 >
-> ![exchange](images/account_migration_adddomain.png){.thumbnail}
+> ![exchange](images/account_migration_adddomain.png){.thumbnail .w-640}
 >
 > Pour plus de détails sur l'ajout d'un nom de domaine, suivez [le guide Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config), [le guide Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) ou [le guide Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra).
 
@@ -69,14 +70,14 @@ Vous souhaitez migrer vos adresses e-mail présentes sur une plateforme Exchange
 
 La migration de vos comptes e-mail se fera en 3 grandes étapes, **Renommer** le compte e-mail d'origine, **créer** le nouveau compte e-mail et **migrer** de la plateforme d'origine vers la nouvelle.
 
-![email-migration](images/migration_platform03.gif){.thumbnail}
+![email-migration](images/migration_platform03.gif){.thumbnail .w-640}
 
 > [!warning]
 >
-> Cas particulier:
+> Cas particuliers :
 >
 > - Si vous devez migrer **un compte Exchange ou Zimbra PRO** vers un compte **Email Pro** ou **Zimbra STARTER**, vous devez vous assurer que vos comptes e-mail n'excèdent pas les 10 Go (Email Pro) ou 15 Go (Zimbra STARTER). Les fonctions collaboratives, la synchronisation des calendriers et contacts ne sont pas présentes sur Email Pro ou Zimbra STARTER et ne peuvent pas être migrées.
-> - Si vous devez migrer **un compte Exchange, Email Pro ou Zimbra** vers un compte **MX Plan**, vous devez vous assurer que votre compte e-mail n'excède pas les 5 Go. Les fonctions collaboratives, la synchronisation des calendriers et contacts  ne sont pas présentes sur MX Plan et ne peuvent pas être migrées.
+> - Si vous devez migrer **un compte Exchange, Email Pro ou Zimbra** vers un compte **MX Plan**, vous devez vous assurer que votre compte e-mail n'excède pas les 5 Go. Les fonctions collaboratives, la synchronisation des calendriers et contacts ne sont pas présentes sur MX Plan et ne peuvent pas être migrées.
 
 #### Renommer
 
@@ -84,15 +85,15 @@ Renommez le compte e-mail à migrer avec un nom provisoire (exemple: pour migrer
 
 Dans l'onglet `Comptes e-mail`{.action} de votre plateforme e-mail, cliquez sur le bouton `...`{.action} puis sur `Modifier`{.action}.
 
-![email-migration](images/migration_platform04.png){.thumbnail}
+![email-migration](images/migration_platform04.png){.thumbnail .w-640}
 
 #### Créer
 
-Créez votre adresse e-mail sur le nouveau compte de votre plateforme Email Pro, Exchange ou MX Plan ( en prenant l'exemple précédent, vous allez donc créer *john.smith@mydomain.ovh* sur votre nouvelle plateforme)
+Créez votre adresse e-mail sur le nouveau compte de votre plateforme Email Pro, Exchange ou MX Plan (en prenant l'exemple précédent, vous allez donc créer *john.smith@mydomain.ovh* sur votre nouvelle plateforme)
 
 Dans l'onglet `Comptes e-mail`{.action} de votre plateforme, cliquez sur le bouton `...`{.action}, à droite du compte e-mail de destination, puis sur `Modifier`{.action}.
 
-![email-migration](images/migration_platform05.png){.thumbnail}
+![email-migration](images/migration_platform05.png){.thumbnail .w-640}
 
 #### Migrer
 
@@ -110,7 +111,7 @@ Migrez le compte e-mail « source » vers le compte de votre nouvelle plateforme
 
 Pour plus d'informations sur OMM, consultez notre guide [Migrer des comptes e-mail via OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).
 
-![email-migration](images/migration_platform06.png){.thumbnail}
+![email-migration](images/migration_platform06.png){.thumbnail .w-640}
 
 Le délai de migration dépend de la quantité de données à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
 
@@ -126,7 +127,7 @@ Si vous souhaitez le supprimer, dirigez-vous dans l'onglet `Comptes e-mail`{.act
 
 Pour cela, sélectionnez le service Email Pro, Exchange ou Zimbra concerné, puis rendez-vous sur l'onglet `Domaines associés`{.action} ou `Domaine`{.action} sur votre plateforme. Vérifiez la rubrique ou la colonne `Diagnostic`{.action}.
 
-![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
+![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail .w-640}
 
 > [!primary]
 >

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.fr-fr.md
@@ -89,7 +89,7 @@ Dans l'onglet `Comptes e-mail`{.action} de votre plateforme e-mail, cliquez sur 
 
 #### Créer
 
-Créez votre adresse e-mail sur le nouveau compte de votre plateforme Email Pro, Exchange ou MX Plan (en prenant l'exemple précédent, vous allez donc créer *john.smith@mydomain.ovh* sur votre nouvelle plateforme)
+Créez votre adresse e-mail sur le nouveau compte de votre plateforme Email Pro, Exchange ou MX Plan (en prenant l'exemple précédent, vous allez donc créer *john.smith@mydomain.ovh* sur votre nouvelle plateforme).
 
 Dans l'onglet `Comptes e-mail`{.action} de votre plateforme, cliquez sur le bouton `...`{.action}, à droite du compte e-mail de destination, puis sur `Modifier`{.action}.
 
@@ -147,11 +147,11 @@ Si vous avez configuré l'un des comptes migrés sur un client de messagerie (ex
 
 ## Aller plus loin
 
-[Gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts).
+[Gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts)
 
-[Premiers pas avec l'offre Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config).
+[Premiers pas avec l'offre Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 
-[Premiers pas avec l'offre Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted).
+[Premiers pas avec l'offre Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
 [Premiers pas avec l'offre Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.it-it.md
@@ -35,17 +35,17 @@ Per migrare i tuoi indirizzi email presenti su una piattaforma Exchange o Email 
 **MX Plan:**
 
 - **Link diretto:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo MX Plan service
+- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo servizio MX Plan
 
 **Email Pro:**
 
 - **Link diretto:** [Email Pro](/links/control-panel/web-email-pro)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua platform
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua piattaforma
 
 **Exchange:**
 
 - **Link diretto:** [Exchange](/links/control-panel/web-exchange)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua platform
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua piattaforma
 
 ---
 <!-- CP-NAV-END:web-exchange -->

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.it-it.md
@@ -24,6 +24,7 @@ Per migrare i tuoi indirizzi email presenti su una piattaforma Exchange o Email 
 
 - Disporre di una piattaforma **"sorgente"** con conti [Exchange](/links/web/emails-hosted-exchange) o [Email Pro](/links/web/email-pro) configurati o [Zimbra](/links/web/zimbra).
 - Disporre di una piattaforma di **"destinazione"** con account [Exchange](/links/web/emails-hosted-exchange), [Email Pro](/links/web/email-pro) o MX Plan (inclusa nella soluzione MX Plan o in una soluzione di [hosting Web OVHcloud](/links/web/hosting)) Questa piattaforma deve disporre di account non configurati o disponibili per accogliere gli indirizzi email che devono essere migrati.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-email-pro -->
 <!-- CP-NAV-START:web-exchange -->
@@ -34,17 +35,17 @@ Per migrare i tuoi indirizzi email presenti su una piattaforma Exchange o Email 
 **MX Plan:**
 
 - **Link diretto:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo servizio MX Plan
+- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo MX Plan service
 
 **Email Pro:**
 
 - **Link diretto:** [Email Pro](/links/control-panel/web-email-pro)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua piattaforma
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Email Pro`{.action} > Seleziona la tua platform
 
 **Exchange:**
 
 - **Link diretto:** [Exchange](/links/control-panel/web-exchange)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua piattaforma
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Exchange`{.action} > Seleziona la tua platform
 
 ---
 <!-- CP-NAV-END:web-exchange -->

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.it-it.md
@@ -125,7 +125,7 @@ Per eliminarlo, seleziona la scheda `Account email`{.action} della tua piattafor
 
 In questa fase, gli account email devono essere già migrati e funzionali. Per motivi di sicurezza, ti consigliamo di assicurarti che la configurazione del tuo dominio sia corretta consultando il tuo Spazio Cliente OVHcloud.
 
-Per farlo, seleziona il servizio Email Pro, Exchange o Zimbra interessato, quindi vai nell'opzione `Domini associati`{.action} o `Dominio`{.action} sulla tua piattaforma. Verifica la sezione o la colonna `Diagnostico`{.action}.
+Per farlo, seleziona il servizio Email Pro, Exchange o Zimbra interessato, quindi vai nell'opzione `Domini associati`{.action} o `Dominio`{.action} sulla tua piattaforma. Verifica la sezione o la colonna `Diagnostica`{.action}.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pl-pl.md
@@ -37,9 +37,9 @@ Chcesz przenieść Twoje konta e-mail obecne na platformę Exchange lub E-mail P
 - **Link bezpośredni:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz usługę MX Plan
 
-**Email Pro:**
+**E-mail Pro:**
 
-- **Link bezpośredni:** [Email Pro](/links/control-panel/web-email-pro)
+- **Link bezpośredni:** [E-mail Pro](/links/control-panel/web-email-pro)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Wybierz platformę
 
 **Exchange:**

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pl-pl.md
@@ -37,9 +37,9 @@ Chcesz przenieść Twoje konta e-mail obecne na platformę Exchange lub E-mail P
 - **Link bezpośredni:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz usługę MX Plan
 
-**E-mail Pro:**
+**Email Pro:**
 
-- **Link bezpośredni:** [E-mail Pro](/links/control-panel/web-email-pro)
+- **Link bezpośredni:** [Email Pro](/links/control-panel/web-email-pro)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Wybierz platformę
 
 **Exchange:**
@@ -60,7 +60,7 @@ Chcesz przenieść Twoje konta e-mail obecne na platformę Exchange lub E-mail P
 >
 > Przed rozpoczęciem migracji, jeśli właśnie zamówiłeś nową ofertę e-mail, najpierw dodaj nazwę domeny do swojej platformy e-mail. Jeśli migrujesz do platformy MX Plan, ponieważ nazwa domeny jest "stała", możesz przejść bezpośrednio do [następnej etapu](#accountsmigration).
 >
-> Wybierz kartę `Domeny przypisane`{.action} lub `Domeny`{.action} na swojej platformie, a następnie kliknij `Dodaj domenę`{.action}. Po dodaniu nazwy domeny upewnij się, że w kolumnie `Status` widoczna jest marka `OK` lub `Aktywny`{.action}.
+> Wybierz kartę `Przypisane domeny`{.action} lub `Domeny`{.action} na swojej platformie, a następnie kliknij `Dodaj domenę`{.action}. Po dodaniu nazwy domeny upewnij się, że w kolumnie `Status` widoczna jest marka `OK` lub `Aktywny`{.action}.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
@@ -125,7 +125,7 @@ Jeśli chcesz go usunąć, przejdź do karty `Konta e-mail`{.action} Twojej pier
 
 Na tym etapie Twoje konta e-mail muszą być migrowane i działać. Ze względów bezpieczeństwa sprawdź, czy konfiguracja Twojej domeny jest poprawna, sprawdzając w Panelu klienta.
 
-Aby to zrobić, wybierz odpowiedni serwis E-mail Pro, Exchange lub Zimbra, a następnie przejdź do karty `Powiązane domeny`{.action} lub `Domeny`{.action} na swojej platformie. Sprawdź sekcję lub kolumnę `Diagnostic`{.action}.
+Aby to zrobić, wybierz odpowiedni serwis E-mail Pro, Exchange lub Zimbra, a następnie przejdź do karty `Przypisane domeny`{.action} lub `Domeny`{.action} na swojej platformie. Sprawdź sekcję lub kolumnę `Diagnostyka`{.action}.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pl-pl.md
@@ -24,6 +24,7 @@ Chcesz przenieść Twoje konta e-mail obecne na platformę Exchange lub E-mail P
 
 - Posiadaj platformę **źródłową** z skonfigurowanymi kontami [Exchange](/links/web/emails-hosted-exchange) lub [E-mail Pro](/links/web/email-pro) lub [Zimbra](/links/web/zimbra).
 - Posiadanie platformy **"docelowej"** z kontami [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) lub MX Plan (w ramach usługi MX Plan lub pakietu [hostingowego OVHcloud](/links/web/hosting)) Na platformie muszą znajdować się nieskonfigurowane lub dostępne konta e-mail, które mają być migrowane.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-email-pro -->
 <!-- CP-NAV-START:web-exchange -->
@@ -33,18 +34,18 @@ Chcesz przenieść Twoje konta e-mail obecne na platformę Exchange lub E-mail P
 
 **MX Plan:**
 
-- **Bezpośredni link:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz swoją usługę MX Plan
+- **Link bezpośredni:** [MX Plan](/links/control-panel/web-mx-plan)
+- **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz usługę MX Plan
 
 **E-mail Pro:**
 
-- **Bezpośredni link:** [E-mail Pro](/links/control-panel/web-email-pro)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Wybierz swoją platformę
+- **Link bezpośredni:** [E-mail Pro](/links/control-panel/web-email-pro)
+- **Ścieżka nawigacji:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Wybierz platformę
 
 **Exchange:**
 
-- **Bezpośredni link:** [Exchange](/links/control-panel/web-exchange)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Exchange`{.action} > Wybierz swoją platformę
+- **Link bezpośredni:** [Exchange](/links/control-panel/web-exchange)
+- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Exchange`{.action} > Wybierz platformę
 
 ---
 <!-- CP-NAV-END:web-exchange -->

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pl-pl.md
@@ -60,7 +60,7 @@ Chcesz przenieść Twoje konta e-mail obecne na platformę Exchange lub E-mail P
 >
 > Przed rozpoczęciem migracji, jeśli właśnie zamówiłeś nową ofertę e-mail, najpierw dodaj nazwę domeny do swojej platformy e-mail. Jeśli migrujesz do platformy MX Plan, ponieważ nazwa domeny jest "stała", możesz przejść bezpośrednio do [następnej etapu](#accountsmigration).
 >
-> Wybierz kartę `Przypisane domeny`{.action} lub `Domeny`{.action} na swojej platformie, a następnie kliknij `Dodaj domenę`{.action}. Po dodaniu nazwy domeny upewnij się, że w kolumnie `Status` widoczna jest marka `OK` lub `Aktywny`{.action}.
+> Wybierz kartę `Przypisane domeny`{.action} lub `Domena`{.action} na swojej platformie, a następnie kliknij `Dodaj domenę`{.action}. Po dodaniu nazwy domeny upewnij się, że w kolumnie `Status` widoczna jest marka `OK` lub `Aktywny`{.action}.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >
@@ -125,7 +125,7 @@ Jeśli chcesz go usunąć, przejdź do karty `Konta e-mail`{.action} Twojej pier
 
 Na tym etapie Twoje konta e-mail muszą być migrowane i działać. Ze względów bezpieczeństwa sprawdź, czy konfiguracja Twojej domeny jest poprawna, sprawdzając w Panelu klienta.
 
-Aby to zrobić, wybierz odpowiedni serwis E-mail Pro, Exchange lub Zimbra, a następnie przejdź do karty `Przypisane domeny`{.action} lub `Domeny`{.action} na swojej platformie. Sprawdź sekcję lub kolumnę `Diagnostyka`{.action}.
+Aby to zrobić, wybierz odpowiedni serwis E-mail Pro, Exchange lub Zimbra, a następnie przejdź do karty `Przypisane domeny`{.action} lub `Domena`{.action} na swojej platformie. Sprawdź sekcję lub kolumnę `Diagnostyka`{.action}.
 
 ![exchange](images/check_the_dns_records_associated_domains.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pt-pt.md
@@ -24,6 +24,7 @@ Deseja migrar os seus endereços de e-mail presentes numa plataforma Exchange ou
 
 - Dispor de uma plataforma **"fonte"** com contas configuradas [Exchange](/links/web/emails-hosted-exchange) ou [E-mail Pro](/links/web/email-pro) ou [Zimbra](/links/web/zimbra).
 - Ter uma plataforma de **"destino"** com contas [Exchange](/links/web/emails-hosted-exchange), [E-mail Pro](/links/web/email-pro) ou MX Plan (através da oferta MX Plan ou incluída numa oferta de [alojamento web OVHcloud](/links/web/hosting)). Esta plataforma deve dispor de contas não configuradas ou disponíveis para acolher os endereços de e-mail que devem ser migrados.
+
 <!-- CP-NAV-START:web-mx-plan -->
 <!-- CP-NAV-START:web-email-pro -->
 <!-- CP-NAV-START:web-exchange -->
@@ -33,17 +34,17 @@ Deseja migrar os seus endereços de e-mail presentes numa plataforma Exchange ou
 
 **MX Plan:**
 
-- **Link direto:** [MX Plan](/links/control-panel/web-mx-plan)
+- **Ligação direta:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Caminho de navegação:** `Web Cloud`{.action} > `MX Plan`{.action} > Selecione o seu serviço MX Plan
 
 **E-mail Pro:**
 
-- **Link direto:** [E-mail Pro](/links/control-panel/web-email-pro)
+- **Ligação direta:** [E-mail Pro](/links/control-panel/web-email-pro)
 - **Caminho de navegação:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Selecione a sua plataforma
 
 **Exchange:**
 
-- **Link direto:** [Exchange](/links/control-panel/web-exchange)
+- **Ligação direta:** [Exchange](/links/control-panel/web-exchange)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Exchange`{.action} > Selecione a sua plataforma
 
 ---

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pt-pt.md
@@ -37,9 +37,9 @@ Deseja migrar os seus endereços de e-mail presentes numa plataforma Exchange ou
 - **Ligação direta:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Caminho de navegação:** `Web Cloud`{.action} > `MX Plan`{.action} > Selecione o seu serviço MX Plan
 
-**E-mail Pro:**
+**Email Pro:**
 
-- **Ligação direta:** [E-mail Pro](/links/control-panel/web-email-pro)
+- **Ligação direta:** [Email Pro](/links/control-panel/web-email-pro)
 - **Caminho de navegação:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Selecione a sua plataforma
 
 **Exchange:**
@@ -60,7 +60,7 @@ Deseja migrar os seus endereços de e-mail presentes numa plataforma Exchange ou
 >
 > Antes de iniciar a sua migração, se acabou de encomendar a sua nova oferta de e-mail, adicione primeiro o nome de domínio à sua plataforma de e-mail. Se estiver a migrar para uma plataforma MX Plan, o nome de domínio anexado sendo "fixo", pode passar diretamente para a [próxima etapa](#accountsmigration).
 >
-> Selecione o separador `Domínios associados`{.action} ou `Domínio`{.action} na sua plataforma, em seguida clique em `Adicionar um domínio`{.action}. Uma vez o nome de domínio adicionado, certifique-se de que a indicação `OK` ou `Ativo`{.action} está bem presente na coluna `Status`.
+> Selecione o separador `Domínios associados`{.action} ou `Domínio`{.action} na sua plataforma, em seguida clique em `Adicionar domínio`{.action}. Uma vez o nome de domínio adicionado, certifique-se de que a indicação `OK` ou `Ativo`{.action} está bem presente na coluna `Status`.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pt-pt.md
@@ -60,7 +60,7 @@ Deseja migrar os seus endereços de e-mail presentes numa plataforma Exchange ou
 >
 > Antes de iniciar a sua migração, se acabou de encomendar a sua nova oferta de e-mail, adicione primeiro o nome de domínio à sua plataforma de e-mail. Se estiver a migrar para uma plataforma MX Plan, o nome de domínio anexado sendo "fixo", pode passar diretamente para a [próxima etapa](#accountsmigration).
 >
-> Selecione o separador `Domínios associados`{.action} ou `Domínio`{.action} na sua plataforma, em seguida clique em `Adicionar domínio`{.action}. Uma vez o nome de domínio adicionado, certifique-se de que a indicação `OK` ou `Ativo`{.action} está bem presente na coluna `Status`.
+> Selecione o separador `Domínios associados`{.action} ou `Domínio`{.action} na sua plataforma, em seguida clique em `Adicionar domínio`{.action}. Uma vez o nome de domínio adicionado, certifique-se de que a indicação `OK` ou `Ativo`{.action} está bem presente na coluna `Estado`.
 >
 > ![exchange](images/account_migration_adddomain.png){.thumbnail}
 >

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_platform/guide.pt-pt.md
@@ -37,9 +37,9 @@ Deseja migrar os seus endereços de e-mail presentes numa plataforma Exchange ou
 - **Ligação direta:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Caminho de navegação:** `Web Cloud`{.action} > `MX Plan`{.action} > Selecione o seu serviço MX Plan
 
-**Email Pro:**
+**E-mail Pro:**
 
-- **Ligação direta:** [Email Pro](/links/control-panel/web-email-pro)
+- **Ligação direta:** [E-mail Pro](/links/control-panel/web-email-pro)
 - **Caminho de navegação:** `Web Cloud`{.action} > `E-mail Pro`{.action} > Selecione a sua plataforma
 
 **Exchange:**


### PR DESCRIPTION

## What type of Pull Request is this?

- Update of existing guides
- Fix

## Description

### manual_email_migration (15 locales) — Major restructuring

- Added CP navigation (CP-NAV) stacked blocks across all locales (EU: MX Plan + Email Pro + Exchange; CA/APAC: MX Plan + Exchange only)
- Removed lengthy step-by-step Outlook export/import walkthroughs (Windows + Mac), replaced with a simplified approach
- Stripped redundant CP login/navigation sentences before in-product actions

### migration_control_panel (12 locales) — Content corrections + minor fixes

- Added CP-NAV stacked blocks
- Extended Zimbra coverage in titles and descriptions
- Fixed two occurrences of the typo "Rouncube" → "Roundcube"
- Corrected button labels (e.g. Disable account → Reset this account, Modify → Edit)
- Removed redundant CP login navigation steps
- added missing step "click the Emails{.action} tab" in the MX Plan migration instructions, before accessing the account-level menu.

### migration_platform (12 locales) — Template alignment

- Added/updated CP-NAV stacked blocks
- Minor content tweaks and blank line fixes

### migration_omm (9 locales) — Minor

- Small date and phrasing updates