### PR TITLE
EN/FR Update backup storage documentation for NFS protocol

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: 'Backup Storage auf einem Dedicated Server verwenden'
 excerpt: 'Erfahren Sie hier, wie Sie zusätzlichen Speicherplatz aktivieren und auf diesen zugreifen'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Ziel
@@ -315,12 +315,12 @@ Nachdem Sie FileZilla auf Ihrem Server installiert haben, können Sie die Softwa
 
 #### NFS
 
-Vergewissern Sie sich zunächst, dass Ihre IP-Blöcke auf den Speicher zugreifen und das NFS-Protokoll verwenden können. Je nach dem von Ihnen verwendeten Linux-Betriebssystem kann es sein, dass der NFS-Client installiert und der NFS/portmap-Dienst gestartet werden muss.
+Der Backup Storage ist nur mit NFSv3 kompatibel. Vergewissern Sie sich zunächst, dass Ihre IP-Blöcke auf den Speicher zugreifen und das NFS-Protokoll verwenden können. Je nach dem von Ihnen verwendeten Linux-Betriebssystem kann es sein, dass der NFS-Client installiert und der NFS/portmap-Dienst gestartet werden muss.
 
 Wenn Sie den NFS-Client installiert und den portmap-Dienst gestartet haben, können Sie die NFS-Freigabe wie eine normale Partition mit folgendem Befehl mounten:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 Ersetzen Sie die Variablen im obenstehenden Beispielbefehl mit Ihren eigenen Werten.

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the backup storage on a dedicated server
 excerpt: 'Find out how to enable and access your additional storage space'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objective
@@ -52,7 +52,7 @@ Your backup storage will be configured within a few minutes. A confirmation emai
 
 ### Managing access control
 
-Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorized by default but have to be selected when adding IP addresses.
+Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorised by default but have to be selected when adding IP addresses.
 
 #### Adding a backup access
 
@@ -150,9 +150,7 @@ An order will be created and once your payment has been processed, you will be n
 > The backup storage service has a limit of three simultaneous connections on an IP.
 >
 
-> [!primary]
-> To retrieve the hostname of your backup storage, click on the `Backup Storage`{.action} tab in the relevant dedicated server interface. Usually written as `ftpback-rbxX-YYY.ip-Z.Z.Z.net` or `ftpback-bhsX-YYY.ip-Z.Z.Z.net`.
->
+To retrieve the Hostname of your backup storage, click on the `Backup Storage`{.action} tab in the interface of the dedicated server concerned. The Hostname is usually written as `ftpback-rbxX-YYY.ip-Z.Z.Z.net` or `ftpback-bhsX-YYY.ip-Z.Z.Z.net`.
 
 #### FTP/FTPS
 
@@ -312,12 +310,12 @@ After installing FileZilla on your server, you can configure it to connect to yo
 
 #### NFS
 
-First make sure that you have authorized your IP blocks to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
+The backup storage is only compatible with NFSv3. First, ensure that you have authorised your IP ranges to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
 
 Once you have the NFS client installed and portmap running, you can mount the NFS share like a normal partition as shown below:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 The code example above contains variables, which you will need to substitute with your own values.
@@ -355,7 +353,7 @@ You can't access this shared folder because your organization's security policie
 >
 > To correct this error, you need to modify the Windows registry. To do this, open the Registry Editor (regedit), then navigate to the key `HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters`.<br>
 > Then set the value of the parameter `AllowInsecureGuestAuth` to "1".<br>
-> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-in/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
+> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-gb/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
 
 ##### Linux
 

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the backup storage on a dedicated server
 excerpt: 'Find out how to enable and access your additional storage space'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objective
@@ -52,7 +52,7 @@ Your backup storage will be configured within a few minutes. A confirmation emai
 
 ### Managing access control
 
-Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorized by default but have to be selected when adding IP addresses.
+Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorised by default but have to be selected when adding IP addresses.
 
 #### Adding a backup access
 
@@ -310,12 +310,12 @@ After installing FileZilla on your server, you can configure it to connect to yo
 
 #### NFS
 
-First make sure that you have authorized your IP blocks to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
+The backup storage is only compatible with NFSv3. First, ensure that you have authorised your IP ranges to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
 
 Once you have the NFS client installed and portmap running, you can mount the NFS share like a normal partition as shown below:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 The code example above contains variables, which you will need to substitute with your own values.
@@ -353,7 +353,7 @@ You can't access this shared folder because your organization's security policie
 >
 > To correct this error, you need to modify the Windows registry. To do this, open the Registry Editor (regedit), then navigate to the key `HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters`.<br>
 > Then set the value of the parameter `AllowInsecureGuestAuth` to "1".<br>
-> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-au/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
+> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-gb/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
 
 ##### Linux
 

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the backup storage on a dedicated server
 excerpt: 'Find out how to enable and access your additional storage space'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objective
@@ -52,7 +52,7 @@ Your backup storage will be configured within a few minutes. A confirmation emai
 
 ### Managing access control
 
-Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorized by default but have to be selected when adding IP addresses.
+Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorised by default but have to be selected when adding IP addresses.
 
 #### Adding a backup access
 
@@ -310,12 +310,12 @@ After installing FileZilla on your server, you can configure it to connect to yo
 
 #### NFS
 
-First make sure that you have authorized your IP blocks to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
+The backup storage is only compatible with NFSv3. First, ensure that you have authorised your IP ranges to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
 
 Once you have the NFS client installed and portmap running, you can mount the NFS share like a normal partition as shown below:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 The code example above contains variables, which you will need to substitute with your own values.
@@ -353,7 +353,7 @@ You can't access this shared folder because your organization's security policie
 >
 > To correct this error, you need to modify the Windows registry. To do this, open the Registry Editor (regedit), then navigate to the key `HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters`.<br>
 > Then set the value of the parameter `AllowInsecureGuestAuth` to "1".<br>
-> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-ca/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
+> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-gb/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
 
 ##### Linux
 

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the backup storage on a dedicated server
 excerpt: 'Find out how to enable and access your additional storage space'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objective
@@ -310,12 +310,12 @@ After installing FileZilla on your server, you can configure it to connect to yo
 
 #### NFS
 
-First make sure that you have authorized your IP blocks to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
+The backup storage is only compatible with NFS3. First, ensure that you have authorised your IP ranges to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
 
 Once you have the NFS client installed and portmap running, you can mount the NFS share like a normal partition as shown below:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 The code example above contains variables, which you will need to substitute with your own values.

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-gb.md
@@ -52,7 +52,7 @@ Your backup storage will be configured within a few minutes. A confirmation emai
 
 ### Managing access control
 
-Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorized by default but have to be selected when adding IP addresses.
+Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorised by default but have to be selected when adding IP addresses.
 
 #### Adding a backup access
 
@@ -310,7 +310,7 @@ After installing FileZilla on your server, you can configure it to connect to yo
 
 #### NFS
 
-The backup storage is only compatible with NFS3. First, ensure that you have authorised your IP ranges to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
+The backup storage is only compatible with NFSv3. First, ensure that you have authorised your IP ranges to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
 
 Once you have the NFS client installed and portmap running, you can mount the NFS share like a normal partition as shown below:
 

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the backup storage on a dedicated server
 excerpt: 'Find out how to enable and access your additional storage space'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objective
@@ -52,7 +52,7 @@ Your backup storage will be configured within a few minutes. A confirmation emai
 
 ### Managing access control
 
-Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorized by default but have to be selected when adding IP addresses.
+Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorised by default but have to be selected when adding IP addresses.
 
 #### Adding a backup access
 
@@ -310,12 +310,12 @@ After installing FileZilla on your server, you can configure it to connect to yo
 
 #### NFS
 
-First make sure that you have authorized your IP blocks to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
+The backup storage is only compatible with NFSv3. First, ensure that you have authorised your IP ranges to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
 
 Once you have the NFS client installed and portmap running, you can mount the NFS share like a normal partition as shown below:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 The code example above contains variables, which you will need to substitute with your own values.
@@ -353,7 +353,7 @@ You can't access this shared folder because your organization's security policie
 >
 > To correct this error, you need to modify the Windows registry. To do this, open the Registry Editor (regedit), then navigate to the key `HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters`.<br>
 > Then set the value of the parameter `AllowInsecureGuestAuth` to "1".<br>
-> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-ie/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
+> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-gb/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
 
 ##### Linux
 

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the backup storage on a dedicated server
 excerpt: 'Find out how to enable and access your additional storage space'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objective
@@ -52,7 +52,7 @@ Your backup storage will be configured within a few minutes. A confirmation emai
 
 ### Managing access control
 
-Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorized by default but have to be selected when adding IP addresses.
+Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorised by default but have to be selected when adding IP addresses.
 
 #### Adding a backup access
 
@@ -310,12 +310,12 @@ After installing FileZilla on your server, you can configure it to connect to yo
 
 #### NFS
 
-First make sure that you have authorized your IP blocks to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
+The backup storage is only compatible with NFSv3. First, ensure that you have authorised your IP ranges to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
 
 Once you have the NFS client installed and portmap running, you can mount the NFS share like a normal partition as shown below:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 The code example above contains variables, which you will need to substitute with your own values.
@@ -353,7 +353,7 @@ You can't access this shared folder because your organization's security policie
 >
 > To correct this error, you need to modify the Windows registry. To do this, open the Registry Editor (regedit), then navigate to the key `HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters`.<br>
 > Then set the value of the parameter `AllowInsecureGuestAuth` to "1".<br>
-> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-sg/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
+> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-gb/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
 
 ##### Linux
 

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: How to use the backup storage on a dedicated server
 excerpt: 'Find out how to enable and access your additional storage space'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objective
@@ -52,7 +52,7 @@ Your backup storage will be configured within a few minutes. A confirmation emai
 
 ### Managing access control
 
-Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorized by default but have to be selected when adding IP addresses.
+Access to the backup storage is restricted by IP address according to an access control list (ACL). Only IPs linked to your OVHcloud customer account will be able to access the storage, once they are whitelisted in the ACL. The access protocols (FTP, NFS and CIFS) are not authorised by default but have to be selected when adding IP addresses.
 
 #### Adding a backup access
 
@@ -310,12 +310,12 @@ After installing FileZilla on your server, you can configure it to connect to yo
 
 #### NFS
 
-First make sure that you have authorized your IP blocks to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
+The backup storage is only compatible with NFSv3. First, ensure that you have authorised your IP ranges to access the storage and use the NFS protocol. Depending on your Linux operating system, you might have to install the **NFS** client and start the NFS/portmap service.
 
 Once you have the NFS client installed and portmap running, you can mount the NFS share like a normal partition as shown below:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 The code example above contains variables, which you will need to substitute with your own values.
@@ -353,7 +353,7 @@ You can't access this shared folder because your organization's security policie
 >
 > To correct this error, you need to modify the Windows registry. To do this, open the Registry Editor (regedit), then navigate to the key `HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters`.<br>
 > Then set the value of the parameter `AllowInsecureGuestAuth` to "1".<br>
-> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-us/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
+> Find more information on this topic on the [Microsoft support pages](https://learn.microsoft.com/en-gb/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
 
 ##### Linux
 

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: 'Utilizar Backup Storage en un servidor dedicado'
 excerpt: 'Cómo activar y acceder al espacio de almacenamiento adicional'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objetivo
@@ -315,12 +315,12 @@ Una vez que haya instalado FileZilla en el servidor, podrá configurarlo para co
 
 #### NFS
 
-En primer lugar, asegúrese de haber autorizado a sus bloques de IP a acceder al espacio de backup y a utilizar el protocolo NFS. Según el sistema operativo Linux, es posible que necesite instalar el cliente NFS e iniciar el servicio NFS/portmap.
+El backup storage solo es compatible con NFSv3. En primer lugar, asegúrese de haber autorizado a sus bloques de IP a acceder al espacio de backup y a utilizar el protocolo NFS. Según el sistema operativo Linux, es posible que necesite instalar el cliente NFS e iniciar el servicio NFS/portmap.
 
 Una vez que haya instalado el cliente NFS y que haya iniciado el servicio portmap, puede montar NFS como una partición normal con el siguiente comando:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 En el comando anterior, sustituya las siguientes variables por el valor correspondiente:

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: 'Utilizar Backup Storage en un servidor dedicado'
 excerpt: 'Cómo activar y acceder al espacio de almacenamiento adicional'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objetivo
@@ -315,12 +315,12 @@ Una vez que haya instalado FileZilla en el servidor, podrá configurarlo para co
 
 #### NFS
 
-En primer lugar, asegúrese de haber autorizado a sus bloques de IP a acceder al espacio de backup y a utilizar el protocolo NFS. Según el sistema operativo Linux, es posible que necesite instalar el cliente NFS e iniciar el servicio NFS/portmap.
+El backup storage solo es compatible con NFSv3. En primer lugar, asegúrese de haber autorizado a sus bloques de IP a acceder al espacio de backup y a utilizar el protocolo NFS. Según el sistema operativo Linux, es posible que necesite instalar el cliente NFS e iniciar el servicio NFS/portmap.
 
 Una vez que haya instalado el cliente NFS y que haya iniciado el servicio portmap, puede montar NFS como una partición normal con el siguiente comando:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 En el comando anterior, sustituya las siguientes variables por el valor correspondiente:
@@ -360,7 +360,6 @@ You can't access this shared folder because your organization's security policie
 > Para corregir este error, es necesario modificar el registro de Windows. Para ello, abra el editor del registro (regedit) y acceda a la clave `HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters`.<br>
 > Asigne el valor "1" al parámetro `AllowInsecureGuestAuth`.<br>
 > Encuentre más información sobre este tema en las [páginas de asistencia de Microsoft](https://learn.microsoft.com/es-mx/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
-
 
 ##### Linux
 

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: 'Utiliser Backup Storage sur un serveur dédié'
 excerpt: 'Découvrez comment activer et accéder à votre espace de stockage supplémentaire'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objectif
@@ -57,7 +57,7 @@ L'accès à votre espace de stockage est restreint par adresses IP à l'aide d'u
 
 #### Ajouter un accès backup
 
-Sélectionnez ensuite l'onglet `Backup Storage`{.action} puis cliquez sur le bouton `Ajouter un accès`{.action}.
+Sélectionnez l'onglet `Backup Storage`{.action} puis cliquez sur le bouton `Ajouter un accès`{.action}.
 
 ![Ajouter un accès backup](images/backup-storage03.png){.thumbnail}
 
@@ -122,19 +122,19 @@ Afin de vérifier que votre adresse IP est bien autorisée, utilisez l'appel sui
 
 ### Réinitialiser votre mot de passe
 
-Sélectionnez ensuite l'onglet `Backup Storage`{.action} puis cliquez sur le bouton `Mot de passe oublié ?`{.action}.
+Sélectionnez l'onglet `Backup Storage`{.action} puis cliquez sur le bouton `Mot de passe oublié ?`{.action}.
 
 Après avoir cliqué sur `Confirmer`{.action} dans la fenêtre qui apparaît alors, un e-mail de récupération de mot de passe sera envoyé à l'adresse e-mail enregistrée sur votre compte administrateur. Suivez les instructions qui y sont contenues pour réinitialiser votre mot de passe.
 
 ### Supprimer le Backup Storage
 
-Sélectionnez ensuite l'onglet `Backup Storage`{.action} puis cliquez sur le bouton `Supprimer le Backup Storage`{.action}.
+Sélectionnez l'onglet `Backup Storage`{.action} puis cliquez sur le bouton `Supprimer le Backup Storage`{.action}.
 
 Cliquez sur `Confirmer`{.action} sur le message d'avertissement pour procéder à la suppression. Votre Backup Storage sera supprimé après quelques minutes. Toutes les données de l'espace de stockage seront supprimées.
 
 ### Commander de l'espace disque supplémentaire
 
-Sélectionnez ensuite l’onglet `Backup Storage`{.action} puis cliquez sur le bouton `Commander de l’espace disque`{.action}.
+Sélectionnez l’onglet `Backup Storage`{.action} puis cliquez sur le bouton `Commander de l’espace disque`{.action}.
 
 ![Commander de l'espace disque supplémentaire](images/backup-storage06.png){.thumbnail}
 
@@ -212,7 +212,7 @@ L'exemple de code ci-dessus contient des variables que vous devrez remplacer par
 > [!primary]
 >
 > Pour utiliser FTPS, vous devez changer le nom du Backup Storage. Par exemple, si le nom du Backup Storage est « ftpback-rbxX-YYY.ip-Z.Z.Z.Z.net », vous devrez le changer sous la forme « ftpback-rbxX-YYY.mybackup.ovh.net ». Il vous faudra également ajouter l’argument \`-ssl\` à la commande ci-dessous.  
-> Si le Backup Storage est situé au Canada (BHS), vous devrez le changer sous la forme « ftpback-bhsX-YYY.mybackup.ovh.ca ».
+> Attention, si le Backup Storage est situé au Canada (BHS), vous devrez le changer sous la forme « ftpback-bhsX-YYY.mybackup.ovh.ca ».
 >
 
 Pour sauvegarder un seul fichier, vous pouvez utiliser la commande suivante :
@@ -264,7 +264,7 @@ L'exemple de code ci-dessus contient des variables que vous devrez remplacer par
 > [!primary]
 >
 > lftp utilise FTP+SSL/TLS par défaut. Vous devez donc changer le nom de votre Backup Storage. Par exemple, si son nom est « ftpback-rbxX-YYY.ip-Z.Z.Z.Z.net », vous devrez le changer sous la forme « ftpback-rbxX-YYY.mybackup.ovh.net ».  
-> Si le Backup Storage est situé au Canada (BHS), vous devrez le changer sous la forme « ftpback-bhsX-YYY.mybackup.ovh.ca ».
+> Attention, si le Backup Storage est situé au Canada (BHS), vous devrez le changer sous la forme « ftpback-bhsX-YYY.mybackup.ovh.ca ».
 >
 
 Pour sauvegarder un seul fichier, vous pouvez utiliser la commande suivante :
@@ -317,12 +317,13 @@ Après avoir installé FileZilla sur votre serveur, vous pouvez le configurer po
 
 #### NFS
 
+Le backup storage est compatible uniquement avec NFSv3.
 Assurez-vous d'abord d’avoir autorisé vos blocs d’IP à accéder au stockage et à utiliser le protocole NFS. Selon votre système d'exploitation Linux, il est possible que vous deviez installer le client NFS et démarrer le service NFS/portmap.
 
 Une fois le client NFS installé et le service portmap lancé, vous pouvez monter le partage NFS comme une partition normale comme indiqué ci-dessous :
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 L'exemple de code ci-dessus contient des variables que vous devrez remplacer par vos propres valeurs.
@@ -358,9 +359,9 @@ You can't access this shared folder because your organization's security policie
 
 > [!primary]
 >
-> Pour corriger cette erreur, il convient de modifier le registre Windows. Pour cela, ouvrez l’éditeur de registre (regedit), puis accédez à la clé `HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters`.<br>
+> Pour corriger cette erreur, il convient de modifier la base de registre de Windows. Pour cela, ouvrez l’éditeur de registre (regedit), puis accédez à la clé `HKLM\SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters`.<br>
 > Attribuez ensuite la valeur « 1 » au paramètre `AllowInsecureGuestAuth`.<br>
-> Retrouvez plus d'informations sur ce sujet sur les [pages d'assistance de Microsoft](https://learn.microsoft.com/fr-ca/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
+> Retrouvez plus d'informations sur ce sujet sur les [pages d'assistance de Microsoft](https://learn.microsoft.com/fr-fr/windows-server/storage/file-server/enable-insecure-guest-logons-smb2-and-smb3).
 
 ##### Linux
 

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.fr-fr.md
@@ -317,7 +317,7 @@ Après avoir installé FileZilla sur votre serveur, vous pouvez le configurer po
 
 #### NFS
 
-Le backup storage est compatible uniquement avec NFS3.
+Le backup storage est compatible uniquement avec NFSv3.
 Assurez-vous d'abord d’avoir autorisé vos blocs d’IP à accéder au stockage et à utiliser le protocole NFS. Selon votre système d'exploitation Linux, il est possible que vous deviez installer le client NFS et démarrer le service NFS/portmap.
 
 Une fois le client NFS installé et le service portmap lancé, vous pouvez monter le partage NFS comme une partition normale comme indiqué ci-dessous :

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.fr-fr.md
@@ -317,12 +317,13 @@ Après avoir installé FileZilla sur votre serveur, vous pouvez le configurer po
 
 #### NFS
 
-Assurez-vous d'abord d’avoir autorisé vos blocs d’IP à accéder au stockage et à utiliser le protocole NFS. Selon votre système d'exploitation Linux, il est possible que vous deviez installer le client NFS et démarrer le service NFS/portmap.
+Le backup storage est compatible uniquement avec NFS3.
+Assurez-vous d'abord d’avoir autorisé vos blocs d’IP à accéder au stockage et à utiliser le protocole NFS3. Selon votre système d'exploitation Linux, il est possible que vous deviez installer le client NFS et démarrer le service NFS/portmap.
 
 Une fois le client NFS installé et le service portmap lancé, vous pouvez monter le partage NFS comme une partition normale comme indiqué ci-dessous :
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 L'exemple de code ci-dessus contient des variables que vous devrez remplacer par vos propres valeurs.

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: 'Utiliser Backup Storage sur un serveur dédié'
 excerpt: 'Découvrez comment activer et accéder à votre espace de stockage supplémentaire'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objectif
@@ -318,7 +318,7 @@ Après avoir installé FileZilla sur votre serveur, vous pouvez le configurer po
 #### NFS
 
 Le backup storage est compatible uniquement avec NFS3.
-Assurez-vous d'abord d’avoir autorisé vos blocs d’IP à accéder au stockage et à utiliser le protocole NFS3. Selon votre système d'exploitation Linux, il est possible que vous deviez installer le client NFS et démarrer le service NFS/portmap.
+Assurez-vous d'abord d’avoir autorisé vos blocs d’IP à accéder au stockage et à utiliser le protocole NFS. Selon votre système d'exploitation Linux, il est possible que vous deviez installer le client NFS et démarrer le service NFS/portmap.
 
 Une fois le client NFS installé et le service portmap lancé, vous pouvez monter le partage NFS comme une partition normale comme indiqué ci-dessous :
 

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Utilizzare il Backup Storage su un server dedicato
 excerpt: Come attivare e accedere allo spazio di storage aggiuntivo
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Obiettivo
@@ -318,10 +318,10 @@ Dopo aver installato FileZilla sul server, è possibile configurarlo per acceder
 
 #### NFS
 
-Per prima cosa, accertati di aver autorizzato i blocchi di indirizzi IP ad accedere allo spazio di storage e utilizzare il protocollo NFS. In base al sistema operativo Linux utilizzato, è possibile che sia necessario installare il client NFS e avviare il servizio NFS/portmap prima di eseguire il mount della share NFS come una normale partizione:
+Il backup storage è compatibile unicamente con NFSv3. Per prima cosa, accertati di aver autorizzato i blocchi di indirizzi IP ad accedere allo spazio di storage e utilizzare il protocollo NFS. In base al sistema operativo Linux utilizzato, è possibile che sia necessario installare il client NFS e avviare il servizio NFS/portmap prima di eseguire il mount della share NFS come una normale partizione:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 Sostituisci le variabili dell’esempio con le informazioni dei tuoi servizi.

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: 'Korzystanie z Backup Storage na serwerze dedykowanym'
 excerpt: 'Dowiedz się, jak aktywować i uzyskać dostęp do dodatkowej przestrzeni dyskowej'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Wprowadzenie
@@ -318,12 +318,12 @@ Zainstaluj klienta FileZilla na Twoim serwerze i skonfiguruj go, aby zalogować 
 
 #### NFS
 
-Upewnij się, że zezwalasz blokom IP na dostęp do przestrzeni dyskowej oraz używania protokołu NFS. W zależności od dystrybucji Linux, jaką posiadasz, być może powinieneś zainstalować klienta NFS i uruchomić usługę NFS/portmap.
+Backup storage jest kompatybilny wyłącznie z NFSv3. Upewnij się, że zezwalasz blokom IP na dostęp do przestrzeni dyskowej oraz używania protokołu NFS. W zależności od dystrybucji Linux, jaką posiadasz, być może powinieneś zainstalować klienta NFS i uruchomić usługę NFS/portmap.
 
 Po zainstalowaniu klienta NFS i uruchomieniu usługi portmap możesz zamontować zasób NFS jako zwykłą partycję, jak pokazano poniżej:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 Poniższy przykład kodu zawiera zmienne, które należy zastąpić odpowiednimi danymi.

--- a/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/services_backup_storage/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: 'Utilizar o Backup Storage num servidor dedicado'
 excerpt: 'Saiba como ativar e aceder ao espaço de armazenamento adicional'
-updated: 2025-10-09
+updated: 2026-03-25
 ---
 
 ## Objetivo
@@ -316,12 +316,12 @@ Depois de instalar o FileZilla no seu servidor, poderá configurá-lo para se li
 
 #### NFS
 
-Em primeiro lugar, certifique-se de que autorizou o acesso dos seus blocos de IP ao armazenamento e que estes podem utilizar o protocolo NFS. Dependendo do seu sistema operativo Linux, é possível que tenha de instalar o cliente NFS e iniciar o serviço NFS/portmap.
+O backup storage é compatível apenas com NFSv3. Em primeiro lugar, certifique-se de que autorizou o acesso dos seus blocos de IP ao armazenamento e que estes podem utilizar o protocolo NFS. Dependendo do seu sistema operativo Linux, é possível que tenha de instalar o cliente NFS e iniciar o serviço NFS/portmap.
 
 Depois de instalar o cliente NFS e o serviço portmap, pode montar a partilha NFS como uma partição normal, tal como indicado abaixo:
 
 ```sh
-mount -t nfs HostName:/export/ftpbackup/ServiceName /FolderMount
+mount -t nfs -o vers=3 HostName:/export/ftpbackup/ServiceName /FolderMount
 ```
 
 O exemplo de código acima contém variáveis que deverá substituir pelos seus próprios valores.


### PR DESCRIPTION
<!--

## What type of Pull Request is this?

<!-- Delete the lines which don't apply: -->
- Update of existing guide(s)
## Description

EN/FR Update backup storage documentation for NFS protocol
following recent backup storage infra update, only nfs3 is compatible now

## Mandatory information

The translations in this Pull Request have been done using:
- No tools

<!-- Delete the line which doesn't apply: -->
- This Pull Request can be merged as soon as possible.

<!-- If you know about the following, please mention it. If you don't know, delete the line.-->
- This Pull Request content should be replicated for the US OVHcloud documentation : NO <!-- https://support.us.ovhcloud.com/hc/en-us -->
