### PR TITLE
SK2616 - New CP preparations for webhosting guides (CP NAV - tabs)

### DIFF
--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.de-de.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.de-de.md
@@ -98,7 +98,7 @@ Klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anz
 >>
 > **Schritt 3**
 >>
->> Geben Sie im angezeigten Fenster die IP-Adresse oder Maske, die Sie autorisieren möchten, unter `IP/mask`{.action} ein und fügen Sie bei Bedarf eine Beschreibung hinzu. Legen Sie dann fest, ob Sie nur Zugriff auf die Datenbanken oder auch auf SFTP gewähren möchten. Klicken Sie abschließend auf `Bestätigen`{.action}.
+>> Geben Sie im angezeigten Fenster die IP-Adresse oder Maske, die Sie autorisieren möchten, unter `IP / Maske`{.action} ein und fügen Sie bei Bedarf eine Beschreibung hinzu. Legen Sie dann fest, ob Sie nur Zugriff auf die Datenbanken oder auch auf SFTP gewähren möchten. Klicken Sie abschließend auf `Bestätigen`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask-confirmation.png){.thumbnail}
 
@@ -149,7 +149,7 @@ Klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anz
 >>
 > **Schritt 2**
 >>
->> Im standardmäßig angezeigten Tab **Allgemeine Informationen** klicken Sie auf `...`{.action} rechts neben "RAM" und dann auf `RAM-Größe ändern`{.action}, um zur Bestellung für diese Änderung geleitet zu werden.
+>> Im standardmäßig angezeigten Tab **Allgemeine Informationen** klicken Sie auf `...`{.action} rechts neben "RAM" und dann auf `RAM-Menge ändern`{.action}, um zur Bestellung für diese Änderung geleitet zu werden.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/change-the-amount-of-ram.png){.thumbnail}
 >>
@@ -287,7 +287,7 @@ Klicken Sie auf die unten stehenden Tabs, um die **3** Schritte nacheinander anz
 >>
 > **Schritt 3**
 >>
->> Um die Version zu ändern, klicken Sie auf `Version aktualisieren`{.action}.
+>> Um die Version zu ändern, klicken Sie auf `Die Version ändern`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/postgre-12-update-version.png){.thumbnail}
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-es.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-es.md
@@ -92,13 +92,13 @@ Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 >>
 > **Etapa 2**
 >>
->> Haga clic en la pestaña `IPs autorizadas`{.action} y, a continuación, en el botón `Añadir una dirección IP / máscara`{.action}.
+>> Haga clic en la pestaña `IP autorizadas`{.action} y, a continuación, en el botón `Añadir una dirección IP/máscara`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask.png){.thumbnail}
 >>
 > **Etapa 3**
 >>
->> En la ventana que aparece, indique en `IP/máscara`{.action} la dirección IP o la máscara que desee autorizar y, si lo desea, añada una descripción. A continuación, indique si desea autorizar el acceso únicamente a las bases de datos o también al SFTP. Por último, haga clic en `Aceptar`{.action}.
+>> En la ventana que aparece, indique en `IP/Máscara`{.action} la dirección IP o la máscara que desee autorizar y, si lo desea, añada una descripción. A continuación, indique si desea autorizar el acceso únicamente a las bases de datos o también al SFTP. Por último, haga clic en `Aceptar`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask-confirmation.png){.thumbnail}
 
@@ -117,7 +117,7 @@ Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 >>
 > **Etapa 2**
 >>
->> Haga clic en la pestaña `IPs autorizadas`{.action}.
+>> Haga clic en la pestaña `IP autorizadas`{.action}.
 >>
 > **Etapa 3**
 >>
@@ -287,7 +287,7 @@ Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 >>
 > **Etapa 3**
 >>
->> Para modificar esta versión, haga clic en `Modificar la versión`{.action}.
+>> Para modificar esta versión, haga clic en `Cambiar la versión`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/postgre-12-update-version.png){.thumbnail}
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-es.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-es.md
@@ -43,16 +43,16 @@ Los servidores de bases de datos Web Cloud Databases le permiten modificar los p
 
 ### Consultar la información general del servidor de bases de datos
 
-Haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Asegúrese de estar en la pestaña `Información general`{.action}.
 >>
@@ -81,22 +81,22 @@ Puede acceder a su Web Cloud Databases desde sus alojamientos web de OVHcloud o 
 
 Para acceder a su instancia Web Cloud Databases, deberá indicar las direcciones IP o rangos de IP autorizados a conectarse a sus bases de datos.
 
-Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `IPs autorizadas`{.action} y, a continuación, en el botón `Añadir una dirección IP / máscara`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask.png){.thumbnail}
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> En la ventana que aparece, indique en `IP/máscara`{.action} la dirección IP o la máscara que desee autorizar y, si lo desea, añada una descripción. A continuación, indique si desea autorizar el acceso únicamente a las bases de datos o también al SFTP. Por último, haga clic en `Aceptar`{.action}.
 >>
@@ -106,20 +106,20 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 
 /// details | Autorizar las conexiones a los alojamientos web de OVHcloud
 
-Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `IPs autorizadas`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Marque `Autorizar a los alojamientos web de OVHcloud a acceder a la base de datos`{.action}.
 >>
@@ -138,22 +138,22 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 > **Esta acción es irreversible y la solución Web Cloud Databases se facturará de forma independiente de su plan de hosting Performance.**
 >
 
-Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la pestaña **Información general** que se muestra por defecto, haga clic en `...`{.action} a la derecha de "RAM" y, a continuación, en `Cambiar la cantidad de RAM`{.action} para acceder al pedido de esta modificación.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/change-the-amount-of-ram.png){.thumbnail}
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Elija la cantidad de RAM deseada y haga clic en `Siguiente`{.action}. A continuación, seleccione la duración deseada.
 >>
@@ -173,20 +173,20 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 
 /// details | Instancia MySQL y MariaDB
 
-Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Configuración`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> En el recuadro **Configuración general de MySQL** encontrará la configuración actualmente establecida para su base de datos. Puede modificarla directamente y hacer clic en `Aplicar`{.action}.
 >>
@@ -234,20 +234,20 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 
 /// details | Instancia PostgreSQL
 
-Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Configuración`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> En el recuadro **Configuración general de PostgreSQL** encontrará la configuración actualmente definida para su base de datos. Puede modificarla directamente y hacer clic en `Aplicar`{.action}.
 >>
@@ -272,20 +272,20 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 
 ### Cambiar la versión MySQL, PostgreSQL o MariaDB del servidor de bases de datos
 
-Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la pestaña **Información general**, la versión actual aparece en la línea **Versión**.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Para modificar esta versión, haga clic en `Modificar la versión`{.action}.
 >>
@@ -335,16 +335,16 @@ Para acceder a los logs de su solución Web Cloud Databases, consulte nuestra gu
 
 /// details | Seguimiento del uso de RAM
 
-Haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Métricas`{.action}. Encontrará el gráfico **"Estadísticas de memoria RAM utilizada"**.
 >>
@@ -356,16 +356,16 @@ Haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
 
 Este gráfico permite realizar un seguimiento, en las últimas 24 horas, de la carga de las conexiones por minuto en su servidor de bases de datos.
 
-Haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Métricas`{.action}. Encontrará el gráfico **"Estadísticas del total de conexiones por minuto"**.
 >>

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-us.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.es-us.md
@@ -92,13 +92,13 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 >>
 > **Paso 2**
 >>
->> Haga clic en la pestaña `IPs autorizadas`{.action} y, a continuación, en el botón `Añadir una dirección IP / máscara`{.action}.
+>> Haga clic en la pestaña `IP autorizadas`{.action} y, a continuación, en el botón `Añadir una dirección IP/máscara`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask.png){.thumbnail}
 >>
 > **Paso 3**
 >>
->> En la ventana que aparece, indique en `IP/máscara`{.action} la dirección IP o la máscara que desee autorizar y, si lo desea, añada una descripción. A continuación, indique si desea autorizar el acceso únicamente a las bases de datos o también al SFTP. Por último, haga clic en `Aceptar`{.action}.
+>> En la ventana que aparece, indique en `IP/Máscara`{.action} la dirección IP o la máscara que desee autorizar y, si lo desea, añada una descripción. A continuación, indique si desea autorizar el acceso únicamente a las bases de datos o también al SFTP. Por último, haga clic en `Aceptar`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask-confirmation.png){.thumbnail}
 
@@ -117,7 +117,7 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 >>
 > **Paso 2**
 >>
->> Haga clic en la pestaña `IPs autorizadas`{.action}.
+>> Haga clic en la pestaña `IP autorizadas`{.action}.
 >>
 > **Paso 3**
 >>
@@ -287,7 +287,7 @@ Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
 >>
 > **Paso 3**
 >>
->> Para modificar esta versión, haga clic en `Modificar la versión`{.action}.
+>> Para modificar esta versión, haga clic en `Cambiar la versión`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/postgre-12-update-version.png){.thumbnail}
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-ca.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-ca.md
@@ -98,7 +98,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 > **Étape 3**
 >>
->> Sur la fenêtre qui s’affiche, indiquez l’adresse IP ou le masque que vous désirez autoriser dans `IP/masque`{.action} puis ajoutez une description si vous le souhaitez. Décidez ensuite si vous voulez donner accès uniquement aux bases de données ou au SFTP. Enfin, cliquez sur `Valider`{.action}.
+>> Sur la fenêtre qui s’affiche, indiquez l’adresse IP ou le masque que vous désirez autoriser dans `IP / masque`{.action} puis ajoutez une description si vous le souhaitez. Décidez ensuite si vous voulez donner accès uniquement aux bases de données ou au SFTP. Enfin, cliquez sur `Valider`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask-confirmation.png){.thumbnail}
 
@@ -223,7 +223,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >> >
 >> > Nous vous recommandons de toujours utiliser le mode par défaut, sauf si votre base de données a été mise à jour depuis une version ayant un mode par défaut différent de la version actuelle.
 >>
->> Effectuez les modifications nécessaires puis cliquez sur `Confirmer`{.action}.
+>> Effectuez les modifications nécessaires puis cliquez sur `Valider`{.action}.
 
 > [!warning]
 >

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-fr.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.fr-fr.md
@@ -98,7 +98,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 > **Étape 3**
 >>
->> Sur la fenêtre qui s’affiche, indiquez l’adresse IP ou le masque que vous désirez autoriser dans `IP/masque`{.action} puis ajoutez une description si vous le souhaitez. Décidez ensuite si vous voulez donner accès uniquement aux bases de données ou au SFTP. Enfin, cliquez sur `Valider`{.action}.
+>> Sur la fenêtre qui s’affiche, indiquez l’adresse IP ou le masque que vous désirez autoriser dans `IP / masque`{.action} puis ajoutez une description si vous le souhaitez. Décidez ensuite si vous voulez donner accès uniquement aux bases de données ou au SFTP. Enfin, cliquez sur `Valider`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask-confirmation.png){.thumbnail}
 
@@ -223,7 +223,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >> >
 >> > Nous vous recommandons de toujours utiliser le mode par défaut, sauf si votre base de données a été mise à jour depuis une version ayant un mode par défaut différent de la version actuelle.
 >>
->> Effectuez les modifications nécessaires puis cliquez sur `Confirmer`{.action}.
+>> Effectuez les modifications nécessaires puis cliquez sur `Valider`{.action}.
 
 > [!warning]
 >

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.it-it.md
@@ -43,16 +43,16 @@ I database server Web Cloud Databases permettono di modificare le impostazioni g
 
 ### Visualizza le informazioni generali del tuo database server
 
-Clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Assicurati di trovarti nella scheda `Informazioni generali`{.action}.
 >>
@@ -81,22 +81,22 @@ Il tuo Web Cloud Databases è accessibile dai tuoi hosting Web OVHcloud e/o dall
 
 Per accedere alla tua istanza Web Cloud Databases, è necessario indicare gli indirizzi IP o le classi di IP autorizzati a connettersi ai tuoi database.
 
-Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `IP autorizzati`{.action}, poi sul pulsante `Aggiungi un indirizzo IP / maschera`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask.png){.thumbnail}
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Nella finestra che appare, indica l'indirizzo IP o la maschera da autorizzare in `IP/mask`{.action}, poi aggiungi una descrizione se necessario. Scegli se fornire l'accesso esclusivamente ai database o anche via SFTP. Infine, clicca su `Conferma`{.action}.
 >>
@@ -106,20 +106,20 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
 
 /// details | Autorizzare le connessioni verso gli hosting Web OVHcloud
 
-Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `IP autorizzati`{.action}.
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Seleziona la casella `Autorizza gli hosting Web OVHcloud ad accedere al database`{.action}.
 >>
@@ -138,22 +138,22 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
 > **Questa azione è irreversibile e l'offerta Web Cloud Databases sarà fatturata separatamente dal tuo hosting Web Performance.**
 >
 
-Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Nella scheda **Informazioni generali** visualizzata di default, clicca su `...`{.action} a destra della voce "RAM", poi su `Modifica la quantità di RAM`{.action} per accedere all'ordine di questa modifica.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/change-the-amount-of-ram.png){.thumbnail}
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Scegli la quantità di RAM desiderata, poi clicca su `Seguente`{.action}. Potrai quindi scegliere la durata desiderata.
 >>
@@ -173,20 +173,20 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
 
 /// details | Istanza MySQL e MariaDB
 
-Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `Configurazione`{.action}.
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Nel riquadro **Configurazione generale di MySQL** troverai la configurazione attualmente definita per il tuo database. Puoi modificarla direttamente, poi clicca su `Applica`{.action}.
 >>
@@ -234,20 +234,20 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
 
 /// details | Istanza PostgreSQL
 
-Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `Configurazione`{.action}.
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Nel riquadro **Configurazione generale di PostgreSQL** troverai la configurazione attualmente definita per il tuo database. Puoi modificarla direttamente, poi clicca su `Applica`{.action}.
 >>
@@ -272,20 +272,20 @@ Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
 
 ### Modifica la versione MySQL, PostgreSQL o MariaDB del database server
 
-Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Nella scheda **Informazioni generali**, la versione attuale compare nella riga **Versione**.
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Per modificare questa versione, clicca su `Modifica la versione`{.action}.
 >>
@@ -335,16 +335,16 @@ Per accedere ai log della tua soluzione Web Cloud Databases, consulta la nostra 
 
 /// details | Monitorare l'utilizzo della RAM
 
-Clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `Metriche`{.action}. Troverai il grafico **"Statistiche della memoria RAM utilizzata"**.
 >>
@@ -356,16 +356,16 @@ Clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
 
 Questo grafico permette di seguire, nelle ultime 24 ore, il carico di connessioni al minuto sul tuo database server.
 
-Clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `Metriche`{.action}. Troverai il grafico **"Statistiche del totale delle connessioni al minuto"**.
 >>

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.it-it.md
@@ -92,7 +92,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `IP autorizzati`{.action}, poi sul pulsante `Aggiungi un indirizzo IP / maschera`{.action}.
+>> Clicca sulla scheda `IP autorizzati`{.action}, poi sul pulsante `Aggiungi un indirizzo IP/mask`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask.png){.thumbnail}
 >>
@@ -155,7 +155,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
 >>
 > **Passaggio 3**
 >>
->> Scegli la quantità di RAM desiderata, poi clicca su `Seguente`{.action}. Potrai quindi scegliere la durata desiderata.
+>> Scegli la quantità di RAM desiderata, poi clicca su `Continua`{.action}. Potrai quindi scegliere la durata desiderata.
 >>
 >> > [!primary]
 >> >

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pl-pl.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pl-pl.md
@@ -98,7 +98,7 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 >>
 > **Krok 3**
 >>
->> W oknie, które się wyświetli, wskaż adres IP lub maskę, którą chcesz autoryzować w `IP/maska`{.action}, a następnie dodaj opis, jeśli chcesz. Zdecyduj, czy chcesz udzielić dostępu wyłącznie do baz danych, czy również do SFTP. Na koniec kliknij `Zatwierdź`{.action}.
+>> W oknie, które się wyświetli, wskaż adres IP lub maskę, którą chcesz autoryzować w `IP / maska`{.action}, a następnie dodaj opis, jeśli chcesz. Zdecyduj, czy chcesz udzielić dostępu wyłącznie do baz danych, czy również do SFTP. Na koniec kliknij `Zatwierdź`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask-confirmation.png){.thumbnail}
 
@@ -121,7 +121,7 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 >>
 > **Krok 3**
 >>
->> Zaznacz opcję `Zezwól hostingom OVHcloud na dostęp do bazy danych`{.action}.
+>> Zaznacz opcję `Zezwól hostingowi OVHcloud na dostęp do bazy danych`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/tab-empty.png){.thumbnail}
 
@@ -188,7 +188,7 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 >>
 > **Krok 3**
 >>
->> W polu **Ogólna konfiguracja MySQL** znajdziesz konfigurację aktualnie zdefiniowaną dla Twojej bazy danych. Możesz ją bezpośrednio zmienić, a następnie kliknąć `Zastosuj`{.action}.
+>> W polu **Ogólna konfiguracja MySQL** znajdziesz konfigurację aktualnie zdefiniowaną dla Twojej bazy danych. Możesz ją bezpośrednio zmienić, a następnie kliknąć `Wyślij`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-mysql.png){.thumbnail}
 >>
@@ -249,7 +249,7 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 >>
 > **Krok 3**
 >>
->> W polu **Ogólna konfiguracja PostgreSQL** znajdziesz konfigurację aktualnie zdefiniowaną dla Twojej bazy danych. Możesz ją bezpośrednio zmienić, a następnie kliknąć `Zastosuj`{.action}.
+>> W polu **Ogólna konfiguracja PostgreSQL** znajdziesz konfigurację aktualnie zdefiniowaną dla Twojej bazy danych. Możesz ją bezpośrednio zmienić, a następnie kliknąć `Wyślij`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/configuration/general-configuration-of-postgresql.png){.thumbnail}
 >>

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pt-pt.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pt-pt.md
@@ -92,13 +92,13 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 >>
 > **Etapa 2**
 >>
->> Clique no separador `IPs autorizados`{.action} e, em seguida, no botão `Adicionar um endereço IP / máscara`{.action}.
+>> Clique no separador `Endereços IP autorizados`{.action} e, em seguida, no botão `Adicionar um endereço IP / máscara`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask.png){.thumbnail}
 >>
 > **Etapa 3**
 >>
->> Na janela que aparece, indique o endereço IP ou a máscara que pretende autorizar em `IP/máscara`{.action} e, se desejar, adicione uma descrição. Decida se pretende conceder acesso apenas às bases de dados ou também ao SFTP. Por fim, clique em `Validar`{.action}.
+>> Na janela que aparece, indique o endereço IP ou a máscara que pretende autorizar em `IP / máscara`{.action} e, se desejar, adicione uma descrição. Decida se pretende conceder acesso apenas às bases de dados ou também ao SFTP. Por fim, clique em `Validar`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask-confirmation.png){.thumbnail}
 
@@ -117,11 +117,11 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 >>
 > **Etapa 2**
 >>
->> Clique no separador `IPs autorizados`{.action}.
+>> Clique no separador `Endereços IP autorizados`{.action}.
 >>
 > **Etapa 3**
 >>
->> Selecione `Autorizar os alojamentos web OVHcloud a aceder à base de dados`{.action}.
+>> Selecione `Autorizar o acesso dos alojamentos web da OVHcloud à base de dados`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/tab-empty.png){.thumbnail}
 
@@ -149,7 +149,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 >>
 > **Etapa 2**
 >>
->> No separador **Informações gerais** apresentado por predefinição, clique em `...`{.action} à direita da menção "RAM" e, em seguida, em `Alterar a quantidade de RAM`{.action} para aceder à encomenda desta alteração.
+>> No separador **Informações gerais** apresentado por predefinição, clique em `...`{.action} à direita da menção "RAM" e, em seguida, em `Alterar quantidade de RAM`{.action} para aceder à encomenda desta alteração.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/change-the-amount-of-ram.png){.thumbnail}
 >>
@@ -287,7 +287,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 >>
 > **Etapa 3**
 >>
->> Para modificar esta versão, clique em `Modificar a versão`{.action}.
+>> Para modificar esta versão, clique em `Alterar versão`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/postgre-12-update-version.png){.thumbnail}
 

--- a/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pt-pt.md
+++ b/pages/web_cloud/web_cloud_databases/configure-database-server/guide.pt-pt.md
@@ -43,16 +43,16 @@ Os servidores de bases de dados Web Cloud Databases permitem-lhe modificar os pa
 
 ### Visualizar as informações gerais do servidor de bases de dados
 
-Clique nos separadores abaixo para ver cada um dos **2** passos.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Certifique-se de que está no separador `Informações gerais`{.action}.
 >>
@@ -81,22 +81,22 @@ O seu Web Cloud Databases está acessível a partir dos seus alojamentos web OVH
 
 Para aceder à sua instância Web Cloud Databases, deve indicar os endereços IP ou intervalos de IP autorizados a ligarem-se às suas bases de dados.
 
-Clique nos separadores abaixo para ver cada um dos **3** passos.
+Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `IPs autorizados`{.action} e, em seguida, no botão `Adicionar um endereço IP / máscara`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/add-an-ip-address-mask.png){.thumbnail}
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Na janela que aparece, indique o endereço IP ou a máscara que pretende autorizar em `IP/máscara`{.action} e, se desejar, adicione uma descrição. Decida se pretende conceder acesso apenas às bases de dados ou também ao SFTP. Por fim, clique em `Validar`{.action}.
 >>
@@ -106,20 +106,20 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
 
 /// details | Autorizar as ligações aos alojamentos web OVHcloud
 
-Clique nos separadores abaixo para ver cada um dos **3** passos.
+Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `IPs autorizados`{.action}.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Selecione `Autorizar os alojamentos web OVHcloud a aceder à base de dados`{.action}.
 >>
@@ -138,22 +138,22 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
 > **Esta ação é irreversível e a oferta Web Cloud Databases será depois faturada independentemente do seu alojamento web Performance.**
 >
 
-Clique nos separadores abaixo para ver cada um dos **3** passos.
+Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> No separador **Informações gerais** apresentado por predefinição, clique em `...`{.action} à direita da menção "RAM" e, em seguida, em `Alterar a quantidade de RAM`{.action} para aceder à encomenda desta alteração.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/change-the-amount-of-ram.png){.thumbnail}
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Escolha a quantidade de RAM pretendida e clique em `Seguinte`{.action}. Poderá então escolher a duração pretendida.
 >>
@@ -173,20 +173,20 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
 
 /// details | Instância MySQL e MariaDB
 
-Clique nos separadores abaixo para ver cada um dos **3** passos.
+Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Configuração`{.action}.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> No quadro **Configuração geral de MySQL**, encontrará a configuração atualmente definida para a sua base de dados. Pode modificá-la diretamente e clicar em `Aplicar`{.action}.
 >>
@@ -234,20 +234,20 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
 
 /// details | Instância PostgreSQL
 
-Clique nos separadores abaixo para ver cada um dos **3** passos.
+Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Configuração`{.action}.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> No quadro **Configuração geral de PostgreSQL**, encontrará a configuração atualmente definida para a sua base de dados. Pode modificá-la diretamente e clicar em `Aplicar`{.action}.
 >>
@@ -272,20 +272,20 @@ Clique nos separadores abaixo para ver cada um dos **3** passos.
 
 ### Alterar a versão MySQL, PostgreSQL ou MariaDB do servidor de bases de dados
 
-Clique nos separadores abaixo para ver cada um dos **3** passos.
+Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> No separador **Informações gerais**, a versão atual aparece na linha **Versão**.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Para modificar esta versão, clique em `Modificar a versão`{.action}.
 >>
@@ -335,16 +335,16 @@ Para aceder aos logs da sua solução Web Cloud Databases, consulte o nosso guia
 
 /// details | Acompanhar a RAM consumida
 
-Clique nos separadores abaixo para ver cada um dos **2** passos.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Métricas`{.action}. Encontrará o gráfico **"Estatísticas de memória RAM utilizada"**.
 >>
@@ -356,16 +356,16 @@ Clique nos separadores abaixo para ver cada um dos **2** passos.
 
 Este gráfico permite acompanhar, nas últimas 24 horas, o volume de ligações por minuto no servidor de bases de dados.
 
-Clique nos separadores abaixo para ver cada um dos **2** passos.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Métricas`{.action}. Encontrará o gráfico **"Estatísticas do total de ligações por minuto"**.
 >>

--- a/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.es-es.md
+++ b/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.es-es.md
@@ -58,16 +58,16 @@ Es posible consultar el contenido de la base de datos a través de una interfaz.
 
 #### Conexión a través de phpMyAdmin de OVHcloud
 
-Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Obtenga la siguiente información de conexión:
 >>
@@ -79,13 +79,13 @@ Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
 >> >
 >> > Si cambia la contraseña de un usuario de la base de datos, todas las aplicaciones o sitios web que acceden a esta base de datos deberán actualizarse en consecuencia.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> En la pestaña `Información general`{.action}, localice la sección **Administración de la base de datos** y haga clic en el enlace de phpMyAdmin en **Interfaz de usuario**.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/database-administration.png){.thumbnail}
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> En la página de conexión de phpMyAdmin, introduzca la información obtenida en el paso 2:
 >>
@@ -112,16 +112,16 @@ Si la conexión se ha realizado correctamente, se mostrará la siguiente página
 >
 > Si utiliza una solución "Web Cloud Databases"/"SQL Privado", recuerde autorizar su IP utilizando la guía sobre la [configuración de su servidor de bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gerer-vos-acces).
 
-Haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Obtenga la siguiente información de conexión:
 >>
@@ -188,16 +188,16 @@ Puede utilizar su propia interfaz phpMyAdmin para explorar el contenido de su ba
 
 ### Conectarse a una base de datos PostgreSQL
 
-Haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Obtenga la siguiente información de conexión:
 >>

--- a/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.it-it.md
@@ -34,7 +34,7 @@ details[open]>summary::before {
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** [Web Cloud Databases](/links/control-panel/web-cloud-databases)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Web Cloud Databases`{.action} > Seleziona il tuo database service
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Web Cloud Databases`{.action} > Seleziona il tuo servizio di database
 
 ---
 <!-- CP-NAV-END:web-cloud-databases -->

--- a/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.it-it.md
@@ -58,16 +58,16 @@ details[open]>summary::before {
 
 #### Connessione tramite phpMyAdmin OVHcloud
 
-Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Recupera le seguenti informazioni di connessione:
 >>
@@ -79,13 +79,13 @@ Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
 >> >
 >> > Se modifichi la password di un utente di database, tutte le applicazioni/siti Web che accedono a questo database devono essere aggiornati di conseguenza.
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Nella scheda `Informazioni generali`{.action}, individua la sezione **"Gestione database"** e clicca sul link phpMyAdmin sotto **"Interfaccia utente"**.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/database-administration.png){.thumbnail}
 >>
-> **Step 4**
+> **Passaggio 4**
 >>
 >> Nella pagina di login di phpMyAdmin, inserisci le informazioni recuperate allo step 2:
 >>
@@ -112,16 +112,16 @@ Se la connessione ha esito positivo, verrà visualizzata la pagina seguente.
 >
 > Se utilizzi una soluzione "Web Cloud Databases"/"SQL Privato", ricorda di autorizzare il tuo IP seguendo la guida sulla [configurazione del tuo database server](/pages/web_cloud/web_cloud_databases/configure-database-server#gerer-vos-acces).
 
-Clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Recupera le seguenti informazioni di connessione:
 >>
@@ -188,16 +188,16 @@ Puoi utilizzare la tua interfaccia phpMyAdmin per esplorare il contenuto del tuo
 
 ### Connettersi a un database PostgreSQL
 
-Clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Recupera le seguenti informazioni di connessione:
 >>

--- a/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.it-it.md
@@ -129,7 +129,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** pa
 >> - **Porta:** visibile nella stessa posizione, voce "Porta" nella parte **SQL**.
 >> - **Nome utente:** visibile nella scheda `Utenti e diritti`{.action}.
 >> - **Password:** la password associata all'utente interessato.
->> - **Nome del database:** visibile nella scheda `Database`{.action}.
+>> - **Nome del database:** visibile nella scheda `Databases`{.action}.
 
 **Clicca sul metodo di connessione che preferisci per visualizzare il contenuto.**
 
@@ -205,7 +205,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** pa
 >> - **Porta:** visibile nella stessa posizione, voce "Porta" nella parte **SQL**.
 >> - **Nome utente:** visibile nella scheda `Utenti e diritti`{.action}.
 >> - **Password:** la password associata all'utente interessato.
->> - **Nome del database:** visibile nella scheda `Database`{.action}.
+>> - **Nome del database:** visibile nella scheda `Databases`{.action}.
 
 **Clicca sul metodo di connessione che preferisci per visualizzare il contenuto.**
 

--- a/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.pt-pt.md
+++ b/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.pt-pt.md
@@ -58,16 +58,16 @@ Pode consultar o conteúdo da sua base de dados através de uma interface. Exist
 
 #### Ligação através do phpMyAdmin OVHcloud
 
-Clique nos separadores abaixo para ver cada um dos **4** passos.
+Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Obtenha as seguintes informações de ligação:
 >>
@@ -79,13 +79,13 @@ Clique nos separadores abaixo para ver cada um dos **4** passos.
 >> >
 >> > Se alterar a palavra-passe de um utilizador de base de dados, todas as aplicações/websites que acedam a essa base de dados devem ser atualizados em conformidade.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> No separador `Informações gerais`{.action}, localize a secção **Gestão da base de dados** e clique na ligação phpMyAdmin em **Interface do utilizador**.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/database-administration.png){.thumbnail}
 >>
-> **Passo 4**
+> **Etapa 4**
 >>
 >> Na página de início de sessão do phpMyAdmin, introduza as informações obtidas no passo 2:
 >>
@@ -112,16 +112,16 @@ Se a ligação for bem-sucedida, será apresentada a página seguinte.
 >
 > Se utilizar uma solução "Web Cloud Databases"/"SQL Privado", não se esqueça de autorizar o seu IP com a ajuda do guia sobre a [configuração do seu servidor de bases de dados](/pages/web_cloud/web_cloud_databases/configure-database-server#gerer-vos-acces).
 
-Clique nos separadores abaixo para ver cada um dos **2** passos.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Obtenha as seguintes informações de ligação:
 >>
@@ -188,16 +188,16 @@ Pode utilizar a sua própria interface phpMyAdmin para explorar o conteúdo da b
 
 ### Ligar-se a uma base de dados PostgreSQL
 
-Clique nos separadores abaixo para ver cada um dos **2** passos.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Obtenha as seguintes informações de ligação:
 >>

--- a/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.pt-pt.md
+++ b/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server/guide.pt-pt.md
@@ -73,7 +73,7 @@ Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 >>
 >> - **Servidor (hostname) e porta:** visíveis no separador `Informações gerais`{.action}, secção `Informações da ligação`.
 >> - **Nome de utilizador:** visível no separador `Utilizadores e permissões`{.action}.
->> - **Palavra-passe:** a palavra-passe associada ao utilizador. Se não se lembra dela, aceda ao separador `Utilizadores e permissões`{.action}, clique em `...`{.action} à direita do utilizador em causa e, em seguida, em `Alterar a palavra-passe`{.action}.
+>> - **Palavra-passe:** a palavra-passe associada ao utilizador. Se não se lembra dela, aceda ao separador `Utilizadores e permissões`{.action}, clique em `...`{.action} à direita do utilizador em causa e, em seguida, em `Alterar palavra-passe`{.action}.
 >>
 >> > [!warning]
 >> >

--- a/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/guide.es-es.md
+++ b/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/guide.es-es.md
@@ -29,20 +29,20 @@ Una base de datos (DB) permite almacenar elementos denominados dinámicos, como 
 
 ### Crear una base de datos
 
-Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en `Añadir una base de datos`{.action}.
 >>
@@ -52,7 +52,7 @@ Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
 >> >
 >> > La creación de esquemas PostgreSQL no está disponible actualmente en los servidores Web Cloud Databases.
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> Cumplimente los campos de acuerdo con los criterios indicados. Puede crear directamente un usuario marcando la casilla **"Crear un usuario"**:
 >>
@@ -69,26 +69,26 @@ Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
 
 Para utilizar un servidor de bases de datos de OVHcloud, cree usuarios con permisos específicos de conexión a una base de datos.
 
-Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Usuarios y permisos`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en `Añadir un usuario`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/add-user.png){.thumbnail}
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> Introduzca un "nombre de usuario" y una "contraseña" y haga clic en `Aceptar`{.action}.
 
@@ -96,26 +96,26 @@ Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
 
 Para permitir que un usuario realice acciones en una base de datos, es necesario asignarle permisos.
 
-Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Usuarios y permisos`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en el botón `...`{.action} a la derecha del usuario correspondiente y luego en `Gestionar los permisos`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/manage-rights.png){.thumbnail}
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> En la columna izquierda **Base de datos**, encontrará la lista de las bases de datos de su servidor.
 >>
@@ -142,20 +142,20 @@ Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
 > una copia de seguridad y descargarla antes de cualquier eliminación.
 >
 
-Haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en el botón `...`{.action} a la derecha de la base de datos correspondiente y luego en `Eliminar la base de datos`{.action}.
 >>

--- a/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/guide.it-it.md
@@ -40,7 +40,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** pa
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}.
+>> Clicca sulla scheda `Databases`{.action}.
 >>
 > **Passaggio 3**
 >>
@@ -153,7 +153,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}.
+>> Clicca sulla scheda `Databases`{.action}.
 >>
 > **Passaggio 3**
 >>

--- a/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/guide.it-it.md
@@ -29,20 +29,20 @@ Un database (DB) permette di archiviare elementi detti dinamici, come commenti o
 
 ### Creare un database
 
-Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `Database`{.action}.
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Clicca su `Aggiungi un database`{.action}.
 >>
@@ -52,7 +52,7 @@ Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
 >> >
 >> > La creazione di schemi PostgreSQL non è attualmente disponibile sui server Web Cloud Databases.
 >>
-> **Step 4**
+> **Passaggio 4**
 >>
 >> Compila i campi in base ai criteri indicati. È possibile creare direttamente un utente selezionando la casella **"Crea un utente"**:
 >>
@@ -69,26 +69,26 @@ Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
 
 Per utilizzare un database server OVHcloud, crea degli utenti con diritti specifici per la connessione a un database.
 
-Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `Utenti e diritti`{.action}.
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Clicca su `Aggiungi un utente`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/add-user.png){.thumbnail}
 >>
-> **Step 4**
+> **Passaggio 4**
 >>
 >> Inserisci un "nome utente" e una "password", poi clicca su `Conferma`{.action}.
 
@@ -96,26 +96,26 @@ Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
 
 Per consentire a un utente di eseguire operazioni su un database, è necessario assegnargli dei diritti.
 
-Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `Utenti e diritti`{.action}.
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Clicca sul pulsante `...`{.action} a destra dell'utente interessato, poi su `Gestisci i diritti`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/manage-rights.png){.thumbnail}
 >>
-> **Step 4**
+> **Passaggio 4**
 >>
 >> Nella colonna di sinistra **Database**, trovi la lista dei database presenti sul tuo server.
 >>
@@ -142,20 +142,20 @@ Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
 > un backup e scaricarlo prima di qualsiasi eliminazione.
 >
 
-Clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `Database`{.action}.
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Clicca sul pulsante `...`{.action} a destra del database interessato, poi su `Elimina il database`{.action}.
 >>

--- a/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/guide.pt-pt.md
+++ b/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/guide.pt-pt.md
@@ -44,7 +44,7 @@ Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 >>
 > **Etapa 3**
 >>
->> Clique em `Adicionar uma base de dados`{.action}.
+>> Clique em `Criar base de dados`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/add-database.png){.thumbnail}
 >>
@@ -84,7 +84,7 @@ Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 >>
 > **Etapa 3**
 >>
->> Clique em `Adicionar um utilizador`{.action}.
+>> Clique em `Adicionar utilizador`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/add-user.png){.thumbnail}
 >>
@@ -111,7 +111,7 @@ Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 >>
 > **Etapa 3**
 >>
->> Clique no botão `...`{.action} à direita do utilizador correspondente e depois em `Gerir as permissões`{.action}.
+>> Clique no botão `...`{.action} à direita do utilizador correspondente e depois em `Gerir permissões`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/manage-rights.png){.thumbnail}
 >>
@@ -157,7 +157,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 >>
 > **Etapa 3**
 >>
->> Clique no botão `...`{.action} à direita da base de dados correspondente e depois em `Eliminar a base de dados`{.action}.
+>> Clique no botão `...`{.action} à direita da base de dados correspondente e depois em `Eliminar base de dados`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/delete-the-database.png){.thumbnail}
 

--- a/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/guide.pt-pt.md
+++ b/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server/guide.pt-pt.md
@@ -29,20 +29,20 @@ Uma base de dados (DB) permite armazenar elementos ditos dinâmicos, como coment
 
 ### Criar uma base de dados
 
-Clique nos separadores abaixo para ver cada um dos **4** passos.
+Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Bases de dados`{.action}.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique em `Adicionar uma base de dados`{.action}.
 >>
@@ -52,7 +52,7 @@ Clique nos separadores abaixo para ver cada um dos **4** passos.
 >> >
 >> > A criação de esquemas PostgreSQL não está atualmente disponível nos servidores Web Cloud Databases.
 >>
-> **Passo 4**
+> **Etapa 4**
 >>
 >> Preencha os campos de acordo com os critérios indicados. Pode criar diretamente um utilizador selecionando a opção **"Criar um utilizador"**:
 >>
@@ -69,26 +69,26 @@ Clique nos separadores abaixo para ver cada um dos **4** passos.
 
 Para utilizar um servidor de bases de dados OVHcloud, crie utilizadores com permissões específicas de ligação a uma base de dados.
 
-Clique nos separadores abaixo para ver cada um dos **4** passos.
+Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Utilizadores e permissões`{.action}.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique em `Adicionar um utilizador`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/add-user.png){.thumbnail}
 >>
-> **Passo 4**
+> **Etapa 4**
 >>
 >> Introduza um "nome de utilizador" e uma "palavra-passe" e clique em `Validar`{.action}.
 
@@ -96,26 +96,26 @@ Clique nos separadores abaixo para ver cada um dos **4** passos.
 
 Para permitir que um utilizador efetue ações numa base de dados, é necessário atribuir-lhe permissões.
 
-Clique nos separadores abaixo para ver cada um dos **4** passos.
+Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Utilizadores e permissões`{.action}.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique no botão `...`{.action} à direita do utilizador correspondente e depois em `Gerir as permissões`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/manage-rights.png){.thumbnail}
 >>
-> **Passo 4**
+> **Etapa 4**
 >>
 >> Na coluna da esquerda **Base de dados**, encontrará a lista das bases de dados do seu servidor.
 >>
@@ -142,20 +142,20 @@ Clique nos separadores abaixo para ver cada um dos **4** passos.
 > uma cópia de segurança e o seu download antes de qualquer eliminação.
 >
 
-Clique nos separadores abaixo para ver cada um dos **3** passos.
+Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Bases de dados`{.action}.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique no botão `...`{.action} à direita da base de dados correspondente e depois em `Eliminar a base de dados`{.action}.
 >>

--- a/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/guide.es-es.md
+++ b/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/guide.es-es.md
@@ -52,26 +52,26 @@ Si se produce un error en la base de datos, es necesario poder restaurar una cop
 
 #### Restaurar una copia de seguridad existente
 
-Haga clic en las pestañas siguientes para ver cada uno de los **4** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action}.
 >>
 >> En la columna **"Copias de seguridad"**, la cifra corresponde al número de copias de seguridad disponibles para la base de datos.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en el botón `...`{.action} a la derecha de la base de datos y luego en `Mostrar las copias de seguridad`{.action}.
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> Se mostrará la lista de las copias de seguridad disponibles. Haga clic en el botón `...`{.action} a la derecha de la copia de seguridad seleccionada y luego en `Restaurar la copia de seguridad`{.action}.
 >>
@@ -83,26 +83,26 @@ Haga clic en las pestañas siguientes para ver cada uno de los **4** pasos.
 
 #### Importar una copia de seguridad local
 
-Haga clic en las pestañas siguientes para ver cada uno de los **4** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en el botón `...`{.action} a la derecha de la base de datos y luego en `Importar archivo`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/import-file.png){.thumbnail}
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> ***Tiene dos posibilidades:***
 >>

--- a/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/guide.it-it.md
@@ -34,7 +34,7 @@ In caso di errore sul database, è necessario essere in grado di ripristinare un
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** [Web Cloud Databases](/links/control-panel/web-cloud-databases)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Web Cloud Databases`{.action} > Seleziona il tuo database service
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Web Cloud Databases`{.action} > Seleziona il tuo servizio di database
 
 ---
 <!-- CP-NAV-END:web-cloud-databases -->

--- a/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/guide.it-it.md
@@ -63,7 +63,7 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **4** passaggi.
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}.
+>> Clicca sulla scheda `Databases`{.action}.
 >>
 >> Nella colonna **"Backup"**, la cifra corrisponde al numero di backup disponibili per il tuo database.
 >>
@@ -94,7 +94,7 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **4** passaggi.
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}.
+>> Clicca sulla scheda `Databases`{.action}.
 >>
 > **Passaggio 3**
 >>
@@ -108,9 +108,9 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **4** passaggi.
 >>
 >> **1 - Importare un nuovo file**
 >>
->> Clicca su **"Importa un nuovo file"**, poi su `Seguente`{.action}.
+>> Clicca su **"Importa un nuovo file"**, poi su `Continua`{.action}.
 >>
->> Inserisci un nome per il file importato, clicca su `Sfoglia`{.action} per selezionarlo, poi su `Invia`{.action} e infine su `Seguente`{.action}.
+>> Inserisci un nome per il file importato, clicca su `Sfoglia`{.action} per selezionarlo, poi su `Invia`{.action} e infine su `Continua`{.action}.
 >>
 >> > [!warning]
 >> >
@@ -118,17 +118,17 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **4** passaggi.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/database-import-new-file-step-2.png){.thumbnail}
 >>
->> Se lo desideri, seleziona **"Svuota il database attuale"** prima dell'importazione e **"Invia un'email alla fine dell'importazione"** per essere informato del completamento dell'operazione sull'indirizzo e-mail di riferimento del tuo account OVHcloud, poi clicca su `Conferma`{.action}.
+>> Se lo desideri, seleziona **"Svuota il database attuale"** prima dell'importazione e **"Invia un'email alla fine dell'importazione"** per essere informato del completamento dell'operazione sull'indirizzo e-mail di riferimento del tuo account OVHcloud, poi clicca su `Invia`{.action}.
 >>
 >> **2 - Utilizzare un file esistente**
 >>
 >> Se hai già importato un file in precedenza, puoi scegliere l'opzione **"Importa un file esistente"**.
 >>
->> Seleziona il file nel menu a tendina e clicca su `Seguente`{.action}.
+>> Seleziona il file nel menu a tendina e clicca su `Continua`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/database-import-existing-file-step-2.png){.thumbnail}
 >>
->> Se lo desideri, seleziona **"Svuota il database attuale"** prima dell'importazione e **"Invia un'email alla fine dell'importazione"** per essere informato del completamento dell'operazione sull'indirizzo e-mail di riferimento del tuo account OVHcloud, poi clicca su `Conferma`{.action}.
+>> Se lo desideri, seleziona **"Svuota il database attuale"** prima dell'importazione e **"Invia un'email alla fine dell'importazione"** per essere informato del completamento dell'operazione sull'indirizzo e-mail di riferimento del tuo account OVHcloud, poi clicca su `Invia`{.action}.
 
 ### Importare un database al di fuori dello Spazio Cliente
 

--- a/pages/web_cloud/web_cloud_databases/retrieve-logs/guide.es-es.md
+++ b/pages/web_cloud/web_cloud_databases/retrieve-logs/guide.es-es.md
@@ -72,16 +72,16 @@ En determinadas situaciones, puede necesitar consultar o recuperar los logs:
 
 ### Visualizar los logs en tiempo real de su Web Cloud Databases
 
-Haga clic en las pestañas siguientes para ver cada uno de los **2** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Logs`{.action}.
 >>
@@ -106,16 +106,16 @@ Para recuperar el historial de logs de su solución Web Cloud Databases, debe co
 > Para comprobarlo, obtenga la dirección IP pública de su punto de acceso a internet y consulte el apartado **Autorizar una dirección IP** de [esta guía](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 >
 
-Para obtener la información de conexión SFTP de su solución Web Cloud Databases, haga clic en las pestañas siguientes para ver cada uno de los **2** pasos.
+Para obtener la información de conexión SFTP de su solución Web Cloud Databases, haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la pestaña `Información general`{.action}, localice el recuadro **Información de conexión**. Debajo de la mención `SFTP`{.action}, encontrará los datos necesarios para conectarse por SFTP.
 >>
@@ -170,28 +170,28 @@ Para suscribir su solución Web Cloud Databases a un flujo de datos en Logs Data
 
 /// details | Caso 1 - Suscribirse a un flujo de datos existente en su solución Logs Data Platform
 
-Haga clic en las pestañas siguientes para ver cada uno de los **4** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Logs`{.action} y, a continuación, en el botón `Suscribirse`{.action} situado a la derecha del recuadro de logs en tiempo real.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/logs/tab-subscribe.png){.thumbnail}
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Si dispone de varias soluciones Logs Data Platform, seleccione la referencia deseada en la lista desplegable situada debajo del botón `Añadir un flujo de datos`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/logs/data-stream.png){.thumbnail}
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> El flujo existente aparece en la tabla de la parte inferior de la página. Haga clic en el botón `Suscribirse`{.action} situado a la derecha de la fila correspondiente.
 >>
@@ -201,28 +201,28 @@ Haga clic en las pestañas siguientes para ver cada uno de los **4** pasos.
 
 /// details | Caso 2 - Suscribirse a un nuevo flujo de datos en su solución Logs Data Platform
 
-Haga clic en las pestañas siguientes para ver cada uno de los **5** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **5** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Logs`{.action} y, a continuación, en el botón `Suscribirse`{.action} situado a la derecha del recuadro de logs en tiempo real.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/logs/tab-subscribe.png){.thumbnail}
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Si dispone de varias soluciones Logs Data Platform, seleccione la referencia deseada en la lista desplegable situada debajo del botón `Añadir un flujo de datos`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/logs/data-stream.png){.thumbnail}
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> Dado que el flujo de datos aún no existe, haga clic en el botón `Añadir un flujo de datos`{.action}. Será redirigido a una página que le permitirá crear un nuevo flujo de datos en su solución Logs Data Platform.
 >>
@@ -230,7 +230,7 @@ Haga clic en las pestañas siguientes para ver cada uno de los **5** pasos.
 >>
 >> Si lo necesita, consulte nuestras guías "[Introducción a Logs Data Platform](/pages/manage_and_operate/observability/logs_data_platform/getting_started_introduction_to_LDP)" (EN) e "[Inicio rápido con Logs Data Platform](/pages/manage_and_operate/observability/logs_data_platform/getting_started_quick_start)" (EN).
 >>
-> **Paso 5**
+> **Etapa 5**
 >>
 >> Una vez completados los formularios, haga clic en `Guardar`{.action}. Será redirigido a la pestaña `Flujo de datos` de su solución Logs Data Platform.
 >>

--- a/pages/web_cloud/web_cloud_databases/retrieve-logs/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/retrieve-logs/guide.it-it.md
@@ -58,7 +58,7 @@ In alcune situazioni, potrebbe essere necessario consultare o recuperare i log:
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** [Web Cloud Databases](/links/control-panel/web-cloud-databases)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Web Cloud Databases`{.action} > Seleziona il tuo database service
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Web Cloud Databases`{.action} > Seleziona il tuo servizio di database
 
 ---
 <!-- CP-NAV-END:web-cloud-databases -->

--- a/pages/web_cloud/web_cloud_databases/save-export-on-database-server/guide.es-es.md
+++ b/pages/web_cloud/web_cloud_databases/save-export-on-database-server/guide.es-es.md
@@ -60,22 +60,22 @@ Su base de datos puede contener una gran cantidad de información esencial para 
 
 #### Realizar una copia de seguridad manual
 
-Haga clic en las pestañas siguientes para ver cada uno de los **3** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action}.
 >>
 >> En la columna **Copias de seguridad**, la cifra corresponde al número de copias de seguridad disponibles para su base de datos.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en el botón `...`{.action} a la derecha de la base de datos y, a continuación, en `Guardar`{.action}.
 >>
@@ -83,28 +83,28 @@ Haga clic en las pestañas siguientes para ver cada uno de los **3** pasos.
 
 #### Exportar una copia de seguridad
 
-Haga clic en las pestañas siguientes para ver cada uno de los **4** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action}.
 >>
 >> En la columna **Copias de seguridad**, la cifra corresponde al número de copias de seguridad disponibles para su base de datos.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en el botón `...`{.action} a la derecha de la base de datos y, a continuación, en `Mostrar las copias de seguridad`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/show-backups.png){.thumbnail}
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> Se mostrará la lista de las copias de seguridad disponibles. Haga clic en el botón `...`{.action} a la derecha de la copia de seguridad seleccionada y, a continuación, en `Descargar la copia de seguridad`{.action}.
 

--- a/pages/web_cloud/web_cloud_databases/save-export-on-database-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/save-export-on-database-server/guide.it-it.md
@@ -71,13 +71,13 @@ Clicca sulle schede qui di seguito per visualizzare ciascuno dei **3** passaggi.
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}.
+>> Clicca sulla scheda `Databases`{.action}.
 >>
 >> Nella colonna **Backup**, il numero corrisponde al numero di backup disponibili per il tuo database.
 >>
 > **Passaggio 3**
 >>
->> Clicca sul pulsante `...`{.action} a destra del database, poi su `Salva adesso`{.action}.
+>> Clicca sul pulsante `...`{.action} a destra del database, poi su `Esegui un backup adesso`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/back-up-now.png){.thumbnail}
 
@@ -94,13 +94,13 @@ Clicca sulle schede qui di seguito per visualizzare ciascuno dei **4** passaggi.
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}.
+>> Clicca sulla scheda `Databases`{.action}.
 >>
 >> Nella colonna **Backup**, il numero corrisponde al numero di backup disponibili per il tuo database.
 >>
 > **Passaggio 3**
 >>
->> Clicca sul pulsante `...`{.action} a destra del database, poi su `Mostra i backup`{.action}.
+>> Clicca sul pulsante `...`{.action} a destra del database, poi su `Visualizza i backup`{.action}.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/show-backups.png){.thumbnail}
 >>

--- a/pages/web_cloud/web_cloud_databases/save-export-on-database-server/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/save-export-on-database-server/guide.it-it.md
@@ -34,7 +34,7 @@ Il tuo database può contenere numerose informazioni essenziali per il tuo sito 
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** [Web Cloud Databases](/links/control-panel/web-cloud-databases)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Web Cloud Databases`{.action} > Seleziona il tuo database service
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Web Cloud Databases`{.action} > Seleziona il tuo servizio di database
 
 ---
 <!-- CP-NAV-END:web-cloud-databases -->

--- a/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.es-es.md
+++ b/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.es-es.md
@@ -30,31 +30,31 @@ Por defecto, su solución Web Cloud Databases está asociada a la red de alojami
 
 ### Activación de su servidor Web Cloud Databases incluido con su plan de alojamiento web
 
-Si su plan de alojamiento incluye la opción Web Cloud Databases, haga clic en las pestañas de abajo para ver cada uno de los **3** pasos.
+Si su plan de alojamiento incluye la opción Web Cloud Databases, haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Desde la pestaña `Información general`, en el apartado `Configuración`, haga clic en el botón `...`{.action} a la derecha de **Web Cloud Databases**. A continuación, haga clic en `Activar`{.action} para iniciar el proceso de activación.
 >>
 >> ![Información general](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/web-cloud-databases-enable.png){.thumbnail}
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Siga las instrucciones proporcionadas para determinar el tipo y la versión de su servidor Web Cloud Databases. A continuación, estará accesible desde la columna izquierda en `Web Cloud Databases`{.action}.
 
 ### Consultar la información general de la instancia
 
-Haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
@@ -64,7 +64,7 @@ Haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
 >> >
 >> > El nombre del servicio Web Cloud Databases en su área de cliente de OVHcloud contiene una parte de su referencia de cliente y termina con tres cifras (001 para el primer servicio Web Cloud Databases instalado, 002 para el segundo, etc.).
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Asegúrese de estar en la pestaña `Información general`{.action}.
 >>
@@ -89,20 +89,20 @@ Haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
 >
 > Este paso no se aplica al sistema de bases de datos Redis.
 
-Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en `Añadir una base de datos`{.action}.
 >>
@@ -112,7 +112,7 @@ Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
 >> >
 >> > La creación de esquemas PostgreSQL no está disponible actualmente en los servidores Web Cloud Databases.
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> Complete los campos siguiendo los criterios indicados. Puede crear directamente un usuario marcando la casilla **"Crear un usuario"**:
 >>
@@ -133,26 +133,26 @@ Haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
 
 Si ha creado el usuario a la vez que su base de datos en el paso anterior, este paso es opcional. Sin embargo, un proyecto puede requerir varios usuarios con permisos diferentes (por ejemplo, lectura/escritura para uno y solo lectura para otro).
 
-Si su proyecto no necesita un usuario adicional, puede pasar al siguiente paso. En caso contrario, haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
+Si su proyecto no necesita un usuario adicional, puede pasar al siguiente paso. En caso contrario, haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Usuarios y permisos`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en `Añadir un usuario`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/add-user.png){.thumbnail}
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> Introduzca un "nombre de usuario" y una "contraseña" y haga clic en `Aceptar`{.action}.
 
@@ -172,22 +172,22 @@ Se describen varios métodos de importación.
 
 Para que su instancia Web Cloud Databases funcione, debe indicar las IP o rangos de IP autorizados a conectarse a sus bases de datos.
 
-Para ello, haga clic en las pestañas de abajo para ver cada uno de los **4** pasos.
+Para ello, haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la página que se muestra, haga clic en la pestaña `IP autorizadas`{.action}.
 >>
 >> ![IP autorizadas](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorised-ips.png){.thumbnail}
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en el botón `Añadir una dirección IP/máscara`{.action} situado encima de la tabla.
 >>
@@ -197,7 +197,7 @@ Para ello, haga clic en las pestañas de abajo para ver cada uno de los **4** pa
 >> >
 >> > Si desea modificar una dirección IP o un rango de IP ya autorizado, haga clic en el botón `...`{.action} a la derecha de la línea correspondiente en la tabla y luego en `Editar la whitelist`{.action}.
 >>
-> **Paso 4**
+> **Etapa 4**
 >>
 >> En la ventana que se abre, deben completarse varios campos:
 >>
@@ -236,16 +236,16 @@ Para ello, necesita las siguientes 5 informaciones:
 |Nombre de host del servidor|El servidor que debe indicar para que su sitio web pueda conectarse a su base de datos.|
 |Puerto del servidor|El puerto de conexión a su instancia Web Cloud Databases para que su sitio web pueda conectarse a su base de datos.|
 
-Para obtener esta información, haga clic en las pestañas de abajo para ver cada uno de los **2** pasos.
+Para obtener esta información, haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Obtenga la siguiente información de conexión:
 >>

--- a/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.it-it.md
@@ -30,31 +30,31 @@ Di default, la soluzione Web Cloud Databases è associata alla rete di hosting W
 
 ### Attivazione del server Web Cloud Databases incluso con il piano di hosting Web
 
-Se il piano di hosting include l'opzione Web Cloud Databases, clicca sulle schede qui sotto per visualizzare i **3** step in sequenza.
+Se il piano di hosting include l'opzione Web Cloud Databases, clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Dalla scheda `Informazioni generali`, nella sezione `Configurazione`, clicca sul pulsante `...`{.action} a destra di **Web Cloud Databases**. Clicca poi su `Attiva`{.action} per avviare il processo di attivazione.
 >>
 >> ![Informazioni generali](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/web-cloud-databases-enable.png){.thumbnail}
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Segui le istruzioni fornite per determinare il tipo e la versione del server Web Cloud Databases. Sarà poi accessibile dalla colonna di sinistra in `Web Cloud Databases`{.action}.
 
 ### Visualizzare le informazioni generali dell'istanza
 
-Clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
@@ -64,7 +64,7 @@ Clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
 >> >
 >> > Il nome del servizio Web Cloud Databases nello Spazio Cliente OVHcloud contiene una parte del riferimento cliente e termina con tre cifre (001 per il primo servizio Web Cloud Databases installato, 002 per il secondo, ecc.).
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Assicurati di trovarti nella scheda `Informazioni generali`{.action}.
 >>
@@ -89,20 +89,20 @@ Clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
 >
 > Questo step non si applica al sistema di database Redis.
 
-Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `Database`{.action}.
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Clicca su `Aggiungi un database`{.action}.
 >>
@@ -112,7 +112,7 @@ Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
 >> >
 >> > La creazione di schemi PostgreSQL non è attualmente disponibile sui server Web Cloud Databases.
 >>
-> **Step 4**
+> **Passaggio 4**
 >>
 >> Compila i campi rispettando i criteri indicati. È possibile creare direttamente un utente selezionando la casella **"Crea un utente"**:
 >>
@@ -133,26 +133,26 @@ Clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
 
 Se l'utente è stato creato contemporaneamente al database nello step precedente, questo passaggio è facoltativo. Tuttavia, un progetto potrebbe richiedere più utenti con diritti diversi (ad esempio, lettura/scrittura per uno e sola lettura per un altro).
 
-Se il progetto non necessita di un utente aggiuntivo, è possibile passare allo step successivo. In caso contrario, clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
+Se il progetto non necessita di un utente aggiuntivo, è possibile passare allo step successivo. In caso contrario, clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Clicca sulla scheda `Utenti e diritti`{.action}.
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Clicca su `Aggiungi un utente`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/add-user.png){.thumbnail}
 >>
-> **Step 4**
+> **Passaggio 4**
 >>
 >> Inserisci un "nome utente" e una "password", poi clicca su `Conferma`{.action}.
 
@@ -172,22 +172,22 @@ Nella guida sono descritti diversi metodi di importazione.
 
 Affinché l'istanza Web Cloud Databases funzioni, è necessario indicare gli IP o gli intervalli di IP autorizzati a connettersi ai database.
 
-Per farlo, clicca sulle schede qui sotto per visualizzare i **4** step in sequenza.
+Per farlo, clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Nella pagina visualizzata, clicca sulla scheda `IP autorizzati`{.action}.
 >>
 >> ![IP autorizzati](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorised-ips.png){.thumbnail}
 >>
-> **Step 3**
+> **Passaggio 3**
 >>
 >> Clicca sul pulsante `Aggiungi un indirizzo IP/mask`{.action} sopra la tabella.
 >>
@@ -197,7 +197,7 @@ Per farlo, clicca sulle schede qui sotto per visualizzare i **4** step in sequen
 >> >
 >> > Per modificare un indirizzo IP o un intervallo di IP già autorizzato, clicca sul pulsante `...`{.action} a destra della riga corrispondente nella tabella, poi su `Modifica la whitelist`{.action}.
 >>
-> **Step 4**
+> **Passaggio 4**
 >>
 >> Nella finestra che si apre, diversi campi devono essere compilati:
 >>
@@ -236,16 +236,16 @@ A tal fine, sono necessarie le seguenti 5 informazioni:
 |Hostname del server|Il server da indicare affinché il sito Web possa connettersi al database.|
 |Porta del server|La porta di connessione all'istanza Web Cloud Databases, necessaria affinché il sito Web possa connettersi al database.|
 
-Per recuperare queste informazioni, clicca sulle schede qui sotto per visualizzare i **2** step in sequenza.
+Per recuperare queste informazioni, clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
 > [!tabs]
-> **Step 1**
+> **Passaggio 1**
 >>
 >> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 2**
+> **Passaggio 2**
 >>
 >> Recupera le seguenti informazioni di connessione:
 >>

--- a/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.it-it.md
@@ -21,7 +21,7 @@ Di default, la soluzione Web Cloud Databases è associata alla rete di hosting W
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** [Web Cloud Databases](/links/control-panel/web-cloud-databases)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Web Cloud Databases`{.action} > Seleziona il tuo database service
+- **Percorso di navigazione:** `Web Cloud`{.action} > `Web Cloud Databases`{.action} > Seleziona il tuo servizio di database
 
 ---
 <!-- CP-NAV-END:web-cloud-databases -->

--- a/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.it-it.md
+++ b/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.it-it.md
@@ -87,7 +87,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** pa
 
 > [!primary]
 >
-> Questo step non si applica al sistema di database Redis.
+> Questo passaggio non si applica al sistema di database Redis.
 
 Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
@@ -100,7 +100,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** pa
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}.
+>> Clicca sulla scheda `Databases`{.action}.
 >>
 > **Passaggio 3**
 >>
@@ -129,11 +129,11 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** pa
 
 > [!primary]
 >
-> Questo step non si applica al sistema di database Redis.
+> Questo passaggio non si applica al sistema di database Redis.
 
-Se l'utente è stato creato contemporaneamente al database nello step precedente, questo passaggio è facoltativo. Tuttavia, un progetto potrebbe richiedere più utenti con diritti diversi (ad esempio, lettura/scrittura per uno e sola lettura per un altro).
+Se l'utente è stato creato contemporaneamente al database nello passaggio precedente, questo passaggio è facoltativo. Tuttavia, un progetto potrebbe richiedere più utenti con diritti diversi (ad esempio, lettura/scrittura per uno e sola lettura per un altro).
 
-Se il progetto non necessita di un utente aggiuntivo, è possibile passare allo step successivo. In caso contrario, clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
+Se il progetto non necessita di un utente aggiuntivo, è possibile passare allo passaggio successivo. In caso contrario, clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
 > [!tabs]
 > **Passaggio 1**
@@ -162,7 +162,7 @@ Per modificare i diritti di un utente esistente, consulta la guida "[Web Cloud D
 
 > [!primary]
 >
-> Questo step si applica se vuoi importare un backup di un database esistente. In caso contrario, passa allo step successivo.
+> Questo passaggio si applica se vuoi importare un backup di un database esistente. In caso contrario, passa allo passaggio successivo.
 
 Per importare un database, consulta la guida "[Ripristinare e importare un database sul server di database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server)".
 
@@ -205,12 +205,12 @@ Per farlo, clicca sulle schede qui sotto per visualizzare in sequenza ciascuno d
 >>
 >> - `IP/mask *`{.action}: Inserisci l'indirizzo IP (ad esempio `203.0.113.44`) o l'intervallo di IP (ad esempio `203.0.113.0/24`, che rappresenta tutti gli indirizzi IP da `203.0.113.0` a `203.0.113.255`) da autorizzare sulla soluzione Web Cloud Databases.
 >> - `Descrizione`{.action} (facoltativo): È possibile aggiungere informazioni sul ruolo dell'indirizzo IP o dell'intervallo di IP interessato.
->> - `Database`{.action}: Seleziona questa casella per consentire all'indirizzo IP o all'intervallo di IP di accedere ai database della soluzione Web Cloud Databases.
+>> - `Databases`{.action}: Seleziona questa casella per consentire all'indirizzo IP o all'intervallo di IP di accedere ai database della soluzione Web Cloud Databases.
 >> - `SFTP`{.action}: Seleziona questa casella per consentire all'indirizzo IP o all'intervallo di IP di accedere ai log della soluzione Web Cloud Databases.
 >>
 >> > [!warning]
 >> >
->> > Si sconsiglia fortemente di selezionare la casella `Database`{.action} per autorizzare l'intervallo di IP `0.0.0.0/0` ad accedere ai database.
+>> > Si sconsiglia fortemente di selezionare la casella `Databases`{.action} per autorizzare l'intervallo di IP `0.0.0.0/0` ad accedere ai database.
 >> >
 >> > Questo consentirebbe a tutti gli indirizzi IPv4 esistenti di accedere ai database.
 >>
@@ -224,7 +224,7 @@ Per farlo, consulta i casi particolari nella guida "[Web Cloud Databases - Come 
 
 ### Associare il sito Web al database
 
-Ora che il database è stato creato, uno o più utenti dispongono dei diritti necessari e almeno un indirizzo IP o gli hosting Web OVHcloud sono stati autorizzati sull'istanza Web Cloud Databases, non resta che associare il sito Web al database. Questo step può essere eseguito in diversi modi, a seconda del sito Web o del CMS (WordPress, Joomla!, ecc.) utilizzato, nonché della fase di installazione del sito Web.
+Ora che il database è stato creato, uno o più utenti dispongono dei diritti necessari e almeno un indirizzo IP o gli hosting Web OVHcloud sono stati autorizzati sull'istanza Web Cloud Databases, non resta che associare il sito Web al database. Questo passaggio può essere eseguito in diversi modi, a seconda del sito Web o del CMS (WordPress, Joomla!, ecc.) utilizzato, nonché della fase di installazione del sito Web.
 
 A tal fine, sono necessarie le seguenti 5 informazioni:
 

--- a/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.pt-pt.md
+++ b/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.pt-pt.md
@@ -30,31 +30,31 @@ Por predefinição, a solução Web Cloud Databases está associada à rede de a
 
 ### Ativação do servidor Web Cloud Databases incluído no plano de alojamento web
 
-Se o seu plano de alojamento inclui a opção Web Cloud Databases, clique nos separadores abaixo para ver cada um dos **3** passos.
+Se o seu plano de alojamento inclui a opção Web Cloud Databases, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em causa.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> No separador `Informações gerais`, na secção `Configuração`, clique no botão `...`{.action} à direita de **Web Cloud Databases**. De seguida, clique em `Ativar`{.action} para iniciar o processo de ativação.
 >>
 >> ![Informações gerais](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/web-cloud-databases-enable.png){.thumbnail}
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Siga as instruções apresentadas para determinar o tipo e a versão do servidor Web Cloud Databases. Ficará depois acessível na coluna da esquerda, em `Web Cloud Databases`{.action}.
 
 ### Consultar as informações gerais da instância
 
-Clique nos separadores abaixo para ver cada um dos **2** passos.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
@@ -64,7 +64,7 @@ Clique nos separadores abaixo para ver cada um dos **2** passos.
 >> >
 >> > O nome do serviço Web Cloud Databases na Área de Cliente OVHcloud contém uma parte da sua referência de cliente e termina com três algarismos (001 para o primeiro serviço Web Cloud Databases instalado, 002 para o segundo, etc.).
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Certifique-se de que está no separador `Informações gerais`{.action}.
 >>
@@ -89,20 +89,20 @@ Clique nos separadores abaixo para ver cada um dos **2** passos.
 >
 > Este passo não se aplica ao sistema de bases de dados Redis.
 
-Clique nos separadores abaixo para ver cada um dos **4** passos.
+Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Bases de dados`{.action}.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique em `Adicionar uma base de dados`{.action}.
 >>
@@ -112,7 +112,7 @@ Clique nos separadores abaixo para ver cada um dos **4** passos.
 >> >
 >> > A criação de esquemas PostgreSQL não está atualmente disponível nos servidores Web Cloud Databases.
 >>
-> **Passo 4**
+> **Etapa 4**
 >>
 >> Preencha os campos de acordo com os critérios indicados. Pode criar diretamente um utilizador assinalando a opção **"Criar um utilizador"**:
 >>
@@ -133,26 +133,26 @@ Clique nos separadores abaixo para ver cada um dos **4** passos.
 
 Se criou o utilizador ao mesmo tempo que a base de dados no passo anterior, este passo é facultativo. No entanto, um projeto pode exigir vários utilizadores com permissões diferentes (por exemplo, leitura/escrita para um e apenas leitura para outro).
 
-Se o seu projeto não necessitar de um utilizador adicional, pode avançar para o passo seguinte. Caso contrário, clique nos separadores abaixo para ver cada um dos **4** passos.
+Se o seu projeto não necessitar de um utilizador adicional, pode avançar para o passo seguinte. Caso contrário, clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Utilizadores e permissões`{.action}.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique em `Adicionar um utilizador`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/add-user.png){.thumbnail}
 >>
-> **Passo 4**
+> **Etapa 4**
 >>
 >> Introduza um "nome de utilizador" e uma "palavra-passe" e clique em `Validar`{.action}.
 
@@ -172,22 +172,22 @@ São descritos vários métodos de importação.
 
 Para que a instância Web Cloud Databases funcione, é necessário indicar os IPs ou intervalos de IP autorizados a conectar-se às bases de dados.
 
-Para isso, clique nos separadores abaixo para ver cada um dos **4** passos.
+Para isso, clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Na página apresentada, clique no separador `IPs autorizados`{.action}.
 >>
 >> ![IPs autorizados](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorised-ips.png){.thumbnail}
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique no botão `Adicionar um endereço IP/máscara`{.action} acima da tabela.
 >>
@@ -197,7 +197,7 @@ Para isso, clique nos separadores abaixo para ver cada um dos **4** passos.
 >> >
 >> > Se pretender alterar um endereço IP ou intervalo de IP já autorizado, clique no botão `...`{.action} à direita da linha correspondente na tabela e depois em `Editar a whitelist`{.action}.
 >>
-> **Passo 4**
+> **Etapa 4**
 >>
 >> Na janela que se abre, vários campos devem ser preenchidos:
 >>
@@ -236,16 +236,16 @@ Para isso, necessita das seguintes 5 informações:
 |Nome de host do servidor|O servidor a indicar para que o website se possa ligar à base de dados.|
 |Porta do servidor|A porta de ligação à instância Web Cloud Databases, para que o website se possa ligar à base de dados.|
 
-Para as obter, clique nos separadores abaixo para ver cada um dos **2** passos.
+Para as obter, clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Obtenha as seguintes informações de ligação:
 >>

--- a/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.pt-pt.md
+++ b/pages/web_cloud/web_cloud_databases/starting_with_clouddb/guide.pt-pt.md
@@ -104,7 +104,7 @@ Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 >>
 > **Etapa 3**
 >>
->> Clique em `Adicionar uma base de dados`{.action}.
+>> Clique em `Criar base de dados`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/add-database.png){.thumbnail}
 >>
@@ -148,7 +148,7 @@ Se o seu projeto não necessitar de um utilizador adicional, pode avançar para 
 >>
 > **Etapa 3**
 >>
->> Clique em `Adicionar um utilizador`{.action}.
+>> Clique em `Adicionar utilizador`{.action}.
 >>
 >> ![web-cloud-databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/users-and-rights/add-user.png){.thumbnail}
 >>
@@ -183,19 +183,19 @@ Para isso, clique nos separadores abaixo para visualizar cada uma das **4** etap
 >>
 > **Etapa 2**
 >>
->> Na página apresentada, clique no separador `IPs autorizados`{.action}.
+>> Na página apresentada, clique no separador `Endereços IP autorizados`{.action}.
 >>
 >> ![IPs autorizados](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorised-ips.png){.thumbnail}
 >>
 > **Etapa 3**
 >>
->> Clique no botão `Adicionar um endereço IP/máscara`{.action} acima da tabela.
+>> Clique no botão `Adicionar um endereço IP / máscara`{.action} acima da tabela.
 >>
 >> ![Interface de IPs autorizados](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/authorized-ips/tab-0000-sftp-hosting-enabled.png){.thumbnail}
 >>
 >> > [!success]
 >> >
->> > Se pretender alterar um endereço IP ou intervalo de IP já autorizado, clique no botão `...`{.action} à direita da linha correspondente na tabela e depois em `Editar a whitelist`{.action}.
+>> > Se pretender alterar um endereço IP ou intervalo de IP já autorizado, clique no botão `...`{.action} à direita da linha correspondente na tabela e depois em `Editar whitelist`{.action}.
 >>
 > **Etapa 4**
 >>
@@ -205,12 +205,12 @@ Para isso, clique nos separadores abaixo para visualizar cada uma das **4** etap
 >>
 >> - `IP/máscara *`{.action}: Introduza o endereço IP (p. ex., `203.0.113.44`) ou o intervalo de IP (p. ex., `203.0.113.0/24` que representa todos os endereços IP de `203.0.113.0` a `203.0.113.255`) que pretende autorizar na solução Web Cloud Databases.
 >> - `Descrição`{.action} (opcional): Pode adicionar informações sobre a função do endereço IP ou do intervalo de IP em questão.
->> - `Bases de dados`{.action}: Assinale esta opção para que o endereço IP ou o intervalo de IP possa aceder às bases de dados da solução Web Cloud Databases.
+>> - `Base de dados`{.action}: Assinale esta opção para que o endereço IP ou o intervalo de IP possa aceder às bases de dados da solução Web Cloud Databases.
 >> - `SFTP`{.action}: Assinale esta opção para que o endereço IP ou o intervalo de IP possa aceder aos logs da solução Web Cloud Databases.
 >>
 >> > [!warning]
 >> >
->> > É fortemente desaconselhado assinalar a opção `Bases de dados`{.action} para autorizar o intervalo de IP `0.0.0.0/0` a aceder às suas bases de dados.
+>> > É fortemente desaconselhado assinalar a opção `Base de dados`{.action} para autorizar o intervalo de IP `0.0.0.0/0` a aceder às suas bases de dados.
 >> >
 >> > Isto permitiria que todos os endereços IPv4 existentes acedessem às suas bases de dados.
 >>
@@ -251,7 +251,7 @@ Para as obter, clique nos separadores abaixo para visualizar cada uma das **2** 
 >>
 >> - **Servidor (nome de host) e porta:** visíveis no separador `Informações gerais`{.action}, na secção `Informações de ligação`.
 >> - **Nome de utilizador:** visível no separador `Utilizadores e permissões`{.action}.
->> - **Palavra-passe:** a palavra-passe associada ao utilizador. Se a esqueceu, aceda ao separador `Utilizadores e permissões`{.action}, clique em `...`{.action} à direita do utilizador em causa e depois em `Alterar a palavra-passe`{.action}.
+>> - **Palavra-passe:** a palavra-passe associada ao utilizador. Se a esqueceu, aceda ao separador `Utilizadores e permissões`{.action}, clique em `...`{.action} à direita do utilizador em causa e depois em `Alterar palavra-passe`{.action}.
 >>
 >> > [!warning]
 >> >

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Backup des FTP-Speicherplatzes Ihres Cloud Web Hostings abrufen"
 excerpt: "Diese Anleitung erklärt, wie Sie ein Backup des FTP-Speicherplatzes Ihres Cloud Web Hostings abrufen"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Ziel

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Backup des FTP-Speicherplatzes Ihres Cloud Web Hostings abrufen"
 excerpt: "Diese Anleitung erklärt, wie Sie ein Backup des FTP-Speicherplatzes Ihres Cloud Web Hostings abrufen"
-updated: 2023-11-16
+updated: 2026-03-26
 ---
 
 ## Ziel
@@ -48,40 +48,54 @@ Nur die oben genannten Backups können von OVHcloud angeboten werden, sofern Ihr
 
 ### Backup exportieren
 
-Im Gegensatz zu den Shared Hosting Paketen von OVHcloud ist es unmöglich, den FTP-Bereich mit einem Klick über das [OVHcloud Kundencenter](/links/manager) wiederherzustellen.
+Im Gegensatz zu den Shared Hosting Paketen von OVHcloud ist es unmöglich, den FTP-Bereich mit einem Klick über das OVHcloud Kundencenter wiederherzustellen.
 
 Es wird ein Link zum Download des Backups erstellt und per E-Mail an die Adresse gesendet, die der Administrator-Kundenkennung des Cloud Web Hostings zugeordnet ist.
 
-#### Schritt 1 - Den per E-Mail versandten Link zur Wiederherstellung erstellen
+Klicken Sie auf die Tabs, um die **5** Schritte anzuzeigen.
 
-Um den Link zur Wiederherstellung zu erstellen, loggen Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager) ein. Gehen Sie in den Bereich `Web Cloud`{.action}, klicken Sie auf `Hosting-Pakete`{.action} und dann auf das betreffende Hosting. 
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Cloud Web aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Wählen Sie den Tab `FTP - SSH`{.action} aus und klicken Sie rechts auf `Backup erstellen`{.action}.
+>>
+>> ![Button Backup erstellen](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+>>
+> **Schritt 3**
+>>
+>> Wählen Sie im neu angezeigten Fenster eines der verfügbaren Backups aus und klicken Sie dann auf `Weiter`{.action}.
+>>
+>> ![Backup-Auswahl](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
+>>
+> **Schritt 4**
+>>
+>> Es erscheint ein zweites Fenster, in dem Sie darauf hingewiesen werden, dass Ihnen der Link zum Download der Backup-Datei per E-Mail gesendet wird und dass OVHcloud keine automatische Wiederherstellung auf Ihrem Cloud Web Hosting durchführen wird.
+>>
+>> ![Bestätigung der Backup-Erstellung](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
+>>
+>> Klicken Sie auf `Bestätigen`{.action}, um Ihre Anfrage zu bestätigen.
+>>
+> **Schritt 5**
+>>
+>> Wenn die Erstellung des Backups erfolgreich gestartet wurde, erscheint in Ihrem OVHcloud Kundencenter folgende Nachricht:
+>>
+>> ![Fortschrittsmeldung des Backups](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
+>>
+>> Die Erstellung des Backups dauert zwischen 10 und 15 Minuten.
 
-Wählen Sie den Tab `FTP - SSH`{.action} aus und klicken Sie rechts auf `Backup erstellen`{.action}.
+### Die Sicherung herunterladen
 
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+Wenn das Backup bereit ist, erhalten Sie eine E-Mail an die E-Mail-Adresse, die der Administrator-Kundenkennung Ihres Cloud Web Hostings zugewiesen ist.
 
-Wählen Sie im neu angezeigten Fenster eines der verfügbaren Backups aus und klicken Sie dann auf `Weiter`{.action}.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
-
-Es erscheint ein zweites Fenster, in dem Sie darauf hingewiesen werden, dass Ihnen der Link zur Wiederherstellung der Backup-Datei per E-Mail gesendet wird und dass OVHcloud keine automatische Wiederherstellung auf Ihrem Cloud Web Hosting durchführen wird.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
-
-Klicken Sie auf `Bestätigen`{.action}, um Ihre Anfrage zu bestätigen.
-
-Wenn die Erstellung des Backups erfolgreich gestartet wurde, erscheint in Ihrem [OVHcloud Kundencenter](/links/manager) folgende Nachricht:
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
-
-Die Erstellung des Backups dauert zwischen 10 und 15 Minuten.
-
-#### Schritt 2 - Backup wiederherstellen
-
-Wenn das Backup bereit ist, erhalten Sie eine E-Mail an die E-Mail-Adresse, die der Administrator-Kundenkennung Ihres Cloud Web Hostings zugewiesen ist.<br>
 Diese E-Mail enthält einen Download-Link, der **9 Tage** ab Eingang der E-Mail gültig ist:
 
-![backupftpcw](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
+![Backup-Download-E-Mail](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
 
 Die heruntergeladene Datei ist im Format *.tar.gz*.
 

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Retrieving the backup of the FTP space on your Cloud Web hosting plan"
 excerpt: "Find out how to retrieve a backup of the FTP space in your Cloud Web hosting plan"
-updated: 2023-11-16
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -48,40 +48,54 @@ Only the backups mentioned above can be offered by OVHcloud, provided that your 
 
 ### Retrieve a backup
 
-Unlike OVHcloud shared hosting, you cannot restore the FTP space in one click from the [OVHcloud Control Panel](/links/manager).
+Unlike OVHcloud shared hosting, you cannot restore the FTP space in one click from the OVHcloud Control Panel.
 
 A link to download the backup is generated, then sent by email to the email address associated with the Cloud Web hosting plan’s admin NIC handle.
 
-#### Step 1 - Generate the recovery link sent by email
+Click on the tabs below to view each of the **5** steps.
 
-To generate the recovery link, log in to the [OVHcloud Control Panel](/links/manager), go to the `Web Cloud`{.action} section, click `Hosting plans`{.action}, then click on the Cloud Web concerned. 
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Select the `FTP - SSH`{.action} tab and click the `Generate a backup`{.action} button on the right.
+>>
+>> ![Generate a backup button](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> In the window that opens, select one of the available backups, then click `Next`{.action}.
+>>
+>> ![Backup selection](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A second window will appear, notifying you that the link to download the backup file will be sent to you by email, and that no automatic restore on your Cloud Web hosting plan will be done by OVHcloud.
+>>
+>> ![Backup generation confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
+>>
+>> Click `Confirm`{.action} to confirm your request.
+>>
+> **Step 5**
+>>
+>> If the backup generation has started successfully, the following message will appear in your OVHcloud Control Panel:
+>>
+>> ![Backup progress message](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
+>>
+>> The backup takes between 10 and 15 minutes.
 
-Select the `FTP - SSH`{.action} tab and click the `Generate a backup`{.action} button on the right.
+### Download the backup
 
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+When the backup is ready, you will receive an email via the email address associated with the admin NIC handle for your Cloud Web hosting plan.
 
-In the window that opens, select one of the available backups, then click `Next`{.action}.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
-
-A second window will appear, notifying you that the link to retrieve the backup file will be sent to you by email, and that no automatic restore on your Cloud Web hosting plan will be done by OVHcloud.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
-
-Click `Confirm`{.action} to confirm your request.
-
-If you have successfully generated the backup, the following message will appear in your [OVHcloud Control Panel](/links/manager):
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
-
-The backup takes between 10 and 15 minutes to be generated.
-
-#### Step 2 - Retrieve the backup
-
-When the backup is ready, you will receive an email via the email address associated with the admin NIC handle for your Cloud Web hosting plan.<br>
 This email contains a download link **valid for 9 days** from receipt of the email:
 
-![backupftpcw](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
+![Backup download email](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
 
 The downloaded file is in the format *.tar.gz*.
 

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Retrieving the backup of the FTP space on your Cloud Web hosting plan"
 excerpt: "Find out how to retrieve a backup of the FTP space in your Cloud Web hosting plan"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Retrieving the backup of the FTP space on your Cloud Web hosting plan"
 excerpt: "Find out how to retrieve a backup of the FTP space in your Cloud Web hosting plan"
-updated: 2023-11-16
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -48,40 +48,54 @@ Only the backups mentioned above can be offered by OVHcloud, provided that your 
 
 ### Retrieve a backup
 
-Unlike OVHcloud shared hosting, you cannot restore the FTP space in one click from the [OVHcloud Control Panel](/links/manager).
+Unlike OVHcloud shared hosting, you cannot restore the FTP space in one click from the OVHcloud Control Panel.
 
 A link to download the backup is generated, then sent by email to the email address associated with the Cloud Web hosting plan’s admin NIC handle.
 
-#### Step 1 - Generate the recovery link sent by email
+Click on the tabs below to view each of the **5** steps.
 
-To generate the recovery link, log in to the [OVHcloud Control Panel](/links/manager), go to the `Web Cloud`{.action} section, click `Hosting plans`{.action}, then click on the Cloud Web concerned. 
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Select the `FTP - SSH`{.action} tab and click the `Generate a backup`{.action} button on the right.
+>>
+>> ![Generate a backup button](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> In the window that opens, select one of the available backups, then click `Next`{.action}.
+>>
+>> ![Backup selection](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A second window will appear, notifying you that the link to download the backup file will be sent to you by email, and that no automatic restore on your Cloud Web hosting plan will be done by OVHcloud.
+>>
+>> ![Backup generation confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
+>>
+>> Click `Confirm`{.action} to confirm your request.
+>>
+> **Step 5**
+>>
+>> If the backup generation has started successfully, the following message will appear in your OVHcloud Control Panel:
+>>
+>> ![Backup progress message](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
+>>
+>> The backup takes between 10 and 15 minutes.
 
-Select the `FTP - SSH`{.action} tab and click the `Generate a backup`{.action} button on the right.
+### Download the backup
 
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+When the backup is ready, you will receive an email via the email address associated with the admin NIC handle for your Cloud Web hosting plan.
 
-In the window that opens, select one of the available backups, then click `Next`{.action}.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
-
-A second window will appear, notifying you that the link to retrieve the backup file will be sent to you by email, and that no automatic restore on your Cloud Web hosting plan will be done by OVHcloud.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
-
-Click `Confirm`{.action} to confirm your request.
-
-If you have successfully generated the backup, the following message will appear in your [OVHcloud Control Panel](/links/manager):
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
-
-The backup takes between 10 and 15 minutes to be generated.
-
-#### Step 2 - Retrieve the backup
-
-When the backup is ready, you will receive an email via the email address associated with the admin NIC handle for your Cloud Web hosting plan.<br>
 This email contains a download link **valid for 9 days** from receipt of the email:
 
-![backupftpcw](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
+![Backup download email](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
 
 The downloaded file is in the format *.tar.gz*.
 

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Retrieving the backup of the FTP space on your Cloud Web hosting plan"
 excerpt: "Find out how to retrieve a backup of the FTP space in your Cloud Web hosting plan"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Exportar la copia de seguridad del espacio FTP de su hosting Cloud Web"
 excerpt: "Descubra cómo descargar una copia de seguridad del espacio FTP de un alojamiento Cloud Web"
-updated: 2023-11-16
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -29,7 +29,7 @@ Su hosting Cloud Web dispone de un espacio de almacenamiento en el que podrá al
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -48,40 +48,54 @@ OVHcloud solo podrá ofrecer las copias de seguridad antes mencionadas, siempre 
 
 ### Obtener una copia de seguridad
 
-A diferencia de los alojamientos compartidos de OVHcloud, no es posible restaurar el espacio FTP en un clic desde el [área de cliente de OVHcloud](/links/manager).
+A diferencia de los alojamientos compartidos de OVHcloud, no es posible restaurar el espacio FTP en un clic desde el área de cliente de OVHcloud.
 
 Se genera un enlace de descarga de la copia de seguridad y se envía por correo electrónico a la dirección de correo electrónico asociada al ID de cliente administrador del hosting Cloud Web.
 
-#### Paso 1 - Generar el enlace de recuperación enviado por correo electrónico
+Haga clic en las fichas siguientes para ver cada una de las **5** etapas.
 
-Para generar el enlace de recuperación, conéctese al [área de cliente de OVHcloud](/links/manager), acceda a la sección `Web Cloud`{.action}, haga clic en `Alojamientos`{.action} y seleccione el Cloud Web correspondiente. 
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el Cloud Web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Seleccione la pestaña `FTP - SSH`{.action} y haga clic en el botón `Generar una copia de seguridad`{.action} a la derecha.
+>>
+>> ![Botón Generar una copia de seguridad](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> En la nueva ventana, seleccione una de las copias de seguridad disponibles y haga clic en `Siguiente`{.action}.
+>>
+>> ![Selección de la copia de seguridad](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
+>>
+> **Etapa 4**
+>>
+>> Se abrirá una segunda ventana indicándole que el enlace de descarga del archivo de backup se enviará por correo electrónico y que OVHcloud no restaurará el alojamiento Cloud Web automáticamente.
+>>
+>> ![Confirmación de generación de la copia de seguridad](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
+>>
+>> Haga clic en `Aceptar`{.action} para confirmar su solicitud.
+>>
+> **Etapa 5**
+>>
+>> Si la generación de la copia de seguridad se ha iniciado correctamente, aparecerá el siguiente mensaje en su área de cliente de OVHcloud:
+>>
+>> ![Mensaje de progreso de la copia de seguridad](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
+>>
+>> La generación de la copia de seguridad tarda entre 10 y 15 minutos.
 
-Seleccione la pestaña `FTP - SSH`{.action} y haga clic en el botón `Generar una copia de seguridad`{.action} a la derecha.
+### Descargar la copia de seguridad
 
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+Una vez finalizada la generación del backup, recibirá un mensaje de correo electrónico en la dirección asociada al usuario de administrador de su hosting Cloud Web.
 
-En la nueva ventana, seleccione una de las copias de seguridad disponibles y haga clic en `Siguiente`{.action}.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
-
-Se abrirá una segunda ventana en la que deberá indicar que el enlace de recuperación del archivo de backup se enviará por correo electrónico y que OVHcloud no restaurará el alojamiento Cloud Web automáticamente.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
-
-Haga clic en `Confirmar`{.action} para aceptar su solicitud.
-
-Si la generación de la copia de seguridad se ha iniciado correctamente, aparecerá el siguiente mensaje en el [área de cliente de OVHcloud](/links/manager):
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
-
-La generación de la copia de seguridad tarda entre 10 y 15 minutos en realizarse.
-
-#### Paso 2 - Descargar la copia de seguridad
-
-Una vez finalizada la generación del backup, recibirá un mensaje de correo electrónico en la dirección asociada al usuario de administrador de su hosting Cloud Web.<br>
 El mensaje de correo electrónico incluye un enlace de descarga **válido durante 9 días** desde la recepción del mensaje de correo electrónico:
 
-![backupftpcw](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
+![E-mail de descarga del backup](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
 
 El archivo así descargado está en formato *.tar.gz*.
 

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Exportar la copia de seguridad del espacio FTP de su hosting Cloud Web"
 excerpt: "Descubra cómo descargar una copia de seguridad del espacio FTP de un alojamiento Cloud Web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Récupérer la sauvegarde de l'espace FTP de son hébergement Cloud Web"
 excerpt: "Découvrez comment récupérer une sauvegarde de l'espace FTP de votre hébergement Cloud Web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.fr-fr.md
@@ -59,25 +59,25 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **5*
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez le Cloud Web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
 >> Sélectionnez l'onglet `FTP - SSH`{.action} et cliquez sur le bouton `Générer une sauvegarde`{.action} à droite.
 >>
->> ![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+>> ![Bouton Générer une sauvegarde](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
 >>
 > **Étape 3**
 >>
 >> Dans la fenêtre qui s'ouvre, sélectionnez l'une des sauvegardes disponibles puis cliquez sur `Suivant`{.action}.
 >>
->> ![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
+>> ![Sélection de la sauvegarde à récupérer](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
 >>
 > **Étape 4**
 >>
->> Une seconde fenêtre apparaît, vous précisant que le lien de récupération du fichier de sauvegarde vous sera envoyé par e-mail et qu'aucune restauration automatique sur votre hébergement Cloud Web ne sera faite par OVHcloud.
+>> Une seconde fenêtre vous indique que le lien de téléchargement de la sauvegarde vous sera envoyé par e-mail et qu'aucune restauration automatique sur votre hébergement Cloud Web ne sera faite par OVHcloud.
 >>
->> ![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
+>> ![Message de confirmation de génération de la sauvegarde](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
 >>
 >> Cliquez sur `Confirmer`{.action} pour valider votre demande.
 >>
@@ -85,17 +85,17 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **5*
 >>
 >> Si la génération de la sauvegarde est bien lancée, le message suivant apparaît dans votre espace client OVHcloud :
 >>
->> ![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
+>> ![Message de confirmation de lancement de la sauvegarde](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
 >>
->> La génération de la sauvegarde prend entre 10 et 15 minutes.
+>> La sauvegarde prend entre 10 et 15 minutes.
 
-### Récupérer la sauvegarde
+### Télécharger la sauvegarde
 
-Une fois la génération de la sauvegarde finalisée, vous recevez un e-mail sur l'adresse e-mail associée à l'identifiant administrateur de votre hébergement Cloud Web.
+Une fois la sauvegarde finalisée, vous recevez un e-mail sur l'adresse e-mail associée à l'identifiant administrateur de votre hébergement Cloud Web.
 
 Cet e-mail contient un lien de téléchargement **valable 9 jours** à compter de la réception de l'e-mail :
 
-![backupftpcw](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
+![E-mail contenant le lien de téléchargement de la sauvegarde](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
 
 Le fichier ainsi téléchargé est au format *.tar.gz*.
 

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Récupérer la sauvegarde de l'espace FTP de son hébergement Cloud Web"
 excerpt: "Découvrez comment récupérer une sauvegarde de l'espace FTP de votre hébergement Cloud Web"
-updated: 2023-11-16
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -48,37 +48,51 @@ Seules les sauvegardes mentionnées ci-dessus pourront être proposées par OVHc
 
 ### Récupérer une sauvegarde
 
-Contrairement aux hébergements mutualisés OVHcloud, il est impossible d'effectuer une restauration de l'espace FTP en un clic depuis [l'espace client OVHcloud](/links/manager).
+Contrairement aux hébergements mutualisés OVHcloud, il est impossible d'effectuer une restauration de l'espace FTP en un clic depuis l'espace client OVHcloud.
 
 Un lien de téléchargement de la sauvegarde est généré puis envoyé par e-mail à l'adresse e-mail associée à l'identifiant client administrateur de l'hébergement Cloud Web.
 
-#### Etape 1 - Générer le lien de récupération envoyé par e-mail
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **5** étapes.
 
-Pour générer le lien de récupération, connectez-vous sur votre [espace client OVHcloud](/links/manager), rendez-vous dans la partie `Web Cloud`{.action}, cliquez sur `Hébergements`{.action} puis sur le Cloud Web concerné. 
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez le Cloud Web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Sélectionnez l'onglet `FTP - SSH`{.action} et cliquez sur le bouton `Générer une sauvegarde`{.action} à droite.
+>>
+>> ![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+>>
+> **Étape 3**
+>>
+>> Dans la fenêtre qui s'ouvre, sélectionnez l'une des sauvegardes disponibles puis cliquez sur `Suivant`{.action}.
+>>
+>> ![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
+>>
+> **Étape 4**
+>>
+>> Une seconde fenêtre apparaît, vous précisant que le lien de récupération du fichier de sauvegarde vous sera envoyé par e-mail et qu'aucune restauration automatique sur votre hébergement Cloud Web ne sera faite par OVHcloud.
+>>
+>> ![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
+>>
+>> Cliquez sur `Confirmer`{.action} pour valider votre demande.
+>>
+> **Étape 5**
+>>
+>> Si la génération de la sauvegarde est bien lancée, le message suivant apparaît dans votre espace client OVHcloud :
+>>
+>> ![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
+>>
+>> La génération de la sauvegarde prend entre 10 et 15 minutes.
 
-Sélectionnez l'onglet `FTP - SSH`{.action} et cliquez sur le bouton `Générer une sauvegarde`{.action} à droite.
+### Récupérer la sauvegarde
 
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+Une fois la génération de la sauvegarde finalisée, vous recevez un e-mail sur l'adresse e-mail associée à l'identifiant administrateur de votre hébergement Cloud Web.
 
-Dans la fenêtre qui s'ouvre, sélectionnez l'une des sauvegardes disponibles puis cliquez sur `Suivant`{.action}.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
-
-Une seconde fenêtre apparaît, vous précisant que le lien de récupération du fichier de sauvegarde vous sera envoyé par e-mail et qu'aucune restauration automatique sur votre hébergement Cloud Web ne sera faite par OVHcloud.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
-
-Cliquez sur `Confirmer`{.action} pour valider votre demande.
-
-Si la génération de la sauvegarde est bien lancée, le message suivant apparaît dans votre [espace client OVHcloud](/links/manager) :
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
-
-La génération de la sauvegarde prend entre 10 et 15 minutes pour être réalisée.
-
-#### Etape 2 - Récupérer la sauvegarde
-
-Une fois la génération de la sauvegarde finalisée, vous recevez un e-mail sur l'adresse e-mail associée à l'identifiant administrateur de votre hébergement Cloud Web.<br>
 Cet e-mail contient un lien de téléchargement **valable 9 jours** à compter de la réception de l'e-mail :
 
 ![backupftpcw](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Recuperare il backup dello spazio FTP del tuo hosting Cloud Web"
 excerpt: "Questa guida ti mostra come recuperare un backup dello spazio FTP del tuo hosting Cloud Web"
-updated: 2023-11-16
+updated: 2026-03-26
 ---
 
 ## Obiettivo
@@ -29,7 +29,7 @@ Il tuo hosting Cloud Web dispone di uno spazio di storage in cui puoi ospitare s
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -48,40 +48,54 @@ OVHcloud può offrire solo i backup indicati, a condizione che il tuo hosting Cl
 
 ### Recupera un backup
 
-Diversamente dagli hosting condivisi OVHcloud, il ripristino dello spazio FTP non può essere effettuato cliccando sul tuo [Spazio Cliente OVHcloud](/links/manager).
+Diversamente dagli hosting condivisi OVHcloud, il ripristino dello spazio FTP non può essere effettuato con un clic dallo Spazio Cliente OVHcloud.
 
 Viene generato un link per scaricare il backup e inviato via email all'indirizzo email associato all'identificativo cliente amministratore dell'hosting Cloud Web.
 
-#### Step 1 - Genera il link di recupero inviato via email
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **5** passaggi.
 
-Per generare il link di recupero, accedi al tuo [Spazio Cliente OVHcloud](/links/manager), accedi alla sezione `Web Cloud`{.action}, clicca su `Hosting`{.action} e poi sul Cloud Web corrispondente. 
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting) e seleziona il Cloud Web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Seleziona la scheda `FTP - SSH`{.action} e clicca sul pulsante `Genera un backup`{.action} a destra.
+>>
+>> ![Pulsante Genera un backup](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+>>
+> **Passaggio 3**
+>>
+>> Nella finestra che si apre, seleziona uno dei backup disponibili e clicca su `Continua`{.action}.
+>>
+>> ![Selezione del backup](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
+>>
+> **Passaggio 4**
+>>
+>> Si apre una seconda finestra indicando che il link per scaricare il file di backup ti verrà inviato via email e che OVHcloud non effettuerà alcun ripristino automatico sul tuo hosting Cloud Web.
+>>
+>> ![Conferma della generazione del backup](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
+>>
+>> Clicca su `Conferma`{.action} per confermare la tua richiesta.
+>>
+> **Passaggio 5**
+>>
+>> Se la generazione del backup è stata avviata correttamente, il seguente messaggio apparirà nel tuo Spazio Cliente OVHcloud:
+>>
+>> ![Messaggio di avanzamento del backup](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
+>>
+>> La generazione del backup richiede tra i 10 e i 15 minuti.
 
-Seleziona la scheda `FTP - SSH`{.action} e clicca sul pulsante `Genera un backup`{.action} a destra.
+### Scaricare il backup
 
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+Una volta completata la generazione del backup, ricevi un'email all'indirizzo email associato all'identificativo amministratore del tuo hosting Cloud Web.
 
-Nella nuova finestra, seleziona uno dei backup disponibili e clicca su `Avanti`{.action}.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
-
-Si apre una nuova finestra in cui viene indicato che il link di recupero del file di backup ti verrà inviato via email e che OVHcloud non effettuerà alcun ripristino automatico sul tuo hosting Cloud Web.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
-
-Clicca su `Conferma`{.action} per confermare la tua richiesta.
-
-Se la generazione del backup è stata avviata correttamente, visualizzi questo messaggio nello [Spazio Cliente OVHcloud](/links/manager):
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
-
-La generazione del backup richiede tra i 10 e i 15 minuti.
-
-#### Step 2 - Recupera il backup
-
-Una volta completata la generazione del backup, ricevi un'email all'indirizzo email associato all'identificativo amministratore del tuo hosting Cloud Web.<br>
 Questa email contiene un link di download **valido 9 giorni** a partire dalla ricezione dell'email:
 
-![backupftpcw](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
+![Email di download del backup](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
 
 Il file caricato è in formato *.tar.gz*.
 

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Recuperare il backup dello spazio FTP del tuo hosting Cloud Web"
 excerpt: "Questa guida ti mostra come recuperare un backup dello spazio FTP del tuo hosting Cloud Web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Obiettivo

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Tworzenie i pobieranie kopii zapasowej przestrzeni FTP na hostingu Cloud Web"
 excerpt: "Dowiedz się, jak pobrać kopię zapasową przestrzeni FTP Twojego hostingu Cloud Web"
-updated: 2023-11-16
+updated: 2026-03-26
 ---
 
 ## Wprowadzenie
@@ -29,7 +29,7 @@ Twój hosting Cloud Web dysponuje przestrzenią dyskową, na której możesz hos
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -46,42 +46,56 @@ Hosting Cloud Web dysponuje automatycznymi kopiami zapasowymi uruchomionymi z na
 
 OVHcloud może zaproponować wyłącznie kopie zapasowe, o których mowa powyżej, pod warunkiem, że Twój hosting Cloud Web istnieje już w wskazanych terminach i pod warunkiem, że infrastruktura będzie dostępna w momencie tworzenia kopii zapasowej.
 
-### Pobierz kopię zapasową
+### Odzyskaj kopię zapasową
 
-W przeciwieństwie do hostingu współdzielonego OVHcloud, przywracanie przestrzeni FTP nie jest możliwe za pomocą jednego kliknięcia w [Panelu klienta OVHcloud](/links/manager).
+W przeciwieństwie do hostingu współdzielonego OVHcloud, przywracanie przestrzeni FTP nie jest możliwe za pomocą jednego kliknięcia w Panelu klienta OVHcloud.
 
 Link do pobrania kopii zapasowej jest generowany, a następnie wysyłany e-mailem na adres e-mail powiązany z identyfikatorem klienta administratora hostingu Cloud Web.
 
-#### Etap 1 - Wygeneruj link do pobrania wysłany e-mailem
+Kliknij poniższe karty, aby wyświetlić kolejne **5** kroki.
 
-Aby wygenerować link do pobrania, zaloguj się do [Panelu klienta OVHcloud](/links/manager), przejdź do sekcji `Web Cloud`{.action}, kliknij `Hosting`{.action}, a następnie odpowiednią usługę Cloud Web. 
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiedni Cloud Web.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Wybierz kartę `FTP - SSH`{.action} i kliknij przycisk `Utwórz kopię zapasową`{.action} po prawej stronie.
+>>
+>> ![Przycisk Utwórz kopię zapasową](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+>>
+> **Krok 3**
+>>
+>> W oknie, które się otworzy, wybierz jedną z dostępnych kopii zapasowych, po czym kliknij `Dalej`{.action}.
+>>
+>> ![Wybór kopii zapasowej](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
+>>
+> **Krok 4**
+>>
+>> Pojawi się drugie okno z informacją, że link do pobrania pliku kopii zapasowej zostanie przesłany e-mailem i że OVHcloud nie przywróci automatycznie danych z Twojego hostingu Cloud Web.
+>>
+>> ![Potwierdzenie generowania kopii zapasowej](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
+>>
+>> Kliknij na `Zatwierdź`{.action}, aby potwierdzić zlecenie.
+>>
+> **Krok 5**
+>>
+>> Jeśli generowanie kopii zapasowej zostało uruchomione, w Panelu klienta OVHcloud pojawi się następujący komunikat:
+>>
+>> ![Komunikat o postępie kopii zapasowej](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
+>>
+>> Tworzenie kopii zapasowej zajmuje od 10 do 15 minut.
 
-Wybierz kartę `FTP - SSH`{.action} i kliknij przycisk `Wygeneruj kopię zapasową`{.action} po prawej stronie.
+### Pobierz kopię zapasową
 
-![kopia zapasowa](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+Po sfinalizowaniu tworzenia kopii zapasowej otrzymasz e-mail na adres e-mail powiązany z identyfikatorem administratora Twojego hostingu Cloud Web.
 
-W oknie, które się otworzy wybierz jedną z dostępnych kopii zapasowych, po czym kliknij `Dalej`{.action}.
-
-![kopia zapasowa](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
-
-Pojawi się drugie okno z informacją, że link do pobrania pliku kopii zapasowej zostanie przesłany e-mailem i że OVHcloud nie przywróci automatycznie danych z Twojego hostingu Cloud Web.
-
-![kopia zapasowa](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
-
-Kliknij na `Zatwierdź`{.action}, aby potwierdzić zlecenie.
-
-Jeśli wygenerowana zostanie kopia zapasowa, w [Panelu klienta OVHcloud](/links/manager) pojawi się następujący komunikat:
-
-![kopia zapasowa](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
-
-Tworzenie kopii zapasowej zajmuje od 10 do 15 minut.
-
-#### Etap 2 - Pobranie kopii zapasowej
-
-Po sfinalizowaniu tworzenia kopii zapasowej otrzymasz e-mail na adres e-mail powiązany z identyfikatorem administratora Twojego hostingu Cloud Web.<br>
 E-mail ten zawiera link do pobrania **ważny przez 9 dni** od otrzymania wiadomości e-mail:
 
-![kopia zapasowa](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
+![E-mail z linkiem do pobrania kopii zapasowej](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
 
 Pobrany plik jest w formacie *.tar.gz*.
 

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Tworzenie i pobieranie kopii zapasowej przestrzeni FTP na hostingu Cloud Web"
 excerpt: "Dowiedz się, jak pobrać kopię zapasową przestrzeni FTP Twojego hostingu Cloud Web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Wprowadzenie

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Recuperar o backup do espaço FTP do seu alojamento Cloud Web"
 excerpt: "Saiba como recuperar um backup do espaço FTP do seu alojamento Cloud Web"
-updated: 2023-11-16
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -29,7 +29,7 @@ O seu alojamento Cloud Web dispõe de um espaço de armazenamento no qual pode a
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -48,40 +48,54 @@ Só os backups mencionados acima podem ser propostos pela OVHcloud, desde que o 
 
 ### Recuperar um backup
 
-Contrariamente aos alojamentos partilhados OVHcloud, é impossível efetuar um restauro do espaço FTP com um clique a partir da [Área de Cliente OVHcloud](/links/manager).
+Contrariamente aos alojamentos partilhados OVHcloud, é impossível efetuar um restauro do espaço FTP com um clique a partir da Área de Cliente OVHcloud.
 
 É gerado um link de download do backup que é enviado por e-mail para o endereço de e-mail associado ao identificador de cliente administrador do alojamento Cloud Web.
 
-#### Etapa 1 - Gerar o link de recuperação enviado por e-mail
+Clique nos separadores abaixo para visualizar cada uma das **5** etapas.
 
-Para gerar o link de recuperação, aceda à [Área de Cliente OVHcloud](/links/manager), aceda à secção `Web Cloud`{.action}, clique em `Alojamentos`{.action} e, a seguir, no Cloud Web em causa. 
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o Cloud Web em causa.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Selecione o separador `FTP - SSH`{.action} e clique no botão `Gerar um backup`{.action} à direita.
+>>
+>> ![Botão Gerar um backup](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Na janela que se abre, selecione um dos backups disponíveis e clique em `Seguinte`{.action}.
+>>
+>> ![Seleção do backup](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
+>>
+> **Etapa 4**
+>>
+>> Aparecerá uma segunda janela indicando que o link de download do ficheiro de backup lhe será enviado por e-mail e que nenhum restauro automático no seu alojamento Cloud Web será feito pela OVHcloud.
+>>
+>> ![Confirmação da geração do backup](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
+>>
+>> Clique em `Validar`{.action} para confirmar o seu pedido.
+>>
+> **Etapa 5**
+>>
+>> Se a geração do backup foi iniciada com sucesso, a seguinte mensagem aparecerá na sua Área de Cliente OVHcloud:
+>>
+>> ![Mensagem de progresso do backup](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
+>>
+>> A geração do backup demora entre 10 e 15 minutos.
 
-Selecione o separador `FTP - SSH`{.action} e clique no botão `Gerar um backup`{.action} à direita.
+### Descarregar o backup
 
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup.png){.thumbnail}
+Uma vez finalizada a geração do backup, receberá um e-mail no endereço de e-mail associado ao identificador administrador do seu alojamento Cloud Web.
 
-Na nova janela, selecione um dos backups disponíveis e clique em `Seguinte`{.action}.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-1.png){.thumbnail}
-
-Aparecerá uma segunda janela que lhe indicará que o link de recuperação do ficheiro de backup lhe será enviado por e-mail e que nenhum restauro automático no seu alojamento Cloud Web será feito pela OVHcloud.
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
-
-Clique em `Confirmar`{.action} para validar o seu pedido.
-
-Se a geração do backup está bem lançada, na [Área de Cliente OVHcloud](/links/manager), aparecerá a seguinte mensagem:
-
-![backupftpcw](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/message-backup-progress.png){.thumbnail}
-
-A geração do backup demora entre 10 e 15 minutos para ser realizado.
-
-#### Etapa 2 - Recuperar o backup
-
-Uma vez finalizada a geração do backup, receberá um e-mail no endereço de e-mail associado ao identificador administrador do seu alojamento Cloud Web.<br>
 Este e-mail contém um link de download **válido para 9 dias** a contar a partir da receção do e-mail:
 
-![backupftpcw](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
+![E-mail de download do backup](/pages/assets/screens/email-sending-to-customer/cloud-web/backup-information.png){.thumbnail}
 
 O ficheiro assim descarregado está no formato *.tar.gz*.
 

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Recuperar o backup do espaço FTP do seu alojamento Cloud Web"
 excerpt: "Saiba como recuperar um backup do espaço FTP do seu alojamento Cloud Web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/backup_ftp_cloud_web/guide.pt-pt.md
@@ -79,7 +79,7 @@ Clique nos separadores abaixo para visualizar cada uma das **5** etapas.
 >>
 >> ![Confirmação da geração do backup](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/ftp-ssh/generate-a-backup-step-2.png){.thumbnail}
 >>
->> Clique em `Validar`{.action} para confirmar o seu pedido.
+>> Clique em `Confirmar`{.action} para confirmar o seu pedido.
 >>
 > **Etapa 5**
 >>

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Administratorpasswort eines CMS ändern"
 excerpt: "Erfahren Sie hier, wie Sie das Administratorpasswort Ihres CMS über dessen Verwaltungsinterface oder mit phpMyAdmin im OVHcloud Kundencenter ändern können"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Ziel
@@ -99,9 +99,26 @@ Sie haben Zugriff auf das Verwaltungsinterface des CMS und kennen Ihr aktuelles 
 
 Sie haben keinen Zugriff mehr auf das Verwaltungsinterface des CMS oder können die Funktion "Passwort vergessen" nicht verwenden, weil die zugehörige E-Mail-Adresse nicht erreichbar ist? Verwenden Sie phpMyAdmin in Ihrem [OVHcloud Kundencenter](/links/manager), um das Passwort direkt über die Datenbank zurückzusetzen.
 
-Verbinden Sie sich mit Ihrem [OVHcloud Kundencenter](/links/manager) und wählen Sie `Web Cloud`{.action}. Klicken Sie auf `Hosting-Pakete`{.action} und wählen Sie das betreffende Angebot aus. Im Tab `Datenbanken`{.action} identifizieren Sie die von Ihrem CMS verwendete Datenbank, klicken Sie auf den Button `...`{.action} und dann auf `Zugang zu phpMyAdmin`{.action} zugreifen.
+Klicken Sie auf die Tabs, um die **4** Schritte anzuzeigen.
 
-Geben Sie die Zugangsdaten (Benutzername und Kennwort) ein, die Sie bei der Erstellung der Datenbank festgelegt haben. Wenn Sie bei phpMyAdmin eingeloggt sind, klicken Sie unten auf den entsprechenden Tab.
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Angebot aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `Datenbanken`{.action} und identifizieren Sie die von Ihrem CMS verwendete Datenbank.
+>>
+> **Schritt 3**
+>>
+>> Klicken Sie auf den Button `...`{.action} und dann auf `Zugang zu phpMyAdmin`{.action}.
+>>
+> **Schritt 4**
+>>
+>> Geben Sie die Zugangsdaten (Benutzername und Kennwort) ein, die Sie bei der Erstellung der Datenbank festgelegt haben. Wenn Sie bei phpMyAdmin eingeloggt sind, klicken Sie unten auf den entsprechenden Tab.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Administratorpasswort eines CMS ändern"
 excerpt: "Erfahren Sie hier, wie Sie das Administratorpasswort Ihres CMS über dessen Verwaltungsinterface oder mit phpMyAdmin im OVHcloud Kundencenter ändern können"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Ziel
@@ -12,7 +12,7 @@ Sie haben den Zugriff auf Ihr Verwaltungsinterface von WordPress, PrestaShop, Jo
 
 ## Voraussetzungen
 
-- Sie verfügen über ein [Webhosting Angebot](/links/web/hosting), mit dem Sie ein 1-Klick-Modul installieren können.
+- Sie verfügen über ein [Webhosting-Angebot](/links/web/hosting), mit dem Sie ein 1-Klick-Modul installieren können.
 - Sie haben ein 1-Klick-Modul auf Ihrem Webhosting erstellt. (Wenn Sie diese Installation noch nicht durchgeführt haben, folgen Sie den Anweisungen in [dieser Anleitung](/pages/web_cloud/web_hosting/cms_install_1_click_modules).)
 
 <!-- CP-NAV-START:web-hosting -->
@@ -53,7 +53,7 @@ Sie haben noch Zugriff auf Ihre E-Mails und das Login-Interface? Diese Methode i
 > [!tabs]
 > WordPress
 >>
->> Um Ihr WordPress-Administratorpasswort über die Option "Passwort vergessen" zu ändern, folgen Sie den Schritten im Abschnitt „[Through the automatic emailer](https://wordpress.org/documentation/article/reset-your-password/#through-the-automatic-emailer)“ der offiziellen WordPress-Dokumentation.
+>> Um Ihr WordPress-Administratorpasswort über die Option "Passwort vergessen" zu ändern, folgen Sie den Schritten im Abschnitt "[Through the automatic emailer](https://wordpress.org/documentation/article/reset-your-password/#through-the-automatic-emailer)“ der offiziellen WordPress-Dokumentation.
 >>
 > PrestaShop
 >>
@@ -61,16 +61,16 @@ Sie haben noch Zugriff auf Ihre E-Mails und das Login-Interface? Diese Methode i
 >>
 > Joomla!
 >>
->> Um Ihr Joomla! Administratorpasswort über die Option "Passwort vergessen" zu ändern, folgen Sie den Schritten im Abschnitt „[Frontend](https://docs.joomla.org/Resetting_a_user_password/en)“ der offiziellen Joomla! Dokumentation.
+>> Um Ihr Joomla! Administratorpasswort über die Option "Passwort vergessen" zu ändern, folgen Sie den Schritten im Abschnitt "[Frontend](https://docs.joomla.org/Resetting_a_user_password/en)“ der offiziellen Joomla! Dokumentation.
 >>
 > Drupal
 >>
 >> Um Ihr Drupal Administratorpasswort über die Option "Passwort vergessen" zu ändern, folgen Sie diesen Schritten:
 >>
->> - Navigieren Sie zum Login-interface.
->> - Klicken Sie auf den Link „Neues Passwort anfordern“.
+>> - Navigieren Sie zum Login-Interface.
+>> - Klicken Sie auf den Link "Neues Passwort anfordern“.
 >> - Geben Sie im angezeigten Dialogfeld entweder den Benutzernamen oder die E-Mail-Adresse ein, die dem Administrator-Account zugeordnet ist.
->> - Klicken Sie auf „Neues Passwort senden“ oder „E-Mail-Adresse für neues Passwort“.
+>> - Klicken Sie auf "Neues Passwort senden“ oder "E-Mail-Adresse für neues Passwort“.
 >> - Öffnen Sie die empfangene E-Mail und klicken Sie auf den bereitgestellten Link.
 >> - Geben Sie Ihr neues Passwort ein und bestätigen Sie es.
 >> - Kehren Sie zur Drupal-Anmeldeseite zurück und melden Sie sich mit dem neuen Passwort an.
@@ -81,7 +81,7 @@ Sie haben Zugriff auf das Verwaltungsinterface des CMS und kennen Ihr aktuelles 
 
 > [!tabs]
 > WordPress
->> Um Ihr WordPress-Administratorpasswort über das Verwaltungsinterface des CMS zu ändern, folgen Sie den Schritten im Abschnitt „[To Change Your Password](https://wordpress.org/documentation/article/reset-your-password/#to-change-your-password)“ der offiziellen WordPress-Dokumentation.
+>> Um Ihr WordPress-Administratorpasswort über das Verwaltungsinterface des CMS zu ändern, folgen Sie den Schritten im Abschnitt "[To Change Your Password](https://wordpress.org/documentation/article/reset-your-password/#to-change-your-password)“ der offiziellen WordPress-Dokumentation.
 >>
 > PrestaShop
 >>
@@ -89,7 +89,7 @@ Sie haben Zugriff auf das Verwaltungsinterface des CMS und kennen Ihr aktuelles 
 >>
 > Joomla!
 >>
->> Um Ihr Joomla! Administratorpasswort über das Administrator-Interface zu ändern, folgen Sie den Schritten im Abschnitt „[Backend](https://docs.joomla.org/Resetting_a_user_password/en)“ der offiziellen Joomla! Dokumentation.
+>> Um Ihr Joomla! Administratorpasswort über das Administrator-Interface zu ändern, folgen Sie den Schritten im Abschnitt "[Backend](https://docs.joomla.org/Resetting_a_user_password/en)“ der offiziellen Joomla! Dokumentation.
 >>
 > Drupal
 >>
@@ -123,15 +123,15 @@ Klicken Sie auf die Tabs, um die **4** Schritte anzuzeigen.
 > [!tabs]
 > WordPress
 >>
->> Folgen Sie den Schritten im Abschnitt „[Through phpMyAdmin](https://wordpress.org/documentation/article/reset-your-password/#through-phpmyadmin)“ der offiziellen WordPress-Dokumentation.
+>> Folgen Sie den Schritten im Abschnitt "[Through phpMyAdmin](https://wordpress.org/documentation/article/reset-your-password/#through-phpmyadmin)“ der offiziellen WordPress-Dokumentation.
 >>
 > PrestaShop
 >>
->> Folgen Sie den Schritten im Abschnitt „[You do not have access to your e-mail address](https://help-center.prestashop.com/hc/en-us/articles/10799006732818-Recover-your-admin-password)“ der offiziellen PrestaShop Dokumentation.
+>> Folgen Sie den Schritten im Abschnitt "[You do not have access to your e-mail address](https://help-center.prestashop.com/hc/en-us/articles/10799006732818-Recover-your-admin-password)“ der offiziellen PrestaShop Dokumentation.
 >>
 > Joomla!
 >>
->> Folgen Sie den Schritten im Abschnitt „[Resetting in phpMyAdmin](https://docs.joomla.org/Resetting_a_user_password/en)“ der offiziellen Joomla! Dokumentation.
+>> Folgen Sie den Schritten im Abschnitt "[Resetting in phpMyAdmin](https://docs.joomla.org/Resetting_a_user_password/en)“ der offiziellen Joomla! Dokumentation.
 >>
 > Drupal
 >>

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -100,9 +100,26 @@ Do you have access to the CMS administration interface and know your current pas
 
 Do you no longer have access to the CMS administration interface, or can't use the "Forgotten your password" feature because the associated email address can't be accessed? Use phpMyAdmin from your [OVHcloud Control Panel](/links/manager) to reset the password directly from the database.
 
-Log in to your [OVHcloud Control Panel](/links/manager) then select `Web Cloud`{.action}. Click `Hosting`{.action} and select the solution concerned. In the `Databases`{.action} tab, identify the database used by your CMS, click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+Click on the tabs below to view each of the **4** steps.
 
-Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the solution concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then identify the database used by your CMS.
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+>>
+> **Step 4**
+>>
+>> Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -100,9 +100,26 @@ Do you have access to the CMS administration interface and know your current pas
 
 Do you no longer have access to the CMS administration interface, or can't use the "Forgotten your password" feature because the associated email address can't be accessed? Use phpMyAdmin from your [OVHcloud Control Panel](/links/manager) to reset the password directly from the database.
 
-Log in to your [OVHcloud Control Panel](/links/manager) then select `Web Cloud`{.action}. Click `Hosting`{.action} and select the solution concerned. In the `Databases`{.action} tab, identify the database used by your CMS, click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+Click on the tabs below to view each of the **4** steps.
 
-Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the solution concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then identify the database used by your CMS.
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+>>
+> **Step 4**
+>>
+>> Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -100,9 +100,26 @@ Do you have access to the CMS administration interface and know your current pas
 
 Do you no longer have access to the CMS administration interface, or can't use the "Forgotten your password" feature because the associated email address can't be accessed? Use phpMyAdmin from your [OVHcloud Control Panel](/links/manager) to reset the password directly from the database.
 
-Log in to your [OVHcloud Control Panel](/links/manager) then select `Web Cloud`{.action}. Click `Hosting`{.action} and select the solution concerned. In the `Databases`{.action} tab, identify the database used by your CMS, click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+Click on the tabs below to view each of the **4** steps.
 
-Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the solution concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then identify the database used by your CMS.
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+>>
+> **Step 4**
+>>
+>> Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -100,9 +100,26 @@ Do you have access to the CMS administration interface and know your current pas
 
 Do you no longer have access to the CMS administration interface, or can't use the "Forgotten your password" feature because the associated email address can't be accessed? Use phpMyAdmin from your [OVHcloud Control Panel](/links/manager) to reset the password directly from the database.
 
-Log in to your [OVHcloud Control Panel](/links/manager) then select `Web Cloud`{.action}. Click `Hosting`{.action} and select the solution concerned. In the `Databases`{.action} tab, identify the database used by your CMS, click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+Click on the tabs below to view each of the **4** steps.
 
-Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the solution concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then identify the database used by your CMS.
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+>>
+> **Step 4**
+>>
+>> Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -100,9 +100,26 @@ Do you have access to the CMS administration interface and know your current pas
 
 Do you no longer have access to the CMS administration interface, or can't use the "Forgotten your password" feature because the associated email address can't be accessed? Use phpMyAdmin from your [OVHcloud Control Panel](/links/manager) to reset the password directly from the database.
 
-Log in to your [OVHcloud Control Panel](/links/manager) then select `Web Cloud`{.action}. Click `Hosting`{.action} and select the solution concerned. In the `Databases`{.action} tab, identify the database used by your CMS, click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+Click on the tabs below to view each of the **4** steps.
 
-Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the solution concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then identify the database used by your CMS.
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+>>
+> **Step 4**
+>>
+>> Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -100,9 +100,26 @@ Do you have access to the CMS administration interface and know your current pas
 
 Do you no longer have access to the CMS administration interface, or can't use the "Forgotten your password" feature because the associated email address can't be accessed? Use phpMyAdmin from your [OVHcloud Control Panel](/links/manager) to reset the password directly from the database.
 
-Log in to your [OVHcloud Control Panel](/links/manager) then select `Web Cloud`{.action}. Click `Hosting`{.action} and select the solution concerned. In the `Databases`{.action} tab, identify the database used by your CMS, click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+Click on the tabs below to view each of the **4** steps.
 
-Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the solution concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then identify the database used by your CMS.
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+>>
+> **Step 4**
+>>
+>> Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "How to change the admin password of a CMS"
 excerpt: "Find out how to change your CMS admin password directly via the CMS admin interface, or by using phpMyAdmin in the OVHcloud Control Panel"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -100,9 +100,26 @@ Do you have access to the CMS administration interface and know your current pas
 
 Do you no longer have access to the CMS administration interface, or can't use the "Forgotten your password" feature because the associated email address can't be accessed? Use phpMyAdmin from your [OVHcloud Control Panel](/links/manager) to reset the password directly from the database.
 
-Log in to your [OVHcloud Control Panel](/links/manager) then select `Web Cloud`{.action}. Click `Hosting`{.action} and select the solution concerned. In the `Databases`{.action} tab, identify the database used by your CMS, click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+Click on the tabs below to view each of the **4** steps.
 
-Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the solution concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then identify the database used by your CMS.
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button, then `Go to phpMyAdmin`{.action}.
+>>
+> **Step 4**
+>>
+>> Enter the database credentials (username and password) that you defined when you created the database. Once you have logged in to phpMyAdmin, click on the relevant tab below.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Cómo cambiar la contraseña de administrador de un CMS"
 excerpt: "Descubra cómo cambiar la contraseña de administrador de un CMS directamente desde la interfaz de administración del CMS o utilizando phpMyAdmin desde el área de cliente de OVHcloud"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -20,7 +20,7 @@ updated: 2024-10-15
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -100,9 +100,26 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 
 ¿Ya no tiene acceso al panel de administración del CMS o no puede utilizar la funcionalidad "Contraseña olvidada" porque no puede acceder a la dirección de correo electrónico asociada? Utilice phpMyAdmin desde su [área de cliente de OVHcloud](/links/manager) para restaurar la contraseña directamente desde la base de datos.
 
-Conéctese a su [área de cliente de OVHcloud](/links/manager) y seleccione `Web Cloud`{.action}. Haga clic en `Alojamientos`{.action} y seleccione el producto correspondiente. En la pestaña `Bases de datos`{.action}, identifique la base de datos utilizada por su CMS, haga clic en el botón `...`{.action} y luego en `Acceder a phpMyAdmin`{.action}.
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
-Introduzca los identificadores de la base de datos (nombre de usuario y contraseña) que haya definido al crear la base de datos. Una vez conectado a phpMyAdmin, haga clic en la pestaña correspondiente a continuación.
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el producto correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action} e identifique la base de datos utilizada por su CMS.
+>>
+> **Etapa 3**
+>>
+>> Haga clic en el botón `...`{.action} y luego en `Acceder a phpMyAdmin`{.action}.
+>>
+> **Etapa 4**
+>>
+>> Introduzca los identificadores de la base de datos (nombre de usuario y contraseña) que haya definido al crear la base de datos. Una vez conectado a phpMyAdmin, haga clic en la pestaña correspondiente a continuación.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Cómo cambiar la contraseña de administrador de un CMS"
 excerpt: "Descubra cómo cambiar la contraseña de administrador de un CMS directamente desde la interfaz de administración del CMS o utilizando phpMyAdmin desde el área de cliente de OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Cómo cambiar la contraseña de administrador de un CMS"
 excerpt: "Descubra cómo cambiar la contraseña de administrador de un CMS directamente desde la interfaz de administración del CMS o utilizando phpMyAdmin desde el área de cliente de OVHcloud"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -20,7 +20,7 @@ updated: 2024-10-15
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -100,9 +100,26 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 
 ¿Ya no tiene acceso al panel de administración del CMS o no puede utilizar la funcionalidad "Contraseña olvidada" porque no puede acceder a la dirección de correo electrónico asociada? Utilice phpMyAdmin desde su [área de cliente de OVHcloud](/links/manager) para restaurar la contraseña directamente desde la base de datos.
 
-Conéctese a su [área de cliente de OVHcloud](/links/manager) y seleccione `Web Cloud`{.action}. Haga clic en `Alojamientos`{.action} y seleccione el producto correspondiente. En la pestaña `Bases de datos`{.action}, identifique la base de datos utilizada por su CMS, haga clic en el botón `...`{.action} y luego en `Acceder a phpMyAdmin`{.action}.
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
-Introduzca los identificadores de la base de datos (nombre de usuario y contraseña) que haya definido al crear la base de datos. Una vez conectado a phpMyAdmin, haga clic en la pestaña correspondiente a continuación.
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el producto correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action} e identifique la base de datos utilizada por su CMS.
+>>
+> **Etapa 3**
+>>
+>> Haga clic en el botón `...`{.action} y luego en `Acceder a phpMyAdmin`{.action}.
+>>
+> **Etapa 4**
+>>
+>> Introduzca los identificadores de la base de datos (nombre de usuario y contraseña) que haya definido al crear la base de datos. Una vez conectado a phpMyAdmin, haga clic en la pestaña correspondiente a continuación.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Cómo cambiar la contraseña de administrador de un CMS"
 excerpt: "Descubra cómo cambiar la contraseña de administrador de un CMS directamente desde la interfaz de administración del CMS o utilizando phpMyAdmin desde el área de cliente de OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Comment changer le mot de passe administrateur d'un CMS"
 excerpt: "Découvrez comment modifier le mot de passe administrateur de votre CMS directement via l’interface d’administration du CMS ou en utilisant phpMyAdmin depuis l’espace client OVHcloud"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -100,9 +100,26 @@ Vous avez accès à l'interface d'administration du CMS et vous connaissez votre
 
 Vous n'avez plus accès à l'interface d'administration du CMS ou vous ne pouvez pas utiliser la fonctionnalité « Mot de passe oublié » parce que l'adresse e-mail associée est inaccessible ? Utilisez phpMyAdmin depuis votre [espace client OVHcloud](/links/manager) pour réinitialiser le mot de passe directement depuis la base de données.
 
-Connectez-vous à votre [espace client OVHcloud](/links/manager) puis sélectionnez `Web Cloud`{.action}. Cliquez sur `Hébergements`{.action} et choisissez l'offre concernée. Dans l'onglet `Bases de données`{.action}, identifiez la base de données utilisée par votre CMS, cliquez sur le bouton `...`{.action} puis sur `Accéder à phpMyAdmin`{.action}.
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4** étapes.
 
-Saisissez les identifiants de la base de données (nom d'utilisateur et mot de passe) que vous avez définis lors de la création de la base de données. Une fois connecté à phpMyAdmin, cliquez sur l'onglet concerné ci-dessous.
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'offre concernée.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action}, puis identifiez la base de données utilisée par votre CMS.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur le bouton `...`{.action} puis sur `Accéder à phpMyAdmin`{.action}.
+>>
+> **Étape 4**
+>>
+>> Saisissez les identifiants de la base de données (nom d'utilisateur et mot de passe) que vous avez définis lors de sa création. Une fois connecté à phpMyAdmin, cliquez sur l'onglet concerné ci-dessous.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Comment changer le mot de passe administrateur d'un CMS"
 excerpt: "Découvrez comment modifier le mot de passe administrateur de votre CMS directement via l’interface d’administration du CMS ou en utilisant phpMyAdmin depuis l’espace client OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Comment changer le mot de passe administrateur d'un CMS"
 excerpt: "Découvrez comment modifier le mot de passe administrateur de votre CMS directement via l’interface d’administration du CMS ou en utilisant phpMyAdmin depuis l’espace client OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Comment changer le mot de passe administrateur d'un CMS"
 excerpt: "Découvrez comment modifier le mot de passe administrateur de votre CMS directement via l’interface d’administration du CMS ou en utilisant phpMyAdmin depuis l’espace client OVHcloud"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -100,9 +100,26 @@ Vous avez accès à l'interface d'administration du CMS et vous connaissez votre
 
 Vous n'avez plus accès à l'interface d'administration du CMS ou vous ne pouvez pas utiliser la fonctionnalité « Mot de passe oublié » parce que l'adresse e-mail associée est inaccessible ? Utilisez phpMyAdmin depuis votre [espace client OVHcloud](/links/manager) pour réinitialiser le mot de passe directement depuis la base de données.
 
-Connectez-vous à votre [espace client OVHcloud](/links/manager) puis sélectionnez `Web Cloud`{.action}. Cliquez sur `Hébergements`{.action} et choisissez l'offre concernée. Dans l'onglet `Bases de données`{.action}, identifiez la base de données utilisée par votre CMS, cliquez sur le bouton `...`{.action} puis sur `Accéder à phpMyAdmin`{.action}.
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4** étapes.
 
-Saisissez les identifiants de la base de données (nom d'utilisateur et mot de passe) que vous avez définis lors de la création de la base de données. Une fois connecté à phpMyAdmin, cliquez sur l'onglet concerné ci-dessous.
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'offre concernée.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action}, puis identifiez la base de données utilisée par votre CMS.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur le bouton `...`{.action} puis sur `Accéder à phpMyAdmin`{.action}.
+>>
+> **Étape 4**
+>>
+>> Saisissez les identifiants de la base de données (nom d'utilisateur et mot de passe) que vous avez définis lors de la création de la base de données. Une fois connecté à phpMyAdmin, cliquez sur l'onglet concerné ci-dessous.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.fr-fr.md
@@ -107,7 +107,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4*
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'offre concernée.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -119,7 +119,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4*
 >>
 > **Étape 4**
 >>
->> Saisissez les identifiants de la base de données (nom d'utilisateur et mot de passe) que vous avez définis lors de la création de la base de données. Une fois connecté à phpMyAdmin, cliquez sur l'onglet concerné ci-dessous.
+>> Saisissez les identifiants de la base de données (nom d'utilisateur et mot de passe) que vous avez définis lors de sa création. Une fois connecté à phpMyAdmin, cliquez sur l'onglet concerné ci-dessous.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.it-it.md
@@ -111,7 +111,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** pa
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action} e identifica il database utilizzato dal tuo CMS.
+>> Clicca sulla scheda `Databases`{.action} e identifica il database utilizzato dal tuo CMS.
 >>
 > **Passaggio 3**
 >>

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Come cambiare la password amministratore di un CMS"
 excerpt: "Questa guida ti mostra come modificare la password amministratore del tuo CMS direttamente tramite l'interfaccia di amministrazione del CMS o utilizzando phpMyAdmin dallo Spazio Cliente OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Obiettivo

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Come cambiare la password amministratore di un CMS"
 excerpt: "Questa guida ti mostra come modificare la password amministratore del tuo CMS direttamente tramite l'interfaccia di amministrazione del CMS o utilizzando phpMyAdmin dallo Spazio Cliente OVHcloud"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Obiettivo
@@ -20,7 +20,7 @@ Hai perso l'accesso all'interfaccia di gestione di WordPress, PrestaShop, Joomla
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -100,9 +100,26 @@ Hai accesso all’interfaccia di gestione del CMS e conosci la tua password attu
 
 Non hai più accesso all'interfaccia di gestione del CMS o non puoi utilizzare la funzionalità "Password dimenticata" perché l'indirizzo email associato non è raggiungibile? Utilizza phpMyAdmin dal tuo [Spazio Cliente OVHcloud](/links/manager) per reimpostare la password direttamente dal database.
 
-Accedi allo [Spazio Cliente OVHcloud](/links/manager) e seleziona `Web Cloud`{.action}. Clicca su `Hosting`{.action} e seleziona il servizio interessato. Nella scheda `Database`{.action}, identifica il database utilizzato dal tuo CMS, clicca sul pulsante `...`{.action} e poi su `Accedi a phpMyAdmin`{.action}.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
-Inserire gli identificativi del database (nome utente e password) definiti durante la creazione del database. Una volta connesso a phpMyAdmin, clicca sulla scheda interessata qui sotto.
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting) e seleziona il servizio interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `Database`{.action} e identifica il database utilizzato dal tuo CMS.
+>>
+> **Passaggio 3**
+>>
+>> Clicca sul pulsante `...`{.action} e poi su `Accedi a phpMyAdmin`{.action}.
+>>
+> **Passaggio 4**
+>>
+>> Inserisci gli identificativi del database (nome utente e password) definiti durante la creazione del database. Una volta connesso a phpMyAdmin, clicca sulla scheda interessata qui sotto.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Jak zmienić hasło administratora CMS"
 excerpt: "Dowiedz się, jak zmienić hasło administratora Twojego CMS bezpośrednio w interfejsie zarządzania CMS lub za pomocą narzędzia phpMyAdmin w Panelu klienta OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Wprowadzenie

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Jak zmienić hasło administratora CMS"
 excerpt: "Dowiedz się, jak zmienić hasło administratora Twojego CMS bezpośrednio w interfejsie zarządzania CMS lub za pomocą narzędzia phpMyAdmin w Panelu klienta OVHcloud"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Wprowadzenie
@@ -20,7 +20,7 @@ Straciłeś dostęp do interfejsu administracyjnego WordPressa, PrestaShop, Joom
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -100,9 +100,26 @@ Masz dostęp do interfejsu administracyjnego CMS i znasz swoje aktualne hasło? 
 
 Nie masz dostępu do interfejsu administracyjnego CMS lub nie możesz użyć funkcji "Nie pamiętasz hasła", ponieważ powiązany adres e-mail jest niedostępny? Użyj narzędzia phpMyAdmin w [Panelu klienta OVHcloud](/links/manager), aby zresetować hasło bezpośrednio z bazy danych.
 
-Zaloguj się do [Panelu klienta OVHcloud](/links/manager) i wybierz opcję `Web Cloud`{.action}. Kliknij pozycję `Hosting`{.action} i wybierz odpowiednią ofertę. W zakładce `Bazy danych`{.action} znajdź bazę danych używaną przez Twój CMS, kliknij przycisk `...`{.action}, a następnie `Dostęp do phpMyAdmin`{.action}.
+Kliknij poniższe karty, aby wyświetlić kolejne **4** kroki.
 
-Wpisz identyfikatory bazy danych (nazwa użytkownika i hasło), które zdefiniowałeś podczas tworzenia bazy danych. Po zalogowaniu do phpMyAdmin kliknij odpowiednią zakładkę poniżej.
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiednią ofertę.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `Bazy danych`{.action} i znajdź bazę danych używaną przez Twój CMS.
+>>
+> **Krok 3**
+>>
+>> Kliknij przycisk `...`{.action}, a następnie `Dostęp do phpMyAdmin`{.action}.
+>>
+> **Krok 4**
+>>
+>> Wpisz identyfikatory bazy danych (nazwa użytkownika i hasło), które zdefiniowałeś podczas tworzenia bazy danych. Po zalogowaniu do phpMyAdmin kliknij odpowiednią zakładkę poniżej.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Como alterar a palavra-passe de um CMS"
 excerpt: "Saiba como alterar a palavra-passe de administrador do seu CMS diretamente através da interface de administração do CMS ou utilizando o phpMyAdmin a partir da Área de Cliente OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/cms-update-password-admin/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/cms-update-password-admin/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Como alterar a palavra-passe de um CMS"
 excerpt: "Saiba como alterar a palavra-passe de administrador do seu CMS diretamente através da interface de administração do CMS ou utilizando o phpMyAdmin a partir da Área de Cliente OVHcloud"
-updated: 2024-10-15
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -20,7 +20,7 @@ Perdeu o acesso à sua interface de administração WordPress, PrestaShop, Jooml
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -100,9 +100,26 @@ Tem acesso à interface de administração do CMS e conhece a sua palavra-passe 
 
 Já não tem acesso à interface de administração do CMS ou não pode utilizar a funcionalidade "Esqueceu-se da Palavra-passe" porque o endereço de e-mail associado está inacessível? Utilize o phpMyAdmin a partir da [Área de Cliente OVHcloud](/links/manager) para repor a palavra-passe diretamente a partir da base de dados.
 
-Aceda à sua [Área de Cliente OVHcloud](/links/manager) e selecione `Web Cloud`{.action}. Clique em `Alojamentos`{.action} e escolha a oferta em causa. No separador `Bases de dados`{.action}", identifique a base de dados utilizada pelo seu CMS, clique no botão `...`{.action} e depois em `Aceder ao phpMyAdmin`{.action}.
+Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 
-Introduza as credenciais da base de dados (nome de utilizador e palavra-passe) definidas durante a criação da base de dados. Depois de se conectar ao phpMyAdmin, clique no respetivo separador abaixo.
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione a oferta em causa.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Clique no separador `Bases de dados`{.action} e identifique a base de dados utilizada pelo seu CMS.
+>>
+> **Etapa 3**
+>>
+>> Clique no botão `...`{.action} e depois em `Aceder ao phpMyAdmin`{.action}.
+>>
+> **Etapa 4**
+>>
+>> Introduza as credenciais da base de dados (nome de utilizador e palavra-passe) definidas durante a criação da base de dados. Depois de se conectar ao phpMyAdmin, clique no respetivo separador abaixo.
 
 > [!tabs]
 > WordPress

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.de-de.md
@@ -37,16 +37,6 @@ Dieses Tutorial hilft Ihnen Schritt für Schritt bei der manuellen Installation 
 - Sie haben ein [OVHcloud Webhosting](/links/web/hosting), das mindestens eine Datenbank enthält.
 - Sie verfügen über einen [Domainnamen](/links/web/domains).
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Zugriff auf das OVHcloud Kundencenter
-
-- **Direkter Link:** [Hosting-Pakete](/links/control-panel/web-hosting)
-- **Navigationspfad:** `Web Cloud`{.action} > `Hosting-Pakete`{.action} > Wählen Sie Ihr Webhosting aus
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## In der praktischen Anwendung
 
@@ -117,7 +107,7 @@ Weitere Informationen finden Sie auf unserer Seite zum [PrestaShop Modul](/links
 > Wir möchten Sie daran erinnern, dass OVHcloud bei der Verwendung von CMS keinerlei Unterstützung leisten kann. Sollten Sie Schwierigkeiten haben, kontaktieren Sie den Herausgeber des von Ihnen gewählten CMS über die Links oben in diesem Tutorial.
 >
 
-### Schritt 1: Installation vorbereiten <a name="step1"></a> 
+### 1 - Installation vorbereiten <a name="step1"></a>
 
 Um ein CMS auf Ihrem [Webhosting](/links/web/hosting) Angebot zu installieren sind einige Vorbereitungen erforderlich.
 
@@ -136,15 +126,14 @@ Konsultieren Sie unsere Dokumentation, die beschreibt [wie Sie eine Website auf 
 
 - Vergewissern Sie sich, dass der Domainname, den Sie für den Zugriff auf Ihr CMS verwenden, sowie dessen "www"-Subdomain auf die IP-Adresse Ihres [OVHcloud Webhostings](/links/web/hosting) verweisen.
 
-Um die IP-Adresse Ihres Webhostings zu erfahren, loggen Sie sich in Ihr [OVHcloud Kundencenter](/links/manager) ein und wählen Sie Ihr Webhosting im Bereich `Web Cloud`{.action} unter `Hosting-Pakete`{.action} aus.<br>
-Im Kasten `Allgemeine Informationen`{.action} finden Sie die IP-Adresse Ihres Webhostings im Eintrag `IPv4`{.action}.
-
-Wenn die aktive DNS-Zone Ihres Domainnamens in Ihrem [OVHcloud Kundencenter](/links/manager) verwaltet wird, vergleichen Sie die IP-Adresse Ihres Hostings mit der in der DNS-Zone Ihres Domainnamens eingetragenen. Verwenden Sie dazu unsere Dokumentation zur [Verwaltung von OVHcloud DNS-Zonen](/pages/web_cloud/domains/dns_zone_edit).
+Die IPv4- (oder IPv6-) Adresse Ihres Webhostings finden Sie in unserer Anleitung "[Webhosting - Liste der IP-Adressen nach Cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> Wenn Sie eine der Optionen `CDN`{.action} oder `IP des Landes`{.action} für Ihren Domainnamen aktiviert haben, verwenden Sie die stattdessen die IP-Adresse, die Sie in unserer [Dokumentation zu IP-Adressen der Webhosting-Cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP) finden können.
+> Wenn Sie eine länderbasierte geolokalisierte IP-Adresse oder eine CDN-Option zwischen Ihrem Domainnamen und Ihrem Webhosting verwenden, nutzen Sie die entsprechende IP-Adresse aus der oben genannten Anleitung.
 >
+
+Wenn die aktive DNS-Zone Ihres Domainnamens in Ihrem [OVHcloud Kundencenter](/links/control-panel/web-dns-zone) verwaltet wird, vergleichen Sie die IP-Adresse Ihres Hostings mit der in der DNS-Zone Ihres Domainnamens eingetragenen. Verwenden Sie dazu unsere Dokumentation zur [Verwaltung von OVHcloud DNS-Zonen](/pages/web_cloud/domains/dns_zone_edit).
 
 Sollten Sie diese Maßnahmen nicht im Kundencenter durchführen können, kontaktieren Sie den Anbieter, der Ihre aktive DNS-Zone verwaltet, um Ihre Domaineinstellungen zu ändern.
 
@@ -178,7 +167,7 @@ Verwenden Sie unsere Anleitung zur [Erstellung einer Datenbank über Ihr Webhost
 
 Wenn Sie das Angebot Web Cloud Databases mit MySQL oder MariaDB nutzen und dieses für die manuelle Installation Ihres CMS verwenden möchten, lesen Sie unsere Anleitung zur [Erstellung einer Datenbank mit Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#datenbank-erstellen).
 
-Sobald die Datenbank erstellt wurde, rufen Sie die Verbindungseinstellungen (Server, Name der Datenbank, Benutzername und Passwort) ab und speichern Sie diese für [Schritt 3](#step3) dieser Anleitung.
+Sobald die Datenbank erstellt wurde, rufen Sie die Verbindungseinstellungen (Server, Name der Datenbank, Benutzername und Passwort) ab und speichern Sie diese für [Teil 3](#step3) dieser Anleitung.
 
 > [!primary]
 >
@@ -192,7 +181,7 @@ Sobald die Datenbank erstellt wurde, rufen Sie die Verbindungseinstellungen (Ser
 > - Um sich mit einer Datenbank von Web Cloud Databases zu verbinden, folgen Sie [dieser Anleitung](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Schritt 2: Die manuelle Installation starten
+### 2 - Die manuelle Installation starten
 
 #### 2.1 Die Quelldateien Ihres CMS abrufen
 
@@ -251,7 +240,7 @@ Wählen Sie den Ordner "**CMS**" als Zielverzeichnis für die Extraktion der Dat
 
 #### 2.3 Die Quelldateien des "CMS"-Ordners zum Wurzelverzeichnis auf Ihrem Webhosting verschieben
 
-Nachdem Sie die Dateien in Ihrem Ordner "**CMS**" dekomprimiert haben, stellen Sie eine [FTP-Verbindung mit Ihrem Webhosting her](/pages/web_cloud/web_hosting/ftp_connection), etwa mithilfe des [Clients FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide). Kopieren Sie die Dateien aus dem Ordner "**CMS**" zum Wurzelverzeichnis für Ihr CMS, das Sie in [Schritt 1](#step1) dieser Anleitung erstellt haben.
+Nachdem Sie die Dateien in Ihrem Ordner "**CMS**" dekomprimiert haben, stellen Sie eine [FTP-Verbindung mit Ihrem Webhosting her](/pages/web_cloud/web_hosting/ftp_connection), etwa mithilfe des [Clients FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide). Kopieren Sie die Dateien aus dem Ordner "**CMS**" zum Wurzelverzeichnis für Ihr CMS, das Sie in [Teil 1](#step1) dieser Anleitung erstellt haben.
 
 Hier ein Beispiel für *WordPress*:
 
@@ -264,7 +253,7 @@ Hier ein Beispiel für *WordPress*:
 
 >[!primary]
 >
-> Wenn das von Ihnen definierte Wurzelverzeichnis nicht automatisch mit den in [Schritt 1](#step1) beschriebenen Aktionen erstellt wurde , können Sie es über FileZilla erstellen.
+> Wenn das von Ihnen definierte Wurzelverzeichnis nicht automatisch mit den in [Teil 1](#step1) beschriebenen Aktionen erstellt wurde , können Sie es über FileZilla erstellen.
 >
 > Es kann einige Minuten dauern, bis die Dateien auf Ihr Hosting übertragen sind.
 >
@@ -385,7 +374,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Schritt 3: Manuelle Installation abschließen <a name="step3"></a> 
+### 3 - Manuelle Installation abschließen <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -12,7 +12,7 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
+> This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 > Find below the links to the respective official pages of the CMS mentioned above:
 >
@@ -38,16 +38,6 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 - An [OVHcloud web hosting plan](/links/web/hosting) that contains at least one database
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
@@ -118,7 +108,7 @@ You can find more information on our [PrestaShop module page](/links/web/hosting
 > Whichever CMS you choose, please note that OVHcloud will not provide assistance with using these CMSs. If you encounter any difficulties, contact the publisher of the CMS you have chosen directly using the links indicated earlier in this tutorial.
 >
 
-### Step 1: Prepare the installation <a name="step1"></a>
+### 1 - Prepare the installation <a name="step1"></a>
 
 To install a CMS on your [web hosting plan](/links/web/hosting), you will need to make some preparations.
 
@@ -137,15 +127,14 @@ Refer to our documentation which describes [how to create a website on your web 
 
 - Make sure that the domain name you will use to access your CMS, along with its subdomain “www”, is mapped to the IP address of your [web hosting plan](/links/web/hosting).
 
-To retrieve the IP address of your Web Hosting plan, log in to your [OVHcloud Control Panel](/links/manager) in the `Web Cloud`{.action} section, then select your Web Hosting plan in the `Hosting`{.action} section.<br>
-In the `General information`{.action} box on your right, you will find the IP address of your web hosting plan in the `IPv4`{.action} form.
-
-If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/manager), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation .
+To retrieve the IPv4 (or IPv6) address of your Web Hosting plan, refer to our guide "[Web Hosting - List of IP addresses by cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> If you have activated the `CDN`{.action} or `Country IP`{.action} options with your domain, use the appropriate IP address by referring to our documentation listing [all shared hosting IP addresses](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> If you have used a country-based geolocated IP address option or enabled a CDN option between your domain name and your web hosting plan, use the appropriate IP address indicated in the guide mentioned above.
 >
+
+If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/control-panel/web-dns-zone), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation.
 
 If you are unable to perform these checks, contact the hosting provider for your active DNS zone to update the pointing of your domain name.
 
@@ -179,7 +168,7 @@ Use our documentation to [create a database from your web hosting plan](/pages/w
 
 If you have a Cloud Databases web hosting plan in MySQL or MariaDB and you would like to use it to manually install your CMS, please refer to our guide on [creating a database on a Cloud Databases web service](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#creating-a-database).
 
-Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [step 3](#step3) in this guide.
+Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [part 3](#step3) in this guide.
 
 > [!primary]
 >
@@ -193,7 +182,7 @@ Once you have created the database, retrieve the connection settings (server, da
 > - To connect to a database on a Web Cloud Databases solution, see [this guide](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Step 2: Start the installation
+### 2 - Start the installation
 
 #### 2.1 Retrieve your CMS source files
 
@@ -252,7 +241,7 @@ Enter the destination **CMS** folder to extract your files to that folder.
 
 #### 2.3 Move the source files from the CMS folder to the root folder of your web hosting plan
 
-Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [step 1](#step1) of this guide.
+Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [part 1](#step1) of this guide.
 
 Below is an example with the CMS *WordPress*:
 
@@ -265,7 +254,7 @@ Below is an example with the CMS *WordPress*:
 
 >[!primary]
 >
-> If the root folder you defined was not created automatically during the actions described in [step 1](#step1), you can create it via FileZilla.
+> If the root folder you defined was not created automatically during the actions described in [part 1](#step1), you can create it via FileZilla.
 >
 > It may take a few minutes to upload files to your web hosting plan.
 >
@@ -386,7 +375,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Step 3: Finalise the installation <a name="step3"></a>
+### 3 - Finalise the installation <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -12,7 +12,7 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
+> This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 > Find below the links to the respective official pages of the CMS mentioned above:
 >
@@ -38,16 +38,6 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 - An [OVHcloud web hosting plan](/links/web/hosting) that contains at least one database
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
@@ -118,7 +108,7 @@ You can find more information on our [PrestaShop module page](/links/web/hosting
 > Whichever CMS you choose, please note that OVHcloud will not provide assistance with using these CMSs. If you encounter any difficulties, contact the publisher of the CMS you have chosen directly using the links indicated earlier in this tutorial.
 >
 
-### Step 1: Prepare the installation <a name="step1"></a>
+### 1 - Prepare the installation <a name="step1"></a>
 
 To install a CMS on your [web hosting plan](/links/web/hosting), you will need to make some preparations.
 
@@ -137,15 +127,14 @@ Refer to our documentation which describes [how to create a website on your web 
 
 - Make sure that the domain name you will use to access your CMS, along with its subdomain “www”, is mapped to the IP address of your [web hosting plan](/links/web/hosting).
 
-To retrieve the IP address of your Web Hosting plan, log in to your [OVHcloud Control Panel](/links/manager) in the `Web Cloud`{.action} section, then select your Web Hosting plan in the `Hosting`{.action} section.<br>
-In the `General information`{.action} box on your right, you will find the IP address of your web hosting plan in the `IPv4`{.action} form.
-
-If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/manager), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation .
+To retrieve the IPv4 (or IPv6) address of your Web Hosting plan, refer to our guide "[Web Hosting - List of IP addresses by cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> If you have activated the `CDN`{.action} or `Country IP`{.action} options with your domain, use the appropriate IP address by referring to our documentation listing [all shared hosting IP addresses](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> If you have used a country-based geolocated IP address option or enabled a CDN option between your domain name and your web hosting plan, use the appropriate IP address indicated in the guide mentioned above.
 >
+
+If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/control-panel/web-dns-zone), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation.
 
 If you are unable to perform these checks, contact the hosting provider for your active DNS zone to update the pointing of your domain name.
 
@@ -179,7 +168,7 @@ Use our documentation to [create a database from your web hosting plan](/pages/w
 
 If you have a Cloud Databases web hosting plan in MySQL or MariaDB and you would like to use it to manually install your CMS, please refer to our guide on [creating a database on a Cloud Databases web service](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#creating-a-database).
 
-Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [step 3](#step3) in this guide.
+Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [part 3](#step3) in this guide.
 
 > [!primary]
 >
@@ -193,7 +182,7 @@ Once you have created the database, retrieve the connection settings (server, da
 > - To connect to a database on a Web Cloud Databases solution, see [this guide](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Step 2: Start the installation
+### 2 - Start the installation
 
 #### 2.1 Retrieve your CMS source files
 
@@ -252,7 +241,7 @@ Enter the destination **CMS** folder to extract your files to that folder.
 
 #### 2.3 Move the source files from the CMS folder to the root folder of your web hosting plan
 
-Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [step 1](#step1) of this guide.
+Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [part 1](#step1) of this guide.
 
 Below is an example with the CMS *WordPress*:
 
@@ -265,7 +254,7 @@ Below is an example with the CMS *WordPress*:
 
 >[!primary]
 >
-> If the root folder you defined was not created automatically during the actions described in [step 1](#step1), you can create it via FileZilla.
+> If the root folder you defined was not created automatically during the actions described in [part 1](#step1), you can create it via FileZilla.
 >
 > It may take a few minutes to upload files to your web hosting plan.
 >
@@ -386,7 +375,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Step 3: Finalise the installation <a name="step3"></a>
+### 3 - Finalise the installation <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -12,7 +12,7 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
+> This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 > Find below the links to the respective official pages of the CMS mentioned above:
 >
@@ -38,16 +38,6 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 - An [OVHcloud web hosting plan](/links/web/hosting) that contains at least one database
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
@@ -118,7 +108,7 @@ You can find more information on our [PrestaShop module page](/links/web/hosting
 > Whichever CMS you choose, please note that OVHcloud will not provide assistance with using these CMSs. If you encounter any difficulties, contact the publisher of the CMS you have chosen directly using the links indicated earlier in this tutorial.
 >
 
-### Step 1: Prepare the installation <a name="step1"></a>
+### 1 - Prepare the installation <a name="step1"></a>
 
 To install a CMS on your [web hosting plan](/links/web/hosting), you will need to make some preparations.
 
@@ -137,15 +127,14 @@ Refer to our documentation which describes [how to create a website on your web 
 
 - Make sure that the domain name you will use to access your CMS, along with its subdomain “www”, is mapped to the IP address of your [web hosting plan](/links/web/hosting).
 
-To retrieve the IP address of your Web Hosting plan, log in to your [OVHcloud Control Panel](/links/manager) in the `Web Cloud`{.action} section, then select your Web Hosting plan in the `Hosting`{.action} section.<br>
-In the `General information`{.action} box on your right, you will find the IP address of your web hosting plan in the `IPv4`{.action} form.
-
-If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/manager), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation .
+To retrieve the IPv4 (or IPv6) address of your Web Hosting plan, refer to our guide "[Web Hosting - List of IP addresses by cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> If you have activated the `CDN`{.action} or `Country IP`{.action} options with your domain, use the appropriate IP address by referring to our documentation listing [all shared hosting IP addresses](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> If you have used a country-based geolocated IP address option or enabled a CDN option between your domain name and your web hosting plan, use the appropriate IP address indicated in the guide mentioned above.
 >
+
+If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/control-panel/web-dns-zone), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation.
 
 If you are unable to perform these checks, contact the hosting provider for your active DNS zone to update the pointing of your domain name.
 
@@ -179,7 +168,7 @@ Use our documentation to [create a database from your web hosting plan](/pages/w
 
 If you have a Cloud Databases web hosting plan in MySQL or MariaDB and you would like to use it to manually install your CMS, please refer to our guide on [creating a database on a Cloud Databases web service](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#creating-a-database).
 
-Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [step 3](#step3) in this guide.
+Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [part 3](#step3) in this guide.
 
 > [!primary]
 >
@@ -193,7 +182,7 @@ Once you have created the database, retrieve the connection settings (server, da
 > - To connect to a database on a Web Cloud Databases solution, see [this guide](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Step 2: Start the installation
+### 2 - Start the installation
 
 #### 2.1 Retrieve your CMS source files
 
@@ -252,7 +241,7 @@ Enter the destination **CMS** folder to extract your files to that folder.
 
 #### 2.3 Move the source files from the CMS folder to the root folder of your web hosting plan
 
-Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [step 1](#step1) of this guide.
+Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [part 1](#step1) of this guide.
 
 Below is an example with the CMS *WordPress*:
 
@@ -265,7 +254,7 @@ Below is an example with the CMS *WordPress*:
 
 >[!primary]
 >
-> If the root folder you defined was not created automatically during the actions described in [step 1](#step1), you can create it via FileZilla.
+> If the root folder you defined was not created automatically during the actions described in [part 1](#step1), you can create it via FileZilla.
 >
 > It may take a few minutes to upload files to your web hosting plan.
 >
@@ -386,7 +375,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Step 3: Finalise the installation <a name="step3"></a>
+### 3 - Finalise the installation <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -12,7 +12,7 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
+> This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 > Find below the links to the respective official pages of the CMS mentioned above:
 >
@@ -38,16 +38,6 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 - An [OVHcloud web hosting plan](/links/web/hosting) that contains at least one database
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
@@ -118,7 +108,7 @@ You can find more information on our [PrestaShop module page](/links/web/hosting
 > Whichever CMS you choose, please note that OVHcloud will not provide assistance with using these CMSs. If you encounter any difficulties, contact the publisher of the CMS you have chosen directly using the links indicated earlier in this tutorial.
 >
 
-### Step 1: Prepare the installation <a name="step1"></a>
+### 1 - Prepare the installation <a name="step1"></a>
 
 To install a CMS on your [web hosting plan](/links/web/hosting), you will need to make some preparations.
 
@@ -137,15 +127,14 @@ Refer to our documentation which describes [how to create a website on your web 
 
 - Make sure that the domain name you will use to access your CMS, along with its subdomain “www”, is mapped to the IP address of your [web hosting plan](/links/web/hosting).
 
-To retrieve the IP address of your Web Hosting plan, log in to your [OVHcloud Control Panel](/links/manager) in the `Web Cloud`{.action} section, then select your Web Hosting plan in the `Hosting`{.action} section.<br>
-In the `General information`{.action} box on your right, you will find the IP address of your web hosting plan in the `IPv4`{.action} form.
-
-If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/manager), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation .
+To retrieve the IPv4 (or IPv6) address of your Web Hosting plan, refer to our guide "[Web Hosting - List of IP addresses by cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> If you have activated the `CDN`{.action} or `Country IP`{.action} options with your domain, use the appropriate IP address by referring to our documentation listing [all shared hosting IP addresses](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> If you have used a country-based geolocated IP address option or enabled a CDN option between your domain name and your web hosting plan, use the appropriate IP address indicated in the guide mentioned above.
 >
+
+If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/control-panel/web-dns-zone), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation.
 
 If you are unable to perform these checks, contact the hosting provider for your active DNS zone to update the pointing of your domain name.
 
@@ -179,7 +168,7 @@ Use our documentation to [create a database from your web hosting plan](/pages/w
 
 If you have a Cloud Databases web hosting plan in MySQL or MariaDB and you would like to use it to manually install your CMS, please refer to our guide on [creating a database on a Cloud Databases web service](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#creating-a-database).
 
-Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [step 3](#step3) in this guide.
+Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [part 3](#step3) in this guide.
 
 > [!primary]
 >
@@ -193,7 +182,7 @@ Once you have created the database, retrieve the connection settings (server, da
 > - To connect to a database on a Web Cloud Databases solution, see [this guide](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Step 2: Start the installation
+### 2 - Start the installation
 
 #### 2.1 Retrieve your CMS source files
 
@@ -252,7 +241,7 @@ Enter the destination **CMS** folder to extract your files to that folder.
 
 #### 2.3 Move the source files from the CMS folder to the root folder of your web hosting plan
 
-Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [step 1](#step1) of this guide.
+Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [part 1](#step1) of this guide.
 
 Below is an example with the CMS *WordPress*:
 
@@ -265,7 +254,7 @@ Below is an example with the CMS *WordPress*:
 
 >[!primary]
 >
-> If the root folder you defined was not created automatically during the actions described in [step 1](#step1), you can create it via FileZilla.
+> If the root folder you defined was not created automatically during the actions described in [part 1](#step1), you can create it via FileZilla.
 >
 > It may take a few minutes to upload files to your web hosting plan.
 >
@@ -386,7 +375,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Step 3: Finalise the installation <a name="step3"></a>
+### 3 - Finalise the installation <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -12,7 +12,7 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
+> This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 > Find below the links to the respective official pages of the CMS mentioned above:
 >
@@ -38,16 +38,6 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 - An [OVHcloud web hosting plan](/links/web/hosting) that contains at least one database
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
@@ -118,7 +108,7 @@ You can find more information on our [PrestaShop module page](/links/web/hosting
 > Whichever CMS you choose, please note that OVHcloud will not provide assistance with using these CMSs. If you encounter any difficulties, contact the publisher of the CMS you have chosen directly using the links indicated earlier in this tutorial.
 >
 
-### Step 1: Prepare the installation <a name="step1"></a>
+### 1 - Prepare the installation <a name="step1"></a>
 
 To install a CMS on your [web hosting plan](/links/web/hosting), you will need to make some preparations.
 
@@ -137,15 +127,14 @@ Refer to our documentation which describes [how to create a website on your web 
 
 - Make sure that the domain name you will use to access your CMS, along with its subdomain “www”, is mapped to the IP address of your [web hosting plan](/links/web/hosting).
 
-To retrieve the IP address of your Web Hosting plan, log in to your [OVHcloud Control Panel](/links/manager) in the `Web Cloud`{.action} section, then select your Web Hosting plan in the `Hosting`{.action} section.<br>
-In the `General information`{.action} box on your right, you will find the IP address of your web hosting plan in the `IPv4`{.action} form.
-
-If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/manager), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation .
+To retrieve the IPv4 (or IPv6) address of your Web Hosting plan, refer to our guide "[Web Hosting - List of IP addresses by cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> If you have activated the `CDN`{.action} or `Country IP`{.action} options with your domain, use the appropriate IP address by referring to our documentation listing [all shared hosting IP addresses](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> If you have used a country-based geolocated IP address option or enabled a CDN option between your domain name and your web hosting plan, use the appropriate IP address indicated in the guide mentioned above.
 >
+
+If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/control-panel/web-dns-zone), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation.
 
 If you are unable to perform these checks, contact the hosting provider for your active DNS zone to update the pointing of your domain name.
 
@@ -179,7 +168,7 @@ Use our documentation to [create a database from your web hosting plan](/pages/w
 
 If you have a Cloud Databases web hosting plan in MySQL or MariaDB and you would like to use it to manually install your CMS, please refer to our guide on [creating a database on a Cloud Databases web service](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#creating-a-database).
 
-Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [step 3](#step3) in this guide.
+Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [part 3](#step3) in this guide.
 
 > [!primary]
 >
@@ -193,7 +182,7 @@ Once you have created the database, retrieve the connection settings (server, da
 > - To connect to a database on a Web Cloud Databases solution, see [this guide](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Step 2: Start the installation
+### 2 - Start the installation
 
 #### 2.1 Retrieve your CMS source files
 
@@ -252,7 +241,7 @@ Enter the destination **CMS** folder to extract your files to that folder.
 
 #### 2.3 Move the source files from the CMS folder to the root folder of your web hosting plan
 
-Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [step 1](#step1) of this guide.
+Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [part 1](#step1) of this guide.
 
 Below is an example with the CMS *WordPress*:
 
@@ -265,7 +254,7 @@ Below is an example with the CMS *WordPress*:
 
 >[!primary]
 >
-> If the root folder you defined was not created automatically during the actions described in [step 1](#step1), you can create it via FileZilla.
+> If the root folder you defined was not created automatically during the actions described in [part 1](#step1), you can create it via FileZilla.
 >
 > It may take a few minutes to upload files to your web hosting plan.
 >
@@ -386,7 +375,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Step 3: Finalise the installation <a name="step3"></a>
+### 3 - Finalise the installation <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -12,7 +12,7 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
+> This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 > Find below the links to the respective official pages of the CMS mentioned above:
 >
@@ -38,16 +38,6 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 - An [OVHcloud web hosting plan](/links/web/hosting) that contains at least one database
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
@@ -118,7 +108,7 @@ You can find more information on our [PrestaShop module page](/links/web/hosting
 > Whichever CMS you choose, please note that OVHcloud will not provide assistance with using these CMSs. If you encounter any difficulties, contact the publisher of the CMS you have chosen directly using the links indicated earlier in this tutorial.
 >
 
-### Step 1: Prepare the installation <a name="step1"></a>
+### 1 - Prepare the installation <a name="step1"></a>
 
 To install a CMS on your [web hosting plan](/links/web/hosting), you will need to make some preparations.
 
@@ -137,15 +127,14 @@ Refer to our documentation which describes [how to create a website on your web 
 
 - Make sure that the domain name you will use to access your CMS, along with its subdomain “www”, is mapped to the IP address of your [web hosting plan](/links/web/hosting).
 
-To retrieve the IP address of your Web Hosting plan, log in to your [OVHcloud Control Panel](/links/manager) in the `Web Cloud`{.action} section, then select your Web Hosting plan in the `Hosting`{.action} section.<br>
-In the `General information`{.action} box on your right, you will find the IP address of your web hosting plan in the `IPv4`{.action} form.
-
-If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/manager), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation .
+To retrieve the IPv4 (or IPv6) address of your Web Hosting plan, refer to our guide "[Web Hosting - List of IP addresses by cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> If you have activated the `CDN`{.action} or `Country IP`{.action} options with your domain, use the appropriate IP address by referring to our documentation listing [all shared hosting IP addresses](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> If you have used a country-based geolocated IP address option or enabled a CDN option between your domain name and your web hosting plan, use the appropriate IP address indicated in the guide mentioned above.
 >
+
+If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/control-panel/web-dns-zone), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation.
 
 If you are unable to perform these checks, contact the hosting provider for your active DNS zone to update the pointing of your domain name.
 
@@ -179,7 +168,7 @@ Use our documentation to [create a database from your web hosting plan](/pages/w
 
 If you have a Cloud Databases web hosting plan in MySQL or MariaDB and you would like to use it to manually install your CMS, please refer to our guide on [creating a database on a Cloud Databases web service](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#creating-a-database).
 
-Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [step 3](#step3) in this guide.
+Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [part 3](#step3) in this guide.
 
 > [!primary]
 >
@@ -193,7 +182,7 @@ Once you have created the database, retrieve the connection settings (server, da
 > - To connect to a database on a Web Cloud Databases solution, see [this guide](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Step 2: Start the installation
+### 2 - Start the installation
 
 #### 2.1 Retrieve your CMS source files
 
@@ -252,7 +241,7 @@ Enter the destination **CMS** folder to extract your files to that folder.
 
 #### 2.3 Move the source files from the CMS folder to the root folder of your web hosting plan
 
-Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [step 1](#step1) of this guide.
+Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [part 1](#step1) of this guide.
 
 Below is an example with the CMS *WordPress*:
 
@@ -265,7 +254,7 @@ Below is an example with the CMS *WordPress*:
 
 >[!primary]
 >
-> If the root folder you defined was not created automatically during the actions described in [step 1](#step1), you can create it via FileZilla.
+> If the root folder you defined was not created automatically during the actions described in [part 1](#step1), you can create it via FileZilla.
 >
 > It may take a few minutes to upload files to your web hosting plan.
 >
@@ -386,7 +375,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Step 3: Finalise the installation <a name="step3"></a>
+### 3 - Finalise the installation <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -12,7 +12,7 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This tutorial is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
+> This tutorial is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or the publisher of the CMS you have chosen to install if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this tutorial.
 >
 > Find below the links to the respective official pages of the CMS mentioned above:
 >
@@ -38,16 +38,6 @@ This tutorial will help you install a CMS (Content Management System) like WordP
 - An [OVHcloud web hosting plan](/links/web/hosting) that contains at least one database
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
@@ -118,7 +108,7 @@ You can find more information on our [PrestaShop module page](/links/web/hosting
 > Whichever CMS you choose, please note that OVHcloud will not provide assistance with using these CMSs. If you encounter any difficulties, contact the publisher of the CMS you have chosen directly using the links indicated earlier in this tutorial.
 >
 
-### Step 1: Prepare the installation <a name="step1"></a>
+### 1 - Prepare the installation <a name="step1"></a>
 
 To install a CMS on your [web hosting plan](/links/web/hosting), you will need to make some preparations.
 
@@ -137,15 +127,14 @@ Refer to our documentation which describes [how to create a website on your web 
 
 - Make sure that the domain name you will use to access your CMS, along with its subdomain “www”, is mapped to the IP address of your [web hosting plan](/links/web/hosting).
 
-To retrieve the IP address of your Web Hosting plan, log in to your [OVHcloud Control Panel](/links/manager) in the `Web Cloud`{.action} section, then select your Web Hosting plan in the `Hosting`{.action} section.<br>
-In the `General information`{.action} box on your right, you will find the IP address of your web hosting plan in the `IPv4`{.action} form.
-
-If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/manager), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation .
+To retrieve the IPv4 (or IPv6) address of your Web Hosting plan, refer to our guide "[Web Hosting - List of IP addresses by cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> If you have activated the `CDN`{.action} or `Country IP`{.action} options with your domain, use the appropriate IP address by referring to our documentation listing [all shared hosting IP addresses](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> If you have used a country-based geolocated IP address option or enabled a CDN option between your domain name and your web hosting plan, use the appropriate IP address indicated in the guide mentioned above.
 >
+
+If your domain’s active DNS zone is managed in your [OVHcloud Control Panel](/links/control-panel/web-dns-zone), compare your hosting plan’s IP address with the one in your domain’s DNS zone, using our [OVHcloud DNS zones](/pages/web_cloud/domains/dns_zone_edit) documentation.
 
 If you are unable to perform these checks, contact the hosting provider for your active DNS zone to update the pointing of your domain name.
 
@@ -179,7 +168,7 @@ Use our documentation to [create a database from your web hosting plan](/pages/w
 
 If you have a Cloud Databases web hosting plan in MySQL or MariaDB and you would like to use it to manually install your CMS, please refer to our guide on [creating a database on a Cloud Databases web service](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#creating-a-database).
 
-Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [step 3](#step3) in this guide.
+Once you have created the database, retrieve the connection settings (server, database name, user name, and password) and save them for [part 3](#step3) in this guide.
 
 > [!primary]
 >
@@ -193,7 +182,7 @@ Once you have created the database, retrieve the connection settings (server, da
 > - To connect to a database on a Web Cloud Databases solution, see [this guide](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Step 2: Start the installation
+### 2 - Start the installation
 
 #### 2.1 Retrieve your CMS source files
 
@@ -252,7 +241,7 @@ Enter the destination **CMS** folder to extract your files to that folder.
 
 #### 2.3 Move the source files from the CMS folder to the root folder of your web hosting plan
 
-Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [step 1](#step1) of this guide.
+Once you have unpacked the files in your **CMS** folder, [log in to your storage space via FTP](/pages/web_cloud/web_hosting/ftp_connection) using [FTP FileZilla client](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) and copy the files from the **CMS** folder to the root folder you defined on your hosting in [part 1](#step1) of this guide.
 
 Below is an example with the CMS *WordPress*:
 
@@ -265,7 +254,7 @@ Below is an example with the CMS *WordPress*:
 
 >[!primary]
 >
-> If the root folder you defined was not created automatically during the actions described in [step 1](#step1), you can create it via FileZilla.
+> If the root folder you defined was not created automatically during the actions described in [part 1](#step1), you can create it via FileZilla.
 >
 > It may take a few minutes to upload files to your web hosting plan.
 >
@@ -386,7 +375,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Step 3: Finalise the installation <a name="step3"></a>
+### 3 - Finalise the installation <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutorial - Installing a CMS manually on your Web Hosting plan"
 excerpt: "Find out more about some of the compatible CMS for Web Hostings"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.es-es.md
@@ -38,16 +38,6 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 - Tener contratado un [plan de hosting de OVHcloud](/links/web/hosting) que contenga al menos una base de datos.
 - Disponer de un [dominio](/links/web/domains)
   
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acceso al área de cliente de OVHcloud
-
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedimiento
 
@@ -118,7 +108,7 @@ Más información en nuestra página relativa a [PrestaShop](/links/web/hosting-
 > No importa cuál sea el CMS que elija, le recordamos que OVHcloud no proporciona soporte sobre el uso de estos CMS. Si necesita ayuda, contacte directamente con el editor del CMS que haya elegido utilizando los enlaces que se indican más arriba en este tutorial.
 >
 
-### Etapa 1 - preparar la instalación <a name="step1"></a>
+### 1 - Preparar la instalación <a name="step1"></a>
 
 Para instalar un CMS en su [plan de hosting](/links/web/hosting), es necesario realizar algunos preparativos.
 
@@ -136,14 +126,14 @@ Consulte nuestra documentación que describe [cómo crear un sitio web en su alo
 
 - Asegúrese de que el dominio que utilizará para acceder al CMS y el subdominio en "www" apuntan a la dirección IP de su [plan de hosting](/links/web/hosting).
 
-Para obtener la dirección IP de su plan de hosting, conéctese a su [área de cliente de OVHcloud](/links/manager) en la sección `Web Cloud`{.action} y seleccione su plan de hosting en la sección `Alojamientos`{.action}.<br>
-En el recuadro `Información general`{.action}, a su derecha, encontrará la dirección IP de su alojamiento web en el formulario `IPv4`{.action}.
-
-Si la zona DNS activa de su dominio está gestionada en su [área de cliente de OVHcloud](/links/manager), compare la dirección IP de su alojamiento con la presente en la zona DNS de su dominio, ayudándole a nuestra documentación sobre las [zonas DNS de OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
+Para obtener la dirección IPv4 (o IPv6) de su plan de hosting, consulte nuestra guía "[Alojamiento web - Lista de direcciones IP por cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> Si ha activado las opciones `CDN`{.action} o `IP del país`{.action} con su dominio, utilice la dirección IP adecuada con nuestra documentación que recoge [todas las direcciones IP de nuestros alojamientos compartidos](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> Si ha utilizado la opción de dirección IP geolocalizada por país o ha activado una opción CDN entre su dominio y su alojamiento web, utilice la dirección IP adecuada indicada en la guía mencionada anteriormente.
+>
+
+Si la zona DNS activa de su dominio está gestionada en su [área de cliente de OVHcloud](/links/control-panel/web-dns-zone), compare la dirección IP de su alojamiento con la presente en la zona DNS de su dominio, ayudándose de nuestra documentación sobre las [zonas DNS de OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
 
 Si no puede realizar estas comprobaciones, póngase en contacto con el proveedor de hosting de su zona DNS activa para actualizar el direccionamiento del dominio.
 
@@ -177,7 +167,7 @@ Utilice nuestra guía para [crear una base de datos desde su plan de hosting](/p
 
 Si tiene un plan Web Cloud Databases en MySQL o MariaDB y quiere utilizarlo para instalar manualmente su CMS, consulte nuestra documentación sobre la [creación de una base de datos en un servicio Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 
-Una vez que haya creado la base de datos, deberá descargar los parámetros de conexión (servidor, nombre de la base de datos, nombre de usuario y contraseña) y conservarlos para [el etapa 3](#step3) de esta guía.
+Una vez que haya creado la base de datos, deberá descargar los parámetros de conexión (servidor, nombre de la base de datos, nombre de usuario y contraseña) y conservarlos para la [parte 3](#step3) de esta guía.
 
 > [!primary]
 >
@@ -191,7 +181,7 @@ Una vez que haya creado la base de datos, deberá descargar los parámetros de c
 > - Para conectarse a una base de datos en un databases de Web Cloud, consulte [esta guía](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Etapa 2 - iniciar la instalación manual
+### 2 - Iniciar la instalación manual
 
 #### 2.1 - Obtener los archivos de origen de su CMS
 
@@ -252,7 +242,7 @@ Indique la carpeta "**CMS**" en la que quiera descargar los archivos desde esta 
 
 #### 2.3 - Mover los archivos fuente de la carpeta "CMS" al "directorio raíz" de su alojamiento web
 
-Una vez descomprimidos los archivos en su carpeta "**CMS**", [conéctese por FTP al espacio de almacenamiento](/pages/web_cloud/web_hosting/ftp_connection) utilizando el [cliente FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) y, a continuación, copie los archivos contenidos en la carpeta "**CMS**" en la "carpeta raíz" que haya establecido en su alojamiento durante el [etapa 1](#step1) de esta guía.
+Una vez descomprimidos los archivos en su carpeta "**CMS**", [conéctese por FTP al espacio de almacenamiento](/pages/web_cloud/web_hosting/ftp_connection) utilizando el [cliente FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) y, a continuación, copie los archivos contenidos en la carpeta "**CMS**" en la "carpeta raíz" que haya establecido en su alojamiento durante el [parte 1](#step1) de esta guía.
 
 A continuación, un ejemplo con el CMS *WordPress*:
 
@@ -265,7 +255,7 @@ A continuación, un ejemplo con el CMS *WordPress*:
 
 > [!primary]
 >
-Si la "carpeta raíz" que ha definido no se ha creado automáticamente en las acciones descritas en el [etapa 1](#step1), puede crearla a través de FileZilla.
+Si la "carpeta raíz" que ha definido no se ha creado automáticamente en las acciones descritas en el [parte 1](#step1), puede crearla a través de FileZilla.
 >
 > El almacenamiento de los archivos en el alojamiento puede tardar unos minutos.
 >
@@ -387,7 +377,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Etapa 3 - Finalizar la instalación manual <a name="step3"></a>
+### 3 - Finalizar la instalación manual <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.es-us.md
@@ -108,7 +108,7 @@ Más información en nuestra página relativa a [PrestaShop](/links/web/hosting-
 > No importa cuál sea el CMS que elija, le recordamos que OVHcloud no proporciona soporte sobre el uso de estos CMS. Si necesita ayuda, contacte directamente con el editor del CMS que haya elegido utilizando los enlaces que se indican más arriba en este tutorial.
 >
 
-### 1 - preparar la instalación <a name="step1"></a>
+### 1 - Preparar la instalación <a name="step1"></a>
 
 Para instalar un CMS en su [plan de hosting](/links/web/hosting), es necesario realizar algunos preparativos.
 
@@ -181,7 +181,7 @@ Una vez que haya creado la base de datos, deberá descargar los parámetros de c
 > - Para conectarse a una base de datos en un databases de Web Cloud, consulte [esta guía](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### 2 - iniciar la instalación manual
+### 2 - Iniciar la instalación manual
 
 #### 2.1 - Obtener los archivos de origen de su CMS
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.es-us.md
@@ -38,16 +38,6 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 - Tener contratado un [plan de hosting de OVHcloud](/links/web/hosting) que contenga al menos una base de datos.
 - Disponer de un [dominio](/links/web/domains)
   
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acceso al área de cliente de OVHcloud
-
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedimiento
 
@@ -118,7 +108,7 @@ Más información en nuestra página relativa a [PrestaShop](/links/web/hosting-
 > No importa cuál sea el CMS que elija, le recordamos que OVHcloud no proporciona soporte sobre el uso de estos CMS. Si necesita ayuda, contacte directamente con el editor del CMS que haya elegido utilizando los enlaces que se indican más arriba en este tutorial.
 >
 
-### Etapa 1 - preparar la instalación <a name="step1"></a>
+### 1 - preparar la instalación <a name="step1"></a>
 
 Para instalar un CMS en su [plan de hosting](/links/web/hosting), es necesario realizar algunos preparativos.
 
@@ -136,14 +126,14 @@ Consulte nuestra documentación que describe [cómo crear un sitio web en su alo
 
 - Asegúrese de que el dominio que utilizará para acceder al CMS y el subdominio en "www" apuntan a la dirección IP de su [plan de hosting](/links/web/hosting).
 
-Para obtener la dirección IP de su plan de hosting, conéctese a su [área de cliente de OVHcloud](/links/manager) en la sección `Web Cloud`{.action} y seleccione su plan de hosting en la sección `Alojamientos`{.action}.<br>
-En el recuadro `Información general`{.action}, a su derecha, encontrará la dirección IP de su alojamiento web en el formulario `IPv4`{.action}.
-
-Si la zona DNS activa de su dominio está gestionada en su [área de cliente de OVHcloud](/links/manager), compare la dirección IP de su alojamiento con la presente en la zona DNS de su dominio, ayudándole a nuestra documentación sobre las [zonas DNS de OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
+Para obtener la dirección IPv4 (o IPv6) de su plan de hosting, consulte nuestra guía "[Alojamiento web - Lista de direcciones IP por cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> Si ha activado las opciones `CDN`{.action} o `IP del país`{.action} con su dominio, utilice la dirección IP adecuada con nuestra documentación que recoge [todas las direcciones IP de nuestros alojamientos compartidos](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> Si ha utilizado la opción de dirección IP geolocalizada por país o ha activado una opción CDN entre su dominio y su alojamiento web, utilice la dirección IP adecuada indicada en la guía mencionada anteriormente.
+>
+
+Si la zona DNS activa de su dominio está gestionada en su [área de cliente de OVHcloud](/links/control-panel/web-dns-zone), compare la dirección IP de su alojamiento con la presente en la zona DNS de su dominio, ayudándose de nuestra documentación sobre las [zonas DNS de OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
 
 Si no puede realizar estas comprobaciones, póngase en contacto con el proveedor de hosting de su zona DNS activa para actualizar el direccionamiento del dominio.
 
@@ -177,7 +167,7 @@ Utilice nuestra guía para [crear una base de datos desde su plan de hosting](/p
 
 Si tiene un plan Web Cloud Databases en MySQL o MariaDB y quiere utilizarlo para instalar manualmente su CMS, consulte nuestra documentación sobre la [creación de una base de datos en un servicio Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 
-Una vez que haya creado la base de datos, deberá descargar los parámetros de conexión (servidor, nombre de la base de datos, nombre de usuario y contraseña) y conservarlos para [el etapa 3](#step3) de esta guía.
+Una vez que haya creado la base de datos, deberá descargar los parámetros de conexión (servidor, nombre de la base de datos, nombre de usuario y contraseña) y conservarlos para la [parte 3](#step3) de esta guía.
 
 > [!primary]
 >
@@ -191,7 +181,7 @@ Una vez que haya creado la base de datos, deberá descargar los parámetros de c
 > - Para conectarse a una base de datos en un databases de Web Cloud, consulte [esta guía](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Etapa 2 - iniciar la instalación manual
+### 2 - iniciar la instalación manual
 
 #### 2.1 - Obtener los archivos de origen de su CMS
 
@@ -252,7 +242,7 @@ Indique la carpeta "**CMS**" en la que quiera descargar los archivos desde esta 
 
 #### 2.3 - Mover los archivos fuente de la carpeta "CMS" al "directorio raíz" de su alojamiento web
 
-Una vez descomprimidos los archivos en su carpeta "**CMS**", [conéctese por FTP al espacio de almacenamiento](/pages/web_cloud/web_hosting/ftp_connection) utilizando el [cliente FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) y, a continuación, copie los archivos contenidos en la carpeta "**CMS**" en la "carpeta raíz" que haya establecido en su alojamiento durante el [etapa 1](#step1) de esta guía.
+Una vez descomprimidos los archivos en su carpeta "**CMS**", [conéctese por FTP al espacio de almacenamiento](/pages/web_cloud/web_hosting/ftp_connection) utilizando el [cliente FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) y, a continuación, copie los archivos contenidos en la carpeta "**CMS**" en la "carpeta raíz" que haya establecido en su alojamiento durante el [parte 1](#step1) de esta guía.
 
 A continuación, un ejemplo con el CMS *WordPress*:
 
@@ -267,7 +257,7 @@ A continuación, un ejemplo con el CMS *WordPress*:
 > [!primary]
 
 >
-Si la "carpeta raíz" que ha definido no se ha creado automáticamente en las acciones descritas en el [etapa 1](#step1), puede crearla a través de FileZilla.
+Si la "carpeta raíz" que ha definido no se ha creado automáticamente en las acciones descritas en el [parte 1](#step1), puede crearla a través de FileZilla.
 >
 > El almacenamiento de los archivos en el alojamiento puede tardar unos minutos.
 >
@@ -389,7 +379,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Etapa 3 - Finalizar la instalación manual <a name="step3"></a>
+### 3 - Finalizar la instalación manual <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutoriel - Installer manuellement un CMS sur mon hébergement"
 excerpt: "Découvrez comment installer manuellement un CMS sur votre hébergement"
-updated: 2025-10-27
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -12,7 +12,7 @@ Ce tutoriel a pour objectif de vous aider à installer manuellement un CMS (Cont
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 > 
-> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou l'éditeur du CMS ue vous aurez choisi d'installer si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
+> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou l'éditeur du CMS ue vous aurez choisi d'installer si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [« Aller plus loin »](#go-further) de ce tutoriel.
 >
 > Pour contacter les différents éditeurs des CMS cités ci-dessus, retrouvez ci-après les liens vers leurs pages officielles respectives :
 >
@@ -38,16 +38,6 @@ Ce tutoriel a pour objectif de vous aider à installer manuellement un CMS (Cont
 - Disposer d'une offre d'[hébergement web](/links/web/hosting) qui contient au moins une base de données.
 - Disposer d'un [nom de domaine](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accès à l'espace client OVHcloud
-
-- **Lien direct :** [Hébergements](/links/control-panel/web-hosting)
-- **Pour accéder à vos services :** `Web Cloud`{.action} > `Hébergements`{.action} > Sélectionnez votre hébergement web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## En pratique
 
@@ -118,7 +108,7 @@ Retrouvez plus d'informations sur notre page relative au [module PrestaShop](/li
 > Quel que soit le CMS que vous choisirez, nous vous rappellons qu'aucune assistance n'est fournie par OVHcloud sur l'utilisation de ces CMS. Si vous éprouvez des difficultés, contactez directement l'éditeur du CMS que vous avez choisi à l'aide des liens indiqués plus haut dans ce tutoriel.
 >
 
-### Etape 1 - préparer l'installation <a name="step1"></a>
+### 1 - préparer l'installation <a name="step1"></a>
 
 Pour installer un CMS sur votre offre d'[hébergement web](/links/web/hosting), quelques préparatifs sont nécessaires.
 
@@ -137,15 +127,14 @@ Consultez notre documentation qui décrit [comment créer un site web sur son h�
 
 - Assurez-vous que le nom de domaine que vous utiliserez pour accéder à votre CMS, ainsi que son sous-domaine en « www », pointent bien vers l'adresse IP de votre offre d'[hébergement web](/links/web/hosting).
 
-Pour récupérer l'adresse IP de votre offre d'hébergement web, connectez-vous à votre [espace client OVHcloud](/links/manager) dans la partie `Web Cloud`{.action} puis sélectionnez votre offre d'hébergement web dans la section `Hébergements`{.action}.<br>
-Dans l'encadré `Informations générales`{.action} sur votre droite, vous trouverez l'adresse IP de votre hébergement web dans le formulaire `IPv4`{.action}.
-
-Si la zone DNS active de votre domaine est gérée dans votre [espace client OVHcloud](/links/manager), comparez l'adresse IP de votre hébergement avec celle présente dans la zone DNS de votre domaine, en vous aidant de notre documentation sur les [zones DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
+Pour récupérer l'adresse IPv4 (ou IPv6) de votre offre d'hébergement web, consultez notre guide « [Hébergement web - Liste des adresses IP par cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP) ».
 
 > [!warning]
 >
-> Si vous avez activé les options `CDN`{.action} ou `IP du pays`{.action} avec votre domaine, utilisez l'adresse IP adaptée en vous aidant de notre documentation recensant [l'ensemble des adresses IP de nos hébergements mutualisés](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> Si vous avez utilisé l'option d'adresse IP géolocalisée par pays ou activé une option CDN entre votre nom de domaine et votre hébergement web, utilisez l'adresse IP adéquate indiquée dans le guide cité ci-dessus.
 >
+
+Si la zone DNS active de votre domaine est gérée dans votre [espace client OVHcloud](/links/control-panel/web-dns-zone), comparez l'adresse IP de votre hébergement avec celle présente dans la zone DNS de votre domaine, en vous aidant de notre documentation sur les [zones DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
 
 Si vous ne parvenez pas à effectuer ces vérifications, contactez l'hébergeur de votre zone DNS active afin de mettre à jour le pointage de votre nom de domaine.
 
@@ -181,7 +170,7 @@ Utilisez notre documentation pour [créer une base de données depuis votre offr
 
 Si vous disposez d'une offre Web Cloud Databases en MySQL ou MariaDB et que vous souhaitez l'utiliser pour installer manuellement votre CMS, consultez notre documentation sur la [création d'une base de données sur un service Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#creer-une-base-de-donnees).
 
-Une fois la base de données créée, récupérez les paramètres de connexion (serveur, nom de la base de données, nom d'utilisateur et mot de passe) et conservez-les pour [l'étape 3](#step3) de ce guide.
+Une fois la base de données créée, récupérez les paramètres de connexion (serveur, nom de la base de données, nom d'utilisateur et mot de passe) et conservez-les pour [la [partie 3](#step3)](#step3) de ce guide.
 
 > [!primary]
 >
@@ -195,7 +184,7 @@ Une fois la base de données créée, récupérez les paramètres de connexion (
 > - Pour vous connecter à une base de données présente sur un Web Cloud Databases, consultez [ce guide](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Etape 2 - démarrer l'installation manuelle
+### 2 - démarrer l'installation manuelle
 
 #### 2.1 - Récupérer les fichiers sources de votre CMS
 
@@ -388,7 +377,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Etape 3 - finaliser l'installation manuelle <a name="step3"></a>
+### 3 - finaliser l'installation manuelle <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutoriel - Installer manuellement un CMS sur mon hébergement"
 excerpt: "Découvrez comment installer manuellement un CMS sur votre hébergement"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutoriel - Installer manuellement un CMS sur mon hébergement"
 excerpt: "Découvrez comment installer manuellement un CMS sur votre hébergement"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Tutoriel - Installer manuellement un CMS sur mon hébergement"
 excerpt: "Découvrez comment installer manuellement un CMS sur votre hébergement"
-updated: 2025-10-27
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -12,7 +12,7 @@ Ce tutoriel a pour objectif de vous aider à installer manuellement un CMS (Cont
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 > 
-> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou l'éditeur du CMS ue vous aurez choisi d'installer si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « [Aller plus loin](#go-further) » de ce tutoriel.
+> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou l'éditeur du CMS ue vous aurez choisi d'installer si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « [Aller plus loin](#go-further) » de ce tutoriel.
 >
 > Pour contacter les différents éditeurs des CMS cités ci-dessus, retrouvez ci-après les liens vers leurs pages officielles respectives :
 >
@@ -37,17 +37,6 @@ Ce tutoriel a pour objectif de vous aider à installer manuellement un CMS (Cont
 
 - Disposer d'une offre d'[hébergement web](/links/web/hosting) qui contient au moins une base de données.
 - Disposer d'un [nom de domaine](/links/web/domains)
-
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accès à l'espace client OVHcloud
-
-- **Lien direct :** [Hébergements](/links/control-panel/web-hosting)
-- **Pour accéder à vos services :** `Web Cloud`{.action} > `Hébergements`{.action} > Sélectionnez votre hébergement web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## En pratique
 
@@ -118,7 +107,7 @@ Retrouvez plus d'informations sur notre page relative au [module PrestaShop](/li
 > Quel que soit le CMS que vous choisirez, nous vous rappellons qu'aucune assistance n'est fournie par OVHcloud sur l'utilisation de ces CMS. Si vous éprouvez des difficultés, contactez directement l'éditeur du CMS que vous avez choisi à l'aide des liens indiqués plus haut dans ce tutoriel.
 >
 
-### Etape 1 - préparer l'installation <a name="step1"></a>
+### 1 - Préparer l'installation <a name="step1"></a>
 
 Pour installer un CMS sur votre offre d'[hébergement web](/links/web/hosting), quelques préparatifs sont nécessaires.
 
@@ -137,15 +126,13 @@ Consultez notre documentation qui décrit [comment créer un site web sur son h�
 
 - Assurez-vous que le nom de domaine que vous utiliserez pour accéder à votre CMS, ainsi que son sous-domaine en « www », pointent bien vers l'adresse IP de votre offre d'[hébergement web](/links/web/hosting).
 
-Pour récupérer l'adresse IP de votre offre d'hébergement web, connectez-vous à votre [espace client OVHcloud](/links/manager) dans la partie `Web Cloud`{.action} puis sélectionnez votre offre d'hébergement web dans la section `Hébergements`{.action}.<br>
-Dans l'encadré `Informations générales`{.action} sur votre droite, vous trouverez l'adresse IP de votre hébergement web dans le formulaire `IPv4`{.action}.
-
-Si la zone DNS active de votre domaine est gérée dans votre [espace client OVHcloud](/links/manager), comparez l'adresse IP de votre hébergement avec celle présente dans la zone DNS de votre domaine, en vous aidant de notre documentation sur les [zones DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
+Pour récupérer l'adresse IPv4 (ou IPv6) de votre offre d'hébergement web, consultez [ce guide](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
 
 > [!warning]
 >
-> Si vous avez activé les options `CDN`{.action} ou `IP du pays`{.action} avec votre domaine, utilisez l'adresse IP adaptée en vous aidant de notre documentation recensant [l'ensemble des adresses IP de nos hébergements mutualisés](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
->
+> Si vous avez utilisé l'option d'adresse IP géolocalisée par pays ou activé une option CDN entre votre nom de domaine et votre hébergement web, utilisez l'adresse IP adéquate indiquée dans le guide cité ci-dessus.
+
+Si la zone DNS active de votre domaine est gérée dans votre [espace client OVHcloud](/links/control-panel/web-dns-zone), comparez l'adresse IP de votre hébergement avec celle présente dans la zone DNS de votre domaine, en vous aidant de notre documentation sur les [zones DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
 
 Si vous ne parvenez pas à effectuer ces vérifications, contactez l'hébergeur de votre zone DNS active afin de mettre à jour le pointage de votre nom de domaine.
 
@@ -179,7 +166,7 @@ Utilisez notre documentation pour [créer une base de données depuis votre offr
 
 Si vous disposez d'une offre Web Cloud Databases en MySQL ou MariaDB et que vous souhaitez l'utiliser pour installer manuellement votre CMS, consultez notre documentation sur la [création d'une base de données sur un service Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#creer-une-base-de-donnees).
 
-Une fois la base de données créée, récupérez les paramètres de connexion (serveur, nom de la base de données, nom d'utilisateur et mot de passe) et conservez-les pour [l'étape 3](#step3) de ce guide.
+Une fois la base de données créée, récupérez les paramètres de connexion (serveur, nom de la base de données, nom d'utilisateur et mot de passe) et conservez-les pour la [partie 3](#step3) de ce guide.
 
 > [!primary]
 >
@@ -193,7 +180,7 @@ Une fois la base de données créée, récupérez les paramètres de connexion (
 > - Pour vous connecter à une base de données présente sur un Web Cloud Databases, consultez [ce guide](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Etape 2 - démarrer l'installation manuelle
+### 2 - Démarrer l'installation manuelle
 
 #### 2.1 - Récupérer les fichiers sources de votre CMS
 
@@ -258,7 +245,7 @@ Indiquez le dossier « **CMS** » en destination afin d'extraire vos fichiers da
 
 #### 2.3 - Déplacer les fichiers sources du dossier « CMS » vers le « dossier racine » sur votre hébergement web
 
-Une fois les fichiers décompressés dans votre dossier « **CMS** », [connectez-vous en FTP à votre espace de stockage](/pages/web_cloud/web_hosting/ftp_connection) à l'aide du [client FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) puis copiez les fichiers contenus dans le dossier « **CMS** » dans le « dossier racine » que vous avez défini sur votre hébergement lors de l'[étape 1](#step1) de ce guide.
+Une fois les fichiers décompressés dans votre dossier « **CMS** », [connectez-vous en FTP à votre espace de stockage](/pages/web_cloud/web_hosting/ftp_connection) à l'aide du [client FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) puis copiez les fichiers contenus dans le dossier « **CMS** » dans le « dossier racine » que vous avez défini sur votre hébergement lors de la [partie 1](#step1) de ce guide.
 
 Ci-dessous, un exemple avec le CMS *WordPress*:
 
@@ -271,7 +258,7 @@ Ci-dessous, un exemple avec le CMS *WordPress*:
 
 >[!primary]
 >
-> Si le « dossier racine » que vous avez défini n'a pas été créé automatiquement lors des actions décrites dans l'[étape 1](#step1), vous pouvez le créer via FileZilla.
+> Si le « dossier racine » que vous avez défini n'a pas été créé automatiquement lors des actions décrites dans la [partie 1](#step1), vous pouvez le créer via FileZilla.
 >
 > Le dépôt des fichiers sur votre hébergement peut prendre quelques minutes.
 >
@@ -392,7 +379,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Etape 3 - finaliser l'installation manuelle <a name="step3"></a>
+### 3 - Finaliser l'installation manuelle <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.fr-fr.md
@@ -12,7 +12,7 @@ Ce tutoriel a pour objectif de vous aider à installer manuellement un CMS (Cont
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 > 
-> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou l'éditeur du CMS ue vous aurez choisi d'installer si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « [Aller plus loin](#go-further) » de ce tutoriel.
+> Nous mettons à votre disposition ce tutoriel afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) ou l'éditeur du CMS que vous aurez choisi d'installer si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section « [Aller plus loin](#go-further) » de ce tutoriel.
 >
 > Pour contacter les différents éditeurs des CMS cités ci-dessus, retrouvez ci-après les liens vers leurs pages officielles respectives :
 >
@@ -126,11 +126,12 @@ Consultez notre documentation qui décrit [comment créer un site web sur son h�
 
 - Assurez-vous que le nom de domaine que vous utiliserez pour accéder à votre CMS, ainsi que son sous-domaine en « www », pointent bien vers l'adresse IP de votre offre d'[hébergement web](/links/web/hosting).
 
-Pour récupérer l'adresse IPv4 (ou IPv6) de votre offre d'hébergement web, consultez [ce guide](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+Pour récupérer l'adresse IPv4 (ou IPv6) de votre offre d'hébergement web, consultez notre guide « [Hébergement web - Liste des adresses IP par cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP) ».
 
 > [!warning]
 >
 > Si vous avez utilisé l'option d'adresse IP géolocalisée par pays ou activé une option CDN entre votre nom de domaine et votre hébergement web, utilisez l'adresse IP adéquate indiquée dans le guide cité ci-dessus.
+>
 
 Si la zone DNS active de votre domaine est gérée dans votre [espace client OVHcloud](/links/control-panel/web-dns-zone), comparez l'adresse IP de votre hébergement avec celle présente dans la zone DNS de votre domaine, en vous aidant de notre documentation sur les [zones DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
 

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.it-it.md
@@ -38,16 +38,6 @@ Questa guida ti mostra come installare manualmente un CMS (Content Management Sy
 - Disporre di un'offerta di [hosting web](/links/web/hosting) che contiene almeno un database.
 - Disporre di un [dominio](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accesso allo Spazio Cliente OVHcloud
-
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedura
 
@@ -118,7 +108,7 @@ Per maggiori informazioni, consulta la nostra pagina relativa al [modulo PrestaS
 > Indipendentemente dal CMS scelto, ti ricordiamo che OVHcloud non fornisce alcuna assistenza sull'utilizzo di questi CMS. In caso di difficoltà o dubbi, contatta direttamente il produttore del CMS scelto utilizzando i link indicati in questa guida.
 >
 
-### Step 1 - preparare l'installazione <a name="step1"></a>
+### 1 - Preparare l'installazione <a name="step1"></a>
 
 Per installare un CMS sulla tua offerta di [hosting Web](/links/web/hosting), sono necessari alcuni preparativi.
 
@@ -137,15 +127,14 @@ Consulta la nostra documentazione che descrive [come creare un sito web sull'hos
 
 - Assicurati che il dominio che utilizzerai per accedere al tuo CMS e il sottodominio in "www" puntino verso l'indirizzo IP della tua offerta di [hosting web](/links/web/hosting).
 
-Accedi allo [Spazio Cliente OVHcloud](/links/manager) nella sezione `Web Cloud`{.action} e seleziona la tua soluzione di hosting Web nella sezione `Hosting`{.action}.<br>
-Nel riquadro `Informazioni generali`{.action} sulla tua destra, clicca su `IPv4`{.action} e seleziona l'indirizzo IP del tuo hosting Web.
-
-Se la zona DNS attiva del tuo dominio è gestita dallo [Spazio Cliente OVHcloud](/links/manager), compara l'indirizzo IP del tuo hosting con quello presente nella zona DNS del tuo dominio, consultando la nostra documentazione sulle [zone DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
+Per recuperare l'indirizzo IPv4 (o IPv6) del tuo hosting web, consulta la nostra guida "[Hosting Web - Elenco degli indirizzi IP per cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> Se hai attivato le opzioni `CDN`{.action} o `IP del paese`{.action} con il tuo dominio, utilizza l'indirizzo IP adattato seguendo la procedura descritta nella guida che contiene [tutti gli indirizzi IP dei nostri hosting condivisi](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> Se hai utilizzato l'opzione di indirizzo IP geolocalizzato per paese o hai attivato un'opzione CDN tra il tuo dominio e il tuo hosting web, utilizza l'indirizzo IP appropriato indicato nella guida sopra citata.
 >
+
+Se la zona DNS attiva del tuo dominio è gestita dallo [Spazio Cliente OVHcloud](/links/control-panel/web-dns-zone), compara l'indirizzo IP del tuo hosting con quello presente nella zona DNS del tuo dominio, consultando la nostra documentazione sulle [zone DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
 
 Se non riesci a effettuare queste verifiche, contatta il provider della tua zona DNS attiva per aggiornare il puntamento del tuo dominio.
 
@@ -179,7 +168,7 @@ Utilizza la nostra documentazione per [creare un database dalla tua offerta di h
 
 Se disponi di un'offerta Web Cloud Databases in MySQL o MariaDB e desideri utilizzarla per installare manualmente il tuo CMS, consulta la nostra guida sulla [creazione di un database su un servizio Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#crea-un-database).
 
-Una volta creato il database, recupera i parametri di connessione (server, nome del database, nome utente e password) e conservali per [step 3](#step3) di questa guida.
+Una volta creato il database, recupera i parametri di connessione (server, nome del database, nome utente e password) e conservali per la [parte 3](#step3) di questa guida.
 
 > [!primary]
 >
@@ -193,7 +182,7 @@ Una volta creato il database, recupera i parametri di connessione (server, nome 
 > - Per connetterti a un database presente su un Web Cloud Databases, consulta [questa guida](https://help.ovhcloud.com/csm/it-web-cloud-db-connecting-database-server?id=kb_article_view&sysparm_article=KB0051461).
 >
 
-### Step 2 - Avvia l'installazione manuale
+### 2 - Avvia l'installazione manuale
 
 #### 2.1 - Recuperare i file sorgente del tuo CMS
 
@@ -252,7 +241,7 @@ Indica la cartella "**CMS**" per estrarre i tuoi file da questa cartella.
 
 ### 2.3 - Sposta i file sorgente della cartella "CMS" sulla cartella root del tuo hosting Web
 
-Una volta che i file decomprimono la cartella "**CMS**", [collegati in FTP al tuo spazio di archiviazione](/pages/web_cloud/web_hosting/ftp_connection) con l'aiuto del [client FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) e copia i file contenuti nella cartella "**CMS**" nella "cartella root" definita sul tuo hosting durante lo [step 1](#step1) di questa guida.
+Una volta che i file decomprimono la cartella "**CMS**", [collegati in FTP al tuo spazio di archiviazione](/pages/web_cloud/web_hosting/ftp_connection) con l'aiuto del [client FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) e copia i file contenuti nella cartella "**CMS**" nella "cartella root" definita sul tuo hosting durante lo [parte 1](#step1) di questa guida.
 
 Di seguito, un esempio con il CMS *WordPress*:
 
@@ -265,7 +254,7 @@ Di seguito, un esempio con il CMS *WordPress*:
 
 > [!primary]
 >
-> Se la cartella root definita non è stata creata automaticamente durante le azioni descritte nello [step 1](#step1), puoi crearla via FileZilla.
+> Se la cartella root definita non è stata creata automaticamente durante le azioni descritte nello [parte 1](#step1), puoi crearla via FileZilla.
 >
 > Il deposito dei file sul tuo hosting può richiedere qualche minuto.
 >
@@ -386,7 +375,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Step 3 - Completare l'installazione manuale <a name="step3"></a>
+### 3 - Completare l'installazione manuale <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.it-it.md
@@ -241,7 +241,7 @@ Indica la cartella "**CMS**" per estrarre i tuoi file da questa cartella.
 
 ### 2.3 - Sposta i file sorgente della cartella "CMS" sulla cartella root del tuo hosting Web
 
-Una volta che i file decomprimono la cartella "**CMS**", [collegati in FTP al tuo spazio di archiviazione](/pages/web_cloud/web_hosting/ftp_connection) con l'aiuto del [client FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) e copia i file contenuti nella cartella "**CMS**" nella "cartella root" definita sul tuo hosting durante lo [parte 1](#step1) di questa guida.
+Una volta che i file decomprimono la cartella "**CMS**", [collegati in FTP al tuo spazio di archiviazione](/pages/web_cloud/web_hosting/ftp_connection) con l'aiuto del [client FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide) e copia i file contenuti nella cartella "**CMS**" nella "cartella root" definita sul tuo hosting durante la [parte 1](#step1) di questa guida.
 
 Di seguito, un esempio con il CMS *WordPress*:
 
@@ -254,7 +254,7 @@ Di seguito, un esempio con il CMS *WordPress*:
 
 > [!primary]
 >
-> Se la cartella root definita non è stata creata automaticamente durante le azioni descritte nello [parte 1](#step1), puoi crearla via FileZilla.
+> Se la cartella root definita non è stata creata automaticamente durante le azioni descritte nella [parte 1](#step1), puoi crearla via FileZilla.
 >
 > Il deposito dei file sul tuo hosting può richiedere qualche minuto.
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.pl-pl.md
@@ -38,16 +38,6 @@ Tutorial ten pomoże Ci ręcznie zainstalować CMS (Content Management System), 
 - Posiadanie oferty [hostingu](/links/web/hosting), która zawiera co najmniej jedną bazę danych.
 - Posiadanie [domeny](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Dostęp do Panelu klienta OVHcloud
-
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## W praktyce
 
@@ -118,7 +108,7 @@ Więcej informacji znajduje się na naszej stronie dotyczącej [modułu PrestaSh
 > Niezależnie od wybranego przez Ciebie CMS, OVHcloud nie udziela żadnej pomocy w zakresie korzystania z tych systemów CMS. Jeśli masz trudności, skontaktuj się z producentem CMS, który wybrałeś za pomocą linków podanych powyżej w tym tutorialu.
 >
 
-### Etap 1 - przygotowanie instalacji <a name="step1"></a>
+### 1 - Przygotowanie instalacji <a name="step1"></a>
 
 Aby zainstalować CMS na Twoim [hostingu](/links/web/hosting), potrzebne są jakieś przygotowania.
 
@@ -137,15 +127,14 @@ Zapoznaj się z naszą dokumentacją, która opisuje [jak utworzyć stronę inte
 
 - Upewnij się, czy domena, której będziesz używał do uzyskania dostępu do CMS-a, jak również jej subdomena w www, wskazują na adres IP Twojej usługi [hosting](/links/web/hosting).
 
-Aby uzyskać adres IP Twojego hostingu, zaloguj się do [Panelu klienta OVHcloud](/links/manager) w części `Web Cloud`{.action} i wybierz ofertę hostingu w sekcji `Hosting`{.action}.<br>
-W ramce `Informacje ogólne`{.action} po prawej stronie znajdziesz adres IP Twojego hostingu w formularzu `IPv4`{.action}.
-
-Jeśli aktywną strefą DNS Twojej domeny jest zarządzana w Twoim [Panelu klienta OVHcloud](/links/manager), porównaj adres IP Twojego hostingu z adresem IP w strefie DNS Twojej domeny, korzystając z naszej dokumentacji dotyczącej [stref DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
+Aby uzyskać adres IPv4 (lub IPv6) Twojego hostingu, zapoznaj się z naszym przewodnikiem "[Hosting - Lista adresów IP według klastra](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> Jeśli aktywowałeś opcje `CDN`{.action} lub `Geolokalizacja IP`{.action} dla Twojej domeny, użyj odpowiedniego adresu IP, korzystając z naszej dokumentacji zawierającej [wszystkie adresy IP naszych hostingów](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> Jeśli korzystasz z opcji geolokalizowanego adresu IP według kraju lub aktywowałeś opcję CDN między domeną a hostingiem, użyj odpowiedniego adresu IP wskazanego w powyższym przewodniku.
 >
+
+Jeśli aktywna strefa DNS Twojej domeny jest zarządzana w Twoim [Panelu klienta OVHcloud](/links/control-panel/web-dns-zone), porównaj adres IP Twojego hostingu z adresem IP w strefie DNS Twojej domeny, korzystając z naszej dokumentacji dotyczącej [stref DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
 
 Jeśli nie jesteś w stanie dokonać tych weryfikacji, skontaktuj się z aktywnym hostingiem w strefie DNS, aby zaktualizować wskazanie Twojej domeny.
 
@@ -179,7 +168,7 @@ Skorzystaj z naszej dokumentacji, aby [utworzyć bazę danych w ramach Twojego h
 
 Jeśli dysponujesz usługą Web Cloud Databases w MySQL lub MariaDB i chcesz z niej korzystać do ręcznej instalacji CMS-a, zapoznaj się z naszą dokumentacją dotyczącą [utworzenia bazy danych w usłudze Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#tworzenie-bazy-danych).
 
-Po utworzeniu bazy danych pobierz parametry połączenia (serwer, nazwa bazy danych, nazwa użytkownika i hasło) i zachowaj je dla [etap 3](#step3) tego przewodnika.
+Po utworzeniu bazy danych pobierz parametry połączenia (serwer, nazwa bazy danych, nazwa użytkownika i hasło) i zachowaj je dla [części 3](#step3) tego przewodnika.
 
 > [!primary]
 >
@@ -193,7 +182,7 @@ Po utworzeniu bazy danych pobierz parametry połączenia (serwer, nazwa bazy dan
 > - Aby zalogować się do bazy danych na stronie WWW Cloud Databases, zapoznaj się z tym [przewodnikiem](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Etap 2 - uruchomienie ręcznej instalacji
+### 2 - Uruchomienie ręcznej instalacji
 
 #### 2.1 - Pobranie plików źródłowych z Twojego CMS
 
@@ -252,7 +241,7 @@ Wpisz folder "**CMS**", aby pobrać pliki z tego folderu.
 
 #### 2.3 - Przenieś pliki źródłowe z katalogu "CMS" do "katalogu głównego" na Twój hosting
 
-Po rozpakowaniu plików w Twoim katalogu "**CMS**", [zaloguj się przez FTP do przestrzeni dyskowej](/pages/web_cloud/web_hosting/ftp_connection) przy użyciu [klienta FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide), a następnie skopiuj pliki zawarte w katalogu "**CMS**" do "katalogu głównego", który zdefiniowałeś na Twoim hostingu podczas [etap 1](#step1)) niniejszego przewodnika.
+Po rozpakowaniu plików w Twoim katalogu "**CMS**", [zaloguj się przez FTP do przestrzeni dyskowej](/pages/web_cloud/web_hosting/ftp_connection) przy użyciu [klienta FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide), a następnie skopiuj pliki zawarte w katalogu "**CMS**" do "katalogu głównego", który zdefiniowałeś na Twoim hostingu podczas [części 1](#step1)) niniejszego przewodnika.
 
 Przykład systemu CMS *WordPress*:
 
@@ -265,7 +254,7 @@ Przykład systemu CMS *WordPress*:
 
 > [!primary]
 >
-> Jeśli "katalog główny", który zdefiniowałeś nie został utworzony automatycznie podczas operacji opisanych w [etap 1](#step1), możesz go utworzyć za pomocą FileZilla.
+> Jeśli "katalog główny", który zdefiniowałeś nie został utworzony automatycznie podczas operacji opisanych w [części 1](#step1), możesz go utworzyć za pomocą FileZilla.
 >
 > Przechowywanie plików na hostingu może zająć kilka minut.
 >
@@ -386,7 +375,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Etap 3 - zakończenie ręcznej instalacji <a name="step3"></a>
+### 3 - Zakończenie ręcznej instalacji <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/cms_manual_installation/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/cms_manual_installation/guide.pt-pt.md
@@ -38,16 +38,6 @@ Este tutorial tem como objetivo ajudá-lo a instalar manualmente um CMS (Content
 - Ter um plano de [alojamento web](/links/web/hosting) que contenha, pelo menos, uma base de dados.
 - Dispor de um [nome de domínio](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acesso à Área de Cliente OVHcloud
-
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
-- **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instruções
 
@@ -118,7 +108,7 @@ Encontre mais informações na nossa página sobre o [módulo PrestaShop](/links
 > Independentemente do CMS que escolher, lembramos que a OVHcloud não fornece nenhuma assistência na utilização destes CMS. Se precisar de ajuda, contacte diretamente o editor do CMS que escolheu através dos links indicados neste tutorial.
 >
 
-### Etapa 1 - preparar a instalação <a name="step1"></a>
+### 1 - Preparar a instalação <a name="step1"></a>
 
 Para instalar um CMS na sua oferta de[alojamento web](/links/web/hosting), é necessário efetuar alguns preparativos.
 
@@ -137,15 +127,14 @@ Consulte a nossa documentação que descreve [como adicionar um site ao seu aloj
 
 - Certifique-se de que o domínio que utiliza para aceder ao seu CMS, bem como o subdomínio "www" apontam para o endereço IP do seu serviço de [alojamento web](/links/web/hosting).
 
-Para obter o endereço IP da sua oferta de alojamento web, aceda à [Área de Cliente OVHcloud](/links/manager) na parte `Web Cloud`{.action} e selecione a sua oferta de alojamento web na secção `Alojamentos`{.action}.<br>
-Na caixa `Informações gerais`{.action} à direita, encontrará o endereço IP do seu alojamento web no formulário `IPv4`{.action}.
-
-Se a zona DNS ativa do seu domínio for gerida no seu [Área de Cliente OVHcloud](/links/manager), compare o endereço IP do seu alojamento com o endereço IP presente na zona DNS do seu domínio, através da nossa documentação sobre as [zonas DNS da OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
+Para obter o endereço IPv4 (ou IPv6) do seu alojamento web, consulte o nosso guia "[Alojamento web - Lista de endereços IP por cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP)".
 
 > [!warning]
 >
-> Se ativou as opções `CDN`{.action} ou `IP do país`{.action} com o seu domínio, utilize o endereço IP adaptado através da nossa documentação que regista [o conjunto dos endereços IP dos nossos alojamentos partilhados](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+> Se utilizou a opção de endereço IP geolocalizado por país ou ativou uma opção CDN entre o seu domínio e o seu alojamento web, utilize o endereço IP adequado indicado no guia acima mencionado.
 >
+
+Se a zona DNS ativa do seu domínio for gerida na sua [Área de Cliente OVHcloud](/links/control-panel/web-dns-zone), compare o endereço IP do seu alojamento com o endereço IP presente na zona DNS do seu domínio, através da nossa documentação sobre as [zonas DNS da OVHcloud](/pages/web_cloud/domains/dns_zone_edit).
 
 Se não conseguir realizar estas verificações, contacte o alojador da sua zona DNS ativa para atualizar o apontamento do seu nome de domínio.
 
@@ -179,7 +168,7 @@ Utilize o nosso manual para [criar uma base de dados a partir do seu alojamento 
 
 Se tiver à sua disposição uma oferta Web Cloud Databases em MySQL ou MariaDB e pretender utilizá-la para instalar manualmente o seu CMS, consulte o nosso manual sobre a [criação de uma base de dados num serviço Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server#criar-uma-base-de-dados).
 
-Depois de criar a base de dados, recupere os parâmetros de ligação (servidor, nome da base de dados, nome de utilizador e palavra-passe) e guarde-os para [etapa 3](#step3) deste guia.
+Depois de criar a base de dados, recupere os parâmetros de ligação (servidor, nome da base de dados, nome de utilizador e palavra-passe) e guarde-os para [parte 3](#step3) deste guia.
 
 > [!primary]
 >
@@ -193,7 +182,7 @@ Depois de criar a base de dados, recupere os parâmetros de ligação (servidor,
 > - Para aceder a uma base de dados presente numa Web Cloud Databases, consulte [este guia](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server).
 >
 
-### Etapa 2 - iniciar a instalação manual
+### 2 - Iniciar a instalação manual
 
 #### 2.1 - Recuperar os ficheiros de origem do seu CMS
 
@@ -252,7 +241,7 @@ Indique a pasta "**CMS**" no destino para extrair os seus ficheiros desta pasta.
 
 #### 2.3 - Migrar os ficheiros de origem do dossier "CMS" para o "dossier raiz" no seu alojamento web
 
-Depois de descomprimir os ficheiros na pasta "**CMS**", [ligue-se ao espaço de armazenamento com FTP](/pages/web_cloud/web_hosting/ftp_connection) através do [cliente FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide), e depois copie os ficheiros na pasta "**CMS**" para a pasta raiz que definiu no seu alojamento durante a [etapa 1](#step1)) deste guia.
+Depois de descomprimir os ficheiros na pasta "**CMS**", [ligue-se ao espaço de armazenamento com FTP](/pages/web_cloud/web_hosting/ftp_connection) através do [cliente FTP FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide), e depois copie os ficheiros na pasta "**CMS**" para a pasta raiz que definiu no seu alojamento durante a [parte 1](#step1)) deste guia.
 
 Abaixo, um exemplo com o CMS *WordPress*:
 
@@ -265,7 +254,7 @@ Abaixo, um exemplo com o CMS *WordPress*:
 
 > [!primary]
 >
-> Se a pasta raiz que definiu não tiver sido criada automaticamente durante as ações descritas na [etapa 1](#step1), pode criá-la através do FileZilla.
+> Se a pasta raiz que definiu não tiver sido criada automaticamente durante as ações descritas na [parte 1](#step1), pode criá-la através do FileZilla.
 >
 > O depósito dos ficheiros no seu alojamento pode levar alguns minutos.
 >
@@ -386,7 +375,7 @@ rmdir ./CMS/
 >> ```
 >> 
 
-### Etapa 3 - finalizar a instalação manual <a name="step3"></a>
+### 3 - Finalizar a instalação manual <a name="step3"></a>
 
 > [!success]
 >

--- a/pages/web_cloud/web_hosting/copy_database/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Inhalt einer Datenbank in eine andere duplizieren"
 excerpt: "Erfahren Sie hier, wie Sie den Inhalt einer OVHcloud Datenbank in eine andere OVHcloud Datenbank kopieren"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Ziel
 
-Ihre Datenbank ist ein zentrales Element Ihrer dynamischen Website. Während des Lebenszyklus Ihrer Website kann es aus praktischen oder technischen Gründen erforderlich sein, den Inhalt Ihrer Datenbank in eine andere Ihrer Datenbanken zu kopieren. Dies is möglich innerhalb der Angebote [Start SQL](/links/web/hosting-options-startsql) oder [Web Cloud Databases](/links/web/databases).
+Ihre Datenbank ist ein zentrales Element Ihrer dynamischen Website. Während des Lebenszyklus Ihrer Website kann es aus praktischen oder technischen Gründen erforderlich sein, den Inhalt Ihrer Datenbank in eine andere Ihrer Datenbanken zu kopieren. Dies ist möglich innerhalb der Angebote [Start SQL](/links/web/hosting-options-startsql) oder [Web Cloud Databases](/links/web/databases).
 
 **Diese Anleitung erklärt, wie Sie den Inhalt einer OVHcloud Datenbank in eine andere OVHcloud Datenbank kopieren.**
 
@@ -96,8 +96,8 @@ Klicken Sie auf die Tabs, um die **6** Schritte anzuzeigen.
 >> >
 >> > Wenn Sie keine Zieldatenbank haben, klicken Sie auf den Link im Fenster, um eine neue Datenbank zu bestellen. Denken Sie daran, sie zu aktivieren:
 >> >
->> > - Für eine Shared SQL Datenbank: Folgen Sie unserer Anleitung „[Datenbank auf Ihrem Webhosting erstellen](/pages/web_cloud/web_hosting/sql_create_database)".
->> > - Für eine Datenbank auf einem Web Cloud Databases Server: Folgen Sie unserer Anleitung „[Datenbank auf einem Web Cloud Databases Server erstellen](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
+>> > - Für eine Shared SQL Datenbank: Folgen Sie unserer Anleitung "[Datenbank auf Ihrem Webhosting erstellen](/pages/web_cloud/web_hosting/sql_create_database)".
+>> > - Für eine Datenbank auf einem Web Cloud Databases Server: Folgen Sie unserer Anleitung "[Datenbank auf einem Web Cloud Databases Server erstellen](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
 >>
 >> - **Auswahl 1 - In eine Start SQL Datenbank kopieren**: Wählen Sie `In Datenbank kopieren`{.action}, und wählen Sie die Zieldatenbank aus der Dropdown-Liste aus.
 >> - **Auswahl 2 - In einen Web Cloud Databases Server kopieren**: Wählen Sie `In eine Web Cloud Databases kopieren`{.action}. Zwei Dropdown-Listen werden angezeigt. Klicken Sie auf die erste, um die Web Cloud Databases Lösung auszuwählen, dann auf die zweite, um die Zieldatenbank auszuwählen.
@@ -112,7 +112,7 @@ Klicken Sie auf die Tabs, um die **6** Schritte anzuzeigen.
 >>
 > **Schritt 6**
 >>
->> Der Kopiervorgang kann einige Minuten dauern. Im Tab `Aktuelle Tasks`{.action} wird eine neue Zeile für Ihre Kopie mit dem Status „Geplant" angezeigt. Wenn der Vorgang abgeschlossen ist, verschwindet die Zeile.
+>> Der Kopiervorgang kann einige Minuten dauern. Im Tab `Aktuelle Tasks`{.action} wird eine neue Zeile für Ihre Kopie mit dem Status "Geplant" angezeigt. Wenn der Vorgang abgeschlossen ist, verschwindet die Zeile.
 >>
 >> ![Aktuelle Tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
@@ -151,8 +151,8 @@ Klicken Sie auf die Tabs, um die **6** Schritte anzuzeigen.
 >> >
 >> > Wenn Sie keine Zieldatenbank haben, klicken Sie auf den Link im Fenster, um eine neue Datenbank zu bestellen. Denken Sie daran, sie zu aktivieren:
 >> >
->> > - Für eine Shared SQL Datenbank: Folgen Sie unserer Anleitung „[Datenbank auf Ihrem Webhosting erstellen](/pages/web_cloud/web_hosting/sql_create_database)".
->> > - Für eine Datenbank auf einem Web Cloud Databases Server: Folgen Sie unserer Anleitung „[Datenbank auf einem Web Cloud Databases Server erstellen](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
+>> > - Für eine Shared SQL Datenbank: Folgen Sie unserer Anleitung "[Datenbank auf Ihrem Webhosting erstellen](/pages/web_cloud/web_hosting/sql_create_database)".
+>> > - Für eine Datenbank auf einem Web Cloud Databases Server: Folgen Sie unserer Anleitung "[Datenbank auf einem Web Cloud Databases Server erstellen](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
 >>
 >> - **Auswahl 1 - In eine Start SQL Datenbank kopieren**: Wählen Sie `In Datenbank kopieren`{.action}, und wählen Sie die Zieldatenbank aus der Dropdown-Liste aus.
 >> - **Auswahl 2 - In einen Web Cloud Databases Server kopieren**: Wählen Sie `In eine Web Cloud Databases kopieren`{.action}. Zwei Dropdown-Listen werden angezeigt. Klicken Sie auf die erste, um die Web Cloud Databases Lösung auszuwählen, dann auf die zweite, um die Zieldatenbank auszuwählen.
@@ -167,7 +167,7 @@ Klicken Sie auf die Tabs, um die **6** Schritte anzuzeigen.
 >>
 > **Schritt 6**
 >>
->> Der Kopiervorgang kann einige Minuten dauern. Im Tab `Aktuelle Tasks`{.action} wird eine neue Zeile für Ihre Kopie mit dem Status „Geplant" angezeigt. Wenn der Vorgang abgeschlossen ist, verschwindet die Zeile.
+>> Der Kopiervorgang kann einige Minuten dauern. Im Tab `Aktuelle Tasks`{.action} wird eine neue Zeile für Ihre Kopie mit dem Status "Geplant" angezeigt. Wenn der Vorgang abgeschlossen ist, verschwindet die Zeile.
 >>
 >> ![Aktuelle Tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.de-de.md
@@ -1,8 +1,22 @@
 ---
 title: "Inhalt einer Datenbank in eine andere duplizieren"
 excerpt: "Erfahren Sie hier, wie Sie den Inhalt einer OVHcloud Datenbank in eine andere OVHcloud Datenbank kopieren"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Ziel
 
@@ -38,18 +52,20 @@ Bevor Sie beginnen, überprüfen Sie diese Voraussetzungen:
 - Die Version des DBMS für beide Datenbanken ist identisch. Obwohl das Duplizieren mit verschiedenen Versionen funktioniert, sollten Sie dieselben Versionen verwenden.
 - Der Inhalt der Quelldatenbank darf die Größe der Zieldatenbank nicht überschreiten.
 
-### Quelldatenbank identifizieren
+### Inhalt einer Datenbank kopieren
 
 Die Duplikationsfunktion ist verfügbar für folgende Dienste:
 
 - [Start SQL](/links/web/hosting-options-startsql) (in einigen unserer [Webhostings](/links/web/hosting) enthalten oder [separat bestellt](/links/web/hosting-options-startsql))
-- [Web Cloud Databases](/links/web/databases) (in unseren [Performance Hostings](/links/web/hosting-performance-offer) enthalten oder [separat bestellt](/links/web/databases)). 
+- [Web Cloud Databases](/links/web/databases) (in unseren [Performance Hostings](/links/web/hosting-performance-offer) enthalten oder [separat bestellt](/links/web/databases)).
 
 Je nach Ihrer Ausgangslage ist der Zugriffspfad zur Quelldatenbank unterschiedlich.
 
-#### Start SQL
+**Klicken Sie auf die passende Situation, um den Inhalt anzuzeigen.**
 
-Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
+/// details | Von einer Start SQL Datenbank
+
+Klicken Sie auf die Tabs, um die **6** Schritte anzuzeigen.
 
 > [!tabs]
 > **Schritt 1**
@@ -60,100 +76,102 @@ Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
 >>
 > **Schritt 2**
 >>
->> Klicken Sie auf den Tab `Datenbanken`{.action}.
+>> Klicken Sie auf den Tab `Datenbanken`{.action}. Die Tabelle listet die auf Ihrem Webhosting erstellten Datenbanken auf.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Start SQL DB-Liste](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Schritt 3**
 >>
+>> Klicken Sie auf den Button `...`{.action} rechts neben der Zeile der Datenbank, deren Inhalt Sie kopieren möchten, und wählen Sie `Datenbank kopieren`{.action}.
+>>
+>> ![CTA_copy_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Schritt 4**
+>>
+>> Ein Fenster fordert Sie auf, Ihre Zieldatenbank auszuwählen.
+>>
+>> ![Interface Copy BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Wenn Sie keine Zieldatenbank haben, klicken Sie auf den Link im Fenster, um eine neue Datenbank zu bestellen. Denken Sie daran, sie zu aktivieren:
+>> >
+>> > - Für eine Shared SQL Datenbank: Folgen Sie unserer Anleitung „[Datenbank auf Ihrem Webhosting erstellen](/pages/web_cloud/web_hosting/sql_create_database)".
+>> > - Für eine Datenbank auf einem Web Cloud Databases Server: Folgen Sie unserer Anleitung „[Datenbank auf einem Web Cloud Databases Server erstellen](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
+>>
+>> - **Auswahl 1 - In eine Start SQL Datenbank kopieren**: Wählen Sie `In Datenbank kopieren`{.action}, und wählen Sie die Zieldatenbank aus der Dropdown-Liste aus.
+>> - **Auswahl 2 - In einen Web Cloud Databases Server kopieren**: Wählen Sie `In eine Web Cloud Databases kopieren`{.action}. Zwei Dropdown-Listen werden angezeigt. Klicken Sie auf die erste, um die Web Cloud Databases Lösung auszuwählen, dann auf die zweite, um die Zieldatenbank auszuwählen.
+>>
+> **Schritt 5**
+>>
+>> Klicken Sie auf `Weiter`{.action}. Die folgende Bestätigungsmeldung wird angezeigt:
+>>
+>> ![BDD-Kopierbestätigungsnachricht](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Wenn Sie die ausgewählte Zieldatenbank nicht überschreiben möchten, klicken Sie auf `Zurück`{.action}, um Ihre Auswahl zu ändern, oder auf `Abbrechen`{.action}, um den Vorgang abzubrechen. Klicken Sie andernfalls auf `Bestätigen`{.action}, um die Duplikation zu bestätigen.
+>>
+> **Schritt 6**
+>>
+>> Der Kopiervorgang kann einige Minuten dauern. Im Tab `Aktuelle Tasks`{.action} wird eine neue Zeile für Ihre Kopie mit dem Status „Geplant" angezeigt. Wenn der Vorgang abgeschlossen ist, verschwindet die Zeile.
+>>
+>> ![Aktuelle Tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-Wenn Sie auf den Tab `Datenbanken`{.action} klicken, wird eine Liste Ihrer Start SQL-Datenbanken angezeigt.
+///
 
-![Liste der SQL-Start-Datenbanken](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+/// details | Von einem Web Cloud Databases Server
 
-#### Web Cloud Databases
-
-Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
+Klicken Sie auf die Tabs, um die **6** Schritte anzuzeigen.
 
 > [!tabs]
 > **Schritt 1**
 >>
->> Loggen Sie sich in Ihr [OVHcloud Kundencenter](/links/manager) ein und gehen Sie dann in den Bereich `Web Cloud`{.action}.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Schritt 2**
->>
->> Klicken Sie auf das Menü `Web Cloud Databases`{.action} und wählen Sie die betreffende Web Cloud Databases Lösung aus.
+>> Gehen Sie auf die Seite [Web Cloud Databases](/links/control-panel/web-cloud-databases), und wählen Sie die betreffende Lösung aus.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Schritt 3**
+> **Schritt 2**
 >>
->> Wenn Sie auf den Tab `Datenbanken`{.action} klicken, wird eine Liste der Datenbanken auf Ihrem Web Cloud Databases Server angezeigt.
+>> Klicken Sie auf den Tab `Datenbanken`{.action}. Die Liste der Datenbanken auf Ihrem Web Cloud Databases Server wird angezeigt.
 >>
 >> ![WCD DB-Liste](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Schritt 3**
+>>
+>> Klicken Sie auf den Button `...`{.action} rechts neben der Zeile der Datenbank, deren Inhalt Sie kopieren möchten, und wählen Sie `Datenbank kopieren`{.action}.
+>>
+>> ![CTA_copy_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Schritt 4**
+>>
+>> Ein Fenster fordert Sie auf, Ihre Zieldatenbank auszuwählen.
+>>
+>> ![Interface Copy BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Wenn Sie keine Zieldatenbank haben, klicken Sie auf den Link im Fenster, um eine neue Datenbank zu bestellen. Denken Sie daran, sie zu aktivieren:
+>> >
+>> > - Für eine Shared SQL Datenbank: Folgen Sie unserer Anleitung „[Datenbank auf Ihrem Webhosting erstellen](/pages/web_cloud/web_hosting/sql_create_database)".
+>> > - Für eine Datenbank auf einem Web Cloud Databases Server: Folgen Sie unserer Anleitung „[Datenbank auf einem Web Cloud Databases Server erstellen](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
+>>
+>> - **Auswahl 1 - In eine Start SQL Datenbank kopieren**: Wählen Sie `In Datenbank kopieren`{.action}, und wählen Sie die Zieldatenbank aus der Dropdown-Liste aus.
+>> - **Auswahl 2 - In einen Web Cloud Databases Server kopieren**: Wählen Sie `In eine Web Cloud Databases kopieren`{.action}. Zwei Dropdown-Listen werden angezeigt. Klicken Sie auf die erste, um die Web Cloud Databases Lösung auszuwählen, dann auf die zweite, um die Zieldatenbank auszuwählen.
+>>
+> **Schritt 5**
+>>
+>> Klicken Sie auf `Weiter`{.action}. Die folgende Bestätigungsmeldung wird angezeigt:
+>>
+>> ![BDD-Kopierbestätigungsnachricht](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Wenn Sie die ausgewählte Zieldatenbank nicht überschreiben möchten, klicken Sie auf `Zurück`{.action}, um Ihre Auswahl zu ändern, oder auf `Abbrechen`{.action}, um den Vorgang abzubrechen. Klicken Sie andernfalls auf `Bestätigen`{.action}, um die Duplikation zu bestätigen.
+>>
+> **Schritt 6**
+>>
+>> Der Kopiervorgang kann einige Minuten dauern. Im Tab `Aktuelle Tasks`{.action} wird eine neue Zeile für Ihre Kopie mit dem Status „Geplant" angezeigt. Wenn der Vorgang abgeschlossen ist, verschwindet die Zeile.
+>>
+>> ![Aktuelle Tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Inhalt einer Datenbank kopieren
-
-Klicken Sie im Tab `Datenbanken`{.action} auf den Button `...`{.action} rechts in der Zeile der Datenbank, deren Inhalt Sie kopieren möchten. Wählen Sie `Datenbank kopieren`{.action}.
-
-![CTA_copy_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-Es wird ein Fenster angezeigt, in dem Sie Ihre Zieldatenbank identifizieren können.
-
-![Interface Copy BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-Wenn Sie keine Zieldatenbank haben, klicken Sie auf den Link im Text, um eine neue Datenbank zu bestellen.
-
-![WCD DB-Liste](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-Sie haben die Wahl zwischen [Start SQL](/links/web/hosting-options-startsql) oder [Web Cloud Databases](/links/web/databases).
-
-> [!primary]
->
-> Ihre neu bestellte Datenbank wird nicht automatisch aktiviert. Loggen Sie sich zum Aktivieren der Datenbank in Ihr [OVHcloud Kundencenter](/links/manager) ein und gehen Sie in den Bereich `Web Cloud`{.action}.
-> 
-> - Für eine Shared SQL Datenbank: Folgen Sie unserer Anleitung „[Datenbank auf Ihrem Webhosting erstellen](/pages/web_cloud/web_hosting/sql_create_database)“.
-> - Für eine Datenbank auf einem Web Cloud Databases Server: Folgen Sie unserer Anleitung „[Datenbank auf einem Web Cloud Databases Server erstellen](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)“.
->
-
-Wenn Sie bereits über eine Zieldatenbank verfügen, wählen Sie zunächst deren Typ aus:
-
-- `In Datenbank kopieren`{.action}: Wenn Sie den Inhalt der Quelldatenbank nach **Start SQL** kopieren möchten.
-- `In eine Web Cloud Databases kopieren`{.action}: Wenn Sie den Inhalt der Quelldatenbank nach **Web Cloud Databases** kopieren möchten.
-
-#### Auswahl 1: Start SQL
-
-Sie haben `In Datenbank kopieren`{.action} ausgewählt. Es werden zwei Dropdownlisten angezeigt. Wählen Sie zuerst das Webhosting aus, auf dem sich Ihre Zieldatenbank befindet. Klicken Sie auf die zweite Dropdown-Liste, um die Start SQL Zieldatenbank auszuwählen.
-
-Klicken Sie auf `Weiter`{.action}. Die folgende Bestätigungsmeldung wird angezeigt:
-
-![BDD-Kopierbestätigungsnachricht](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Wenn Sie die ausgewählte Zieldatenbank nicht überschreiben möchten, klicken Sie auf `Zurück`{.action}, um Ihre Auswahl zu ändern, oder auf `Abbrechen`{.action}, um den Vorgang abzubrechen. Klicken Sie andernfalls auf `Bestätigen`{.action}, um den Inhalt der Quelldatenbank in die Zieldatenbank zu duplizieren.
-
-Die folgende Bestätigungsmeldung wird angezeigt:
-
-![BDD-Erfolgsmeldung](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-Der Kopiervorgang kann einige Minuten dauern. Um den Status zu überprüfen, öffnen Sie den Tab `Aktuelle Tasks`{.action}. In der Tabelle wird eine Zeile für das Kopieren mit dem Status „Geplant“ angezeigt. Wenn der Vorgang abgeschlossen ist, wird die Zeile gelöscht.
-
-![Aktuelle Tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Auswahl 2: Web Cloud Databases
-
-Sie haben `In eine Web Cloud Databases kopieren`{.action} ausgewählt. Es werden zwei Dropdownlisten angezeigt. Wählen Sie zuerst den Server von Web Cloud Databases aus, auf dem sich Ihre Zieldatenbank befindet. Klicken Sie auf die zweite Dropdown-Liste, um die Zieldatenbank auf Ihrem Web Cloud Databases Server auszuwählen.
-
-Klicken Sie auf `Weiter`{.action}. Die folgende Bestätigungsmeldung wird angezeigt:
-
-![BDD-Kopierbestätigungsnachricht](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Wenn Sie die ausgewählte Zieldatenbank nicht überschreiben möchten, klicken Sie auf `Zurück`{.action}, um Ihre Auswahl zu ändern, oder auf `Abbrechen`{.action}, um den Vorgang abzubrechen. Klicken Sie andernfalls auf `Bestätigen`{.action}, um den Inhalt der Quelldatenbank in die Zieldatenbank zu duplizieren.
-
-Der Kopiervorgang kann einige Minuten dauern. Um den Status zu überprüfen, öffnen Sie den Tab `Aktuelle Tasks`{.action}. In der Tabelle wird eine Zeile für das Kopieren mit dem Status „Geplant“ angezeigt. Wenn der Vorgang abgeschlossen ist, wird die Zeile gelöscht.
-
-![Aktuelle Tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Konfiguration Ihrer Website mit einer neuen Datenbank
 
@@ -178,14 +196,16 @@ Für weitere Informationen oder wenn Sie ein anderes CMS verwenden, lesen Sie un
 
 > [!primary]
 >
-> Die Duplikaton Ihrer Datenbank ist keine Migration. Die Quelldatenbank bleibt bestehen, bis Sie sie löschen. Sie können also Ihre Website weiterhin mit der alten Datenbank betreiben.
+> Die Duplikation Ihrer Datenbank ist keine Migration. Die Quelldatenbank bleibt bestehen, bis Sie sie löschen. Sie können also Ihre Website weiterhin mit der alten Datenbank betreiben.
 >
 
 ### Fehlerbehebung
 
 Beim Kopieren des Datenbankinhalts können Probleme auftreten.
 
-#### In der Liste werden keine Datenbanken angezeigt
+**Klicken Sie auf die passende Situation, um den Inhalt anzuzeigen.**
+
+/// details | In der Liste werden keine Datenbanken angezeigt
 
 Dies bedeutet, dass nur eine Datenbank aktiv ist. Zum Kopieren der Quelldatenbank ist auch eine aktive Zieldatenbank erforderlich. Sie haben mehrere Möglichkeiten:
 
@@ -193,22 +213,30 @@ Dies bedeutet, dass nur eine Datenbank aktiv ist. Zum Kopieren der Quelldatenban
 - Konfigurieren Sie eine neue Datenbank auf Ihrem [Web Cloud Databases](/links/web/databases) Server.
 - Bestellen Sie eine neue Datenbank innerhalb der Angebote [Start SQL](/links/web/hosting-options-startsql) oder [Web Cloud Databases](/links/web/databases).
 
-#### Es wird bereits eine Aktion ausgeführt
+///
+
+/// details | Es wird bereits eine Aktion ausgeführt
 
 Diese Meldung bedeutet, dass bereits ein Task für die Datenbank ausgeführt wird. Gehen Sie auf den Tab `Aktuelle Tasks`{.action} zum Überprüfen laufender Operationen. Ist das der Fall, warten Sie, bis der Vorgang abgeschlossen ist, und starten Sie dann ggf. die Duplikation neu.
 
-#### Die Zieldatenbank enthält nicht genügend Speicherplatz
+///
+
+/// details | Die Zieldatenbank enthält nicht genügend Speicherplatz
 
 Ihre Zieldatenbank enthält nicht genügend Speicherplatz. Sie haben zwei Möglichkeiten:
 
 - Eine neue Datenbank des Typs [Start SQL](/links/web/hosting-options-startsql) mit mehr Speicherplatz bestellen.
 - Wenn Sie bereits über einen [Web Cloud Databases](/links/web/databases) Server verfügen, wechseln Sie zu einem Angebot mit mehr Speicherplatz.
 
-#### Quell- und Zieldatenbank sind nicht kompatibel
+///
+
+/// details | Quell- und Zieldatenbank sind nicht kompatibel
 
 Diese Benachrichtigung bedeutet, dass das **D**ata**b**ase **M**anagement **S**ystem (**DBMS**) Ihrer Quelldatenbank nicht mit dem DBMS Ihrer Zieldatenbank übereinstimmt.
 
 Dieser Fehler kann beispielsweise auftreten, wenn Sie MySQL für die Quelldatenbank und PostgreSQL für die Zieldatenbank verwenden.
+
+///
 
 ## Weiterführende Informationen
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-asia.md
@@ -1,8 +1,22 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -39,18 +53,20 @@ Before you begin, make sure that:
 - The version of your DBMS is the same for both your databases (source and destination). Although the duplication may work with different versions, it is recommended that you use the same versions.
 - The contents of the source database must not exceed the size of the destination database.
 
-### Identify your source database
+### Copy the contents of a database
 
-This feature is available for:
+This feature is available for copying:
 
 - A [Start SQL](/links/web/hosting-options-startsql) database (included in some of our [web hostings](/links/web/hosting) or [ordered separately](/links/web/hosting-options-startsql)).
-- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)). 
+- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)).
 
 Depending on your situation, the path to your source database is different.
 
-#### Start SQL database
+**Click on your situation to view the content.**
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Start SQL database
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
@@ -61,99 +77,102 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `Databases`{.action} tab.
+>> Click on the `Databases`{.action} tab. The table lists the databases created on your web hosting plan.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Start SQL DB list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> You will see a list of your Start SQL databases.
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![List of SQL Start databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Web Cloud Databases server
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
 >>
->> Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Step 2**
->>
->> Click the `Web Cloud Databases`{.action} menu, then choose the Web Cloud Databases solution concerned.
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the solution concerned.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 3**
+> **Step 2**
 >>
->> By clicking on the `Databases`{.action} tab, you will see a list of the databases on your Web Cloud Databases server.
+>> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
 >> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
+>>
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copy the contents of a database
-
-In the `Databases`{.action} tab, regardless of your solution, click the `...`{.action} button to the right of the row of the database you want to duplicate, then select `Copy database`{.action}.
-
-![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-A window will pop up to identify your destination database.
-
-![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-If you do not have a destination database, click on the link to purchase a new database as shown in the screenshot below.
-
-![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-You can choose between a [Start SQL](/links/web/hosting-options-startsql) solution, or a [Web Cloud Databases](/links/web/databases) server.
-
-> [!primary]
->
-> When you purchase your new database, it is not activated by default. To enable it, log in to your [OVHcloud Control Panel](/links/manager) and go to the `Web Cloud`{.action} section.
-> 
-> - For a Shared SQL database: Follow our guide on [Creating a database on your Web Hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
-> - For a database on a Web Cloud Databases server: Follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
->
-
-If you already have a destination database, first choose its type:
-
--`Copy to database`{.action}: If you want to copy the contents of your source database to a **Start SQL** database.
--`Copy to a Web Cloud Databases`{.action}: If you want to copy the content from your source database to a **Web Cloud Databases** database.
-
-#### Choice 1 - Copy to a Start SQL database
-
-You have selected `Copy to database`{.action}. Two drop-down lists appear. Click the first button, then select the web hosting plan of your destination Start SQL database. Once you have selected a web hosting plan, click on the second drop-down list to choose the destination Start SQL database.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-The following confirmation message is displayed:
-
-![Database success message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Choice 2 - Copy to a database on a Web Cloud Databases server
-
-You have selected `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click on the first link, then select the Web Cloud Databases solution that your destination database is based on. Once you have selected the Web Cloud Databases solution, click on the second drop-down list to choose the destination database on your Web Cloud Databases server.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configuring your website with a new database
 
@@ -165,9 +184,9 @@ To connect the new database to your website, edit the configuration file for you
 
 > [!warning]
 >
-> It is recommended that you make a copy of your website’s configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
+> It is recommended that you make a copy of your website's configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
 
-For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan’s storage space (FTP), then update the following fields:
+For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan's storage space (FTP), then update the following fields:
 
 - DB_NAME
 - DB_USER
@@ -185,30 +204,40 @@ For more details, or if you are using another CMS, please refer to our guide on 
 
 During the process of copying the contents of the database, you may encounter difficulties.
 
-#### No databases are displayed in the list
+**Click on your situation to view the content.**
+
+/// details | No databases are displayed in the list
 
 This means that you only have one active database. To copy your source database, you also need an active destination database. To do this, you can:
 
-- Configure a new database available on your Web Hosting plan.
+- Configure a new database available on your web hosting plan.
 - Configure a new database on your [Web Cloud Databases](/links/web/databases) server.
 - Order a [Start SQL](/links/web/hosting-options-startsql) solution or a [Web Cloud Databases](/links/web/databases) database server.
 
-#### You already have an action in progress
+///
+
+/// details | You already have an action in progress
 
 This message means that a task is already in progress on your database. Go to the `Ongoing tasks`{.action} tab to check this. If so, wait for the task to finish, then restart the duplication process of your database.
 
-#### The destination database does not contain enough space
+///
+
+/// details | The destination database does not contain enough space
 
 Your destination database is not of a sufficient size. There are two ways to resolve this:
 
 - Order a new [Start SQL](/links/web/hosting-options-startsql) database with more space.
 - If you have a [Web Cloud Databases](/links/web/databases) server, switch to a Web Cloud Databases solution with more storage space.
 
-#### The source and destination databases are incompatible
+///
+
+/// details | The source and destination databases are incompatible
 
 This notification means that the **D**ata**b**ase **M**anagement **S**ystem (**DBMS**) in your source database is not the same as the DBMS in your destination database.
 
 For example, this error can occur when you use MySQL for your source database, and PostgreSQL for your destination database.
+
+///
 
 ## Go further
 
@@ -218,7 +247,7 @@ For example, this error can occur when you use MySQL for your source database, a
 
 [Restore and import a database on your database server](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/)
 
-[Retrieve the backup of a web hosting plan’s database](/pages/web_cloud/web_hosting/sql_database_export)
+[Retrieve the backup of a web hosting plan's database](/pages/web_cloud/web_hosting/sql_database_export)
 
 [Import a backup into a web hosting database](/pages/web_cloud/web_hosting/sql_importing_mysql_database)
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-asia.md
@@ -85,13 +85,13 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -101,7 +101,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>
@@ -134,19 +134,19 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
->> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>> ![Web Cloud Databases database list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -156,7 +156,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-au.md
@@ -1,8 +1,22 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -39,18 +53,20 @@ Before you begin, make sure that:
 - The version of your DBMS is the same for both your databases (source and destination). Although the duplication may work with different versions, it is recommended that you use the same versions.
 - The contents of the source database must not exceed the size of the destination database.
 
-### Identify your source database
+### Copy the contents of a database
 
-This feature is available for:
+This feature is available for copying:
 
 - A [Start SQL](/links/web/hosting-options-startsql) database (included in some of our [web hostings](/links/web/hosting) or [ordered separately](/links/web/hosting-options-startsql)).
-- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)). 
+- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)).
 
 Depending on your situation, the path to your source database is different.
 
-#### Start SQL database
+**Click on your situation to view the content.**
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Start SQL database
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
@@ -61,99 +77,102 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `Databases`{.action} tab.
+>> Click on the `Databases`{.action} tab. The table lists the databases created on your web hosting plan.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Start SQL DB list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> You will see a list of your Start SQL databases.
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![List of SQL Start databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Web Cloud Databases server
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
 >>
->> Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Step 2**
->>
->> Click the `Web Cloud Databases`{.action} menu, then choose the Web Cloud Databases solution concerned.
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the solution concerned.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 3**
+> **Step 2**
 >>
->> By clicking on the `Databases`{.action} tab, you will see a list of the databases on your Web Cloud Databases server.
+>> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
 >> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
+>>
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copy the contents of a database
-
-In the `Databases`{.action} tab, regardless of your solution, click the `...`{.action} button to the right of the row of the database you want to duplicate, then select `Copy database`{.action}.
-
-![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-A window will pop up to identify your destination database.
-
-![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-If you do not have a destination database, click on the link to purchase a new database as shown in the screenshot below.
-
-![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-You can choose between a [Start SQL](/links/web/hosting-options-startsql) solution, or a [Web Cloud Databases](/links/web/databases) server.
-
-> [!primary]
->
-> When you purchase your new database, it is not activated by default. To enable it, log in to your [OVHcloud Control Panel](/links/manager) and go to the `Web Cloud`{.action} section.
-> 
-> - For a Shared SQL database: Follow our guide on [Creating a database on your Web Hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
-> - For a database on a Web Cloud Databases server: Follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
->
-
-If you already have a destination database, first choose its type:
-
--`Copy to database`{.action}: If you want to copy the contents of your source database to a **Start SQL** database.
--`Copy to a Web Cloud Databases`{.action}: If you want to copy the content from your source database to a **Web Cloud Databases** database.
-
-#### Choice 1 - Copy to a Start SQL database
-
-You have selected `Copy to database`{.action}. Two drop-down lists appear. Click the first button, then select the web hosting plan of your destination Start SQL database. Once you have selected a web hosting plan, click on the second drop-down list to choose the destination Start SQL database.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-The following confirmation message is displayed:
-
-![Database success message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Choice 2 - Copy to a database on a Web Cloud Databases server
-
-You have selected `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click on the first link, then select the Web Cloud Databases solution that your destination database is based on. Once you have selected the Web Cloud Databases solution, click on the second drop-down list to choose the destination database on your Web Cloud Databases server.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configuring your website with a new database
 
@@ -165,9 +184,9 @@ To connect the new database to your website, edit the configuration file for you
 
 > [!warning]
 >
-> It is recommended that you make a copy of your website’s configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
+> It is recommended that you make a copy of your website's configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
 
-For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan’s storage space (FTP), then update the following fields:
+For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan's storage space (FTP), then update the following fields:
 
 - DB_NAME
 - DB_USER
@@ -185,30 +204,40 @@ For more details, or if you are using another CMS, please refer to our guide on 
 
 During the process of copying the contents of the database, you may encounter difficulties.
 
-#### No databases are displayed in the list
+**Click on your situation to view the content.**
+
+/// details | No databases are displayed in the list
 
 This means that you only have one active database. To copy your source database, you also need an active destination database. To do this, you can:
 
-- Configure a new database available on your Web Hosting plan.
+- Configure a new database available on your web hosting plan.
 - Configure a new database on your [Web Cloud Databases](/links/web/databases) server.
 - Order a [Start SQL](/links/web/hosting-options-startsql) solution or a [Web Cloud Databases](/links/web/databases) database server.
 
-#### You already have an action in progress
+///
+
+/// details | You already have an action in progress
 
 This message means that a task is already in progress on your database. Go to the `Ongoing tasks`{.action} tab to check this. If so, wait for the task to finish, then restart the duplication process of your database.
 
-#### The destination database does not contain enough space
+///
+
+/// details | The destination database does not contain enough space
 
 Your destination database is not of a sufficient size. There are two ways to resolve this:
 
 - Order a new [Start SQL](/links/web/hosting-options-startsql) database with more space.
 - If you have a [Web Cloud Databases](/links/web/databases) server, switch to a Web Cloud Databases solution with more storage space.
 
-#### The source and destination databases are incompatible
+///
+
+/// details | The source and destination databases are incompatible
 
 This notification means that the **D**ata**b**ase **M**anagement **S**ystem (**DBMS**) in your source database is not the same as the DBMS in your destination database.
 
 For example, this error can occur when you use MySQL for your source database, and PostgreSQL for your destination database.
+
+///
 
 ## Go further
 
@@ -218,7 +247,7 @@ For example, this error can occur when you use MySQL for your source database, a
 
 [Restore and import a database on your database server](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/)
 
-[Retrieve the backup of a web hosting plan’s database](/pages/web_cloud/web_hosting/sql_database_export)
+[Retrieve the backup of a web hosting plan's database](/pages/web_cloud/web_hosting/sql_database_export)
 
 [Import a backup into a web hosting database](/pages/web_cloud/web_hosting/sql_importing_mysql_database)
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-au.md
@@ -85,13 +85,13 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -101,7 +101,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>
@@ -134,19 +134,19 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
->> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>> ![Web Cloud Databases database list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -156,7 +156,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-ca.md
@@ -1,8 +1,22 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -39,18 +53,20 @@ Before you begin, make sure that:
 - The version of your DBMS is the same for both your databases (source and destination). Although the duplication may work with different versions, it is recommended that you use the same versions.
 - The contents of the source database must not exceed the size of the destination database.
 
-### Identify your source database
+### Copy the contents of a database
 
-This feature is available for:
+This feature is available for copying:
 
 - A [Start SQL](/links/web/hosting-options-startsql) database (included in some of our [web hostings](/links/web/hosting) or [ordered separately](/links/web/hosting-options-startsql)).
-- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)). 
+- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)).
 
 Depending on your situation, the path to your source database is different.
 
-#### Start SQL database
+**Click on your situation to view the content.**
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Start SQL database
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
@@ -61,99 +77,102 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `Databases`{.action} tab.
+>> Click on the `Databases`{.action} tab. The table lists the databases created on your web hosting plan.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Start SQL DB list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> You will see a list of your Start SQL databases.
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![List of SQL Start databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Web Cloud Databases server
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
 >>
->> Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Step 2**
->>
->> Click the `Web Cloud Databases`{.action} menu, then choose the Web Cloud Databases solution concerned.
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the solution concerned.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 3**
+> **Step 2**
 >>
->> By clicking on the `Databases`{.action} tab, you will see a list of the databases on your Web Cloud Databases server.
+>> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
 >> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
+>>
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copy the contents of a database
-
-In the `Databases`{.action} tab, regardless of your solution, click the `...`{.action} button to the right of the row of the database you want to duplicate, then select `Copy database`{.action}.
-
-![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-A window will pop up to identify your destination database.
-
-![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-If you do not have a destination database, click on the link to purchase a new database as shown in the screenshot below.
-
-![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-You can choose between a [Start SQL](/links/web/hosting-options-startsql) solution, or a [Web Cloud Databases](/links/web/databases) server.
-
-> [!primary]
->
-> When you purchase your new database, it is not activated by default. To enable it, log in to your [OVHcloud Control Panel](/links/manager) and go to the `Web Cloud`{.action} section.
-> 
-> - For a Shared SQL database: Follow our guide on [Creating a database on your Web Hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
-> - For a database on a Web Cloud Databases server: Follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
->
-
-If you already have a destination database, first choose its type:
-
--`Copy to database`{.action}: If you want to copy the contents of your source database to a **Start SQL** database.
--`Copy to a Web Cloud Databases`{.action}: If you want to copy the content from your source database to a **Web Cloud Databases** database.
-
-#### Choice 1 - Copy to a Start SQL database
-
-You have selected `Copy to database`{.action}. Two drop-down lists appear. Click the first button, then select the web hosting plan of your destination Start SQL database. Once you have selected a web hosting plan, click on the second drop-down list to choose the destination Start SQL database.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-The following confirmation message is displayed:
-
-![Database success message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Choice 2 - Copy to a database on a Web Cloud Databases server
-
-You have selected `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click on the first link, then select the Web Cloud Databases solution that your destination database is based on. Once you have selected the Web Cloud Databases solution, click on the second drop-down list to choose the destination database on your Web Cloud Databases server.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configuring your website with a new database
 
@@ -165,9 +184,9 @@ To connect the new database to your website, edit the configuration file for you
 
 > [!warning]
 >
-> It is recommended that you make a copy of your website’s configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
+> It is recommended that you make a copy of your website's configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
 
-For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan’s storage space (FTP), then update the following fields:
+For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan's storage space (FTP), then update the following fields:
 
 - DB_NAME
 - DB_USER
@@ -185,30 +204,40 @@ For more details, or if you are using another CMS, please refer to our guide on 
 
 During the process of copying the contents of the database, you may encounter difficulties.
 
-#### No databases are displayed in the list
+**Click on your situation to view the content.**
+
+/// details | No databases are displayed in the list
 
 This means that you only have one active database. To copy your source database, you also need an active destination database. To do this, you can:
 
-- Configure a new database available on your Web Hosting plan.
+- Configure a new database available on your web hosting plan.
 - Configure a new database on your [Web Cloud Databases](/links/web/databases) server.
 - Order a [Start SQL](/links/web/hosting-options-startsql) solution or a [Web Cloud Databases](/links/web/databases) database server.
 
-#### You already have an action in progress
+///
+
+/// details | You already have an action in progress
 
 This message means that a task is already in progress on your database. Go to the `Ongoing tasks`{.action} tab to check this. If so, wait for the task to finish, then restart the duplication process of your database.
 
-#### The destination database does not contain enough space
+///
+
+/// details | The destination database does not contain enough space
 
 Your destination database is not of a sufficient size. There are two ways to resolve this:
 
 - Order a new [Start SQL](/links/web/hosting-options-startsql) database with more space.
 - If you have a [Web Cloud Databases](/links/web/databases) server, switch to a Web Cloud Databases solution with more storage space.
 
-#### The source and destination databases are incompatible
+///
+
+/// details | The source and destination databases are incompatible
 
 This notification means that the **D**ata**b**ase **M**anagement **S**ystem (**DBMS**) in your source database is not the same as the DBMS in your destination database.
 
 For example, this error can occur when you use MySQL for your source database, and PostgreSQL for your destination database.
+
+///
 
 ## Go further
 
@@ -218,7 +247,7 @@ For example, this error can occur when you use MySQL for your source database, a
 
 [Restore and import a database on your database server](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/)
 
-[Retrieve the backup of a web hosting plan’s database](/pages/web_cloud/web_hosting/sql_database_export)
+[Retrieve the backup of a web hosting plan's database](/pages/web_cloud/web_hosting/sql_database_export)
 
 [Import a backup into a web hosting database](/pages/web_cloud/web_hosting/sql_importing_mysql_database)
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-ca.md
@@ -85,13 +85,13 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -101,7 +101,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>
@@ -134,19 +134,19 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
->> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>> ![Web Cloud Databases database list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -156,7 +156,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-gb.md
@@ -1,8 +1,22 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -39,18 +53,20 @@ Before you begin, make sure that:
 - The version of your DBMS is the same for both your databases (source and destination). Although the duplication may work with different versions, it is recommended that you use the same versions.
 - The contents of the source database must not exceed the size of the destination database.
 
-### Identify your source database
+### Copy the contents of a database
 
-This feature is available for:
+This feature is available for copying:
 
 - A [Start SQL](/links/web/hosting-options-startsql) database (included in some of our [web hostings](/links/web/hosting) or [ordered separately](/links/web/hosting-options-startsql)).
-- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)). 
+- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)).
 
 Depending on your situation, the path to your source database is different.
 
-#### Start SQL database
+**Click on your situation to view the content.**
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Start SQL database
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
@@ -61,99 +77,102 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `Databases`{.action} tab.
+>> Click on the `Databases`{.action} tab. The table lists the databases created on your web hosting plan.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Start SQL DB list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> You will see a list of your Start SQL databases.
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![List of SQL Start databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Web Cloud Databases server
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
 >>
->> Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Step 2**
->>
->> Click the `Web Cloud Databases`{.action} menu, then choose the Web Cloud Databases solution concerned.
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the solution concerned.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 3**
+> **Step 2**
 >>
->> By clicking on the `Databases`{.action} tab, you will see a list of the databases on your Web Cloud Databases server.
+>> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
 >> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
+>>
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copy the contents of a database
-
-In the `Databases`{.action} tab, regardless of your solution, click the `...`{.action} button to the right of the row of the database you want to duplicate, then select `Copy database`{.action}.
-
-![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-A window will pop up to identify your destination database.
-
-![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-If you do not have a destination database, click on the link to purchase a new database as shown in the screenshot below.
-
-![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-You can choose between a [Start SQL](/links/web/hosting-options-startsql) solution, or a [Web Cloud Databases](/links/web/databases) server.
-
-> [!primary]
->
-> When you purchase your new database, it is not activated by default. To enable it, log in to your [OVHcloud Control Panel](/links/manager) and go to the `Web Cloud`{.action} section.
-> 
-> - For a Shared SQL database: Follow our guide on [Creating a database on your Web Hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
-> - For a database on a Web Cloud Databases server: Follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
->
-
-If you already have a destination database, first choose its type:
-
--`Copy to database`{.action}: If you want to copy the contents of your source database to a **Start SQL** database.
--`Copy to a Web Cloud Databases`{.action}: If you want to copy the content from your source database to a **Web Cloud Databases** database.
-
-#### Choice 1 - Copy to a Start SQL database
-
-You have selected `Copy to database`{.action}. Two drop-down lists appear. Click the first button, then select the web hosting plan of your destination Start SQL database. Once you have selected a web hosting plan, click on the second drop-down list to choose the destination Start SQL database.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-The following confirmation message is displayed:
-
-![Database success message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Choice 2 - Copy to a database on a Web Cloud Databases server
-
-You have selected `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click on the first link, then select the Web Cloud Databases solution that your destination database is based on. Once you have selected the Web Cloud Databases solution, click on the second drop-down list to choose the destination database on your Web Cloud Databases server.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configuring your website with a new database
 
@@ -165,9 +184,9 @@ To connect the new database to your website, edit the configuration file for you
 
 > [!warning]
 >
-> It is recommended that you make a copy of your website’s configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
+> It is recommended that you make a copy of your website's configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
 
-For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan’s storage space (FTP), then update the following fields:
+For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan's storage space (FTP), then update the following fields:
 
 - DB_NAME
 - DB_USER
@@ -185,30 +204,40 @@ For more details, or if you are using another CMS, please refer to our guide on 
 
 During the process of copying the contents of the database, you may encounter difficulties.
 
-#### No databases are displayed in the list
+**Click on your situation to view the content.**
+
+/// details | No databases are displayed in the list
 
 This means that you only have one active database. To copy your source database, you also need an active destination database. To do this, you can:
 
-- Configure a new database available on your Web Hosting plan.
+- Configure a new database available on your web hosting plan.
 - Configure a new database on your [Web Cloud Databases](/links/web/databases) server.
 - Order a [Start SQL](/links/web/hosting-options-startsql) solution or a [Web Cloud Databases](/links/web/databases) database server.
 
-#### You already have an action in progress
+///
+
+/// details | You already have an action in progress
 
 This message means that a task is already in progress on your database. Go to the `Ongoing tasks`{.action} tab to check this. If so, wait for the task to finish, then restart the duplication process of your database.
 
-#### The destination database does not contain enough space
+///
+
+/// details | The destination database does not contain enough space
 
 Your destination database is not of a sufficient size. There are two ways to resolve this:
 
 - Order a new [Start SQL](/links/web/hosting-options-startsql) database with more space.
 - If you have a [Web Cloud Databases](/links/web/databases) server, switch to a Web Cloud Databases solution with more storage space.
 
-#### The source and destination databases are incompatible
+///
+
+/// details | The source and destination databases are incompatible
 
 This notification means that the **D**ata**b**ase **M**anagement **S**ystem (**DBMS**) in your source database is not the same as the DBMS in your destination database.
 
 For example, this error can occur when you use MySQL for your source database, and PostgreSQL for your destination database.
+
+///
 
 ## Go further
 
@@ -218,7 +247,7 @@ For example, this error can occur when you use MySQL for your source database, a
 
 [Restore and import a database on your database server](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/)
 
-[Retrieve the backup of a web hosting plan’s database](/pages/web_cloud/web_hosting/sql_database_export)
+[Retrieve the backup of a web hosting plan's database](/pages/web_cloud/web_hosting/sql_database_export)
 
 [Import a backup into a web hosting database](/pages/web_cloud/web_hosting/sql_importing_mysql_database)
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-gb.md
@@ -85,13 +85,13 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -101,7 +101,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>
@@ -134,19 +134,19 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
->> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>> ![Web Cloud Databases database list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -156,7 +156,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-ie.md
@@ -1,8 +1,22 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -39,18 +53,20 @@ Before you begin, make sure that:
 - The version of your DBMS is the same for both your databases (source and destination). Although the duplication may work with different versions, it is recommended that you use the same versions.
 - The contents of the source database must not exceed the size of the destination database.
 
-### Identify your source database
+### Copy the contents of a database
 
-This feature is available for:
+This feature is available for copying:
 
 - A [Start SQL](/links/web/hosting-options-startsql) database (included in some of our [web hostings](/links/web/hosting) or [ordered separately](/links/web/hosting-options-startsql)).
-- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)). 
+- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)).
 
 Depending on your situation, the path to your source database is different.
 
-#### Start SQL database
+**Click on your situation to view the content.**
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Start SQL database
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
@@ -61,99 +77,102 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `Databases`{.action} tab.
+>> Click on the `Databases`{.action} tab. The table lists the databases created on your web hosting plan.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Start SQL DB list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> You will see a list of your Start SQL databases.
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![List of SQL Start databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Web Cloud Databases server
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
 >>
->> Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Step 2**
->>
->> Click the `Web Cloud Databases`{.action} menu, then choose the Web Cloud Databases solution concerned.
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the solution concerned.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 3**
+> **Step 2**
 >>
->> By clicking on the `Databases`{.action} tab, you will see a list of the databases on your Web Cloud Databases server.
+>> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
 >> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
+>>
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copy the contents of a database
-
-In the `Databases`{.action} tab, regardless of your solution, click the `...`{.action} button to the right of the row of the database you want to duplicate, then select `Copy database`{.action}.
-
-![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-A window will pop up to identify your destination database.
-
-![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-If you do not have a destination database, click on the link to purchase a new database as shown in the screenshot below.
-
-![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-You can choose between a [Start SQL](/links/web/hosting-options-startsql) solution, or a [Web Cloud Databases](/links/web/databases) server.
-
-> [!primary]
->
-> When you purchase your new database, it is not activated by default. To enable it, log in to your [OVHcloud Control Panel](/links/manager) and go to the `Web Cloud`{.action} section.
-> 
-> - For a Shared SQL database: Follow our guide on [Creating a database on your Web Hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
-> - For a database on a Web Cloud Databases server: Follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
->
-
-If you already have a destination database, first choose its type:
-
--`Copy to database`{.action}: If you want to copy the contents of your source database to a **Start SQL** database.
--`Copy to a Web Cloud Databases`{.action}: If you want to copy the content from your source database to a **Web Cloud Databases** database.
-
-#### Choice 1 - Copy to a Start SQL database
-
-You have selected `Copy to database`{.action}. Two drop-down lists appear. Click the first button, then select the web hosting plan of your destination Start SQL database. Once you have selected a web hosting plan, click on the second drop-down list to choose the destination Start SQL database.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-The following confirmation message is displayed:
-
-![Database success message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Choice 2 - Copy to a database on a Web Cloud Databases server
-
-You have selected `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click on the first link, then select the Web Cloud Databases solution that your destination database is based on. Once you have selected the Web Cloud Databases solution, click on the second drop-down list to choose the destination database on your Web Cloud Databases server.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configuring your website with a new database
 
@@ -165,9 +184,9 @@ To connect the new database to your website, edit the configuration file for you
 
 > [!warning]
 >
-> It is recommended that you make a copy of your website’s configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
+> It is recommended that you make a copy of your website's configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
 
-For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan’s storage space (FTP), then update the following fields:
+For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan's storage space (FTP), then update the following fields:
 
 - DB_NAME
 - DB_USER
@@ -185,30 +204,40 @@ For more details, or if you are using another CMS, please refer to our guide on 
 
 During the process of copying the contents of the database, you may encounter difficulties.
 
-#### No databases are displayed in the list
+**Click on your situation to view the content.**
+
+/// details | No databases are displayed in the list
 
 This means that you only have one active database. To copy your source database, you also need an active destination database. To do this, you can:
 
-- Configure a new database available on your Web Hosting plan.
+- Configure a new database available on your web hosting plan.
 - Configure a new database on your [Web Cloud Databases](/links/web/databases) server.
 - Order a [Start SQL](/links/web/hosting-options-startsql) solution or a [Web Cloud Databases](/links/web/databases) database server.
 
-#### You already have an action in progress
+///
+
+/// details | You already have an action in progress
 
 This message means that a task is already in progress on your database. Go to the `Ongoing tasks`{.action} tab to check this. If so, wait for the task to finish, then restart the duplication process of your database.
 
-#### The destination database does not contain enough space
+///
+
+/// details | The destination database does not contain enough space
 
 Your destination database is not of a sufficient size. There are two ways to resolve this:
 
 - Order a new [Start SQL](/links/web/hosting-options-startsql) database with more space.
 - If you have a [Web Cloud Databases](/links/web/databases) server, switch to a Web Cloud Databases solution with more storage space.
 
-#### The source and destination databases are incompatible
+///
+
+/// details | The source and destination databases are incompatible
 
 This notification means that the **D**ata**b**ase **M**anagement **S**ystem (**DBMS**) in your source database is not the same as the DBMS in your destination database.
 
 For example, this error can occur when you use MySQL for your source database, and PostgreSQL for your destination database.
+
+///
 
 ## Go further
 
@@ -218,7 +247,7 @@ For example, this error can occur when you use MySQL for your source database, a
 
 [Restore and import a database on your database server](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/)
 
-[Retrieve the backup of a web hosting plan’s database](/pages/web_cloud/web_hosting/sql_database_export)
+[Retrieve the backup of a web hosting plan's database](/pages/web_cloud/web_hosting/sql_database_export)
 
 [Import a backup into a web hosting database](/pages/web_cloud/web_hosting/sql_importing_mysql_database)
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-ie.md
@@ -85,13 +85,13 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -101,7 +101,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>
@@ -134,19 +134,19 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
->> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>> ![Web Cloud Databases database list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -156,7 +156,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-sg.md
@@ -1,8 +1,22 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -39,18 +53,20 @@ Before you begin, make sure that:
 - The version of your DBMS is the same for both your databases (source and destination). Although the duplication may work with different versions, it is recommended that you use the same versions.
 - The contents of the source database must not exceed the size of the destination database.
 
-### Identify your source database
+### Copy the contents of a database
 
-This feature is available for:
+This feature is available for copying:
 
 - A [Start SQL](/links/web/hosting-options-startsql) database (included in some of our [web hostings](/links/web/hosting) or [ordered separately](/links/web/hosting-options-startsql)).
-- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)). 
+- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)).
 
 Depending on your situation, the path to your source database is different.
 
-#### Start SQL database
+**Click on your situation to view the content.**
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Start SQL database
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
@@ -61,99 +77,102 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `Databases`{.action} tab.
+>> Click on the `Databases`{.action} tab. The table lists the databases created on your web hosting plan.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Start SQL DB list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> You will see a list of your Start SQL databases.
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![List of SQL Start databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Web Cloud Databases server
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
 >>
->> Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Step 2**
->>
->> Click the `Web Cloud Databases`{.action} menu, then choose the Web Cloud Databases solution concerned.
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the solution concerned.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 3**
+> **Step 2**
 >>
->> By clicking on the `Databases`{.action} tab, you will see a list of the databases on your Web Cloud Databases server.
+>> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
 >> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
+>>
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copy the contents of a database
-
-In the `Databases`{.action} tab, regardless of your solution, click the `...`{.action} button to the right of the row of the database you want to duplicate, then select `Copy database`{.action}.
-
-![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-A window will pop up to identify your destination database.
-
-![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-If you do not have a destination database, click on the link to purchase a new database as shown in the screenshot below.
-
-![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-You can choose between a [Start SQL](/links/web/hosting-options-startsql) solution, or a [Web Cloud Databases](/links/web/databases) server.
-
-> [!primary]
->
-> When you purchase your new database, it is not activated by default. To enable it, log in to your [OVHcloud Control Panel](/links/manager) and go to the `Web Cloud`{.action} section.
-> 
-> - For a Shared SQL database: Follow our guide on [Creating a database on your Web Hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
-> - For a database on a Web Cloud Databases server: Follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
->
-
-If you already have a destination database, first choose its type:
-
--`Copy to database`{.action}: If you want to copy the contents of your source database to a **Start SQL** database.
--`Copy to a Web Cloud Databases`{.action}: If you want to copy the content from your source database to a **Web Cloud Databases** database.
-
-#### Choice 1 - Copy to a Start SQL database
-
-You have selected `Copy to database`{.action}. Two drop-down lists appear. Click the first button, then select the web hosting plan of your destination Start SQL database. Once you have selected a web hosting plan, click on the second drop-down list to choose the destination Start SQL database.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-The following confirmation message is displayed:
-
-![Database success message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Choice 2 - Copy to a database on a Web Cloud Databases server
-
-You have selected `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click on the first link, then select the Web Cloud Databases solution that your destination database is based on. Once you have selected the Web Cloud Databases solution, click on the second drop-down list to choose the destination database on your Web Cloud Databases server.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configuring your website with a new database
 
@@ -165,9 +184,9 @@ To connect the new database to your website, edit the configuration file for you
 
 > [!warning]
 >
-> It is recommended that you make a copy of your website’s configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
+> It is recommended that you make a copy of your website's configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
 
-For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan’s storage space (FTP), then update the following fields:
+For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan's storage space (FTP), then update the following fields:
 
 - DB_NAME
 - DB_USER
@@ -185,30 +204,40 @@ For more details, or if you are using another CMS, please refer to our guide on 
 
 During the process of copying the contents of the database, you may encounter difficulties.
 
-#### No databases are displayed in the list
+**Click on your situation to view the content.**
+
+/// details | No databases are displayed in the list
 
 This means that you only have one active database. To copy your source database, you also need an active destination database. To do this, you can:
 
-- Configure a new database available on your Web Hosting plan.
+- Configure a new database available on your web hosting plan.
 - Configure a new database on your [Web Cloud Databases](/links/web/databases) server.
 - Order a [Start SQL](/links/web/hosting-options-startsql) solution or a [Web Cloud Databases](/links/web/databases) database server.
 
-#### You already have an action in progress
+///
+
+/// details | You already have an action in progress
 
 This message means that a task is already in progress on your database. Go to the `Ongoing tasks`{.action} tab to check this. If so, wait for the task to finish, then restart the duplication process of your database.
 
-#### The destination database does not contain enough space
+///
+
+/// details | The destination database does not contain enough space
 
 Your destination database is not of a sufficient size. There are two ways to resolve this:
 
 - Order a new [Start SQL](/links/web/hosting-options-startsql) database with more space.
 - If you have a [Web Cloud Databases](/links/web/databases) server, switch to a Web Cloud Databases solution with more storage space.
 
-#### The source and destination databases are incompatible
+///
+
+/// details | The source and destination databases are incompatible
 
 This notification means that the **D**ata**b**ase **M**anagement **S**ystem (**DBMS**) in your source database is not the same as the DBMS in your destination database.
 
 For example, this error can occur when you use MySQL for your source database, and PostgreSQL for your destination database.
+
+///
 
 ## Go further
 
@@ -218,7 +247,7 @@ For example, this error can occur when you use MySQL for your source database, a
 
 [Restore and import a database on your database server](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/)
 
-[Retrieve the backup of a web hosting plan’s database](/pages/web_cloud/web_hosting/sql_database_export)
+[Retrieve the backup of a web hosting plan's database](/pages/web_cloud/web_hosting/sql_database_export)
 
 [Import a backup into a web hosting database](/pages/web_cloud/web_hosting/sql_importing_mysql_database)
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-sg.md
@@ -85,13 +85,13 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -101,7 +101,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>
@@ -134,19 +134,19 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
->> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>> ![Web Cloud Databases database list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -156,7 +156,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-us.md
@@ -1,8 +1,22 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -39,18 +53,20 @@ Before you begin, make sure that:
 - The version of your DBMS is the same for both your databases (source and destination). Although the duplication may work with different versions, it is recommended that you use the same versions.
 - The contents of the source database must not exceed the size of the destination database.
 
-### Identify your source database
+### Copy the contents of a database
 
-This feature is available for:
+This feature is available for copying:
 
 - A [Start SQL](/links/web/hosting-options-startsql) database (included in some of our [web hostings](/links/web/hosting) or [ordered separately](/links/web/hosting-options-startsql)).
-- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)). 
+- A database hosted on a [Web Cloud Databases](/links/web/databases) server (included with our [Performance web hosting](/links/web/hosting-performance-offer) or [ordered separately](/links/web/databases)).
 
 Depending on your situation, the path to your source database is different.
 
-#### Start SQL database
+**Click on your situation to view the content.**
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Start SQL database
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
@@ -61,99 +77,102 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `Databases`{.action} tab.
+>> Click on the `Databases`{.action} tab. The table lists the databases created on your web hosting plan.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Start SQL DB list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> You will see a list of your Start SQL databases.
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![List of SQL Start databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Click on the tabs below to view each of the **3** steps.
+/// details | From a Web Cloud Databases server
+
+Click on the tabs below to view each of the **6** steps.
 
 > [!tabs]
 > **Step 1**
 >>
->> Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Step 2**
->>
->> Click the `Web Cloud Databases`{.action} menu, then choose the Web Cloud Databases solution concerned.
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the solution concerned.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Step 3**
+> **Step 2**
 >>
->> By clicking on the `Databases`{.action} tab, you will see a list of the databases on your Web Cloud Databases server.
+>> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
 >> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
+>>
+>> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> A window will prompt you to choose your destination database.
+>>
+>> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > If you do not have a destination database, click the link in the window to purchase one. Remember to activate it:
+>> >
+>> > - For a Shared SQL database: follow our guide [Creating a database on your web hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
+>> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
+>>
+>> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>>
+> **Step 5**
+>>
+>> Click `Next`{.action}. The following confirmation message is displayed:
+>>
+>> ![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> If you do not want to overwrite the destination database, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm the duplication.
+>>
+> **Step 6**
+>>
+>> The copy may take several minutes. In the `Ongoing tasks`{.action} tab, a new row for your copy will appear with a "scheduled" status. Once the operation is complete, the row disappears.
+>>
+>> ![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copy the contents of a database
-
-In the `Databases`{.action} tab, regardless of your solution, click the `...`{.action} button to the right of the row of the database you want to duplicate, then select `Copy database`{.action}.
-
-![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-A window will pop up to identify your destination database.
-
-![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-If you do not have a destination database, click on the link to purchase a new database as shown in the screenshot below.
-
-![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-You can choose between a [Start SQL](/links/web/hosting-options-startsql) solution, or a [Web Cloud Databases](/links/web/databases) server.
-
-> [!primary]
->
-> When you purchase your new database, it is not activated by default. To enable it, log in to your [OVHcloud Control Panel](/links/manager) and go to the `Web Cloud`{.action} section.
-> 
-> - For a Shared SQL database: Follow our guide on [Creating a database on your Web Hosting plan](/pages/web_cloud/web_hosting/sql_create_database).
-> - For a database on a Web Cloud Databases server: Follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
->
-
-If you already have a destination database, first choose its type:
-
--`Copy to database`{.action}: If you want to copy the contents of your source database to a **Start SQL** database.
--`Copy to a Web Cloud Databases`{.action}: If you want to copy the content from your source database to a **Web Cloud Databases** database.
-
-#### Choice 1 - Copy to a Start SQL database
-
-You have selected `Copy to database`{.action}. Two drop-down lists appear. Click the first button, then select the web hosting plan of your destination Start SQL database. Once you have selected a web hosting plan, click on the second drop-down list to choose the destination Start SQL database.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-The following confirmation message is displayed:
-
-![Database success message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Choice 2 - Copy to a database on a Web Cloud Databases server
-
-You have selected `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click on the first link, then select the Web Cloud Databases solution that your destination database is based on. Once you have selected the Web Cloud Databases solution, click on the second drop-down list to choose the destination database on your Web Cloud Databases server.
-
-Click `Next`{.action}. The following confirmation message is displayed:
-
-![Copy DB confirmation message](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-If you do not want to overwrite the destination database you have chosen, click `Back`{.action} to change your choice, or `Cancel`{.action} to cancel everything. Otherwise, click `Confirm`{.action} to confirm that you want to duplicate the contents of the source database to the destination database.
-
-It may take several minutes to copy the database. To check the progress, go to the `Ongoing tasks`{.action} tab. In the table, a new row will appear for your copy with a status of "scheduled". Once the operation is complete, the line disappears.
-
-![Ongoing tasks](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configuring your website with a new database
 
@@ -165,9 +184,9 @@ To connect the new database to your website, edit the configuration file for you
 
 > [!warning]
 >
-> It is recommended that you make a copy of your website’s configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
+> It is recommended that you make a copy of your website's configuration file before editing it. This ensures that you can replace the new version of the file with the old one if your configuration fails.
 
-For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan’s storage space (FTP), then update the following fields:
+For example, if you use WordPress, you will need to modify the *wp-config.php* configuration file in the root folder of your WordPress application, in your hosting plan's storage space (FTP), then update the following fields:
 
 - DB_NAME
 - DB_USER
@@ -185,30 +204,40 @@ For more details, or if you are using another CMS, please refer to our guide on 
 
 During the process of copying the contents of the database, you may encounter difficulties.
 
-#### No databases are displayed in the list
+**Click on your situation to view the content.**
+
+/// details | No databases are displayed in the list
 
 This means that you only have one active database. To copy your source database, you also need an active destination database. To do this, you can:
 
-- Configure a new database available on your Web Hosting plan.
+- Configure a new database available on your web hosting plan.
 - Configure a new database on your [Web Cloud Databases](/links/web/databases) server.
 - Order a [Start SQL](/links/web/hosting-options-startsql) solution or a [Web Cloud Databases](/links/web/databases) database server.
 
-#### You already have an action in progress
+///
+
+/// details | You already have an action in progress
 
 This message means that a task is already in progress on your database. Go to the `Ongoing tasks`{.action} tab to check this. If so, wait for the task to finish, then restart the duplication process of your database.
 
-#### The destination database does not contain enough space
+///
+
+/// details | The destination database does not contain enough space
 
 Your destination database is not of a sufficient size. There are two ways to resolve this:
 
 - Order a new [Start SQL](/links/web/hosting-options-startsql) database with more space.
 - If you have a [Web Cloud Databases](/links/web/databases) server, switch to a Web Cloud Databases solution with more storage space.
 
-#### The source and destination databases are incompatible
+///
+
+/// details | The source and destination databases are incompatible
 
 This notification means that the **D**ata**b**ase **M**anagement **S**ystem (**DBMS**) in your source database is not the same as the DBMS in your destination database.
 
 For example, this error can occur when you use MySQL for your source database, and PostgreSQL for your destination database.
+
+///
 
 ## Go further
 
@@ -218,7 +247,7 @@ For example, this error can occur when you use MySQL for your source database, a
 
 [Restore and import a database on your database server](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server/)
 
-[Retrieve the backup of a web hosting plan’s database](/pages/web_cloud/web_hosting/sql_database_export)
+[Retrieve the backup of a web hosting plan's database](/pages/web_cloud/web_hosting/sql_database_export)
 
 [Import a backup into a web hosting database](/pages/web_cloud/web_hosting/sql_importing_mysql_database)
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-us.md
@@ -85,13 +85,13 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -101,7 +101,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>
@@ -134,19 +134,19 @@ Click on the tabs below to view each of the **6** steps.
 >>
 >> Click on the `Databases`{.action} tab. The list of databases on your Web Cloud Databases server is displayed.
 >>
->> ![WCD DB List](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>> ![Web Cloud Databases database list](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> Click the `...`{.action} button to the right of the row of the database you want to copy, then select `Copy database`{.action}.
 >>
->> ![CTA_copy_DB](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>> ![Copy database button](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
 >>
 > **Step 4**
 >>
 >> A window will prompt you to choose your destination database.
 >>
->> ![Copy DB Interface](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>> ![Database copy destination selection](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
@@ -156,7 +156,7 @@ Click on the tabs below to view each of the **6** steps.
 >> > - For a database on a Web Cloud Databases server: follow our guide [Creating a database on a Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server).
 >>
 >> - **Choice 1 - Copy to a Start SQL database**: select `Copy to database`{.action}, then choose the destination database from the drop-down list.
->> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Databases`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
+>> - **Choice 2 - Copy to a Web Cloud Databases server**: select `Copy to a Web Cloud Database`{.action}. Two drop-down lists appear. Click the first one to select the Web Cloud Databases solution, then click the second one to choose the destination database.
 >>
 > **Step 5**
 >>

--- a/pages/web_cloud/web_hosting/copy_database/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplicating the contents of one database to another"
 excerpt: "Find out how to duplicate the content of an OVHcloud database into another OVHcloud database"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplicar el contenido de una base de datos en otra"
 excerpt: "Descubra cómo copiar el contenido de una base de datos de OVHcloud en otra base de datos de OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.es-es.md
@@ -1,8 +1,22 @@
 ---
 title: "Duplicar el contenido de una base de datos en otra"
 excerpt: "Descubra cómo copiar el contenido de una base de datos de OVHcloud en otra base de datos de OVHcloud"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo
 
@@ -12,7 +26,7 @@ Su base de datos es un elemento central en la construcción de su sitio web din�
 
 > [!primary]
 >
-> Gracias a esta funcionalidad, las bases de datos no se mueven, sino que se copian. Esto se debe a que la base de datos original no se elimina automáticamente, a diferencia de un proceso de migración. Sólo se duplica el contenido de la base de datos de origen para copiarlo en la base de datos de destino.
+> Gracias a esta funcionalidad, las bases de datos no se mueven, sino que se copian. Esto se debe a que la base de datos original no se elimina automáticamente, a diferencia de un proceso de migración. Solo se duplica el contenido de la base de datos de origen para copiarlo en la base de datos de destino.
 >
 
 ## Requisitos
@@ -25,7 +39,7 @@ Su base de datos es un elemento central en la construcción de su sitio web din�
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -39,121 +53,126 @@ Antes de empezar, asegúrese de que:
 - La versión de su SGBD es la misma para sus dos bases de datos (origen y destino). Aunque la copia puede funcionar con versiones diferentes, se recomienda utilizar las mismas versiones.
 - El contenido de la base de datos de origen no debe superar el tamaño de la base de datos de destino.
 
-### Identificar mi base de datos de origen
+### Copiar el contenido de una base de datos
 
-Esta funcionalidad está disponible para la copia: 
+Esta funcionalidad está disponible para la copia:
 
-- una base de datos [Start SQL](/links/web/hosting-options-startsql) (incluida en algunos de nuestros [alojamientos web](/links/web/hosting) o [contratada por separado](/links/web/hosting-options-startsql);
-- de una base de datos alojada en un servidor [Web Cloud Databases](/links/web/databases) (incluida con nuestros [planes de hosting Performance](/links/web/hosting-performance-offer) o [contratada por separado](/links/web/databases). 
+- de una base de datos [Start SQL](/links/web/hosting-options-startsql) (incluida en algunos de nuestros [alojamientos web](/links/web/hosting) o [contratada por separado](/links/web/hosting-options-startsql));
+- de una base de datos alojada en un servidor [Web Cloud Databases](/links/web/databases) (incluida con nuestros [planes de hosting Performance](/links/web/hosting-performance-offer) o [contratada por separado](/links/web/databases)).
 
 En función de su situación, la ruta de acceso a la base de datos de origen es diferente.
 
-#### Base de datos Start SQL
+**Haga clic en la situación correspondiente para ver el contenido.**
 
-Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
+/// details | Desde una base de datos Start SQL
+
+Haga clic en las fichas siguientes para ver cada una de las **6** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Etapa 2**
 >>
->> En la nueva página, haga clic en la pestaña `Bases de datos`{.action}.
+>> Haga clic en la pestaña `Bases de datos`{.action}. La tabla muestra las bases de datos creadas en su plan de alojamiento web.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Lista de BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Etapa 3**
 >>
->> Aparecerá la lista de sus bases de datos Start SQL.
+>> Haga clic en el botón `...`{.action} situado a la derecha de la línea correspondiente a la base de datos cuyo contenido desee copiar y seleccione `Copiar la base de datos`{.action}.
 >>
->> ![Lista de BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copie_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Etapa 4**
+>>
+>> Se abrirá una ventana en la que podrá elegir su base de datos de destino.
+>>
+>> ![Interfaz de copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Si no tiene una base de datos de destino, haga clic en el enlace de la ventana para adquirir una nueva. No olvide activarla:
+>> >
+>> > - Para una base de datos Shared SQL: siga nuestra guía « [Crear una base de datos en un alojamiento web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Para una base de datos en un servidor Web Cloud Databases: siga nuestra guía « [Crear una base de datos en un servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Opción 1 - Copiar en una base Start SQL**: seleccione `Copiar en una base de datos`{.action} y elija la base de datos de destino en la lista desplegable.
+>> - **Opción 2 - Copiar en un servidor Web Cloud Databases**: seleccione `Copiar en un servicio Web Cloud Databases`{.action}. Aparecen dos listas desplegables. Haga clic en la primera para seleccionar la solución Web Cloud Databases y en la segunda para elegir la base de datos de destino.
+>>
+> **Etapa 5**
+>>
+>> Haga clic en `Siguiente`{.action}. Aparecerá el siguiente mensaje de confirmación:
+>>
+>> ![Mensaje de confirmación copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Si no desea sobrescribir la base de datos de destino elegida, haga clic en `Anterior`{.action} para cambiar su elección o en `Cancelar`{.action} para cancelar todo. De lo contrario, haga clic en `Aceptar`{.action} para confirmar la duplicación.
+>>
+> **Etapa 6**
+>>
+>> La copia puede tardar varios minutos. En la pestaña `Tareas en curso`{.action}, aparecerá una nueva línea correspondiente a su copia con el estado «Planificado». Una vez finalizada la operación, la línea desaparece.
+>>
+>> ![Tareas en curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
+/// details | Desde un servidor Web Cloud Databases
+
+Haga clic en las fichas siguientes para ver cada una de las **6** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Conéctese a su [área de cliente de OVHcloud](/links/manager) y acceda a la sección `Web Cloud`{.action}.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Etapa 2**
->>
->> Haga clic en el menú `Web Cloud Databases`{.action} y seleccione la solución Web Cloud Databases correspondiente.
+>> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Etapa 3**
+> **Etapa 2**
 >>
->> Al hacer clic en la pestaña `Bases de datos`{.action}, aparecerá la lista de bases de datos presentes en su servidor Web Cloud Databases.
+>> Haga clic en la pestaña `Bases de datos`{.action}. Se mostrará la lista de bases de datos presentes en su servidor Web Cloud Databases.
 >>
 >> ![Lista de bases de datos WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Haga clic en el botón `...`{.action} situado a la derecha de la línea correspondiente a la base de datos cuyo contenido desee copiar y seleccione `Copiar la base de datos`{.action}.
+>>
+>> ![CTA_copie_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Etapa 4**
+>>
+>> Se abrirá una ventana en la que podrá elegir su base de datos de destino.
+>>
+>> ![Interfaz de copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Si no tiene una base de datos de destino, haga clic en el enlace de la ventana para adquirir una nueva. No olvide activarla:
+>> >
+>> > - Para una base de datos Shared SQL: siga nuestra guía « [Crear una base de datos en un alojamiento web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Para una base de datos en un servidor Web Cloud Databases: siga nuestra guía « [Crear una base de datos en un servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Opción 1 - Copiar en una base Start SQL**: seleccione `Copiar en una base de datos`{.action} y elija la base de datos de destino en la lista desplegable.
+>> - **Opción 2 - Copiar en un servidor Web Cloud Databases**: seleccione `Copiar en un servicio Web Cloud Databases`{.action}. Aparecen dos listas desplegables. Haga clic en la primera para seleccionar la solución Web Cloud Databases y en la segunda para elegir la base de datos de destino.
+>>
+> **Etapa 5**
+>>
+>> Haga clic en `Siguiente`{.action}. Aparecerá el siguiente mensaje de confirmación:
+>>
+>> ![Mensaje de confirmación copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Si no desea sobrescribir la base de datos de destino elegida, haga clic en `Anterior`{.action} para cambiar su elección o en `Cancelar`{.action} para cancelar todo. De lo contrario, haga clic en `Aceptar`{.action} para confirmar la duplicación.
+>>
+> **Etapa 6**
+>>
+>> La copia puede tardar varios minutos. En la pestaña `Tareas en curso`{.action}, aparecerá una nueva línea correspondiente a su copia con el estado «Planificado». Una vez finalizada la operación, la línea desaparece.
+>>
+>> ![Tareas en curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copiar el contenido de una base de datos
-
-En la pestaña `Bases de datos`{.action}, haga clic en el botón `...`{.action} situado al final de la línea correspondiente a la base de datos cuyo contenido desee copiar y seleccione `Copiar base de datos`{.action}.
-
-![CTA_copie_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-Se abrirá una ventana en la que podrá identificar la base de datos de destino.
-
-![Interfaz de copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-Si no tiene una base de datos destino y como se muestra en la siguiente captura de pantalla, haga clic en el vínculo para adquirir una nueva base de datos:
-
-![Lista de bases de datos WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-Puede elegir entre contratar un servicio "[start SQL](/links/web/hosting-options-startsql)" o un servidor de bases de datos "[Web Cloud Databases](/links/web/databases)".
-
-> [!primary]
->
-> La nueva base de datos no está activada de forma predeterminada cuando la adquiere. No olvide activarlo. Para ello, conéctese a su [área de cliente de OVHcloud](/links/manager) y acceda a la sección `Web Cloud`{.action}.
-> 
-> - Para una base de datos Shared SQL, siga nuestra guía "[Crear una base de datos en un alojamiento web](/pages/web_cloud/web_hosting/sql_create_database)";
-> - Para una base de datos que estará presente en un servidor Web Cloud Databases, siga nuestra guía "[Crear una base de datos en un servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
->
-
-Si ya tiene una base de datos destino, seleccione primero el tipo de base de datos:
-
-- `Copiar en una base de datos`{.action}: si desea copiar el contenido de la base de datos de origen en una base de datos **Start SQL** (destino).
-- `Copiar en un servicio Web Cloud Databases`{.action}: si desea copiar el contenido de la base de datos de origen en una base de datos **Web Cloud Databases** (destino).
-
-#### Opción 1 - Copiar en una base de datos Start SQL
-
-Acaba de seleccionar `Copiar en una base de datos`{.action}. Aparecen dos listas desplegables. Haga clic en la primera y seleccione el alojamiento web en el que se encuentra la base de datos Start SQL de destino. Una vez seleccionado el alojamiento web, haga clic en la segunda lista desplegable para elegir la base de datos Start SQL de destino.
-
-Haga clic en `Siguiente`{.action}. Aparecerá el siguiente mensaje de confirmación:
-
-![Mensaje de confirmación copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Si no desea sobrescribir la base de datos de destino elegida, haga clic en `Anterior`{.action} para cambiar su elección o en `Cancelar`{.action} para cancelar todo. De lo contrario, haga clic en `Aceptar`{.action} para confirmar la duplicación del contenido de la base de datos de origen en la de destino.
-
-Aparecerá el siguiente mensaje de confirmación:
-
-![Mensaje de éxito de BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-La copia de la base de datos puede tardar varios minutos. Para verificar que la copia se ha registrado correctamente, acceda a la pestaña `Tareas en curso`{.action}. En la tabla, aparecerá una nueva línea correspondiente a su copia con el estado "Planificado". Una vez finalizada la operación, la línea desaparece.
-
-![Tareas en curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Opción 2 - Copiar en una base de datos presente en un servidor Web Cloud Databases
-
-Acaba de seleccionar `Copiar en un servicio Web Cloud Databases`{.action}. Aparecen dos listas desplegables. Haga clic en la primera y seleccione la solución Web Cloud Databases en la que se encuentra la base de datos de destino. Una vez seleccionada la solución Web Cloud Databases, haga clic en el segundo menú desplegable para elegir la base de datos de destino de su servidor Web Cloud Databases.
-
-Haga clic en `Siguiente`{.action}. Aparecerá el siguiente mensaje de confirmación:
-
-![Mensaje de confirmación copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Si no desea sobrescribir la base de datos de destino elegida, haga clic en `Anterior`{.action} para cambiar su elección o en `Cancelar`{.action} para cancelar todo. De lo contrario, haga clic en `Aceptar`{.action} para confirmar la duplicación del contenido de la base de datos de origen en la de destino.
-
-La copia de la base de datos puede tardar varios minutos. Para verificar que la copia se ha registrado correctamente, acceda a la pestaña `Tareas en curso`{.action}. En la tabla, aparecerá una nueva línea correspondiente a su copia con el estado "Planificado". Una vez finalizada la operación, la línea desaparece.
-
-![Tareas en curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configurar un sitio web con una nueva base de datos
 
@@ -161,7 +180,7 @@ Una vez realizada la copia de la base de datos de origen, deberá realizar una �
 
 En la pestaña `Tareas en curso`{.action}, asegúrese de que la copia ha finalizado (la línea correspondiente a su copia ha desaparecido).
 
-Para conectar la nueva base de datos a su sitio web, edite el fichero de configuración de **C**ontent **M**anagement **S**ystem (**CMS**) e introduzca la información de conexión de la nueva base de datos.
+Para conectar la nueva base de datos a su sitio web, edite el fichero de configuración de su **C**ontent **M**anagement **S**ystem (**CMS**) e introduzca la información de conexión de la nueva base de datos.
 
 > [!warning]
 >
@@ -185,30 +204,40 @@ Para más información, o si utiliza otro CMS, consulte nuestra guía [Cambiar l
 
 Puede haber problemas durante el proceso de copia del contenido de la base de datos.
 
-#### No aparece ninguna base de datos en la lista
+**Haga clic en la situación correspondiente para ver el contenido.**
 
-Esta notificación significa que sólo tiene una base de datos activa. Para copiar la base de datos de origen, también necesita una base de datos de destino activa. Para ello, puede:
+/// details | No aparece ninguna base de datos en la lista
 
-- Configurar una nueva base de datos disponible en su alojamiento web;
-- Configurar una nueva base de datos en su servidor [Web Cloud Databases](/links/web/databases);
-- Contratar un servicio "[start SQL](/links/web/hosting-options-startsql)" o un servidor de bases de datos "[Web Cloud Databases](/links/web/databases)"
+Esta notificación significa que solo tiene una base de datos activa. Para copiar la base de datos de origen, también necesita una base de datos de destino activa. Para ello, puede:
 
-#### Ya tiene una acción en curso
+- Configurar una nueva base de datos disponible en su alojamiento web.
+- Configurar una nueva base de datos en su servidor [Web Cloud Databases](/links/web/databases).
+- Contratar un servicio [start SQL](/links/web/hosting-options-startsql) o un servidor de bases de datos [Web Cloud Databases](/links/web/databases).
+
+///
+
+/// details | Ya tiene una acción en curso
 
 Este mensaje indica que ya hay una tarea en curso en la base de datos. Acceda a la pestaña `Tareas en curso`{.action} y compruebe que tiene una operación en curso. En ese caso, espere a que termine para volver a copiar la base de datos, si es necesario.
 
-#### La base de datos de destino no tiene espacio suficiente
+///
+
+/// details | La base de datos de destino no tiene espacio suficiente
 
 No hay suficiente espacio en la base de datos de destino. Puede elegir entre dos soluciones:
 
 - Contratar una nueva base de datos [start SQL](/links/web/hosting-options-startsql) con más espacio.
 - Si tiene un servidor [Web Cloud Databases](/links/web/databases), cambie a una solución Web Cloud Databases con más espacio de almacenamiento.
 
-#### Las bases de datos de origen y de destino no son compatibles
+///
+
+/// details | Las bases de datos de origen y de destino no son compatibles
 
 Esta notificación significa que el **S**istema de **G**estión de **B**ases de **D**atos (**SGBD**) de la base de datos de origen no es el mismo que el SGBD de la base de datos de destino.
 
 Por ejemplo, este error puede producirse al utilizar MySQL para la base de datos de origen y PostgreSQL para la base de datos de destino.
+
+///
 
 ## Más información
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplicar el contenido de una base de datos en otra"
 excerpt: "Descubra cómo copiar el contenido de una base de datos de OVHcloud en otra base de datos de OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.es-us.md
@@ -1,8 +1,22 @@
 ---
 title: "Duplicar el contenido de una base de datos en otra"
 excerpt: "Descubra cómo copiar el contenido de una base de datos de OVHcloud en otra base de datos de OVHcloud"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo
 
@@ -12,7 +26,7 @@ Su base de datos es un elemento central en la construcción de su sitio web din�
 
 > [!primary]
 >
-> Gracias a esta funcionalidad, las bases de datos no se mueven, sino que se copian. Esto se debe a que la base de datos original no se elimina automáticamente, a diferencia de un proceso de migración. Sólo se duplica el contenido de la base de datos de origen para copiarlo en la base de datos de destino.
+> Gracias a esta funcionalidad, las bases de datos no se mueven, sino que se copian. Esto se debe a que la base de datos original no se elimina automáticamente, a diferencia de un proceso de migración. Solo se duplica el contenido de la base de datos de origen para copiarlo en la base de datos de destino.
 >
 
 ## Requisitos
@@ -25,7 +39,7 @@ Su base de datos es un elemento central en la construcción de su sitio web din�
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -39,121 +53,126 @@ Antes de empezar, asegúrese de que:
 - La versión de su SGBD es la misma para sus dos bases de datos (origen y destino). Aunque la copia puede funcionar con versiones diferentes, se recomienda utilizar las mismas versiones.
 - El contenido de la base de datos de origen no debe superar el tamaño de la base de datos de destino.
 
-### Identificar mi base de datos de origen
+### Copiar el contenido de una base de datos
 
-Esta funcionalidad está disponible para la copia: 
+Esta funcionalidad está disponible para la copia:
 
-- una base de datos [Start SQL](/links/web/hosting-options-startsql) (incluida en algunos de nuestros [alojamientos web](/links/web/hosting) o [contratada por separado](/links/web/hosting-options-startsql);
-- de una base de datos alojada en un servidor [Web Cloud Databases](/links/web/databases) (incluida con nuestros [planes de hosting Performance](/links/web/hosting-performance-offer) o [contratada por separado](/links/web/databases). 
+- de una base de datos [Start SQL](/links/web/hosting-options-startsql) (incluida en algunos de nuestros [alojamientos web](/links/web/hosting) o [contratada por separado](/links/web/hosting-options-startsql));
+- de una base de datos alojada en un servidor [Web Cloud Databases](/links/web/databases) (incluida con nuestros [planes de hosting Performance](/links/web/hosting-performance-offer) o [contratada por separado](/links/web/databases)).
 
 En función de su situación, la ruta de acceso a la base de datos de origen es diferente.
 
-#### Base de datos Start SQL
+**Haga clic en la situación correspondiente para ver el contenido.**
 
-Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
+/// details | Desde una base de datos Start SQL
+
+Haga clic en las fichas siguientes para ver cada una de las **6** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Etapa 2**
 >>
->> En la nueva página, haga clic en la pestaña `Bases de datos`{.action}.
+>> Haga clic en la pestaña `Bases de datos`{.action}. La tabla muestra las bases de datos creadas en su plan de alojamiento web.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Lista de BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Etapa 3**
 >>
->> Aparecerá la lista de sus bases de datos Start SQL.
+>> Haga clic en el botón `...`{.action} situado a la derecha de la línea correspondiente a la base de datos cuyo contenido desee copiar y seleccione `Copiar la base de datos`{.action}.
 >>
->> ![Lista de BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copie_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Etapa 4**
+>>
+>> Se abrirá una ventana en la que podrá elegir su base de datos de destino.
+>>
+>> ![Interfaz de copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Si no tiene una base de datos de destino, haga clic en el enlace de la ventana para adquirir una nueva. No olvide activarla:
+>> >
+>> > - Para una base de datos Shared SQL: siga nuestra guía « [Crear una base de datos en un alojamiento web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Para una base de datos en un servidor Web Cloud Databases: siga nuestra guía « [Crear una base de datos en un servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Opción 1 - Copiar en una base Start SQL**: seleccione `Copiar en una base de datos`{.action} y elija la base de datos de destino en la lista desplegable.
+>> - **Opción 2 - Copiar en un servidor Web Cloud Databases**: seleccione `Copiar en un servicio Web Cloud Databases`{.action}. Aparecen dos listas desplegables. Haga clic en la primera para seleccionar la solución Web Cloud Databases y en la segunda para elegir la base de datos de destino.
+>>
+> **Etapa 5**
+>>
+>> Haga clic en `Siguiente`{.action}. Aparecerá el siguiente mensaje de confirmación:
+>>
+>> ![Mensaje de confirmación copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Si no desea sobrescribir la base de datos de destino elegida, haga clic en `Anterior`{.action} para cambiar su elección o en `Cancelar`{.action} para cancelar todo. De lo contrario, haga clic en `Aceptar`{.action} para confirmar la duplicación.
+>>
+> **Etapa 6**
+>>
+>> La copia puede tardar varios minutos. En la pestaña `Tareas en curso`{.action}, aparecerá una nueva línea correspondiente a su copia con el estado «Planificado». Una vez finalizada la operación, la línea desaparece.
+>>
+>> ![Tareas en curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
+/// details | Desde un servidor Web Cloud Databases
+
+Haga clic en las fichas siguientes para ver cada una de las **6** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Conéctese a su [área de cliente de OVHcloud](/links/manager) y acceda a la sección `Web Cloud`{.action}.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Etapa 2**
->>
->> Haga clic en el menú `Web Cloud Databases`{.action} y seleccione la solución Web Cloud Databases correspondiente.
+>> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione la solución correspondiente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Etapa 3**
+> **Etapa 2**
 >>
->> Al hacer clic en la pestaña `Bases de datos`{.action}, aparecerá la lista de bases de datos presentes en su servidor Web Cloud Databases.
+>> Haga clic en la pestaña `Bases de datos`{.action}. Se mostrará la lista de bases de datos presentes en su servidor Web Cloud Databases.
 >>
 >> ![Lista de bases de datos WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Haga clic en el botón `...`{.action} situado a la derecha de la línea correspondiente a la base de datos cuyo contenido desee copiar y seleccione `Copiar la base de datos`{.action}.
+>>
+>> ![CTA_copie_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Etapa 4**
+>>
+>> Se abrirá una ventana en la que podrá elegir su base de datos de destino.
+>>
+>> ![Interfaz de copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Si no tiene una base de datos de destino, haga clic en el enlace de la ventana para adquirir una nueva. No olvide activarla:
+>> >
+>> > - Para una base de datos Shared SQL: siga nuestra guía « [Crear una base de datos en un alojamiento web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Para una base de datos en un servidor Web Cloud Databases: siga nuestra guía « [Crear una base de datos en un servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Opción 1 - Copiar en una base Start SQL**: seleccione `Copiar en una base de datos`{.action} y elija la base de datos de destino en la lista desplegable.
+>> - **Opción 2 - Copiar en un servidor Web Cloud Databases**: seleccione `Copiar en un servicio Web Cloud Databases`{.action}. Aparecen dos listas desplegables. Haga clic en la primera para seleccionar la solución Web Cloud Databases y en la segunda para elegir la base de datos de destino.
+>>
+> **Etapa 5**
+>>
+>> Haga clic en `Siguiente`{.action}. Aparecerá el siguiente mensaje de confirmación:
+>>
+>> ![Mensaje de confirmación copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Si no desea sobrescribir la base de datos de destino elegida, haga clic en `Anterior`{.action} para cambiar su elección o en `Cancelar`{.action} para cancelar todo. De lo contrario, haga clic en `Aceptar`{.action} para confirmar la duplicación.
+>>
+> **Etapa 6**
+>>
+>> La copia puede tardar varios minutos. En la pestaña `Tareas en curso`{.action}, aparecerá una nueva línea correspondiente a su copia con el estado «Planificado». Una vez finalizada la operación, la línea desaparece.
+>>
+>> ![Tareas en curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copiar el contenido de una base de datos
-
-En la pestaña `Bases de datos`{.action}, haga clic en el botón `...`{.action} situado al final de la línea correspondiente a la base de datos cuyo contenido desee copiar y seleccione `Copiar base de datos`{.action}.
-
-![CTA_copie_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-Se abrirá una ventana en la que podrá identificar la base de datos de destino.
-
-![Interfaz de copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-Si no tiene una base de datos destino y como se muestra en la siguiente captura de pantalla, haga clic en el vínculo para adquirir una nueva base de datos:
-
-![Lista de bases de datos WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-Puede elegir entre contratar un servicio "[start SQL](/links/web/hosting-options-startsql)" o un servidor de bases de datos "[Web Cloud Databases](/links/web/databases)".
-
-> [!primary]
->
-> La nueva base de datos no está activada de forma predeterminada cuando la adquiere. No olvide activarlo. Para ello, conéctese a su [área de cliente de OVHcloud](/links/manager) y acceda a la sección `Web Cloud`{.action}.
-> 
-> - Para una base de datos Shared SQL, siga nuestra guía "[Crear una base de datos en un alojamiento web](/pages/web_cloud/web_hosting/sql_create_database)";
-> - Para una base de datos que estará presente en un servidor Web Cloud Databases, siga nuestra guía "[Crear una base de datos en un servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
->
-
-Si ya tiene una base de datos destino, seleccione primero el tipo de base de datos:
-
-- `Copiar en una base de datos`{.action}: si desea copiar el contenido de la base de datos de origen en una base de datos **Start SQL** (destino).
-- `Copiar en un servicio Web Cloud Databases`{.action}: si desea copiar el contenido de la base de datos de origen en una base de datos **Web Cloud Databases** (destino).
-
-#### Opción 1 - Copiar en una base de datos Start SQL
-
-Acaba de seleccionar `Copiar en una base de datos`{.action}. Aparecen dos listas desplegables. Haga clic en la primera y seleccione el alojamiento web en el que se encuentra la base de datos Start SQL de destino. Una vez seleccionado el alojamiento web, haga clic en la segunda lista desplegable para elegir la base de datos Start SQL de destino.
-
-Haga clic en `Siguiente`{.action}. Aparecerá el siguiente mensaje de confirmación:
-
-![Mensaje de confirmación copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Si no desea sobrescribir la base de datos de destino elegida, haga clic en `Anterior`{.action} para cambiar su elección o en `Cancelar`{.action} para cancelar todo. De lo contrario, haga clic en `Aceptar`{.action} para confirmar la duplicación del contenido de la base de datos de origen en la de destino.
-
-Aparecerá el siguiente mensaje de confirmación:
-
-![Mensaje de éxito de BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-La copia de la base de datos puede tardar varios minutos. Para verificar que la copia se ha registrado correctamente, acceda a la pestaña `Tareas en curso`{.action}. En la tabla, aparecerá una nueva línea correspondiente a su copia con el estado "Planificado". Una vez finalizada la operación, la línea desaparece.
-
-![Tareas en curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Opción 2 - Copiar en una base de datos presente en un servidor Web Cloud Databases
-
-Acaba de seleccionar `Copiar en un servicio Web Cloud Databases`{.action}. Aparecen dos listas desplegables. Haga clic en la primera y seleccione la solución Web Cloud Databases en la que se encuentra la base de datos de destino. Una vez seleccionada la solución Web Cloud Databases, haga clic en el segundo menú desplegable para elegir la base de datos de destino de su servidor Web Cloud Databases.
-
-Haga clic en `Siguiente`{.action}. Aparecerá el siguiente mensaje de confirmación:
-
-![Mensaje de confirmación copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Si no desea sobrescribir la base de datos de destino elegida, haga clic en `Anterior`{.action} para cambiar su elección o en `Cancelar`{.action} para cancelar todo. De lo contrario, haga clic en `Aceptar`{.action} para confirmar la duplicación del contenido de la base de datos de origen en la de destino.
-
-La copia de la base de datos puede tardar varios minutos. Para verificar que la copia se ha registrado correctamente, acceda a la pestaña `Tareas en curso`{.action}. En la tabla, aparecerá una nueva línea correspondiente a su copia con el estado "Planificado". Una vez finalizada la operación, la línea desaparece.
-
-![Tareas en curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configurar un sitio web con una nueva base de datos
 
@@ -161,7 +180,7 @@ Una vez realizada la copia de la base de datos de origen, deberá realizar una �
 
 En la pestaña `Tareas en curso`{.action}, asegúrese de que la copia ha finalizado (la línea correspondiente a su copia ha desaparecido).
 
-Para conectar la nueva base de datos a su sitio web, edite el fichero de configuración de **C**ontent **M**anagement **S**ystem (**CMS**) e introduzca la información de conexión de la nueva base de datos.
+Para conectar la nueva base de datos a su sitio web, edite el fichero de configuración de su **C**ontent **M**anagement **S**ystem (**CMS**) e introduzca la información de conexión de la nueva base de datos.
 
 > [!warning]
 >
@@ -185,30 +204,40 @@ Para más información, o si utiliza otro CMS, consulte nuestra guía [Cambiar l
 
 Puede haber problemas durante el proceso de copia del contenido de la base de datos.
 
-#### No aparece ninguna base de datos en la lista
+**Haga clic en la situación correspondiente para ver el contenido.**
 
-Esta notificación significa que sólo tiene una base de datos activa. Para copiar la base de datos de origen, también necesita una base de datos de destino activa. Para ello, puede:
+/// details | No aparece ninguna base de datos en la lista
 
-- Configurar una nueva base de datos disponible en su alojamiento web;
-- Configurar una nueva base de datos en su servidor [Web Cloud Databases](/links/web/databases);
-- Contratar un servicio "[start SQL](/links/web/hosting-options-startsql)" o un servidor de bases de datos "[Web Cloud Databases](/links/web/databases)"
+Esta notificación significa que solo tiene una base de datos activa. Para copiar la base de datos de origen, también necesita una base de datos de destino activa. Para ello, puede:
 
-#### Ya tiene una acción en curso
+- Configurar una nueva base de datos disponible en su alojamiento web.
+- Configurar una nueva base de datos en su servidor [Web Cloud Databases](/links/web/databases).
+- Contratar un servicio [start SQL](/links/web/hosting-options-startsql) o un servidor de bases de datos [Web Cloud Databases](/links/web/databases).
+
+///
+
+/// details | Ya tiene una acción en curso
 
 Este mensaje indica que ya hay una tarea en curso en la base de datos. Acceda a la pestaña `Tareas en curso`{.action} y compruebe que tiene una operación en curso. En ese caso, espere a que termine para volver a copiar la base de datos, si es necesario.
 
-#### La base de datos de destino no tiene espacio suficiente
+///
+
+/// details | La base de datos de destino no tiene espacio suficiente
 
 No hay suficiente espacio en la base de datos de destino. Puede elegir entre dos soluciones:
 
 - Contratar una nueva base de datos [start SQL](/links/web/hosting-options-startsql) con más espacio.
 - Si tiene un servidor [Web Cloud Databases](/links/web/databases), cambie a una solución Web Cloud Databases con más espacio de almacenamiento.
 
-#### Las bases de datos de origen y de destino no son compatibles
+///
+
+/// details | Las bases de datos de origen y de destino no son compatibles
 
 Esta notificación significa que el **S**istema de **G**estión de **B**ases de **D**atos (**SGBD**) de la base de datos de origen no es el mismo que el SGBD de la base de datos de destino.
 
 Por ejemplo, este error puede producirse al utilizar MySQL para la base de datos de origen y PostgreSQL para la base de datos de destino.
+
+///
 
 ## Más información
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Dupliquer le contenu d'une base de données dans une autre"
 excerpt: "Découvrez comment copier le contenu d'une base de données OVHcloud dans une autre base de données OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.fr-ca.md
@@ -1,8 +1,22 @@
 ---
 title: "Dupliquer le contenu d'une base de données dans une autre"
 excerpt: "Découvrez comment copier le contenu d'une base de données OVHcloud dans une autre base de données OVHcloud"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objectif
 
@@ -12,13 +26,13 @@ Votre base de données est un élément central dans la construction de votre si
 
 > [!primary]
 >
-> Grâce à cette fonctionnalité, les bases de données ne sont pas déplacées mais copiées. En effet, la base de données d’origine n’est pas supprimée automatiquement, contrairement à un processus de migration. Seul le contenu de la base de données source est dupliqué pour être copié dans la base de données de destination.
+> Grâce à cette fonctionnalité, les bases de données ne sont pas déplacées mais copiées. En effet, la base de données d'origine n'est pas supprimée automatiquement, contrairement à un processus de migration. Seul le contenu de la base de données source est dupliqué pour être copié dans la base de données de destination.
 >
 
 ## Prérequis
 
-- Disposer d’offres de bases de données [start SQL](/links/web/hosting-options-startsql) et/ou [Web Cloud Databases](/links/web/databases). Les deux bases de données concernées doivent être préalablement créées pour pouvoir utiliser l'outil de duplication.
-- Disposer des droits suffisants sur l’ensemble des services de base de données concernées. Retrouvez plus d'informations sur notre guide [Gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts).
+- Disposer d'offres de bases de données [start SQL](/links/web/hosting-options-startsql) et/ou [Web Cloud Databases](/links/web/databases). Les deux bases de données concernées doivent être préalablement créées pour pouvoir utiliser l'outil de duplication.
+- Disposer des droits suffisants sur l'ensemble des services de base de données concernées. Retrouvez plus d'informations sur notre guide [Gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts).
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -39,18 +53,20 @@ Avant de commencer, assurez-vous que :
 - La version de votre SGBD est la même pour vos deux bases de données (source et destination). Même si la copie peut fonctionner avec des versions différentes, il est conseillé d'utiliser les mêmes versions.
 - Le contenu de la base de données source ne doit pas excéder la taille de la base de données de destination.
 
-### Identifier ma base de données source
+### Copier le contenu d'une base de données
 
-Cette fonctionnalité est disponible pour la copie : 
+Cette fonctionnalité est disponible pour la copie :
 
 - d'une base de données [Start SQL](/links/web/hosting-options-startsql) (incluse dans certains de nos [hébergements web](/links/web/hosting) ou [commandée séparément](/links/web/hosting-options-startsql));
-- d'une base de données présente sur un serveur [Web Cloud Databases](/links/web/databases) (incluse avec nos [hébergements Performance](/links/web/hosting-performance-offer) ou [commandée séparément](/links/web/databases)). 
+- d'une base de données présente sur un serveur [Web Cloud Databases](/links/web/databases) (incluse avec nos [hébergements Performance](/links/web/hosting-performance-offer) ou [commandée séparément](/links/web/databases)).
 
 Selon votre situation, le chemin pour accéder à votre base de données source est différent.
 
-#### Base de données Start SQL
+**Cliquez sur la situation de votre choix pour afficher le contenu.**
 
-Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+/// details | Depuis une base de données Start SQL
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **6** étapes.
 
 > [!tabs]
 > **Étape 1**
@@ -61,105 +77,108 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 > **Étape 2**
 >>
->> Sur la page qui s'affiche, cliquez sur l'onglet `Bases de données`{.action}. 
->>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
->> 
-> **Étape 3**
->>
->> Eine Liste Ihrer Start SQL-Datenbanken wird angezeigt.
+>> Cliquez sur l'onglet `Bases de données`{.action}. Le tableau liste les bases de données créées sur votre offre d'hébergement web.
 >>
 >> ![Liste des BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>>
+> **Étape 3**
+>>
+>> Cliquez sur le bouton `...`{.action} à droite de la ligne correspondant à la base de données dont vous souhaitez copier le contenu, puis sélectionnez `Copier la base de données`{.action}.
+>>
+>> ![CTA_copier_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Étape 4**
+>>
+>> Une fenêtre vous invite à choisir votre base de données de destination.
+>>
+>> ![Interface copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Si vous n'avez pas de base de données de destination, cliquez sur le lien présent dans la fenêtre pour en acheter une. N'oubliez pas de l'activer :
+>> >
+>> > - Pour une base de données « Shared SQL » : suivez notre guide « [Créer une base de données sur son hébergement web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Pour une base de données sur un serveur « Web Cloud Databases » : suivez notre guide « [Créer une base de données sur un serveur Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Choix 1 - Copier vers une base Start SQL** : sélectionnez `Copier vers une base de données`{.action}, puis choisissez la base de données de destination dans la liste déroulante.
+>> - **Choix 2 - Copier vers un serveur Web Cloud Databases** : sélectionnez `Copier vers un Web Cloud Databases`{.action}. Deux listes déroulantes s'affichent. Cliquez sur la première puis sélectionnez l'offre Web Cloud Databases, puis sur la deuxième pour choisir la base de données de destination.
+>>
+> **Étape 5**
+>>
+>> Cliquez sur `Suivant`{.action}. Le message de confirmation suivant s'affiche :
+>>
+>> ![Message de confirmation copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Si vous ne souhaitez pas écraser la base de données de destination, cliquez sur `Précédent`{.action} pour modifier votre choix ou sur `Annuler`{.action} pour tout annuler. Sinon, cliquez sur `Valider`{.action} pour confirmer la duplication.
+>>
+> **Étape 6**
+>>
+>> La copie peut prendre plusieurs minutes. Dans l'onglet `Tâches en cours`{.action}, une nouvelle ligne correspondant à votre copie apparaît avec un statut « planifié ». Une fois l'opération terminée, la ligne disparaît.
+>>
+>> ![Tâches en cours](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+/// details | Depuis un serveur Web Cloud Databases
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **6** étapes.
 
 > [!tabs]
 > **Étape 1**
 >>
->> Connectez-vous à votre [espace client OVHcloud](/links/manager), puis rendez-vous dans la partie `Web Cloud`{.action}.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Étape 2**
->>
->> Cliquez sur le menu `Web Cloud Databases`{.action}, puis choisissez la solution Web Cloud Databases concernée.
+>> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez la solution concernée.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Étape 3**
+> **Étape 2**
 >>
->> En cliquant sur l’onglet `Bases de données`{.action}, la liste des bases de données présentes sur votre serveur Web Cloud Databases s’affiche.
+>> Cliquez sur l'onglet `Bases de données`{.action}. La liste des bases de données présentes sur votre serveur Web Cloud Databases s'affiche.
 >>
 >> ![Liste des BDD WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Étape 3**
+>>
+>> Cliquez sur le bouton `...`{.action} à droite de la ligne correspondant à la base de données dont vous souhaitez copier le contenu, puis sélectionnez `Copier la base de données`{.action}.
+>>
+>> ![CTA_copier_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Étape 4**
+>>
+>> Une fenêtre vous invite à choisir votre base de données de destination.
+>>
+>> ![Interface copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Si vous n'avez pas de base de données de destination, cliquez sur le lien présent dans la fenêtre pour en acheter une. N'oubliez pas de l'activer :
+>> >
+>> > - Pour une base de données « Shared SQL » : suivez notre guide « [Créer une base de données sur son hébergement web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Pour une base de données sur un serveur « Web Cloud Databases » : suivez notre guide « [Créer une base de données sur un serveur Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Choix 1 - Copier vers une base Start SQL** : sélectionnez `Copier vers une base de données`{.action}, puis choisissez la base de données de destination dans la liste déroulante.
+>> - **Choix 2 - Copier vers un serveur Web Cloud Databases** : sélectionnez `Copier vers un Web Cloud Databases`{.action}. Deux listes déroulantes s'affichent. Cliquez sur la première puis sélectionnez l'offre Web Cloud Databases, puis sur la deuxième pour choisir la base de données de destination.
+>>
+> **Étape 5**
+>>
+>> Cliquez sur `Suivant`{.action}. Le message de confirmation suivant s'affiche :
+>>
+>> ![Message de confirmation copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Si vous ne souhaitez pas écraser la base de données de destination, cliquez sur `Précédent`{.action} pour modifier votre choix ou sur `Annuler`{.action} pour tout annuler. Sinon, cliquez sur `Valider`{.action} pour confirmer la duplication.
+>>
+> **Étape 6**
+>>
+>> La copie peut prendre plusieurs minutes. Dans l'onglet `Tâches en cours`{.action}, une nouvelle ligne correspondant à votre copie apparaît avec un statut « planifié ». Une fois l'opération terminée, la ligne disparaît.
+>>
+>> ![Tâches en cours](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copier le contenu d'une base de données
-
-Toujours dans l'onglet `Bases de données`{.action} et quelle que soit votre offre, cliquez sur le bouton `...`{.action} à droite de la ligne correspondant à la base de données dont vous souhaitez copier le contenu, puis sélectionnez `Copier la base de données`{.action}.
-
-![CTA_copier_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-Une fenêtre s’affiche afin d’identifier votre base de données de destination.
-
-![Interface copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-Si vous ne possédez pas de base de données de destination et comme nous le montre la capture écran ci-après, cliquez sur le lien présent pour acheter une nouvelle base de données :
-
-![Liste des BDD WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-Vous pourrez choisir entre acheter une offre « [start SQL](/links/web/hosting-options-startsql) » ou un serveur de bases de données « [Web Cloud Databases](/links/web/databases) ».
-
-> [!primary]
->
-> Lorsque vous achetez votre nouvelle base de données, celle-ci n’est pas activée par défaut. N'oubliez pas de l'activer. Pour cela, connectez-vous à votre [espace client OVHcloud](/links/manager), puis rendez-vous dans la partie `Web Cloud`{.action}.
-> 
-> - Pour une base de données « Shared SQL » : suivez notre guide « [Créer une base de données sur son hébergement web](/pages/web_cloud/web_hosting/sql_create_database) »;
-> - Pour une base de données qui sera présente sur un serveur « Web Cloud Databases » : suivez notre guide « [Créer une base de données sur un serveur Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
->
-
-Si vous possédez déjà une base de données de destination, choisissez d'abord son type :
-
-- `Copier vers une base de données`{.action} : si vous souhaitez copier le contenu de votre base de données source vers une base de données **Start SQL** (destination).
-- `Copier vers un Web Cloud Databases`{.action} : si vous souhaitez copier le contenu de votre base de données source vers une base de données **Web Cloud Databas** (destination).
-
-#### Choix 1 - Copier vers une base de données Start SQL
-
-Vous venez de sélectionner `Copier vers une base de données`{.action}. Deux listes déroulantes s'affichent. Cliquez sur la première puis sélectionnez l’hébergement web sur lequel se trouve votre base de données Start SQL de destination. Une fois l’hébergement web sélectionné, cliquez sur la deuxième liste déroulante pour choisir la base de données Start SQL de destination.
-
-Cliquez sur `Suivant`{.action}. Le message de confirmation ci-après s’affiche :
-
-![Message de confirmation copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Si vous ne souhaitez pas écraser la base de données de destination choisie, cliquez sur `Précédent`{.action} pour modifier votre choix ou sur `Annuler`{.action} pour tout annuler. Sinon, cliquez sur `Valider`{.action} pour confirmer la duplication du contenu de la base de données source vers la base de données de destination.
-
-Le message de confirmation suivant s’affiche :
-
-![Message de succès BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-La copie de la base de données peut prendre plusieurs minutes. Pour vérifier que la copie a bien été prise en compte, dirigez-vous dans l’onglet `Tâches en cours`{.action}. Dans le tableau, une nouvelle ligne correspondant à votre copie apparaît avec un statut « planifié ». Une fois l’opération terminée, la ligne disparaît.
-
-![Tâches en cours](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Choix 2 - Copier vers une base de données présente sur un serveur Web Cloud Databases
-
-Vous venez de sélectionner `Copier vers un Web Cloud Databases`{.action}. Deux listes déroulantes s'affichent. Cliquez sur la première puis sélectionnez l'offre Web Cloud Databases sur laquelle se trouve votre base de données de destination. Une fois l'offre Web Cloud Databases sélectionnée, cliquez sur la deuxième liste déroulante pour choisir la base de données de destination présente sur votre serveur Web Cloud Databases.
-
-Cliquez sur `Suivant`{.action}. Le message de confirmation suivant s’affiche :
-
-![Message de confirmation copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Si vous ne souhaitez pas écraser la base de données de destination choisie, cliquez sur `Précédent`{.action} pour modifier votre choix ou sur `Annuler`{.action} pour tout annuler. Sinon, cliquez sur `Valider`{.action} pour confirmer la duplication du contenu de la base de données source vers la base de données de destination.
-
-La copie de la base de données peut prendre plusieurs minutes. Pour vérifier que la copie a bien été prise en compte, dirigez-vous dans l’onglet `Tâches en cours`{.action}. Dans le tableau, une nouvelle ligne correspondant à votre copie apparaît avec un statut « planifié ». Une fois l’opération terminée, la ligne disparaît.
-
-![Tâches en cours](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configurer son site web avec sa nouvelle base de données
 
 Une fois la copie de votre base de données source effectuée, vous devrez réaliser une dernière action si vous souhaitez utiliser votre nouvelle base de données.
 
-Dans l’onglet `Tâches en cours`{.action}, assurez-vous que la copie est bien terminée (la ligne correspondante à votre copie a disparu).
+Assurez-vous que la copie est bien terminée (la ligne correspondant à votre copie dans l'onglet `Tâches en cours`{.action} a disparu).
 
 Pour connecter la nouvelle base de données à votre site web, éditez le fichier de configuration de votre **C**ontent **M**anagement **S**ystem (**CMS**) et saisissez les informations de connexion de la nouvelle base de données.
 
@@ -178,37 +197,47 @@ Pour plus de détail, ou si vous utilisez un autre CMS, consultez notre guide [M
 
 > [!primary]
 >
-> La copie de votre base de données n’est pas une migration. Votre base de données source existe toujours tant que vous ne la supprimez pas. Vous pourrez ainsi toujours reconfigurer votre site web avec son ancienne base de données si nécessaire.
+> La copie de votre base de données n'est pas une migration. Votre base de données source existe toujours tant que vous ne la supprimez pas. Vous pourrez ainsi toujours reconfigurer votre site web avec son ancienne base de données si nécessaire.
 >
 
 ### Cas d'usages
 
 Durant le processus de copie du contenu de la base de données, vous pouvez rencontrer des difficultés.
 
-#### Aucune base de données ne s’affiche dans la liste
+**Cliquez sur la situation de votre choix pour afficher le contenu.**
 
-Cette notification signifie que vous ne possédez qu’une seule base de données active. Pour copier votre base de données source, il vous faut également une base de données de destination active. Pour cela, vous pouvez:
+/// details | Aucune base de données ne s'affiche dans la liste
 
-- Configurer une nouvelle base de données disponible sur votre hébergement web;
-- Configurer une nouvelle base de données sur votre serveur [Web Cloud Databases](/links/web/databases);
-- Commander une offre « [start SQL](/links/web/hosting-options-startsql) » ou un serveur de bases de données « [Web Cloud Databases](/links/web/databases) »
+Cette notification signifie que vous ne possédez qu'une seule base de données active. Pour copier votre base de données source, il vous faut également une base de données de destination active. Pour cela, vous pouvez :
 
-#### Vous avez déjà une action en cours
+- Configurer une nouvelle base de données disponible sur votre hébergement web.
+- Configurer une nouvelle base de données sur votre serveur [Web Cloud Databases](/links/web/databases).
+- Commander une offre « [start SQL](/links/web/hosting-options-startsql) » ou un serveur de bases de données « [Web Cloud Databases](/links/web/databases) ».
 
-Ce message signifie qu’une tâche est déjà en cours sur votre base de données. Dirigez-vous dans l’onglet `Tâches en cours`{.action} et vérifiez que vous avez bien une opération déjà en cours. Si c’est le cas, attendez qu’elle soit terminée pour recommencer la copie de votre base de données si nécessaire.
+///
 
-#### La base de données de destination ne contient pas assez d’espace
+/// details | Vous avez déjà une action en cours
 
-Votre base de données de destination ne contient pas assez d’espace. Deux solutions s’offrent à vous :
+Ce message signifie qu'une tâche est déjà en cours sur votre base de données. Dirigez-vous dans l'onglet `Tâches en cours`{.action} et vérifiez que vous avez bien une opération déjà en cours. Si c'est le cas, attendez qu'elle soit terminée pour recommencer la copie de votre base de données si nécessaire.
 
-- Commander une nouvelle base de données [start SQL](/links/web/hosting-options-startsql) avec plus d’espace.
-- Si vous possédez un serveur [Web Cloud Databases](/links/web/databases), Changez pour une offre Web Cloud Databases disposant de plus d’espace de stockage.
+///
 
-#### Les bases de données source et destination sont incompatibles
+/// details | La base de données de destination ne contient pas assez d'espace
 
-Cette notification signifie que le **S**ystème de **G**estion de **B**ases de **D**onnées (**SGBD**) de votre base de données source n’est pas le même que le SGBD de votre base de données de destination.
+Votre base de données de destination ne contient pas assez d'espace. Deux solutions s'offrent à vous :
+
+- Commander une nouvelle base de données [start SQL](/links/web/hosting-options-startsql) avec plus d'espace.
+- Si vous possédez un serveur [Web Cloud Databases](/links/web/databases), changez pour une offre Web Cloud Databases disposant de plus d'espace de stockage.
+
+///
+
+/// details | Les bases de données source et destination sont incompatibles
+
+Cette notification signifie que le **S**ystème de **G**estion de **B**ases de **D**onnées (**SGBD**) de votre base de données source n'est pas le même que le SGBD de votre base de données de destination.
 
 Par exemple, cette erreur peut survenir lorsque vous utilisez MySQL pour votre base de données source, et PostgreSQL pour votre base de données de destination.
+
+///
 
 ## Aller plus loin
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.fr-fr.md
@@ -1,8 +1,22 @@
 ---
 title: "Dupliquer le contenu d'une base de données dans une autre"
 excerpt: "Découvrez comment copier le contenu d'une base de données OVHcloud dans une autre base de données OVHcloud"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objectif
 
@@ -39,127 +53,132 @@ Avant de commencer, assurez-vous que :
 - La version de votre SGBD est la même pour vos deux bases de données (source et destination). Même si la copie peut fonctionner avec des versions différentes, il est conseillé d'utiliser les mêmes versions.
 - Le contenu de la base de données source ne doit pas excéder la taille de la base de données de destination.
 
-### Identifier ma base de données source
+### Copier le contenu d’une base de données
 
-Cette fonctionnalité est disponible pour la copie : 
+Cette fonctionnalité est disponible pour la copie :
 
-- d'une base de données [Start SQL](/links/web/hosting-options-startsql) (incluse dans certains de nos [hébergements web](/links/web/hosting) ou [commandée séparément](/links/web/hosting-options-startsql));
-- d'une base de données présente sur un serveur [Web Cloud Databases](/links/web/databases) (incluse avec nos [hébergements Performance](/links/web/hosting-performance-offer) ou [commandée séparément](/links/web/databases)). 
+- d’une base de données [Start SQL](/links/web/hosting-options-startsql) (incluse dans certains de nos [hébergements web](/links/web/hosting) ou [commandée séparément](/links/web/hosting-options-startsql));
+- d’une base de données présente sur un serveur [Web Cloud Databases](/links/web/databases) (incluse avec nos [hébergements Performance](/links/web/hosting-performance-offer) ou [commandée séparément](/links/web/databases)).
 
 Selon votre situation, le chemin pour accéder à votre base de données source est différent.
 
-#### Base de données Start SQL
+**Cliquez sur la situation de votre choix pour afficher le contenu.**
 
-Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+/// details | Depuis une base de données Start SQL
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **6** étapes.
 
 > [!tabs]
 > **Étape 1**
 >>
->> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l’hébergement web concerné.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
->> Sur la page qui s'affiche, cliquez sur l'onglet `Bases de données`{.action}. 
->>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
->> 
-> **Étape 3**
->>
->> La liste de vos bases de données Start SQL s’affiche.
+>> Cliquez sur l’onglet `Bases de données`{.action}. Le tableau qui apparaît contient les bases de données créées sur votre offre d’hébergement web.
 >>
 >> ![Liste des BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>>
+> **Étape 3**
+>>
+>> Cliquez sur le bouton `...`{.action} à droite de la ligne correspondant à la base de données dont vous souhaitez copier le contenu, puis sélectionnez `Copier la base de données`{.action}.
+>>
+>> ![CTA_copier_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Étape 4**
+>>
+>> Une fenêtre s’affiche afin d’identifier votre base de données de destination.
+>>
+>> ![Interface copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Si vous ne possédez pas de base de données de destination, cliquez sur le lien présent dans la fenêtre pour en acheter une. N’oubliez pas de l’activer :
+>> >
+>> > - Pour une base de données « Shared SQL » : suivez notre guide « [Créer une base de données sur son hébergement web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Pour une base de données sur un serveur « Web Cloud Databases » : suivez notre guide « [Créer une base de données sur un serveur Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Choix 1 - Copier vers une base Start SQL** : sélectionnez `Copier vers une base de données hébergée chez OVHcloud`{.action}, puis choisissez la base de données de destination dans la liste déroulante.
+>> - **Choix 2 - Copier vers un serveur Web Cloud Databases** : sélectionnez `Copier vers un Web Cloud Databases`{.action}. Deux listes déroulantes s’affichent. Cliquez sur la première puis sélectionnez l’offre Web Cloud Databases, puis sur la deuxième pour choisir la base de données de destination.
+>>
+> **Étape 5**
+>>
+>> Cliquez sur `Suivant`{.action}. Le message de confirmation suivant s’affiche :
+>>
+>> ![Message de confirmation copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Si vous ne souhaitez pas écraser la base de données de destination, cliquez sur `Précédent`{.action} pour modifier votre choix ou sur `Annuler`{.action} pour tout annuler. Sinon, cliquez sur `Valider`{.action} pour confirmer la duplication.
+>>
+> **Étape 6**
+>>
+>> La copie peut prendre plusieurs minutes. Dans l’onglet `Tâches en cours`{.action}, une nouvelle ligne correspondant à votre copie apparaît avec un statut « planifié ». Une fois l’opération terminée, la ligne disparaît.
+>>
+>> ![Tâches en cours](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+/// details | Depuis un serveur Web Cloud Databases
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **6** étapes.
 
 > [!tabs]
 > **Étape 1**
 >>
->> Connectez-vous à votre [espace client OVHcloud](/links/manager), puis rendez-vous dans la partie `Web Cloud`{.action}.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Étape 2**
->>
->> Cliquez sur le menu `Web Cloud Databases`{.action}, puis choisissez la solution Web Cloud Databases concernée.
+>> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez la solution concernée.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Étape 3**
+> **Étape 2**
 >>
->> En cliquant sur l’onglet `Bases de données`{.action}, la liste des bases de données présentes sur votre serveur Web Cloud Databases s’affiche.
+>> Cliquez sur l’onglet `Bases de données`{.action}. La liste des bases de données présentes sur votre serveur Web Cloud Databases s’affiche.
 >>
 >> ![Liste des BDD WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Étape 3**
+>>
+>> Cliquez sur le bouton `...`{.action} à droite de la ligne correspondant à la base de données dont vous souhaitez copier le contenu, puis sélectionnez `Copier la base de données`{.action}.
+>>
+>> ![CTA_copier_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Étape 4**
+>>
+>> Une fenêtre s’affiche afin d’identifier votre base de données de destination.
+>>
+>> ![Interface copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Si vous ne possédez pas de base de données de destination, cliquez sur le lien présent dans la fenêtre pour en acheter une. N’oubliez pas de l’activer :
+>> >
+>> > - Pour une base de données « Shared SQL » : suivez notre guide « [Créer une base de données sur son hébergement web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Pour une base de données sur un serveur « Web Cloud Databases » : suivez notre guide « [Créer une base de données sur un serveur Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Choix 1 - Copier vers une base Start SQL** : sélectionnez `Copier vers une base de données hébergée chez OVHcloud`{.action}, puis choisissez la base de données de destination dans la liste déroulante.
+>> - **Choix 2 - Copier vers un serveur Web Cloud Databases** : sélectionnez `Copier vers un Web Cloud Databases`{.action}. Deux listes déroulantes s’affichent. Cliquez sur la première puis sélectionnez l’offre Web Cloud Databases, puis sur la deuxième pour choisir la base de données de destination.
+>>
+> **Étape 5**
+>>
+>> Cliquez sur `Suivant`{.action}. Le message de confirmation suivant s’affiche :
+>>
+>> ![Message de confirmation copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Si vous ne souhaitez pas écraser la base de données de destination, cliquez sur `Précédent`{.action} pour modifier votre choix ou sur `Annuler`{.action} pour tout annuler. Sinon, cliquez sur `Valider`{.action} pour confirmer la duplication.
+>>
+> **Étape 6**
+>>
+>> La copie peut prendre plusieurs minutes. Dans l’onglet `Tâches en cours`{.action}, une nouvelle ligne correspondant à votre copie apparaît avec un statut « planifié ». Une fois l’opération terminée, la ligne disparaît.
+>>
+>> ![Tâches en cours](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copier le contenu d'une base de données
-
-Toujours dans l'onglet `Bases de données`{.action} et quelle que soit votre offre, cliquez sur le bouton `...`{.action} à droite de la ligne correspondant à la base de données dont vous souhaitez copier le contenu, puis sélectionnez `Copier la base de données`{.action}.
-
-![CTA_copier_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-Une fenêtre s’affiche afin d’identifier votre base de données de destination.
-
-![Interface copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-Si vous ne possédez pas de base de données de destination et comme nous le montre la capture écran ci-après, cliquez sur le lien présent pour acheter une nouvelle base de données :
-
-![Liste des BDD WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-Vous pourrez choisir entre acheter une offre « [start SQL](/links/web/hosting-options-startsql) » ou un serveur de bases de données « [Web Cloud Databases](/links/web/databases) ».
-
-> [!primary]
->
-> Lorsque vous achetez votre nouvelle base de données, celle-ci n’est pas activée par défaut. N'oubliez pas de l'activer. Pour cela, connectez-vous à votre [espace client OVHcloud](/links/manager), puis rendez-vous dans la partie `Web Cloud`{.action}.
-> 
-> - Pour une base de données « Shared SQL » : suivez notre guide « [Créer une base de données sur son hébergement web](/pages/web_cloud/web_hosting/sql_create_database) »;
-> - Pour une base de données qui sera présente sur un serveur « Web Cloud Databases » : suivez notre guide « [Créer une base de données sur un serveur Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
->
-
-Si vous possédez déjà une base de données de destination, choisissez d'abord son type :
-
-- `Copier vers une base de données`{.action} : si vous souhaitez copier le contenu de votre base de données source vers une base de données **Start SQL** (destination).
-- `Copier vers un Web Cloud Databases`{.action} : si vous souhaitez copier le contenu de votre base de données source vers une base de données **Web Cloud Databas** (destination).
-
-#### Choix 1 - Copier vers une base de données Start SQL
-
-Vous venez de sélectionner `Copier vers une base de données`{.action}. Deux listes déroulantes s'affichent. Cliquez sur la première puis sélectionnez l’hébergement web sur lequel se trouve votre base de données Start SQL de destination. Une fois l’hébergement web sélectionné, cliquez sur la deuxième liste déroulante pour choisir la base de données Start SQL de destination.
-
-Cliquez sur `Suivant`{.action}. Le message de confirmation ci-après s’affiche :
-
-![Message de confirmation copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Si vous ne souhaitez pas écraser la base de données de destination choisie, cliquez sur `Précédent`{.action} pour modifier votre choix ou sur `Annuler`{.action} pour tout annuler. Sinon, cliquez sur `Valider`{.action} pour confirmer la duplication du contenu de la base de données source vers la base de données de destination.
-
-Le message de confirmation suivant s’affiche :
-
-![Message de succès BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-La copie de la base de données peut prendre plusieurs minutes. Pour vérifier que la copie a bien été prise en compte, dirigez-vous dans l’onglet `Tâches en cours`{.action}. Dans le tableau, une nouvelle ligne correspondant à votre copie apparaît avec un statut « planifié ». Une fois l’opération terminée, la ligne disparaît.
-
-![Tâches en cours](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Choix 2 - Copier vers une base de données présente sur un serveur Web Cloud Databases
-
-Vous venez de sélectionner `Copier vers un Web Cloud Databases`{.action}. Deux listes déroulantes s'affichent. Cliquez sur la première puis sélectionnez l'offre Web Cloud Databases sur laquelle se trouve votre base de données de destination. Une fois l'offre Web Cloud Databases sélectionnée, cliquez sur la deuxième liste déroulante pour choisir la base de données de destination présente sur votre serveur Web Cloud Databases.
-
-Cliquez sur `Suivant`{.action}. Le message de confirmation suivant s’affiche :
-
-![Message de confirmation copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Si vous ne souhaitez pas écraser la base de données de destination choisie, cliquez sur `Précédent`{.action} pour modifier votre choix ou sur `Annuler`{.action} pour tout annuler. Sinon, cliquez sur `Valider`{.action} pour confirmer la duplication du contenu de la base de données source vers la base de données de destination.
-
-La copie de la base de données peut prendre plusieurs minutes. Pour vérifier que la copie a bien été prise en compte, dirigez-vous dans l’onglet `Tâches en cours`{.action}. Dans le tableau, une nouvelle ligne correspondant à votre copie apparaît avec un statut « planifié ». Une fois l’opération terminée, la ligne disparaît.
-
-![Tâches en cours](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configurer son site web avec sa nouvelle base de données
 
 Une fois la copie de votre base de données source effectuée, vous devrez réaliser une dernière action si vous souhaitez utiliser votre nouvelle base de données.
 
-Dans l’onglet `Tâches en cours`{.action}, assurez-vous que la copie est bien terminée (la ligne correspondante à votre copie a disparu).
+Assurez-vous que la copie est bien terminée (la ligne mentionnée dans l'étape 6, correspondante à votre copie, a disparu).
 
 Pour connecter la nouvelle base de données à votre site web, éditez le fichier de configuration de votre **C**ontent **M**anagement **S**ystem (**CMS**) et saisissez les informations de connexion de la nouvelle base de données.
 
@@ -181,11 +200,13 @@ Pour plus de détail, ou si vous utilisez un autre CMS, consultez notre guide [M
 > La copie de votre base de données n’est pas une migration. Votre base de données source existe toujours tant que vous ne la supprimez pas. Vous pourrez ainsi toujours reconfigurer votre site web avec son ancienne base de données si nécessaire.
 >
 
-### Cas d'usages
+### Cas d’usages
 
 Durant le processus de copie du contenu de la base de données, vous pouvez rencontrer des difficultés.
 
-#### Aucune base de données ne s’affiche dans la liste
+**Cliquez sur la situation de votre choix pour afficher le contenu.**
+
+/// details | Aucune base de données ne s’affiche dans la liste
 
 Cette notification signifie que vous ne possédez qu’une seule base de données active. Pour copier votre base de données source, il vous faut également une base de données de destination active. Pour cela, vous pouvez:
 
@@ -193,22 +214,30 @@ Cette notification signifie que vous ne possédez qu’une seule base de donnée
 - Configurer une nouvelle base de données sur votre serveur [Web Cloud Databases](/links/web/databases);
 - Commander une offre « [start SQL](/links/web/hosting-options-startsql) » ou un serveur de bases de données « [Web Cloud Databases](/links/web/databases) »
 
-#### Vous avez déjà une action en cours
+///
+
+/// details | Vous avez déjà une action en cours
 
 Ce message signifie qu’une tâche est déjà en cours sur votre base de données. Dirigez-vous dans l’onglet `Tâches en cours`{.action} et vérifiez que vous avez bien une opération déjà en cours. Si c’est le cas, attendez qu’elle soit terminée pour recommencer la copie de votre base de données si nécessaire.
 
-#### La base de données de destination ne contient pas assez d’espace
+///
+
+/// details | La base de données de destination ne contient pas assez d’espace
 
 Votre base de données de destination ne contient pas assez d’espace. Deux solutions s’offrent à vous :
 
 - Commander une nouvelle base de données [start SQL](/links/web/hosting-options-startsql) avec plus d’espace.
-- Si vous possédez un serveur [Web Cloud Databases](/links/web/databases), Changez pour une offre Web Cloud Databases disposant de plus d’espace de stockage.
+- Si vous possédez un serveur [Web Cloud Databases](/links/web/databases), changez pour une offre Web Cloud Databases disposant de plus d’espace de stockage.
 
-#### Les bases de données source et destination sont incompatibles
+///
+
+/// details | Les bases de données source et destination sont incompatibles
 
 Cette notification signifie que le **S**ystème de **G**estion de **B**ases de **D**onnées (**SGBD**) de votre base de données source n’est pas le même que le SGBD de votre base de données de destination.
 
 Par exemple, cette erreur peut survenir lorsque vous utilisez MySQL pour votre base de données source, et PostgreSQL pour votre base de données de destination.
+
+///
 
 ## Aller plus loin
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Dupliquer le contenu d'une base de données dans une autre"
 excerpt: "Découvrez comment copier le contenu d'une base de données OVHcloud dans une autre base de données OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.fr-fr.md
@@ -77,7 +77,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **6*
 >>
 > **Étape 2**
 >>
->> Cliquez sur l’onglet `Bases de données`{.action}. Le tableau qui apparaît contient les bases de données créées sur votre offre d’hébergement web.
+>> Cliquez sur l’onglet `Bases de données`{.action}. Le tableau liste les bases de données créées sur votre offre d’hébergement web.
 >>
 >> ![Liste des BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
@@ -89,18 +89,18 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **6*
 >>
 > **Étape 4**
 >>
->> Une fenêtre s’affiche afin d’identifier votre base de données de destination.
+>> Une fenêtre vous invite à choisir votre base de données de destination.
 >>
 >> ![Interface copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
->> > Si vous ne possédez pas de base de données de destination, cliquez sur le lien présent dans la fenêtre pour en acheter une. N’oubliez pas de l’activer :
+>> > Si vous n'avez pas de base de données de destination, cliquez sur le lien présent dans la fenêtre pour en acheter une. N’oubliez pas de l’activer :
 >> >
 >> > - Pour une base de données « Shared SQL » : suivez notre guide « [Créer une base de données sur son hébergement web](/pages/web_cloud/web_hosting/sql_create_database) ».
 >> > - Pour une base de données sur un serveur « Web Cloud Databases » : suivez notre guide « [Créer une base de données sur un serveur Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
 >>
->> - **Choix 1 - Copier vers une base Start SQL** : sélectionnez `Copier vers une base de données hébergée chez OVHcloud`{.action}, puis choisissez la base de données de destination dans la liste déroulante.
+>> - **Choix 1 - Copier vers une base Start SQL** : sélectionnez `Copier vers une base de données`{.action}, puis choisissez la base de données de destination dans la liste déroulante.
 >> - **Choix 2 - Copier vers un serveur Web Cloud Databases** : sélectionnez `Copier vers un Web Cloud Databases`{.action}. Deux listes déroulantes s’affichent. Cliquez sur la première puis sélectionnez l’offre Web Cloud Databases, puis sur la deuxième pour choisir la base de données de destination.
 >>
 > **Étape 5**
@@ -144,18 +144,18 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **6*
 >>
 > **Étape 4**
 >>
->> Une fenêtre s’affiche afin d’identifier votre base de données de destination.
+>> Une fenêtre vous invite à choisir votre base de données de destination.
 >>
 >> ![Interface copier BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
 >>
 >> > [!primary]
 >> >
->> > Si vous ne possédez pas de base de données de destination, cliquez sur le lien présent dans la fenêtre pour en acheter une. N’oubliez pas de l’activer :
+>> > Si vous n'avez pas de base de données de destination, cliquez sur le lien présent dans la fenêtre pour en acheter une. N’oubliez pas de l’activer :
 >> >
 >> > - Pour une base de données « Shared SQL » : suivez notre guide « [Créer une base de données sur son hébergement web](/pages/web_cloud/web_hosting/sql_create_database) ».
 >> > - Pour une base de données sur un serveur « Web Cloud Databases » : suivez notre guide « [Créer une base de données sur un serveur Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
 >>
->> - **Choix 1 - Copier vers une base Start SQL** : sélectionnez `Copier vers une base de données hébergée chez OVHcloud`{.action}, puis choisissez la base de données de destination dans la liste déroulante.
+>> - **Choix 1 - Copier vers une base Start SQL** : sélectionnez `Copier vers une base de données`{.action}, puis choisissez la base de données de destination dans la liste déroulante.
 >> - **Choix 2 - Copier vers un serveur Web Cloud Databases** : sélectionnez `Copier vers un Web Cloud Databases`{.action}. Deux listes déroulantes s’affichent. Cliquez sur la première puis sélectionnez l’offre Web Cloud Databases, puis sur la deuxième pour choisir la base de données de destination.
 >>
 > **Étape 5**
@@ -178,7 +178,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **6*
 
 Une fois la copie de votre base de données source effectuée, vous devrez réaliser une dernière action si vous souhaitez utiliser votre nouvelle base de données.
 
-Assurez-vous que la copie est bien terminée (la ligne mentionnée dans l'étape 6, correspondante à votre copie, a disparu).
+Assurez-vous que la copie est bien terminée (la ligne correspondant à votre copie dans l'onglet `Tâches en cours`{.action} a disparu).
 
 Pour connecter la nouvelle base de données à votre site web, éditez le fichier de configuration de votre **C**ontent **M**anagement **S**ystem (**CMS**) et saisissez les informations de connexion de la nouvelle base de données.
 
@@ -208,11 +208,11 @@ Durant le processus de copie du contenu de la base de données, vous pouvez renc
 
 /// details | Aucune base de données ne s’affiche dans la liste
 
-Cette notification signifie que vous ne possédez qu’une seule base de données active. Pour copier votre base de données source, il vous faut également une base de données de destination active. Pour cela, vous pouvez:
+Cette notification signifie que vous ne possédez qu’une seule base de données active. Pour copier votre base de données source, il vous faut également une base de données de destination active. Pour cela, vous pouvez :
 
-- Configurer une nouvelle base de données disponible sur votre hébergement web;
-- Configurer une nouvelle base de données sur votre serveur [Web Cloud Databases](/links/web/databases);
-- Commander une offre « [start SQL](/links/web/hosting-options-startsql) » ou un serveur de bases de données « [Web Cloud Databases](/links/web/databases) »
+- Configurer une nouvelle base de données disponible sur votre hébergement web.
+- Configurer une nouvelle base de données sur votre serveur [Web Cloud Databases](/links/web/databases).
+- Commander une offre « [start SQL](/links/web/hosting-options-startsql) » ou un serveur de bases de données « [Web Cloud Databases](/links/web/databases) ».
 
 ///
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.it-it.md
@@ -1,14 +1,28 @@
 ---
 title: "Duplicare il contenuto di un database in un altro"
 excerpt: "Questa guida ti mostra come copiare il contenuto di un database OVHcloud in un altro database OVHcloud"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Obiettivo
 
 Il database è un elemento centrale nella costruzione di un sito Web dinamico. Durante il ciclo di vita del sito Web, per motivi pratici o tecnici, potrebbe essere necessario copiare il contenuto del database in un altro database [start SQL](/links/web/hosting-options-startsql) o [Web Cloud Databases](/links/web/databases).
 
-**Questa guida ti mostra come copiare il contenuto di un database OVHcloud in un altro database OVHcloud**
+**Questa guida ti mostra come copiare il contenuto di un database OVHcloud in un altro database OVHcloud.**
 
 > [!primary]
 >
@@ -18,14 +32,14 @@ Il database è un elemento centrale nella costruzione di un sito Web dinamico. D
 ## Prerequisiti
 
 - Disporre di offerte di database [start SQL](/links/web/hosting-options-startsql) e/o [Web Cloud Databases](/links/web/databases). Prima di poter utilizzare lo strumento di replica è necessario creare preventivamente i due database interessati.
-- di disporre dei diritti sufficienti su tutti i servizi di database interessati. Per maggiori informazioni consulta la nostra guida [Gestire i contatti dei servizi](/pages/account_and_service_management/account_information/managing_contacts).
+- Disporre dei diritti sufficienti su tutti i servizi di database interessati. Per maggiori informazioni consulta la nostra guida [Gestire i contatti dei servizi](/pages/account_and_service_management/account_information/managing_contacts).
 
 <!-- CP-NAV-START:web-hosting -->
 ---
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -35,129 +49,134 @@ Il database è un elemento centrale nella costruzione di un sito Web dinamico. D
 
 Prima di iniziare, assicurati che:
 
-- Il vostro **D**ata**b**ase **M**anagement **S**ystem (MySQL, PostgreSQL, ecc...) è lo stesso per i vostri due database (sorgente e destinazione).
-- La versione del tuo DBMS è la stessa per i tuoi due database (sorgente e destinazione). Anche se la copia può funzionare con versioni diverse, è consigliabile utilizzare le stesse versioni.
+- Il **D**ata**b**ase **M**anagement **S**ystem (MySQL, PostgreSQL, ecc.) è lo stesso per i due database (sorgente e destinazione).
+- La versione del DBMS è la stessa per i due database (sorgente e destinazione). Anche se la copia può funzionare con versioni diverse, è consigliabile utilizzare le stesse versioni.
 - Il contenuto del database di origine non deve superare le dimensioni del database di destinazione.
 
-### Identificare il database sorgente
+### Copiare il contenuto di un database
 
-Questa funzionalità è disponibile per la copia: 
+Questa funzionalità è disponibile per la copia:
 
-- un database [Start SQL](/links/web/hosting-options-startsql) (incluso in alcuni dei nostri [hosting Web](/links/web/hosting) o [ordinato separatamente](/links/web/hosting-options-startsql);
-- di un database presente su un server [Web Cloud Databases](/links/web/databases) (incluso con i nostri [hosting Performance](/links/web/hosting-performance-offer) o [ordinato separatamente](/links/web/databases). 
+- di un database [Start SQL](/links/web/hosting-options-startsql) (incluso in alcuni dei nostri [hosting Web](/links/web/hosting) o [ordinato separatamente](/links/web/hosting-options-startsql));
+- di un database presente su un server [Web Cloud Databases](/links/web/databases) (incluso con i nostri [hosting Performance](/links/web/hosting-performance-offer) o [ordinato separatamente](/links/web/databases)).
 
 Il percorso per accedere al database di origine è diverso in base alla situazione.
 
-#### Database Start SQL
+**Clicca sulla situazione corrispondente per visualizzare il contenuto.**
 
-Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passi.
+/// details | Da un database Start SQL
+
+Clicca sulle schede qui sotto per visualizzare ciascuno dei **6** passaggi.
 
 > [!tabs]
 > **Passaggio 1**
 >>
->> Accedi alla pagina [Hosting plans](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Passaggio 2**
 >>
->> Nella nuova pagina clicca sulla scheda `Database`{.action}.
+>> Clicca sulla scheda `Database`{.action}. La tabella elenca i database creati sul tuo piano di hosting Web.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Lista dei BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Passaggio 3**
 >>
->> Compare la lista dei database Start SQL.
+>> Clicca sul pulsante `...`{.action} a destra della riga corrispondente al database di cui vuoi copiare il contenuto, poi seleziona `Copiare il database`{.action}.
 >>
->> ![Lista dei BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copiare_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Passaggio 4**
+>>
+>> Verrà visualizzata una finestra per scegliere il database di destinazione.
+>>
+>> ![Interfaccia copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Se non disponi di un database di destinazione, clicca sul link nella finestra per acquistarne uno. Ricordati di attivarlo:
+>> >
+>> > - Per un database Shared SQL: consulta la nostra guida « [Creare un database sul proprio hosting Web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Per un database su un server Web Cloud Databases: consulta la nostra guida « [Creare un database su un server Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Scelta 1 - Copiare verso un database Start SQL**: seleziona `Copiare verso un database`{.action} e scegli il database di destinazione nell'elenco a discesa.
+>> - **Scelta 2 - Copiare verso un server Web Cloud Databases**: seleziona `Copiare verso un Web Cloud Databases`{.action}. Vengono visualizzati due elenchi a discesa. Clicca sul primo per selezionare la soluzione Web Cloud Databases, poi sul secondo per scegliere il database di destinazione.
+>>
+> **Passaggio 5**
+>>
+>> Clicca su `Continua`{.action}. Viene visualizzato il seguente messaggio di conferma:
+>>
+>> ![Messaggio di conferma copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Se non si desidera sovrascrivere il database di destinazione selezionato, clicca su `Indietro`{.action} per modificare la scelta o su `Annulla`{.action} per annullare tutto. In caso contrario, clicca su `Conferma`{.action} per confermare la duplicazione.
+>>
+> **Passaggio 6**
+>>
+>> La copia del database potrebbe richiedere alcuni minuti. Nella scheda `Task in corso`{.action} viene visualizzata una nuova riga con lo stato "Pianificato" per la copia. Al termine dell'operazione, la riga scompare.
+>>
+>> ![Task in corso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passi.
+/// details | Da un server Web Cloud Databases
+
+Clicca sulle schede qui sotto per visualizzare ciascuno dei **6** passaggi.
 
 > [!tabs]
 > **Passaggio 1**
 >>
->> Accedi allo [Spazio Cliente OVHcloud](/links/manager) e clicca su `Web Cloud`{.action}.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Passaggio 2**
->>
->> Clicca sul menu `Web Cloud Databases`{.action} e seleziona la soluzione Web Cloud Databases interessata.
+>> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona la soluzione interessata.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passaggio 3**
+> **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action} per visualizzare la lista dei database presenti sul tuo server Web Cloud Databases.
+>> Clicca sulla scheda `Database`{.action}. La lista dei database presenti sul server Web Cloud Databases viene visualizzata.
 >>
 >> ![Lista dei database WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Passaggio 3**
+>>
+>> Clicca sul pulsante `...`{.action} a destra della riga corrispondente al database di cui vuoi copiare il contenuto, poi seleziona `Copiare il database`{.action}.
+>>
+>> ![CTA_copiare_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Passaggio 4**
+>>
+>> Verrà visualizzata una finestra per scegliere il database di destinazione.
+>>
+>> ![Interfaccia copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Se non disponi di un database di destinazione, clicca sul link nella finestra per acquistarne uno. Ricordati di attivarlo:
+>> >
+>> > - Per un database Shared SQL: consulta la nostra guida « [Creare un database sul proprio hosting Web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Per un database su un server Web Cloud Databases: consulta la nostra guida « [Creare un database su un server Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Scelta 1 - Copiare verso un database Start SQL**: seleziona `Copiare verso un database`{.action} e scegli il database di destinazione nell'elenco a discesa.
+>> - **Scelta 2 - Copiare verso un server Web Cloud Databases**: seleziona `Copiare verso un Web Cloud Databases`{.action}. Vengono visualizzati due elenchi a discesa. Clicca sul primo per selezionare la soluzione Web Cloud Databases, poi sul secondo per scegliere il database di destinazione.
+>>
+> **Passaggio 5**
+>>
+>> Clicca su `Continua`{.action}. Viene visualizzato il seguente messaggio di conferma:
+>>
+>> ![Messaggio di conferma copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Se non si desidera sovrascrivere il database di destinazione selezionato, clicca su `Indietro`{.action} per modificare la scelta o su `Annulla`{.action} per annullare tutto. In caso contrario, clicca su `Conferma`{.action} per confermare la duplicazione.
+>>
+> **Passaggio 6**
+>>
+>> La copia del database potrebbe richiedere alcuni minuti. Nella scheda `Task in corso`{.action} viene visualizzata una nuova riga con lo stato "Pianificato" per la copia. Al termine dell'operazione, la riga scompare.
+>>
+>> ![Task in corso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copia il contenuto di un database
-
-Sempre nella scheda `Database`{.action} e qualunque sia la tua offerta, clicca sul pulsante `...`{.action} a destra della riga corrispondente al database di cui vuoi copiare il contenuto, poi seleziona `Copia il database`{.action}.
-
-![CTA_copiare_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-Verrà visualizzata una finestra che consente di identificare il database di destinazione.
-
-![Interfaccia copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-Se non si dispone di un database di destinazione e come illustrato nella schermata seguente, fare clic sul collegamento per acquistare un nuovo database:
-
-![Lista dei database WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-È possibile scegliere se acquistare un'offerta "[start SQL](/links/web/hosting-options-startsql)" o un server di database "[Web Cloud Databases](/links/web/databases)".
-
-> [!primary]
->
-> Il nuovo database acquistato non è abilitato per impostazione predefinita. Ricordati di attivarla. Per farlo, accedi al tuo [Spazio Cliente OVHcloud](/links/manager), sezione `Web Cloud`{.action}.
-> 
-> - Per un database "Shared SQL": consulta la nostra guida "[Creare un database sul proprio hosting Web](/pages/web_cloud/web_hosting/sql_create_database)";
-> - Per creare un database che sarà presente su un server "Web Cloud Databases": consulta la nostra guida "[Creare un database su un server Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
->
-
-Se si dispone già di un database di destinazione, scegliere innanzitutto il tipo di database:
-
-- `Copiare verso un database`{.action}: per copiare il contenuto del database di origine in un database **Start SQL** (destinazione).
-- `Copiare verso un Web Cloud Databases`{.action}: per copiare il contenuto del database di origine in un database **Web Cloud Databases** (destinazione).
-
-#### Scelta 1 - Copiare verso un database Start SQL
-
-Hai selezionato `Copiare verso un database`{.action}. Vengono visualizzati due elenchi a discesa. Clicca sulla prima e seleziona l’hosting Web sul quale si trova il database Start SQL di destinazione. Una volta selezionato l'hosting Web, clicca sul secondo elenco a discesa per scegliere il database Start SQL di destinazione.
-
-Clicca su `Continua`{.action}. Viene visualizzato il seguente messaggio di conferma:
-
-![Messaggio di conferma copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Se non si desidera sovrascrivere il database di destinazione selezionato, fare clic su `Indietro`{.action} per modificare la scelta o su `Annulla`{.action} per annullare tutto. In caso contrario, clicca su `Conferma`{.action} per confermare la duplicazione del contenuto del database di origine verso il database di destinazione.
-
-Viene visualizzato il seguente messaggio di conferma:
-
-![Messaggio di riuscita BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-La copia del database potrebbe richiedere alcuni minuti. Per verificare che la copia sia stata presa in carico, clicca sulla scheda `Task in corso`{.action}. Nella tabella viene visualizzata una nuova riga con lo stato "Pianificato" per la copia. Al termine dell'operazione, la linea scompare.
-
-![Attività in corso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Scelta 2 - Copia in un database presente su un server Web Cloud Databases
-
-Hai selezionato `Copiare verso un Web Cloud Databases`{.action}. Vengono visualizzati due elenchi a discesa. Clicca sulla prima e seleziona il servizio Web Cloud Databases sul quale si trova il database di destinazione. Una volta selezionata la soluzione Web Cloud Databases, clicca sul secondo elenco a discesa per scegliere il database di destinazione presente sul tuo server Web Cloud Databases.
-
-Clicca su `Continua`{.action}. Viene visualizzato il seguente messaggio di conferma:
-
-![Messaggio di conferma copia BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Se non si desidera sovrascrivere il database di destinazione selezionato, fare clic su `Indietro`{.action} per modificare la scelta o su `Annulla`{.action} per annullare tutto. In caso contrario, clicca su `Conferma`{.action} per confermare la duplicazione del contenuto del database di origine verso il database di destinazione.
-
-La copia del database potrebbe richiedere alcuni minuti. Per verificare che la copia sia stata presa in carico, clicca sulla scheda `Task in corso`{.action}. Nella tabella viene visualizzata una nuova riga con lo stato "Pianificato" per la copia. Al termine dell'operazione, la linea scompare.
-
-![Attività in corso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configura il tuo sito Web con il nuovo database
 
-Una volta effettuata la copia del database di origine, sarà necessario effettuare un’ultima operazione per utilizzare il nuovo database.
+Una volta effettuata la copia del database di origine, sarà necessario effettuare un'ultima operazione per utilizzare il nuovo database.
 
 Nella scheda `Task in corso`{.action}, assicurati che la copia sia terminata (la riga corrispondente alla copia è scomparsa).
 
@@ -178,37 +197,47 @@ Per maggiori informazioni o se utilizzi un altro CMS, consulta la nostra guida [
 
 > [!primary]
 >
-> Copiare il database non è una migrazione. Il database di origine esiste ancora fino a quando non viene eliminato. Ciò significa che, se necessario, potrete sempre riconfigurare il vostro sito web con il vecchio database.
+> Copiare il database non è una migrazione. Il database di origine esiste ancora fino a quando non viene eliminato. Ciò significa che potrai sempre riconfigurare il tuo sito Web con il vecchio database, se necessario.
 >
 
 ### Casi d'uso
 
 Durante il processo di copia del contenuto del database potrebbero verificarsi problemi.
 
-#### Nell'elenco non compare alcun database
+**Clicca sulla situazione corrispondente per visualizzare il contenuto.**
+
+/// details | Nell'elenco non compare alcun database
 
 Questa notifica indica che è attivo un solo database. Per copiare il database di origine, è necessario disporre anche di un database di destinazione attivo. Per farlo, puoi:
 
-- Configura un nuovo database disponibile sul tuo hosting Web;
-- Configura un nuovo database sul tuo server [Web Cloud Databases](/links/web/databases);
-- Ordinare un'offerta "[start SQL](/links/web/hosting-options-startsql)" o un server di database "[Web Cloud Databases](/links/web/databases)"
+- Configurare un nuovo database disponibile sul tuo hosting Web.
+- Configurare un nuovo database sul tuo server [Web Cloud Databases](/links/web/databases).
+- Ordinare un'offerta [start SQL](/links/web/hosting-options-startsql) o un server di database [Web Cloud Databases](/links/web/databases).
 
-#### Hai già un'azione in corso
+///
 
-Questo messaggio indica che sul database è già in corso un'operazione. Clicca sulla scheda `Task in corso`{.action} e verifica di avere un'operazione già in corso. In caso affermativo, attendi il completamento dell’operazione per riprovare a copiare il database.
+/// details | Hai già un'azione in corso
 
-#### Il database di destinazione non contiene spazio sufficiente
+Questo messaggio indica che sul database è già in corso un'operazione. Clicca sulla scheda `Task in corso`{.action} e verifica di avere un'operazione già in corso. In caso affermativo, attendi il completamento dell'operazione per riprovare a copiare il database.
+
+///
+
+/// details | Il database di destinazione non contiene spazio sufficiente
 
 Spazio insufficiente nel database di destinazione. Le soluzioni disponibili sono due:
 
 - Ordinare un nuovo database [start SQL](/links/web/hosting-options-startsql) con più spazio.
 - Se possiedi un server [Web Cloud Databases](/links/web/databases), scegli un'offerta Web Cloud Databases con più spazio di storage.
 
-#### I database di origine e di destinazione sono incompatibili
+///
+
+/// details | I database di origine e di destinazione sono incompatibili
 
 Questa notifica significa che il **D**ata**b**ase **M**anagement **S**ystem (**DBMS**) del database di origine non è lo stesso del DBMS del database di destinazione.
 
 Ad esempio, questo errore può verificarsi quando si utilizza MySQL per il database di origine e PostgreSQL per il database di destinazione.
+
+///
 
 ## Per saperne di più
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplicare il contenuto di un database in un altro"
 excerpt: "Questa guida ti mostra come copiare il contenuto di un database OVHcloud in un altro database OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.it-it.md
@@ -77,7 +77,7 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **6** passaggi.
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}. La tabella elenca i database creati sul tuo piano di hosting Web.
+>> Clicca sulla scheda `Databases`{.action}. La tabella elenca i database creati sul tuo piano di hosting Web.
 >>
 >> ![Lista dei BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
@@ -113,7 +113,7 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **6** passaggi.
 >>
 > **Passaggio 6**
 >>
->> La copia del database potrebbe richiedere alcuni minuti. Nella scheda `Task in corso`{.action} viene visualizzata una nuova riga con lo stato "Pianificato" per la copia. Al termine dell'operazione, la riga scompare.
+>> La copia del database potrebbe richiedere alcuni minuti. Nella scheda `Operazioni in corso`{.action} viene visualizzata una nuova riga con lo stato "Pianificato" per la copia. Al termine dell'operazione, la riga scompare.
 >>
 >> ![Task in corso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
@@ -132,7 +132,7 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **6** passaggi.
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}. La lista dei database presenti sul server Web Cloud Databases viene visualizzata.
+>> Clicca sulla scheda `Databases`{.action}. La lista dei database presenti sul server Web Cloud Databases viene visualizzata.
 >>
 >> ![Lista dei database WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
 >>
@@ -168,7 +168,7 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **6** passaggi.
 >>
 > **Passaggio 6**
 >>
->> La copia del database potrebbe richiedere alcuni minuti. Nella scheda `Task in corso`{.action} viene visualizzata una nuova riga con lo stato "Pianificato" per la copia. Al termine dell'operazione, la riga scompare.
+>> La copia del database potrebbe richiedere alcuni minuti. Nella scheda `Operazioni in corso`{.action} viene visualizzata una nuova riga con lo stato "Pianificato" per la copia. Al termine dell'operazione, la riga scompare.
 >>
 >> ![Task in corso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
@@ -178,7 +178,7 @@ Clicca sulle schede qui sotto per visualizzare ciascuno dei **6** passaggi.
 
 Una volta effettuata la copia del database di origine, sarà necessario effettuare un'ultima operazione per utilizzare il nuovo database.
 
-Nella scheda `Task in corso`{.action}, assicurati che la copia sia terminata (la riga corrispondente alla copia è scomparsa).
+Nella scheda `Operazioni in corso`{.action}, assicurati che la copia sia terminata (la riga corrispondente alla copia è scomparsa).
 
 Per connettere il nuovo database al sito Web, modifica il file di configurazione del tuo **C**ontent **M**anagement **S**ystem (**CMS**) e inserisci le informazioni di connessione del nuovo database.
 
@@ -218,7 +218,7 @@ Questa notifica indica che è attivo un solo database. Per copiare il database d
 
 /// details | Hai già un'azione in corso
 
-Questo messaggio indica che sul database è già in corso un'operazione. Clicca sulla scheda `Task in corso`{.action} e verifica di avere un'operazione già in corso. In caso affermativo, attendi il completamento dell'operazione per riprovare a copiare il database.
+Questo messaggio indica che sul database è già in corso un'operazione. Clicca sulla scheda `Operazioni in corso`{.action} e verifica di avere un'operazione già in corso. In caso affermativo, attendi il completamento dell'operazione per riprovare a copiare il database.
 
 ///
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.pl-pl.md
@@ -1,8 +1,22 @@
 ---
 title: "Duplikuj zawartość jednej bazy danych do innej"
 excerpt: "Dowiedz się, jak skopiować zawartość bazy danych OVHcloud do innej bazy danych OVHcloud"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Wprowadzenie
 
@@ -25,7 +39,7 @@ Twoja baza danych jest kluczowym elementem w budowaniu dynamicznej strony WWW. W
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -39,121 +53,126 @@ Zanim rozpoczniesz, upewnij się, że:
 - Wersja DBMS jest taka sama dla obu baz (źródłowej i docelowej). Nawet jeśli kopiowanie może działać z różnymi wersjami, zaleca się korzystanie z tych samych wersji.
 - Zawartość źródłowej bazy danych nie może przekraczać rozmiaru docelowej bazy danych.
 
-### Identyfikacja źródłowej bazy danych
+### Kopiuj zawartość bazy danych
 
-Funkcja ta jest dostępna do skopiowania: 
+Funkcja ta jest dostępna do skopiowania:
 
 - bazy danych [Start SQL](/links/web/hosting-options-startsql) (zawartej w niektórych naszych [hostingach www](/links/web/hosting) lub [zamówionej oddzielnie](/links/web/hosting-options-startsql));
-- bazy danych zainstalowanej na serwerze [Web Cloud Databases](/links/web/databases) (zawartej w ofercie [Hosting Performance](/links/web/hosting-performance-offer) lub [zamówionej oddzielnie](/links/web/databases)). 
+- bazy danych zainstalowanej na serwerze [Web Cloud Databases](/links/web/databases) (zawartej w ofercie [Hosting Performance](/links/web/hosting-performance-offer) lub [zamówionej oddzielnie](/links/web/databases)).
 
 W zależności od Twojego przypadku ścieżka dostępu do źródłowej bazy danych jest inna.
 
-#### Baza danych Start SQL
+**Kliknij na odpowiednią sytuację, aby wyświetlić zawartość.**
 
-Kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
+/// details | Z bazy danych Start SQL
+
+Kliknij poniższe zakładki, aby wyświetlić kolejne **6** kroków.
 
 > [!tabs]
 > **Krok 1**
 >>
->> Przejdź na stronę [Hosting plans](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Krok 2**
 >>
->> Na stronie, która się wyświetli kliknij zakładkę `Bazy danych`{.action}.
+>> Kliknij zakładkę `Bazy danych`{.action}. Tabela zawiera listę baz danych utworzonych na Twoim hostingu.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Lista baz danych Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Krok 3**
 >>
->> Wyświetli się lista baz danych Start SQL.
+>> Kliknij przycisk `...`{.action} po prawej stronie wiersza odpowiadającego bazie danych, której zawartość chcesz skopiować, a następnie wybierz `Kopiuj bazę danych`{.action}.
 >>
->> ![Lista baz danych Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copier_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Krok 4**
+>>
+>> Wyświetli się okno, w którym wybierzesz docelową bazę danych.
+>>
+>> ![Interfejs kopiowania bazy danych](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Jeśli nie posiadasz docelowej bazy danych, kliknij link w oknie, aby kupić nową bazę danych. Pamiętaj o jej aktywacji:
+>> >
+>> > - W przypadku bazy danych Shared SQL: zapoznaj się z przewodnikiem « [Tworzenie bazy danych na hostingu WWW OVHcloud](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - W przypadku bazy danych na serwerze Web Cloud Databases: zapoznaj się z naszym przewodnikiem « [Tworzenie bazy danych na serwerze Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Wybór 1 - Skopiuj do bazy danych Start SQL**: wybierz `Skopiuj do bazy danych`{.action}, a następnie wybierz docelową bazę danych z listy rozwijanej.
+>> - **Wybór 2 - Skopiuj do serwera Web Cloud Databases**: wybierz `Skopiuj do Web Cloud Databases`{.action}. Pojawią się dwie listy rozwijane. Kliknij pierwszą, aby wybrać ofertę Web Cloud Databases, a następnie drugą, aby wybrać docelową bazę danych.
+>>
+> **Krok 5**
+>>
+>> Kliknij przycisk `Dalej`{.action}. Pojawi się następujący komunikat potwierdzający:
+>>
+>> ![Wiadomość potwierdzająca skopiuj bazy danych](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Jeśli nie chcesz nadpisywać wybranej docelowej bazy danych, kliknij przycisk `Wstecz`{.action}, aby zmienić wybór lub kliknij przycisk `Anuluj`{.action}, aby anulować wszystkie operacje. W przeciwnym razie kliknij przycisk `Zatwierdź`{.action}, aby potwierdzić duplikowanie.
+>>
+> **Krok 6**
+>>
+>> Kopiowanie bazy danych może potrwać kilka minut. W zakładce `Zadania w trakcie`{.action} pojawi się nowy wiersz odpowiadający kopii ze statusem „Zaplanowany". Po jej zakończeniu wiersz znika.
+>>
+>> ![Zadania w trakcie](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
+/// details | Z serwera Web Cloud Databases
+
+Kliknij poniższe zakładki, aby wyświetlić kolejne **6** kroków.
 
 > [!tabs]
 > **Krok 1**
 >>
->> Zaloguj się do [Panelu klienta OVHcloud](/links/manager) i przejdź do sekcji `Web Cloud`{.action}.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Krok 2**
->>
->> Kliknij menu `Web Cloud Databases`{.action}, następnie wybierz odpowiednie rozwiązanie Web Cloud Databases.
+>> Przejdź na stronę [Web Cloud Databases](/links/control-panel/web-cloud-databases), następnie wybierz odpowiednie rozwiązanie.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Krok 3**
+> **Krok 2**
 >>
->> Po kliknięciu na zakładkę `Bazy danych`{.action} wyświetli się lista baz danych obecnych na Twoim serwerze Web Cloud Databases.
+>> Kliknij zakładkę `Bazy danych`{.action}. Wyświetli się lista baz danych obecnych na Twoim serwerze Web Cloud Databases.
 >>
 >> ![Lista baz danych WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Krok 3**
+>>
+>> Kliknij przycisk `...`{.action} po prawej stronie wiersza odpowiadającego bazie danych, której zawartość chcesz skopiować, a następnie wybierz `Kopiuj bazę danych`{.action}.
+>>
+>> ![CTA_copier_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Krok 4**
+>>
+>> Wyświetli się okno, w którym wybierzesz docelową bazę danych.
+>>
+>> ![Interfejs kopiowania bazy danych](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Jeśli nie posiadasz docelowej bazy danych, kliknij link w oknie, aby kupić nową bazę danych. Pamiętaj o jej aktywacji:
+>> >
+>> > - W przypadku bazy danych Shared SQL: zapoznaj się z przewodnikiem « [Tworzenie bazy danych na hostingu WWW OVHcloud](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - W przypadku bazy danych na serwerze Web Cloud Databases: zapoznaj się z naszym przewodnikiem « [Tworzenie bazy danych na serwerze Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Wybór 1 - Skopiuj do bazy danych Start SQL**: wybierz `Skopiuj do bazy danych`{.action}, a następnie wybierz docelową bazę danych z listy rozwijanej.
+>> - **Wybór 2 - Skopiuj do serwera Web Cloud Databases**: wybierz `Skopiuj do Web Cloud Databases`{.action}. Pojawią się dwie listy rozwijane. Kliknij pierwszą, aby wybrać ofertę Web Cloud Databases, a następnie drugą, aby wybrać docelową bazę danych.
+>>
+> **Krok 5**
+>>
+>> Kliknij przycisk `Dalej`{.action}. Pojawi się następujący komunikat potwierdzający:
+>>
+>> ![Wiadomość potwierdzająca skopiuj bazy danych](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Jeśli nie chcesz nadpisywać wybranej docelowej bazy danych, kliknij przycisk `Wstecz`{.action}, aby zmienić wybór lub kliknij przycisk `Anuluj`{.action}, aby anulować wszystkie operacje. W przeciwnym razie kliknij przycisk `Zatwierdź`{.action}, aby potwierdzić duplikowanie.
+>>
+> **Krok 6**
+>>
+>> Kopiowanie bazy danych może potrwać kilka minut. W zakładce `Zadania w trakcie`{.action} pojawi się nowy wiersz odpowiadający kopii ze statusem „Zaplanowany". Po jej zakończeniu wiersz znika.
+>>
+>> ![Zadania w trakcie](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Kopiuj zawartość bazy danych
-
-W zakładce `Bazy danych`{.action} i bez względu na ofertę, kliknij przycisk `...`{.action} po prawej stronie wiersza odpowiadającego bazie danych, której zawartość chcesz skopiować, a następnie wybierz `Kopiuj bazę danych`{.action}.
-
-![CTA_copier_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-Wyświetli się okno, w którym zidentyfikujesz docelową bazę danych.
-
-![Interfejs kopiowania bazy danych](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-Jeśli nie posiadasz docelowej bazy danych i jak pokazuje poniższy zrzut ekranu, kliknij poniższe łącze, aby kupić nową bazę danych:
-
-![Lista baz danych WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-Możesz wybrać zakup usługi "[start SQL](/links/web/hosting-options-startsql)" lub serwera baz danych "[Web Cloud Databases](/links/web/databases)".
-
-> [!primary]
->
-> Gdy kupujesz nową bazę danych, nie jest ona włączona domyślnie. Nie zapomnij go aktywować. W tym celu zaloguj się do [Panelu klienta OVHcloud](/links/manager), a następnie przejdź do sekcji `Web Cloud`{.action}.
-> 
-> - W przypadku bazy danych "Shared SQL": zapoznaj się z przewodnikiem "[Tworzenie bazy danych na hostingu WWW OVHcloud](/pages/web_cloud/web_hosting/sql_create_database)";
-> - W przypadku bazy danych, która będzie dostępna na serwerze "Web Cloud Databases": zapoznaj się z naszym przewodnikiem "[Tworzenie bazy danych na serwerze Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
->
-
-Jeśli posiadasz już docelową bazę danych, najpierw wybierz jej typ:
-
-- `Skopiuj do bazy danych`{.action} : jeśli chcesz skopiować zawartość ze źródłowej bazy danych do bazy danych **Start SQL** (docelowa).
-- `Skopiuj do Web Cloud Databases`{.action} : jeśli chcesz skopiować zawartość źródłowej bazy danych do bazy danych **Web Cloud Databas** (docelowa).
-
-#### Wybór 1 - Skopiuj do bazy danych Start SQL
-
-Właśnie wybrałeś `Skopiuj do bazy danych`{.action}. Pojawią się dwie listy rozwijane. Kliknij pierwszy z nich, a następnie wybierz hosting, na którym znajduje się docelowa baza danych Start SQL. Po wybraniu hostingu kliknij drugą listę rozwijaną, aby wybrać docelową bazę danych Start SQL.
-
-Kliknij przycisk `Dalej`{.action}. Pojawi się następujący komunikat potwierdzający:
-
-![Wiadomość potwierdzająca skopiuj bazy danych](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Jeśli nie chcesz nadpisywać wybranej docelowej bazy danych, kliknij przycisk `Wstecz`{.action}, aby zmienić wybór lub kliknij przycisk `Anuluj`{.action}, aby anulować wszystkie operacje. W przeciwnym razie kliknij przycisk `Zatwierdź`{.action}, aby potwierdzić duplikowanie zawartości źródłowej bazy danych do docelowej bazy danych.
-
-Pojawi się następujący komunikat potwierdzający:
-
-![Wiadomość o sukcesie bazy danych](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-Kopiowanie bazy danych może potrwać kilka minut. Aby upewnić się, że kopia została utworzona, przejdź do zakładki `Zadania w trakcie`{.action}. W tabeli pojawi się nowy wiersz odpowiadający kopii ze statusem "Zaplanowany". Po jej zakończeniu linia znika.
-
-![Zadania w trakcie](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Wybór 2 - Kopiuj do bazy danych dostępnej na serwerze Web Cloud Databases
-
-Właśnie wybrałeś `Skopiuj do Web Cloud Databases`{.action}. Pojawią się dwie listy rozwijane. Kliknij pierwszą pozycję, a następnie wybierz ofertę Web Cloud Databases, na której znajduje się docelowa baza danych. Po wybraniu oferty Web Cloud Databases kliknij drugą rozwijaną listę, aby wybrać docelową bazę danych na Twoim serwerze Web Cloud Databases.
-
-Kliknij przycisk `Dalej`{.action}. Pojawi się następujący komunikat potwierdzający:
-
-![Wiadomość potwierdzająca skopiuj bazy danych](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Jeśli nie chcesz nadpisywać wybranej docelowej bazy danych, kliknij przycisk `Wstecz`{.action}, aby zmienić wybór lub kliknij przycisk `Anuluj`{.action}, aby anulować wszystkie operacje. W przeciwnym razie kliknij przycisk `Zatwierdź`{.action}, aby potwierdzić duplikowanie zawartości źródłowej bazy danych do docelowej bazy danych.
-
-Kopiowanie bazy danych może potrwać kilka minut. Aby upewnić się, że kopia została utworzona, przejdź do zakładki `Zadania w trakcie`{.action}. W tabeli pojawi się nowy wiersz odpowiadający kopii ze statusem "Zaplanowany". Po jej zakończeniu linia znika.
-
-![Zadania w trakcie](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Konfiguracja strony WWW z nową bazą danych
 
@@ -161,7 +180,7 @@ Jeśli chcesz użyć nowej bazy danych, po skopiowaniu źródłowej bazy danych 
 
 W zakładce `Zadania w trakcie`{.action} upewnij się, że kopia została ukończona (wiersz odpowiadający kopii zniknął).
 
-Aby połączyć nową bazę danych ze stroną WWW, edytuj plik konfiguracyjny **C**ontent **M**mnagement **S**ystem (**CMS**) i wprowadź informacje dotyczące połączenia z nową bazą danych.
+Aby połączyć nową bazę danych ze stroną WWW, edytuj plik konfiguracyjny **C**ontent **M**anagement **S**ystem (**CMS**) i wprowadź informacje dotyczące połączenia z nową bazą danych.
 
 > [!warning]
 >
@@ -185,30 +204,40 @@ Aby uzyskać więcej informacji lub skorzystać z innego CMS-a, zapoznaj się z 
 
 Mogą wystąpić problemy podczas procesu kopiowania zawartości bazy danych.
 
-#### Baza danych nie wyświetla się na liście
+**Kliknij na odpowiednią sytuację, aby wyświetlić zawartość.**
+
+/// details | Baza danych nie wyświetla się na liście
 
 To powiadomienie oznacza, że posiadasz tylko jedną aktywną bazę danych. Do skopiowania źródłowej bazy danych potrzebna jest również aktywna docelowa baza danych. W tym celu możesz:
 
-- Skonfiguruj nową bazę danych dostępną na Twoim hostingu;
-- Skonfiguruj nową bazę danych na swoim serwerze [Web Cloud Databases](/links/web/databases);
-- Zamów ofertę "[start SQL](/links/web/hosting-options-startsql)" lub serwer baz danych "[Web Cloud Databases](/links/web/databases)"
+- Skonfigurować nową bazę danych dostępną na Twoim hostingu.
+- Skonfigurować nową bazę danych na swoim serwerze [Web Cloud Databases](/links/web/databases).
+- Zamówić ofertę [start SQL](/links/web/hosting-options-startsql) lub serwer baz danych [Web Cloud Databases](/links/web/databases).
 
-#### Trwa już wykonywanie operacji
+///
+
+/// details | Trwa już wykonywanie operacji
 
 Ten komunikat oznacza, że dla Twojej bazy danych trwa już wykonywanie zadania. Przejdź do karty `Zadania w trakcie`{.action} i sprawdź, czy wykonujesz już operację. Jeśli tak jest, poczekaj na jej zakończenie, aby w razie potrzeby przesłać kopię bazy danych ponownie.
 
-#### Baza danych docelowa nie zawiera wystarczającej ilości miejsca
+///
+
+/// details | Baza danych docelowa nie zawiera wystarczającej ilości miejsca
 
 Docelowa baza danych nie zawiera wystarczającej ilości miejsca. Dostępne są dwa rozwiązania:
 
 - Zamów nową bazę danych [start SQL](/links/web/hosting-options-startsql) dysponującą większą przestrzenią.
 - Jeśli posiadasz serwer [Web Cloud Databases](/links/web/databases), zmień ofertę Web Cloud Databases dysponującą większą przestrzenią dyskową.
 
-#### Źródłowa i docelowa baza danych są niezgodne
+///
+
+/// details | Źródłowa i docelowa baza danych są niezgodne
 
 To powiadomienie oznacza, że **D**ata**b**ase **M**anagement **S**ystem (**DBMS**) w źródłowej bazie danych nie jest identyczny z systemem DBMS docelowej bazy danych.
 
 Ten błąd może się pojawić na przykład podczas używania MySQL dla źródłowej bazy danych i PostgreSQL dla docelowej bazy danych.
+
+///
 
 ## Sprawdź również
 
@@ -226,4 +255,4 @@ W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj
 
 Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](/links/support).
 
-Dołącz do [grona naszych użytkowników](/links/community). 
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/pages/web_cloud/web_hosting/copy_database/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplikuj zawartość jednej bazy danych do innej"
 excerpt: "Dowiedz się, jak skopiować zawartość bazy danych OVHcloud do innej bazy danych OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>
@@ -113,7 +113,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **6** kroków.
 >>
 > **Krok 6**
 >>
->> Kopiowanie bazy danych może potrwać kilka minut. W zakładce `Zadania w trakcie`{.action} pojawi się nowy wiersz odpowiadający kopii ze statusem „Zaplanowany". Po jej zakończeniu wiersz znika.
+>> Kopiowanie bazy danych może potrwać kilka minut. W zakładce `Zadania w trakcie`{.action} pojawi się nowy wiersz odpowiadający kopii ze statusem "Zaplanowany". Po jej zakończeniu wiersz znika.
 >>
 >> ![Zadania w trakcie](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
@@ -168,7 +168,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **6** kroków.
 >>
 > **Krok 6**
 >>
->> Kopiowanie bazy danych może potrwać kilka minut. W zakładce `Zadania w trakcie`{.action} pojawi się nowy wiersz odpowiadający kopii ze statusem „Zaplanowany". Po jej zakończeniu wiersz znika.
+>> Kopiowanie bazy danych może potrwać kilka minut. W zakładce `Zadania w trakcie`{.action} pojawi się nowy wiersz odpowiadający kopii ze statusem "Zaplanowany". Po jej zakończeniu wiersz znika.
 >>
 >> ![Zadania w trakcie](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.pl-pl.md
@@ -97,8 +97,8 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **6** kroków.
 >> >
 >> > Jeśli nie posiadasz docelowej bazy danych, kliknij link w oknie, aby kupić nową bazę danych. Pamiętaj o jej aktywacji:
 >> >
->> > - W przypadku bazy danych Shared SQL: zapoznaj się z przewodnikiem « [Tworzenie bazy danych na hostingu WWW OVHcloud](/pages/web_cloud/web_hosting/sql_create_database) ».
->> > - W przypadku bazy danych na serwerze Web Cloud Databases: zapoznaj się z naszym przewodnikiem « [Tworzenie bazy danych na serwerze Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>> > - W przypadku bazy danych Shared SQL: zapoznaj się z przewodnikiem "[Tworzenie bazy danych na hostingu WWW OVHcloud](/pages/web_cloud/web_hosting/sql_create_database)".
+>> > - W przypadku bazy danych na serwerze Web Cloud Databases: zapoznaj się z naszym przewodnikiem "[Tworzenie bazy danych na serwerze Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
 >>
 >> - **Wybór 1 - Skopiuj do bazy danych Start SQL**: wybierz `Skopiuj do bazy danych`{.action}, a następnie wybierz docelową bazę danych z listy rozwijanej.
 >> - **Wybór 2 - Skopiuj do serwera Web Cloud Databases**: wybierz `Skopiuj do Web Cloud Databases`{.action}. Pojawią się dwie listy rozwijane. Kliknij pierwszą, aby wybrać ofertę Web Cloud Databases, a następnie drugą, aby wybrać docelową bazę danych.
@@ -113,7 +113,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **6** kroków.
 >>
 > **Krok 6**
 >>
->> Kopiowanie bazy danych może potrwać kilka minut. W zakładce `Zadania w trakcie`{.action} pojawi się nowy wiersz odpowiadający kopii ze statusem "Zaplanowany". Po jej zakończeniu wiersz znika.
+>> Kopiowanie bazy danych może potrwać kilka minut. W zakładce `Zadania w toku`{.action} pojawi się nowy wiersz odpowiadający kopii ze statusem "Zaplanowany". Po jej zakończeniu wiersz znika.
 >>
 >> ![Zadania w trakcie](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
@@ -152,8 +152,8 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **6** kroków.
 >> >
 >> > Jeśli nie posiadasz docelowej bazy danych, kliknij link w oknie, aby kupić nową bazę danych. Pamiętaj o jej aktywacji:
 >> >
->> > - W przypadku bazy danych Shared SQL: zapoznaj się z przewodnikiem « [Tworzenie bazy danych na hostingu WWW OVHcloud](/pages/web_cloud/web_hosting/sql_create_database) ».
->> > - W przypadku bazy danych na serwerze Web Cloud Databases: zapoznaj się z naszym przewodnikiem « [Tworzenie bazy danych na serwerze Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>> > - W przypadku bazy danych Shared SQL: zapoznaj się z przewodnikiem "[Tworzenie bazy danych na hostingu WWW OVHcloud](/pages/web_cloud/web_hosting/sql_create_database)".
+>> > - W przypadku bazy danych na serwerze Web Cloud Databases: zapoznaj się z naszym przewodnikiem "[Tworzenie bazy danych na serwerze Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
 >>
 >> - **Wybór 1 - Skopiuj do bazy danych Start SQL**: wybierz `Skopiuj do bazy danych`{.action}, a następnie wybierz docelową bazę danych z listy rozwijanej.
 >> - **Wybór 2 - Skopiuj do serwera Web Cloud Databases**: wybierz `Skopiuj do Web Cloud Databases`{.action}. Pojawią się dwie listy rozwijane. Kliknij pierwszą, aby wybrać ofertę Web Cloud Databases, a następnie drugą, aby wybrać docelową bazę danych.
@@ -168,7 +168,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **6** kroków.
 >>
 > **Krok 6**
 >>
->> Kopiowanie bazy danych może potrwać kilka minut. W zakładce `Zadania w trakcie`{.action} pojawi się nowy wiersz odpowiadający kopii ze statusem "Zaplanowany". Po jej zakończeniu wiersz znika.
+>> Kopiowanie bazy danych może potrwać kilka minut. W zakładce `Zadania w toku`{.action} pojawi się nowy wiersz odpowiadający kopii ze statusem "Zaplanowany". Po jej zakończeniu wiersz znika.
 >>
 >> ![Zadania w trakcie](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
@@ -178,7 +178,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **6** kroków.
 
 Jeśli chcesz użyć nowej bazy danych, po skopiowaniu źródłowej bazy danych wykonaj ostatnią czynność.
 
-W zakładce `Zadania w trakcie`{.action} upewnij się, że kopia została ukończona (wiersz odpowiadający kopii zniknął).
+W zakładce `Zadania w toku`{.action} upewnij się, że kopia została ukończona (wiersz odpowiadający kopii zniknął).
 
 Aby połączyć nową bazę danych ze stroną WWW, edytuj plik konfiguracyjny **C**ontent **M**anagement **S**ystem (**CMS**) i wprowadź informacje dotyczące połączenia z nową bazą danych.
 
@@ -218,7 +218,7 @@ To powiadomienie oznacza, że posiadasz tylko jedną aktywną bazę danych. Do s
 
 /// details | Trwa już wykonywanie operacji
 
-Ten komunikat oznacza, że dla Twojej bazy danych trwa już wykonywanie zadania. Przejdź do karty `Zadania w trakcie`{.action} i sprawdź, czy wykonujesz już operację. Jeśli tak jest, poczekaj na jej zakończenie, aby w razie potrzeby przesłać kopię bazy danych ponownie.
+Ten komunikat oznacza, że dla Twojej bazy danych trwa już wykonywanie zadania. Przejdź do karty `Zadania w toku`{.action} i sprawdź, czy wykonujesz już operację. Jeśli tak jest, poczekaj na jej zakończenie, aby w razie potrzeby przesłać kopię bazy danych ponownie.
 
 ///
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.pt-pt.md
@@ -1,8 +1,22 @@
 ---
 title: "Duplicar o conteúdo de uma base de dados em outra"
 excerpt: "Saiba como copiar o conteúdo de uma base de dados OVHcloud para outra base de dados OVHcloud"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo
 
@@ -25,7 +39,7 @@ A sua base de dados é um elemento central na construção do seu website dinâm
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -39,121 +53,126 @@ Antes de começar, certifique-se de que:
 - A versão do seu DBMS é a mesma para as suas duas bases de dados (origem e destino). Embora a cópia possa funcionar com versões diferentes, é aconselhável usar as mesmas versões.
 - O conteúdo da base de dados de origem não deve exceder a dimensão da base de dados de destino.
 
-### Identificar a minha base de dados de origem
+### Copiar o conteúdo de uma base de dados
 
-Esta funcionalidade está disponível para cópia: 
+Esta funcionalidade está disponível para cópia:
 
 - de uma base de dados [Start SQL](/links/web/hosting-options-startsql) (incluída em alguns dos nossos [alojamentos web](/links/web/hosting) ou [encomendada em separado](/links/web/hosting-options-startsql));
-- de uma base de dados presente num servidor [Web Cloud Databases](/links/web/databases) (incluída nos nossos [alojamentos Performance](/links/web/hosting-performance-offer) ou [encomendada em separado](/links/web/databases)). 
+- de uma base de dados presente num servidor [Web Cloud Databases](/links/web/databases) (incluída nos nossos [alojamentos Performance](/links/web/hosting-performance-offer) ou [encomendada em separado](/links/web/databases)).
 
 Dependendo da sua situação, o caminho para aceder à base de dados de origem é diferente.
 
-#### Base de dados Start SQL
+**Clique na situação correspondente para ver o conteúdo.**
 
-Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
+/// details | A partir de uma base de dados Start SQL
+
+Clique nos separadores abaixo para visualizar cada uma das **6** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Aceda à página [Hosting plans](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Etapa 2**
 >>
->> Na página que se abrir, clique no separador `Bases de dados`{.action}.
+>> Clique no separador `Bases de dados`{.action}. A tabela lista as bases de dados criadas no seu plano de alojamento web.
 >>
->> ![Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases.png){.thumbnail}
+>> ![Lista das BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
 >>
 > **Etapa 3**
 >>
->> A lista das bases de dados Start SQL é apresentada.
+>> Clique no botão `...`{.action} à direita da linha correspondente à base de dados cujo conteúdo pretende copiar e selecione `Copiar a base de dados`{.action}.
 >>
->> ![Lista das BDD Start SQL](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/sharedsql-dashboard-db-list.png){.thumbnail}
+>> ![CTA_copiar_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Etapa 4**
+>>
+>> Aparecerá uma janela para escolher a sua base de dados de destino.
+>>
+>> ![Interface copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Se não tiver uma base de dados de destino, clique no link na janela para adquirir uma nova. Não se esqueça de a ativar:
+>> >
+>> > - Para uma base de dados Shared SQL: siga o nosso guia « [Criar uma base de dados no alojamento web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Para uma base de dados num servidor Web Cloud Databases: siga o nosso guia « [Criar uma base de dados num servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Escolha 1 - Copiar para uma base Start SQL**: selecione `Copiar para uma base de dados`{.action} e escolha a base de dados de destino na lista suspensa.
+>> - **Escolha 2 - Copiar para um servidor Web Cloud Databases**: selecione `Copiar para um Web Cloud Databases`{.action}. Aparecem duas listas suspensas. Clique na primeira para selecionar a solução Web Cloud Databases e na segunda para escolher a base de dados de destino.
+>>
+> **Etapa 5**
+>>
+>> Clique em `Seguinte`{.action}. Surge a seguinte mensagem de confirmação:
+>>
+>> ![Mensagem de confirmação copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Se não pretender substituir a base de dados de destino escolhida, clique em `Anterior`{.action} para alterar a sua escolha ou em `Cancelar`{.action} para cancelar tudo. Caso contrário, clique em `Validar`{.action} para confirmar a duplicação.
+>>
+> **Etapa 6**
+>>
+>> A cópia pode demorar alguns minutos. No separador `Operações em curso`{.action}, é apresentada uma nova linha para a cópia com um estado «planeado». Quando a operação for concluída, a linha desaparece.
+>>
+>> ![Operações em curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-#### Web Cloud Databases
+///
 
-Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
+/// details | A partir de um servidor Web Cloud Databases
+
+Clique nos separadores abaixo para visualizar cada uma das **6** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Aceda à [Área de Cliente OVHcloud](/links/manager) e aceda à secção `Web Cloud`{.action}.
->>
->> ![Web Cloud](/pages/assets/screens/control_panel/product-selection/web-cloud.png){.thumbnail}
->>
-> **Etapa 2**
->>
->> Clique no menu suspenso `Web Cloud Databases`{.action} e escolha a solução Web Cloud Databases correspondente.
+>> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e escolha a solução correspondente.
 >>
 >> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Etapa 3**
+> **Etapa 2**
 >>
->> Ao clicar no separador `Bases de dados`{.action}, será apresentada uma lista das bases de dados presentes no servidor Web Cloud Databases.
+>> Clique no separador `Bases de dados`{.action}. A lista das bases de dados presentes no servidor Web Cloud Databases é apresentada.
 >>
 >> ![Lista das BDDs WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/wcdb-dashboard-db-list.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Clique no botão `...`{.action} à direita da linha correspondente à base de dados cujo conteúdo pretende copiar e selecione `Copiar a base de dados`{.action}.
+>>
+>> ![CTA_copiar_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
+>>
+> **Etapa 4**
+>>
+>> Aparecerá uma janela para escolher a sua base de dados de destino.
+>>
+>> ![Interface copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
+>>
+>> > [!primary]
+>> >
+>> > Se não tiver uma base de dados de destino, clique no link na janela para adquirir uma nova. Não se esqueça de a ativar:
+>> >
+>> > - Para uma base de dados Shared SQL: siga o nosso guia « [Criar uma base de dados no alojamento web](/pages/web_cloud/web_hosting/sql_create_database) ».
+>> > - Para uma base de dados num servidor Web Cloud Databases: siga o nosso guia « [Criar uma base de dados num servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>>
+>> - **Escolha 1 - Copiar para uma base Start SQL**: selecione `Copiar para uma base de dados`{.action} e escolha a base de dados de destino na lista suspensa.
+>> - **Escolha 2 - Copiar para um servidor Web Cloud Databases**: selecione `Copiar para um Web Cloud Databases`{.action}. Aparecem duas listas suspensas. Clique na primeira para selecionar a solução Web Cloud Databases e na segunda para escolher a base de dados de destino.
+>>
+> **Etapa 5**
+>>
+>> Clique em `Seguinte`{.action}. Surge a seguinte mensagem de confirmação:
+>>
+>> ![Mensagem de confirmação copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
+>>
+>> Se não pretender substituir a base de dados de destino escolhida, clique em `Anterior`{.action} para alterar a sua escolha ou em `Cancelar`{.action} para cancelar tudo. Caso contrário, clique em `Validar`{.action} para confirmar a duplicação.
+>>
+> **Etapa 6**
+>>
+>> A cópia pode demorar alguns minutos. No separador `Operações em curso`{.action}, é apresentada uma nova linha para a cópia com um estado «planeado». Quando a operação for concluída, a linha desaparece.
+>>
+>> ![Operações em curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
-### Copiar o conteúdo de uma base de dados
-
-Ainda no separador `Bases de dados`{.action}, e qualquer que seja a sua oferta, clique no botão `...`{.action} à direita da linha correspondente à base de dados cujo conteúdo pretende copiar e, a seguir, selecione `Copiar a base de dados`{.action}".
-
-![CTA_copiar_BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/databases/copy-db-tool.png){.thumbnail}
-
-Aparecerá uma janela a fim de identificar a base de dados de destino.
-
-![Interface copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-1.png){.thumbnail}
-
-Se você não tiver um banco de dados de destino e nos mostrar a captura de tela abaixo, clique no link presente para comprar um novo banco de dados:
-
-![Lista das BDDs WCD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-link-to-buy-db.png){.thumbnail}
-
-Poderá escolher entre comprar uma oferta "[start SQL](/links/web/hosting-options-startsql)" ou um servidor de bases de dados "[Web Cloud Databases](/links/web/databases)".
-
-> [!primary]
->
-> Quando adquire uma nova base de dados, esta não é ativada de forma predefinida. Não se esqueça de a ativar. Para isso, aceda à [Área de Cliente OVHcloud](/links/manager) e aceda à secção `Web Cloud`{.action}.
-> 
-> - Para uma base de dados "Shared SQL": siga o nosso guia "[Criar uma base de dados no alojamento web](/pages/web_cloud/web_hosting/sql_create_database)";
-> - Para uma base de dados que estará presente num servidor "Web Cloud Databases": siga o nosso guia "[Criar uma base de dados num servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
->
-
-Se você já tiver um banco de dados de destino, escolha primeiro o tipo:
-
-- `Copiar para uma base de dados`{.action}: se deseja copiar o conteúdo da sua base de dados fonte para uma base de dados **Start SQL** (destino).
-- `Copiar para um Web Cloud Databases`{.action}: se deseja copiar o conteúdo da sua base de dados source para uma base de dados **Web Cloud Databases** (destino).
-
-#### Escolha 1 - Copiar para uma base de dados Start SQL
-
-Acaba de selecionar `Copiar para uma base de dados`{.action}. Aparecem duas listas suspensas. Clique na primeira e selecione o alojamento web em que se encontra a sua base de dados Start SQL de destino. Depois de selecionar o alojamento web, clique na segunda lista pendente para escolher a base de dados Start SQL de destino.
-
-Clique em `Seguinte`{.action}. Surge a seguinte mensagem de confirmação:
-
-![Mensagem de confirmação copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Se não pretender substituir a base de dados de destino escolhida, clique em `Anterior`{.action} para alterar a sua escolha ou em `Cancelar`{.action} para cancelar tudo. Caso contrário, clique em `Validar`{.action} para confirmar a duplicação do conteúdo da base de dados de origem para a base de dados de destino.
-
-Surge a seguinte mensagem de confirmação:
-
-![Mensagem de sucesso BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-copied-successfull.png){.thumbnail}
-
-A cópia da base de dados pode demorar alguns minutos. Para verificar se a cópia foi registada, aceda ao separador `Operações em curso`{.action}. Na tabela, é apresentada uma nova linha para a cópia com um estado "planeado". Quando a operação for concluída, a linha desaparecerá.
-
-![Tarefas em curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
-
-#### Escolha 2 - Copiar para uma base de dados presente num servidor Web Cloud Databases
-
-Acaba de selecionar `Copiar para um Web Cloud Databases`{.action}. Aparecem duas listas suspensas. Clique na primeira e selecione o serviço Web Cloud Databases em que se encontra a base de dados de destino. Uma vez selecionada a oferta Web Cloud Databases, clique na segunda lista pendente para escolher a base de dados de destino presente no servidor Web Cloud Databases.
-
-Clique em `Seguinte`{.action}. Surge a seguinte mensagem de confirmação:
-
-![Mensagem de confirmação copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
-
-Se não pretender substituir a base de dados de destino escolhida, clique em `Anterior`{.action} para alterar a sua escolha ou em `Cancelar`{.action} para cancelar tudo. Caso contrário, clique em `Validar`{.action} para confirmar a duplicação do conteúdo da base de dados de origem para a base de dados de destino.
-
-A cópia da base de dados pode demorar alguns minutos. Para verificar se a cópia foi registada, aceda ao separador `Operações em curso`{.action}. Na tabela, é apresentada uma nova linha para a cópia com um estado "planeado". Quando a operação for concluída, a linha desaparecerá.
-
-![Tarefas em curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
+///
 
 ### Configurar o seu website com a sua nova base de dados
 
@@ -185,30 +204,40 @@ Para obter mais informações ou se utilizar outro CMS, consulte o nosso guia [A
 
 Durante o processo de cópia do conteúdo da base de dados, poderá encontrar dificuldades.
 
-#### Não aparece nenhuma base de dados na lista
+**Clique na situação correspondente para ver o conteúdo.**
 
-Esta notificação significa que dispõe de apenas uma base de dados ativa. Para copiar a base de dados de origem, é também necessário um banco de dados de destino ativo. Para isso, pode:
+/// details | Não aparece nenhuma base de dados na lista
 
-- Configurar uma nova base de dados disponível no seu alojamento web;
-- Configurar uma nova base de dados no seu servidor [Web Cloud Databases](/links/web/databases);
-- Encomendar uma oferta "[start SQL](/links/web/hosting-options-startsql)" ou um servidor de bases de dados "[Web Cloud Databases](/links/web/databases)"
+Esta notificação significa que dispõe de apenas uma base de dados ativa. Para copiar a base de dados de origem, é também necessário uma base de dados de destino ativa. Para isso, pode:
 
-#### Já tem uma ação em curso
+- Configurar uma nova base de dados disponível no seu alojamento web.
+- Configurar uma nova base de dados no seu servidor [Web Cloud Databases](/links/web/databases).
+- Encomendar uma oferta [start SQL](/links/web/hosting-options-startsql) ou um servidor de bases de dados [Web Cloud Databases](/links/web/databases).
+
+///
+
+/// details | Já tem uma ação em curso
 
 Esta mensagem significa que uma tarefa já está em curso na base de dados. Aceda ao separador `Operações em curso`{.action} e verifique que tem uma operação já em curso. Se for o caso, aguarde até que a operação esteja concluída para recomeçar a cópia da base de dados, se necessário.
 
-#### A base de dados de destino não contém espaço suficiente
+///
+
+/// details | A base de dados de destino não contém espaço suficiente
 
 A sua base de dados de destino não contém espaço suficiente. Pode usufruir de duas soluções:
 
 - Encomendar uma nova base de dados [start SQL](/links/web/hosting-options-startsql) com mais espaço.
-- Se possui um servidor [Web Cloud Databases](/links/web/databases), Mude para uma oferta Web Cloud Databases que dispõe de mais espaço de armazenamento.
+- Se possui um servidor [Web Cloud Databases](/links/web/databases), mude para uma oferta Web Cloud Databases que dispõe de mais espaço de armazenamento.
 
-#### As bases de dados de origem e de destino são incompatíveis
+///
+
+/// details | As bases de dados de origem e de destino são incompatíveis
 
 Esta notificação significa que o **D**ata**b**ase **M**anagement **S**ystem (**DBMS**) da sua base de dados de origem não é o mesmo que o DBMS da sua base de dados de destino.
 
-Por exemplo, este erro pode ocorrer quando utiliza MySQL para a sua base de dados source e PostgreSQL para a sua base de dados de destino.
+Por exemplo, este erro pode ocorrer quando utiliza MySQL para a sua base de dados de origem e PostgreSQL para a sua base de dados de destino.
+
+///
 
 ## Quer saber mais?
 

--- a/pages/web_cloud/web_hosting/copy_database/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Duplicar o conteúdo de uma base de dados em outra"
 excerpt: "Saiba como copiar o conteúdo de uma base de dados OVHcloud para outra base de dados OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/copy_database/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/copy_database/guide.pt-pt.md
@@ -97,8 +97,8 @@ Clique nos separadores abaixo para visualizar cada uma das **6** etapas.
 >> >
 >> > Se não tiver uma base de dados de destino, clique no link na janela para adquirir uma nova. Não se esqueça de a ativar:
 >> >
->> > - Para uma base de dados Shared SQL: siga o nosso guia « [Criar uma base de dados no alojamento web](/pages/web_cloud/web_hosting/sql_create_database) ».
->> > - Para uma base de dados num servidor Web Cloud Databases: siga o nosso guia « [Criar uma base de dados num servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>> > - Para uma base de dados Shared SQL: siga o nosso guia "[Criar uma base de dados no alojamento web](/pages/web_cloud/web_hosting/sql_create_database)".
+>> > - Para uma base de dados num servidor Web Cloud Databases: siga o nosso guia "[Criar uma base de dados num servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
 >>
 >> - **Escolha 1 - Copiar para uma base Start SQL**: selecione `Copiar para uma base de dados`{.action} e escolha a base de dados de destino na lista suspensa.
 >> - **Escolha 2 - Copiar para um servidor Web Cloud Databases**: selecione `Copiar para um Web Cloud Databases`{.action}. Aparecem duas listas suspensas. Clique na primeira para selecionar a solução Web Cloud Databases e na segunda para escolher a base de dados de destino.
@@ -109,11 +109,11 @@ Clique nos separadores abaixo para visualizar cada uma das **6** etapas.
 >>
 >> ![Mensagem de confirmação copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
 >>
->> Se não pretender substituir a base de dados de destino escolhida, clique em `Anterior`{.action} para alterar a sua escolha ou em `Cancelar`{.action} para cancelar tudo. Caso contrário, clique em `Validar`{.action} para confirmar a duplicação.
+>> Se não pretender substituir a base de dados de destino escolhida, clique em `Anterior`{.action} para alterar a sua escolha ou em `Cancelar`{.action} para cancelar tudo. Caso contrário, clique em `Confirmar`{.action} para confirmar a duplicação.
 >>
 > **Etapa 6**
 >>
->> A cópia pode demorar alguns minutos. No separador `Operações em curso`{.action}, é apresentada uma nova linha para a cópia com um estado «planeado». Quando a operação for concluída, a linha desaparece.
+>> A cópia pode demorar alguns minutos. No separador `Operações em curso`{.action}, é apresentada uma nova linha para a cópia com um estado "planeado". Quando a operação for concluída, a linha desaparece.
 >>
 >> ![Operações em curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
@@ -152,8 +152,8 @@ Clique nos separadores abaixo para visualizar cada uma das **6** etapas.
 >> >
 >> > Se não tiver uma base de dados de destino, clique no link na janela para adquirir uma nova. Não se esqueça de a ativar:
 >> >
->> > - Para uma base de dados Shared SQL: siga o nosso guia « [Criar uma base de dados no alojamento web](/pages/web_cloud/web_hosting/sql_create_database) ».
->> > - Para uma base de dados num servidor Web Cloud Databases: siga o nosso guia « [Criar uma base de dados num servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server) ».
+>> > - Para uma base de dados Shared SQL: siga o nosso guia "[Criar uma base de dados no alojamento web](/pages/web_cloud/web_hosting/sql_create_database)".
+>> > - Para uma base de dados num servidor Web Cloud Databases: siga o nosso guia "[Criar uma base de dados num servidor Web Cloud Databases](/pages/web_cloud/web_cloud_databases/create-db-and-user-on-db-server)".
 >>
 >> - **Escolha 1 - Copiar para uma base Start SQL**: selecione `Copiar para uma base de dados`{.action} e escolha a base de dados de destino na lista suspensa.
 >> - **Escolha 2 - Copiar para um servidor Web Cloud Databases**: selecione `Copiar para um Web Cloud Databases`{.action}. Aparecem duas listas suspensas. Clique na primeira para selecionar a solução Web Cloud Databases e na segunda para escolher a base de dados de destino.
@@ -164,11 +164,11 @@ Clique nos separadores abaixo para visualizar cada uma das **6** etapas.
 >>
 >> ![Mensagem de confirmação copiar BDD](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-step-2.png){.thumbnail}
 >>
->> Se não pretender substituir a base de dados de destino escolhida, clique em `Anterior`{.action} para alterar a sua escolha ou em `Cancelar`{.action} para cancelar tudo. Caso contrário, clique em `Validar`{.action} para confirmar a duplicação.
+>> Se não pretender substituir a base de dados de destino escolhida, clique em `Anterior`{.action} para alterar a sua escolha ou em `Cancelar`{.action} para cancelar tudo. Caso contrário, clique em `Confirmar`{.action} para confirmar a duplicação.
 >>
 > **Etapa 6**
 >>
->> A cópia pode demorar alguns minutos. No separador `Operações em curso`{.action}, é apresentada uma nova linha para a cópia com um estado «planeado». Quando a operação for concluída, a linha desaparece.
+>> A cópia pode demorar alguns minutos. No separador `Operações em curso`{.action}, é apresentada uma nova linha para a cópia com um estado "planeado". Quando a operação for concluída, a linha desaparece.
 >>
 >> ![Operações em curso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/copy-db-tool-ongoing-tasks.png){.thumbnail}
 
@@ -255,4 +255,4 @@ Para serviços especializados (referenciamento, desenvolvimento, etc), contacte 
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 
-Fale com nossa [comunidade de utilizadores](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Automatische Tasks mit einem Webhosting verwenden"
 excerpt: "Erfahren Sie hier, wie Sie automatisierte Tasks auf Ihrem Webhosting konfigurieren"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -27,15 +27,15 @@ updated: 2025-02-20
  }
 </style>
 
-## Ziel 
+## Ziel
 
-Auf Ihrem OVHcloud Webhosting können Sie Skripte verwenden, um bestimmte Operationen zu automatisieren. Die Erstellung eines geplanten Tasks ("CRON job") ist die einfachste Methode sicherzustellen, dass Ihre Skripte zu bestimmten Zeiten ausgeführt werden, ohne dass weitere Aktionen Ihrerseits erforderlich sind. 
+Auf Ihrem OVHcloud Webhosting können Sie Skripte verwenden, um bestimmte Operationen zu automatisieren. Ein geplanter Task ("CRON Job") ermöglicht es, dass Ihre Skripte zu bestimmten Zeiten ausgeführt werden, ohne dass weitere Aktionen Ihrerseits erforderlich sind.
 
 **Hier erfahren Sie, wie Sie CRON-Tasks erstellen, um Ihre geplanten Tasks auf einem Webhosting zu automatisieren.**
 
 > [!warning]
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-> 
+>
 > Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen an die [OVHcloud Community](/links/community) zu richten. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
 >
 
@@ -56,64 +56,70 @@ Auf Ihrem OVHcloud Webhosting können Sie Skripte verwenden, um bestimmte Operat
 
 ## In der praktischen Anwendung
 
-Loggen Sie sich in Ihrem OVHcloud Kundencenter ein und öffnen Sie `Hosting-Pakete`{.action} im Bereich `Web Cloud`{.action}.
-
-Wählen Sie das betreffende Hosting aus, klicken Sie auf den Tab `Mehr`{.action} und dann auf `Cron`{.action}.
-
-In diesem Bereich erhalten Sie einen Überblick über Ihre geplanten Tasks und deren Einstellungen.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Erstellung eines automatisierten Tasks
 
-#### Schritt 1: Definition der allgemeinen Parameter
+Klicken Sie auf die Tabs, um die **5** Schritte anzuzeigen.
 
-Um einen CRON-Task zu erstellen, klicken Sie rechts auf den Button `Eine Planung hinzufügen`{.action}. Sie können die Task-Einstellungen im neuen Fenster anpassen.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Option|Beschreibung|   
-|---|---|   
-|Auszuführender Befehl|Legen Sie den Zugriffspfad zur Datei mit Ihrem Skript fest. Beispiel: *www/jobs/cron.php*|   
-|Sprache |Wählen Sie die vom Skript verwendete PHP-Version aus.|
-|Aktivierung|Wählen Sie aus, ob der Task nach seiner Erstellung aktiv sein soll oder später aktiviert wird.| 
-|Logs per E-Mail|Wenn nötig wählen Sie einen Kontakt (Administrator oder Technischer) aus, an den im Falle eines Ausführungsfehlers ein Bericht versendet wird. Sie können auch eine andere E-Mail-Adresse angeben.| 
-|Beschreibung|Geben Sie eine Beschreibung ein, um Ihre Tasks zu dokumentieren.| 
-
-Klicken Sie auf `Weiter`{.action}, um zu Schritt 2 zu kommen.
-
-#### Schritt 2: Frequenzdefinition
-
-Das Interface bietet zwei Wege, um die Frequenz Ihres Tasks zu konfigurieren. Verwenden Sie **Einfacher Modus** für eine vereinfachte Auswahl von Planungsoptionen für Anfänger. Wenn Sie eine Frequenz ähnlich eines CRON-Tabellenformats (*crontab*) lieber direkt eingeben möchten, wählen Sie den **Experten-Modus**.
-
-|Einfacher Modus|
-|---|
-|Verwenden Sie die Auswahlmenüs, um die Uhrzeit, die Tage eines Monats, die Wochentage und die Monate der Ausführung anzugeben.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> Mit der Auswahl `Tage`{.action} können Sie die Ausführungsfrequenz für einen monatlichen Zyklus festlegen.
->
-> Mit der Auswahl `Wochentage`{.action} können Sie zusätzliche Ausführungszeitpunkte festlegen, jedoch in einem wöchentlichen Zyklus.
->
-
-|Experten-Modus| 
-|---|
-|Geben Sie numerische Werte ein wie in einem *crontab*. Die Sterne stehen für "jeden Wert" des Zeitraums, was bedeutet, dass die Aufgabe in diesem Beispiel **einmal pro Stunde täglich** kontinuierlich ausgeführt würde.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-Sie können während der Konfiguration zwischen den beiden Ansichten wechseln, um die Änderungen zu sehen. Beachten Sie auch die [Einschränkungen bei der Task-Planung auf einem Webhosting](./#einschrankungen-bei-geplanten-tasks-auf-ihrem-webhosting).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Schritt 3: Abschluss der Installation
-
-Die Zusammenfassung listet alle Ihre Einstellungen auf, einschließlich der *crontab*-Notation der Ausführungsfrequenz. Wenn alles korrekt ist, klicken Sie auf `Bestätigen`{.action}.
-
-![cron bestätiging](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-Der Task wird in einigen Minuten bereit sein. Sie können dann alle Einstellungen ändern oder den Task löschen, indem Sie auf `...`{.action} in der Task-Übersichtstabelle im OVHcloud Kundencenter klicken.
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting), und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `Mehr`{.action} und dann auf `Cron`{.action}. Sie erhalten einen Überblick über Ihre geplanten Tasks und deren Einstellungen.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> Um einen CRON-Task zu erstellen, klicken Sie rechts auf den Button `Zeitplan hinzufügen`{.action}.
+>>
+> **Schritt 3**
+>>
+>> Passen Sie die Task-Einstellungen im angezeigten Fenster an.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Option|Beschreibung|
+>> |---|---|
+>> |Auszuführender Befehl|Legen Sie den Zugriffspfad zur Datei mit Ihrem Skript fest. Beispiel: *www/jobs/cron.php*|
+>> |Sprache|Wählen Sie die vom Skript verwendete PHP-Version aus.|
+>> |Aktivierung|Wählen Sie aus, ob der Task nach seiner Erstellung aktiv sein soll oder später aktiviert wird.|
+>> |Logs per E-Mail|Wenn nötig wählen Sie einen Kontakt (Administrator oder Technischer) aus, an den im Falle eines Ausführungsfehlers ein Bericht versendet wird. Sie können auch eine andere E-Mail-Adresse angeben.|
+>> |Beschreibung|Geben Sie eine Beschreibung ein, um Ihre Tasks zu dokumentieren.|
+>>
+>> Klicken Sie auf `Weiter`{.action}.
+>>
+> **Schritt 4**
+>>
+>> Das Interface bietet zwei Wege, um die Frequenz Ihres Tasks zu konfigurieren:
+>>
+>> - **Einfacher Modus**: Verwenden Sie die Auswahlmenüs, um die Uhrzeit, die Tage eines Monats, die Wochentage und die Monate der Ausführung anzugeben.
+>> - **Experten-Modus**: Geben Sie numerische Werte ein wie in einem *crontab*.
+>>
+>> |Einfacher Modus|Experten-Modus|
+>> |---|---|
+>> |Verwenden Sie die Auswahlmenüs, um die Uhrzeit, die Tage eines Monats, die Wochentage und die Monate der Ausführung anzugeben.|Geben Sie numerische Werte ein wie in einem *crontab*. Die Sterne stehen für "jeden Wert" des Zeitraums, was bedeutet, dass die Aufgabe in diesem Beispiel **einmal pro Stunde täglich** kontinuierlich ausgeführt würde.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > Mit der Auswahl `Tage`{.action} können Sie die Ausführungsfrequenz für einen monatlichen Zyklus festlegen.
+>> >
+>> > Mit der Auswahl `Wochentage`{.action} können Sie zusätzliche Ausführungszeitpunkte festlegen, jedoch in einem wöchentlichen Zyklus.
+>>
+>> Sie können während der Konfiguration zwischen den beiden Ansichten wechseln. Beachten Sie auch die [Einschränkungen bei der Task-Planung auf einem Webhosting](./#einschrankungen-bei-geplanten-tasks-auf-ihrem-webhosting).
+>>
+>> Klicken Sie auf `Weiter`{.action}.
+>>
+> **Schritt 5**
+>>
+>> Die Zusammenfassung listet alle Ihre Einstellungen auf, einschließlich der *crontab*-Notation der Ausführungsfrequenz. Wenn alles korrekt ist, klicken Sie auf `Bestätigen`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> Der Task wird in einigen Minuten bereit sein. Sie können dann alle Einstellungen ändern oder den Task löschen, indem Sie auf `...`{.action} in der Task-Übersichtstabelle im OVHcloud Kundencenter klicken.
 
 ### Task bearbeiten oder löschen
 
@@ -156,7 +162,7 @@ Ein einfacher Test, um zu sehen, ob Ihr Skript einen Fehler verursacht, ist, es 
 #### Überprüfung der Nutzung absoluter Pfade
 
 Achten Sie immer darauf, absolute Zugriffspfade zu den Dateien Ihrer Skripte zu verwenden. Die Konstante "DIR" kann beispielsweise dazu dienen, den aktuellen Pfad in PHP-Skripten zu erhalten ([PHP-Dokumentation](https://www.php.net/manual/de/language.constants.predefined.php)).
- 
+
 #### Überprüfung der Ausführungsprotokolle
 
 In den Logs Ihres Webhostings, einsehbar im [OVHcloud Kundencenter](/links/manager), finden Sie die Log-Kategorie "cron".
@@ -168,35 +174,35 @@ Weitere Informationen finden Sie in unserer Anleitung zu [Statistiken und Logs](
 - Beispiel für ein erfolgreich ausgeführtes Skript
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Beispiel für einen Fehlschlag aufgrund einer Überschreitung der Ausführungsdauer
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Beispiel eines Fehlers, da die Skriptdatei im angegebenen Zugriffspfad nicht gefunden werden kann
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Beispiel eines Fehlers wegen Zugriffsrechten (chmod) oder einer fehlerhaften Konfiguration der .ovhconfig-Datei
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Weiterführende Informationen <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Automatische Tasks mit einem Webhosting verwenden"
 excerpt: "Erfahren Sie hier, wie Sie automatisierte Tasks auf Ihrem Webhosting konfigurieren"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-asia.md
@@ -29,7 +29,7 @@ updated: 2026-03-31
 
 ## Objective
 
-On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") runs your scripts at specific times, automatically.
 
 **This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
@@ -70,7 +70,7 @@ Click on the tabs below to view each of the **5** steps.
 >>
 > **Step 2**
 >>
->> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>> Click on the `More`{.action} tab, then `cron`{.action}. You will see an overview of your scheduled tasks and their settings.
 >>
 >> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
 >>
@@ -135,7 +135,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `More`{.action} tab, then `Cron`{.action}.
+>> On the page that pops up, click on the `More`{.action} tab, then `cron`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,20 +29,20 @@ updated: 2025-02-20
 
 ## Objective
 
-On OVHcloud Web Hostings, you can use scripts to automate certain operations. Creating a scheduled task ("cron job") is the easiest way to ensure your scripts are running at specific times without further actions necessary on your part. 
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
 
-**This guide explains how to create cron jobs to automate scheduled tasks on a Web Hosting.**
+**This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- An [OVHcloud Web Hosting plan](/links/web/hosting)
+- An [OVHcloud web hosting plan](/links/web/hosting)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -57,62 +57,70 @@ On OVHcloud Web Hostings, you can use scripts to automate certain operations. Cr
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action} in the top navigation bar. Click `Hosting plans`{.action}, then choose the Web Hosting plan concerned. Next, navigate to the `cron`{.action} tab by selecting it in the `More`{.action} submenu.
-
-In this section you will see an overview of your scheduled jobs and their settings.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Creating an automated task
 
-#### Step 1: Defining general settings
+Click on the tabs below to view each of the **5** steps.
 
-To create a new cron task, click on the `Add a scheduling`{.action} button on the right-hand side. You can customise the settings for the task in the new window.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Option|Description|   
-|---|---|   
-|Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|   
-|Language|Select the PHP version the script is using.|
-|Activation|Choose whether the task will be active after creation or activated later.| 
-|Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.| 
-|Description|Enter a description to keep track of what your tasks do.| 
-
-Click on `Next`{.action} to proceed to the second step.
-
-#### Step 2: Setting the frequency
-
-The interface offers two modes to configure the frequency of your task. Use the **Basic mode** for a beginner-friendly selection of scheduling options. If you prefer to directly enter a frequency, similar to a cron table format (*crontab*), choose the **Advanced mode**.
-
-|Basic mode|
-|---|
-|Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-|Advanced mode| 
-|---|
-|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
->
-> The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
->
-
-You can switch between the two modes during configuration to view the changes accordingly. Please also note the [limitations when scheduling a task on a Web Hosting](./#limitations-of-web-hosting-tasks).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Step 3: Finishing the setup
-
-The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
-
-![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> To create a cron job, click on the `Add a scheduling`{.action} button on the right-hand side.
+>>
+> **Step 3**
+>>
+>> Customise the task settings in the window that appears.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Option|Description|
+>> |---|---|
+>> |Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|
+>> |Language|Select the PHP version the script is using.|
+>> |Activation|Choose whether the task will be active after creation or activated later.|
+>> |Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.|
+>> |Description|Enter a description to keep track of what your tasks do.|
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 4**
+>>
+>> The interface offers two modes to configure the frequency of your task:
+>>
+>> - **Basic mode**: use the drop-down menus to specify the time of day, days of a month, week days and months for the task.
+>> - **Expert mode**: enter numeric values as you would in a *crontab*.
+>>
+>> |Basic mode|Expert mode|
+>> |---|---|
+>> |Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
+>> >
+>> > The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
+>>
+>> You can switch between the two modes during configuration. Please also note the [limitations when scheduling a task on a web hosting plan](./#limitations-of-web-hosting-tasks).
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 5**
+>>
+>> The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
 
 ### Modify or delete a scheduled task
 
@@ -135,7 +143,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> Click on the `Edit`{.action} or `Delete`{.action} button, depending on the action you want to perform on the scheduled task.
 
-### Limitations of Web Hosting tasks
+### Limitations of web hosting tasks
 
 |Functionality|Description|
 |---|---|
@@ -155,10 +163,10 @@ A simple test to see if your script will produce an error is to run it in a web 
 #### Verifying the usage of absolute paths
 
 Always make sure to use absolute paths to files in your scripts. The "DIR" constant, for example, can help to receive the current path in PHP scripts ([PHP documentation](http://php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Checking your execution logs
 
-In your Web Hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
+In your web hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
 
 Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) for details.
 
@@ -167,35 +175,35 @@ Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) f
 - Example of a successfully finished execution output
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output due to exceeded execution time
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output because the script file was not found in the specified path
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Example of a failed execution output because of a permissions error (chmod) or incorrect configuration of the .ovhconfig file
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Go further <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-au.md
@@ -29,7 +29,7 @@ updated: 2026-03-31
 
 ## Objective
 
-On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") runs your scripts at specific times, automatically.
 
 **This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
@@ -70,7 +70,7 @@ Click on the tabs below to view each of the **5** steps.
 >>
 > **Step 2**
 >>
->> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>> Click on the `More`{.action} tab, then `cron`{.action}. You will see an overview of your scheduled tasks and their settings.
 >>
 >> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
 >>
@@ -135,7 +135,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `More`{.action} tab, then `Cron`{.action}.
+>> On the page that pops up, click on the `More`{.action} tab, then `cron`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,20 +29,20 @@ updated: 2025-02-20
 
 ## Objective
 
-On OVHcloud Web Hostings, you can use scripts to automate certain operations. Creating a scheduled task ("cron job") is the easiest way to ensure your scripts are running at specific times without further actions necessary on your part. 
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
 
-**This guide explains how to create cron jobs to automate scheduled tasks on a Web Hosting.**
+**This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- An [OVHcloud Web Hosting plan](/links/web/hosting)
+- An [OVHcloud web hosting plan](/links/web/hosting)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -57,62 +57,70 @@ On OVHcloud Web Hostings, you can use scripts to automate certain operations. Cr
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action} in the top navigation bar. Click `Hosting plans`{.action}, then choose the Web Hosting plan concerned. Next, navigate to the `cron`{.action} tab by selecting it in the `More`{.action} submenu.
-
-In this section you will see an overview of your scheduled jobs and their settings.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Creating an automated task
 
-#### Step 1: Defining general settings
+Click on the tabs below to view each of the **5** steps.
 
-To create a new cron task, click on the `Add a scheduling`{.action} button on the right-hand side. You can customise the settings for the task in the new window.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Option|Description|   
-|---|---|   
-|Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|   
-|Language|Select the PHP version the script is using.|
-|Activation|Choose whether the task will be active after creation or activated later.| 
-|Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.| 
-|Description|Enter a description to keep track of what your tasks do.| 
-
-Click on `Next`{.action} to proceed to the second step.
-
-#### Step 2: Setting the frequency
-
-The interface offers two modes to configure the frequency of your task. Use the **Basic mode** for a beginner-friendly selection of scheduling options. If you prefer to directly enter a frequency, similar to a cron table format (*crontab*), choose the **Advanced mode**.
-
-|Basic mode|
-|---|
-|Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-|Advanced mode| 
-|---|
-|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
->
-> The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
->
-
-You can switch between the two modes during configuration to view the changes accordingly. Please also note the [limitations when scheduling a task on a Web Hosting](./#limitations-of-web-hosting-tasks).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Step 3: Finishing the setup
-
-The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
-
-![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> To create a cron job, click on the `Add a scheduling`{.action} button on the right-hand side.
+>>
+> **Step 3**
+>>
+>> Customise the task settings in the window that appears.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Option|Description|
+>> |---|---|
+>> |Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|
+>> |Language|Select the PHP version the script is using.|
+>> |Activation|Choose whether the task will be active after creation or activated later.|
+>> |Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.|
+>> |Description|Enter a description to keep track of what your tasks do.|
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 4**
+>>
+>> The interface offers two modes to configure the frequency of your task:
+>>
+>> - **Basic mode**: use the drop-down menus to specify the time of day, days of a month, week days and months for the task.
+>> - **Expert mode**: enter numeric values as you would in a *crontab*.
+>>
+>> |Basic mode|Expert mode|
+>> |---|---|
+>> |Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
+>> >
+>> > The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
+>>
+>> You can switch between the two modes during configuration. Please also note the [limitations when scheduling a task on a web hosting plan](./#limitations-of-web-hosting-tasks).
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 5**
+>>
+>> The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
 
 ### Modify or delete a scheduled task
 
@@ -135,7 +143,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> Click on the `Edit`{.action} or `Delete`{.action} button, depending on the action you want to perform on the scheduled task.
 
-### Limitations of Web Hosting tasks
+### Limitations of web hosting tasks
 
 |Functionality|Description|
 |---|---|
@@ -155,10 +163,10 @@ A simple test to see if your script will produce an error is to run it in a web 
 #### Verifying the usage of absolute paths
 
 Always make sure to use absolute paths to files in your scripts. The "DIR" constant, for example, can help to receive the current path in PHP scripts ([PHP documentation](http://php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Checking your execution logs
 
-In your Web Hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
+In your web hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
 
 Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) for details.
 
@@ -167,35 +175,35 @@ Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) f
 - Example of a successfully finished execution output
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output due to exceeded execution time
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output because the script file was not found in the specified path
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Example of a failed execution output because of a permissions error (chmod) or incorrect configuration of the .ovhconfig file
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Go further <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-ca.md
@@ -29,7 +29,7 @@ updated: 2026-03-31
 
 ## Objective
 
-On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") runs your scripts at specific times, automatically.
 
 **This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
@@ -70,7 +70,7 @@ Click on the tabs below to view each of the **5** steps.
 >>
 > **Step 2**
 >>
->> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>> Click on the `More`{.action} tab, then `cron`{.action}. You will see an overview of your scheduled tasks and their settings.
 >>
 >> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
 >>
@@ -135,7 +135,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `More`{.action} tab, then `Cron`{.action}.
+>> On the page that pops up, click on the `More`{.action} tab, then `cron`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,20 +29,20 @@ updated: 2025-02-20
 
 ## Objective
 
-On OVHcloud Web Hostings, you can use scripts to automate certain operations. Creating a scheduled task ("cron job") is the easiest way to ensure your scripts are running at specific times without further actions necessary on your part. 
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
 
-**This guide explains how to create cron jobs to automate scheduled tasks on a Web Hosting.**
+**This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- An [OVHcloud Web Hosting plan](/links/web/hosting)
+- An [OVHcloud web hosting plan](/links/web/hosting)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -57,62 +57,70 @@ On OVHcloud Web Hostings, you can use scripts to automate certain operations. Cr
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action} in the top navigation bar. Click `Hosting plans`{.action}, then choose the Web Hosting plan concerned. Next, navigate to the `cron`{.action} tab by selecting it in the `More`{.action} submenu.
-
-In this section you will see an overview of your scheduled jobs and their settings.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Creating an automated task
 
-#### Step 1: Defining general settings
+Click on the tabs below to view each of the **5** steps.
 
-To create a new cron task, click on the `Add a scheduling`{.action} button on the right-hand side. You can customise the settings for the task in the new window.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Option|Description|   
-|---|---|   
-|Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|   
-|Language|Select the PHP version the script is using.|
-|Activation|Choose whether the task will be active after creation or activated later.| 
-|Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.| 
-|Description|Enter a description to keep track of what your tasks do.| 
-
-Click on `Next`{.action} to proceed to the second step.
-
-#### Step 2: Setting the frequency
-
-The interface offers two modes to configure the frequency of your task. Use the **Basic mode** for a beginner-friendly selection of scheduling options. If you prefer to directly enter a frequency, similar to a cron table format (*crontab*), choose the **Advanced mode**.
-
-|Basic mode|
-|---|
-|Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-|Advanced mode| 
-|---|
-|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
->
-> The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
->
-
-You can switch between the two modes during configuration to view the changes accordingly. Please also note the [limitations when scheduling a task on a Web Hosting](./#limitations-of-web-hosting-tasks).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Step 3: Finishing the setup
-
-The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
-
-![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> To create a cron job, click on the `Add a scheduling`{.action} button on the right-hand side.
+>>
+> **Step 3**
+>>
+>> Customise the task settings in the window that appears.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Option|Description|
+>> |---|---|
+>> |Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|
+>> |Language|Select the PHP version the script is using.|
+>> |Activation|Choose whether the task will be active after creation or activated later.|
+>> |Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.|
+>> |Description|Enter a description to keep track of what your tasks do.|
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 4**
+>>
+>> The interface offers two modes to configure the frequency of your task:
+>>
+>> - **Basic mode**: use the drop-down menus to specify the time of day, days of a month, week days and months for the task.
+>> - **Expert mode**: enter numeric values as you would in a *crontab*.
+>>
+>> |Basic mode|Expert mode|
+>> |---|---|
+>> |Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
+>> >
+>> > The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
+>>
+>> You can switch between the two modes during configuration. Please also note the [limitations when scheduling a task on a web hosting plan](./#limitations-of-web-hosting-tasks).
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 5**
+>>
+>> The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
 
 ### Modify or delete a scheduled task
 
@@ -135,7 +143,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> Click on the `Edit`{.action} or `Delete`{.action} button, depending on the action you want to perform on the scheduled task.
 
-### Limitations of Web Hosting tasks
+### Limitations of web hosting tasks
 
 |Functionality|Description|
 |---|---|
@@ -155,10 +163,10 @@ A simple test to see if your script will produce an error is to run it in a web 
 #### Verifying the usage of absolute paths
 
 Always make sure to use absolute paths to files in your scripts. The "DIR" constant, for example, can help to receive the current path in PHP scripts ([PHP documentation](http://php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Checking your execution logs
 
-In your Web Hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
+In your web hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
 
 Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) for details.
 
@@ -167,35 +175,35 @@ Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) f
 - Example of a successfully finished execution output
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output due to exceeded execution time
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output because the script file was not found in the specified path
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Example of a failed execution output because of a permissions error (chmod) or incorrect configuration of the .ovhconfig file
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Go further <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-gb.md
@@ -29,7 +29,7 @@ updated: 2026-03-31
 
 ## Objective
 
-On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") runs your scripts at specific times, automatically.
 
 **This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
@@ -70,7 +70,7 @@ Click on the tabs below to view each of the **5** steps.
 >>
 > **Step 2**
 >>
->> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>> Click on the `More`{.action} tab, then `cron`{.action}. You will see an overview of your scheduled tasks and their settings.
 >>
 >> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
 >>
@@ -135,7 +135,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `More`{.action} tab, then `Cron`{.action}.
+>> On the page that pops up, click on the `More`{.action} tab, then `cron`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,20 +29,20 @@ updated: 2025-02-20
 
 ## Objective
 
-On OVHcloud Web Hostings, you can use scripts to automate certain operations. Creating a scheduled task ("cron job") is the easiest way to ensure your scripts are running at specific times without further actions necessary on your part. 
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
 
-**This guide explains how to create cron jobs to automate scheduled tasks on a Web Hosting.**
+**This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- An [OVHcloud Web Hosting plan](/links/web/hosting)
+- An [OVHcloud web hosting plan](/links/web/hosting)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -57,62 +57,70 @@ On OVHcloud Web Hostings, you can use scripts to automate certain operations. Cr
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action} in the top navigation bar. Click `Hosting plans`{.action}, then choose the Web Hosting plan concerned. Next, navigate to the `cron`{.action} tab by selecting it in the `More`{.action} submenu.
-
-In this section you will see an overview of your scheduled jobs and their settings.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Creating an automated task
 
-#### Step 1: Defining general settings
+Click on the tabs below to view each of the **5** steps.
 
-To create a new cron task, click on the `Add a scheduling`{.action} button on the right-hand side. You can customise the settings for the task in the new window.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Option|Description|   
-|---|---|   
-|Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|   
-|Language|Select the PHP version the script is using.|
-|Activation|Choose whether the task will be active after creation or activated later.| 
-|Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.| 
-|Description|Enter a description to keep track of what your tasks do.| 
-
-Click on `Next`{.action} to proceed to the second step.
-
-#### Step 2: Setting the frequency
-
-The interface offers two modes to configure the frequency of your task. Use the **Basic mode** for a beginner-friendly selection of scheduling options. If you prefer to directly enter a frequency, similar to a cron table format (*crontab*), choose the **Advanced mode**.
-
-|Basic mode|
-|---|
-|Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-|Advanced mode| 
-|---|
-|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
->
-> The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
->
-
-You can switch between the two modes during configuration to view the changes accordingly. Please also note the [limitations when scheduling a task on a Web Hosting](./#limitations-of-web-hosting-tasks).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Step 3: Finishing the setup
-
-The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
-
-![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> To create a cron job, click on the `Add a scheduling`{.action} button on the right-hand side.
+>>
+> **Step 3**
+>>
+>> Customise the task settings in the window that appears.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Option|Description|
+>> |---|---|
+>> |Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|
+>> |Language|Select the PHP version the script is using.|
+>> |Activation|Choose whether the task will be active after creation or activated later.|
+>> |Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.|
+>> |Description|Enter a description to keep track of what your tasks do.|
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 4**
+>>
+>> The interface offers two modes to configure the frequency of your task:
+>>
+>> - **Basic mode**: use the drop-down menus to specify the time of day, days of a month, week days and months for the task.
+>> - **Expert mode**: enter numeric values as you would in a *crontab*.
+>>
+>> |Basic mode|Expert mode|
+>> |---|---|
+>> |Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
+>> >
+>> > The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
+>>
+>> You can switch between the two modes during configuration. Please also note the [limitations when scheduling a task on a web hosting plan](./#limitations-of-web-hosting-tasks).
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 5**
+>>
+>> The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
 
 ### Modify or delete a scheduled task
 
@@ -135,7 +143,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> Click on the `Edit`{.action} or `Delete`{.action} button, depending on the action you want to perform on the scheduled task.
 
-### Limitations of Web Hosting tasks
+### Limitations of web hosting tasks
 
 |Functionality|Description|
 |---|---|
@@ -155,10 +163,10 @@ A simple test to see if your script will produce an error is to run it in a web 
 #### Verifying the usage of absolute paths
 
 Always make sure to use absolute paths to files in your scripts. The "DIR" constant, for example, can help to receive the current path in PHP scripts ([PHP documentation](http://php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Checking your execution logs
 
-In your Web Hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
+In your web hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
 
 Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) for details.
 
@@ -167,35 +175,35 @@ Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) f
 - Example of a successfully finished execution output
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output due to exceeded execution time
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output because the script file was not found in the specified path
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Example of a failed execution output because of a permissions error (chmod) or incorrect configuration of the .ovhconfig file
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Go further <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-ie.md
@@ -29,7 +29,7 @@ updated: 2026-03-31
 
 ## Objective
 
-On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") runs your scripts at specific times, automatically.
 
 **This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
@@ -70,7 +70,7 @@ Click on the tabs below to view each of the **5** steps.
 >>
 > **Step 2**
 >>
->> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>> Click on the `More`{.action} tab, then `cron`{.action}. You will see an overview of your scheduled tasks and their settings.
 >>
 >> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
 >>
@@ -135,7 +135,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `More`{.action} tab, then `Cron`{.action}.
+>> On the page that pops up, click on the `More`{.action} tab, then `cron`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,20 +29,20 @@ updated: 2025-02-20
 
 ## Objective
 
-On OVHcloud Web Hostings, you can use scripts to automate certain operations. Creating a scheduled task ("cron job") is the easiest way to ensure your scripts are running at specific times without further actions necessary on your part. 
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
 
-**This guide explains how to create cron jobs to automate scheduled tasks on a Web Hosting.**
+**This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- An [OVHcloud Web Hosting plan](/links/web/hosting)
+- An [OVHcloud web hosting plan](/links/web/hosting)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -57,62 +57,70 @@ On OVHcloud Web Hostings, you can use scripts to automate certain operations. Cr
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action} in the top navigation bar. Click `Hosting plans`{.action}, then choose the Web Hosting plan concerned. Next, navigate to the `cron`{.action} tab by selecting it in the `More`{.action} submenu.
-
-In this section you will see an overview of your scheduled jobs and their settings.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Creating an automated task
 
-#### Step 1: Defining general settings
+Click on the tabs below to view each of the **5** steps.
 
-To create a new cron task, click on the `Add a scheduling`{.action} button on the right-hand side. You can customise the settings for the task in the new window.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Option|Description|   
-|---|---|   
-|Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|   
-|Language|Select the PHP version the script is using.|
-|Activation|Choose whether the task will be active after creation or activated later.| 
-|Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.| 
-|Description|Enter a description to keep track of what your tasks do.| 
-
-Click on `Next`{.action} to proceed to the second step.
-
-#### Step 2: Setting the frequency
-
-The interface offers two modes to configure the frequency of your task. Use the **Basic mode** for a beginner-friendly selection of scheduling options. If you prefer to directly enter a frequency, similar to a cron table format (*crontab*), choose the **Advanced mode**.
-
-|Basic mode|
-|---|
-|Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-|Advanced mode| 
-|---|
-|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
->
-> The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
->
-
-You can switch between the two modes during configuration to view the changes accordingly. Please also note the [limitations when scheduling a task on a Web Hosting](./#limitations-of-web-hosting-tasks).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Step 3: Finishing the setup
-
-The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
-
-![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> To create a cron job, click on the `Add a scheduling`{.action} button on the right-hand side.
+>>
+> **Step 3**
+>>
+>> Customise the task settings in the window that appears.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Option|Description|
+>> |---|---|
+>> |Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|
+>> |Language|Select the PHP version the script is using.|
+>> |Activation|Choose whether the task will be active after creation or activated later.|
+>> |Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.|
+>> |Description|Enter a description to keep track of what your tasks do.|
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 4**
+>>
+>> The interface offers two modes to configure the frequency of your task:
+>>
+>> - **Basic mode**: use the drop-down menus to specify the time of day, days of a month, week days and months for the task.
+>> - **Expert mode**: enter numeric values as you would in a *crontab*.
+>>
+>> |Basic mode|Expert mode|
+>> |---|---|
+>> |Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
+>> >
+>> > The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
+>>
+>> You can switch between the two modes during configuration. Please also note the [limitations when scheduling a task on a web hosting plan](./#limitations-of-web-hosting-tasks).
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 5**
+>>
+>> The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
 
 ### Modify or delete a scheduled task
 
@@ -135,7 +143,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> Click on the `Edit`{.action} or `Delete`{.action} button, depending on the action you want to perform on the scheduled task.
 
-### Limitations of Web Hosting tasks
+### Limitations of web hosting tasks
 
 |Functionality|Description|
 |---|---|
@@ -155,10 +163,10 @@ A simple test to see if your script will produce an error is to run it in a web 
 #### Verifying the usage of absolute paths
 
 Always make sure to use absolute paths to files in your scripts. The "DIR" constant, for example, can help to receive the current path in PHP scripts ([PHP documentation](http://php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Checking your execution logs
 
-In your Web Hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
+In your web hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
 
 Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) for details.
 
@@ -167,35 +175,35 @@ Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) f
 - Example of a successfully finished execution output
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output due to exceeded execution time
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output because the script file was not found in the specified path
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Example of a failed execution output because of a permissions error (chmod) or incorrect configuration of the .ovhconfig file
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Go further <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-sg.md
@@ -29,7 +29,7 @@ updated: 2026-03-31
 
 ## Objective
 
-On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") runs your scripts at specific times, automatically.
 
 **This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
@@ -70,7 +70,7 @@ Click on the tabs below to view each of the **5** steps.
 >>
 > **Step 2**
 >>
->> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>> Click on the `More`{.action} tab, then `cron`{.action}. You will see an overview of your scheduled tasks and their settings.
 >>
 >> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
 >>
@@ -135,7 +135,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `More`{.action} tab, then `Cron`{.action}.
+>> On the page that pops up, click on the `More`{.action} tab, then `cron`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,20 +29,20 @@ updated: 2025-02-20
 
 ## Objective
 
-On OVHcloud Web Hostings, you can use scripts to automate certain operations. Creating a scheduled task ("cron job") is the easiest way to ensure your scripts are running at specific times without further actions necessary on your part. 
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
 
-**This guide explains how to create cron jobs to automate scheduled tasks on a Web Hosting.**
+**This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- An [OVHcloud Web Hosting plan](/links/web/hosting)
+- An [OVHcloud web hosting plan](/links/web/hosting)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -57,62 +57,70 @@ On OVHcloud Web Hostings, you can use scripts to automate certain operations. Cr
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action} in the top navigation bar. Click `Hosting plans`{.action}, then choose the Web Hosting plan concerned. Next, navigate to the `cron`{.action} tab by selecting it in the `More`{.action} submenu.
-
-In this section you will see an overview of your scheduled jobs and their settings.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Creating an automated task
 
-#### Step 1: Defining general settings
+Click on the tabs below to view each of the **5** steps.
 
-To create a new cron task, click on the `Add a scheduling`{.action} button on the right-hand side. You can customise the settings for the task in the new window.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Option|Description|   
-|---|---|   
-|Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|   
-|Language|Select the PHP version the script is using.|
-|Activation|Choose whether the task will be active after creation or activated later.| 
-|Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.| 
-|Description|Enter a description to keep track of what your tasks do.| 
-
-Click on `Next`{.action} to proceed to the second step.
-
-#### Step 2: Setting the frequency
-
-The interface offers two modes to configure the frequency of your task. Use the **Basic mode** for a beginner-friendly selection of scheduling options. If you prefer to directly enter a frequency, similar to a cron table format (*crontab*), choose the **Advanced mode**.
-
-|Basic mode|
-|---|
-|Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-|Advanced mode| 
-|---|
-|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
->
-> The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
->
-
-You can switch between the two modes during configuration to view the changes accordingly. Please also note the [limitations when scheduling a task on a Web Hosting](./#limitations-of-web-hosting-tasks).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Step 3: Finishing the setup
-
-The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
-
-![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> To create a cron job, click on the `Add a scheduling`{.action} button on the right-hand side.
+>>
+> **Step 3**
+>>
+>> Customise the task settings in the window that appears.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Option|Description|
+>> |---|---|
+>> |Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|
+>> |Language|Select the PHP version the script is using.|
+>> |Activation|Choose whether the task will be active after creation or activated later.|
+>> |Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.|
+>> |Description|Enter a description to keep track of what your tasks do.|
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 4**
+>>
+>> The interface offers two modes to configure the frequency of your task:
+>>
+>> - **Basic mode**: use the drop-down menus to specify the time of day, days of a month, week days and months for the task.
+>> - **Expert mode**: enter numeric values as you would in a *crontab*.
+>>
+>> |Basic mode|Expert mode|
+>> |---|---|
+>> |Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
+>> >
+>> > The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
+>>
+>> You can switch between the two modes during configuration. Please also note the [limitations when scheduling a task on a web hosting plan](./#limitations-of-web-hosting-tasks).
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 5**
+>>
+>> The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
 
 ### Modify or delete a scheduled task
 
@@ -135,7 +143,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> Click on the `Edit`{.action} or `Delete`{.action} button, depending on the action you want to perform on the scheduled task.
 
-### Limitations of Web Hosting tasks
+### Limitations of web hosting tasks
 
 |Functionality|Description|
 |---|---|
@@ -155,10 +163,10 @@ A simple test to see if your script will produce an error is to run it in a web 
 #### Verifying the usage of absolute paths
 
 Always make sure to use absolute paths to files in your scripts. The "DIR" constant, for example, can help to receive the current path in PHP scripts ([PHP documentation](http://php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Checking your execution logs
 
-In your Web Hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
+In your web hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
 
 Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) for details.
 
@@ -167,35 +175,35 @@ Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) f
 - Example of a successfully finished execution output
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output due to exceeded execution time
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output because the script file was not found in the specified path
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Example of a failed execution output because of a permissions error (chmod) or incorrect configuration of the .ovhconfig file
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Go further <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-us.md
@@ -29,7 +29,7 @@ updated: 2026-03-31
 
 ## Objective
 
-On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") runs your scripts at specific times, automatically.
 
 **This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
@@ -70,7 +70,7 @@ Click on the tabs below to view each of the **5** steps.
 >>
 > **Step 2**
 >>
->> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>> Click on the `More`{.action} tab, then `cron`{.action}. You will see an overview of your scheduled tasks and their settings.
 >>
 >> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
 >>
@@ -135,7 +135,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `More`{.action} tab, then `Cron`{.action}.
+>> On the page that pops up, click on the `More`{.action} tab, then `cron`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,20 +29,20 @@ updated: 2025-02-20
 
 ## Objective
 
-On OVHcloud Web Hostings, you can use scripts to automate certain operations. Creating a scheduled task ("cron job") is the easiest way to ensure your scripts are running at specific times without further actions necessary on your part. 
+On your OVHcloud web hosting, you can use scripts to automate certain operations. A scheduled task ("cron job") allows your scripts to run at specific times without further actions on your part.
 
-**This guide explains how to create cron jobs to automate scheduled tasks on a Web Hosting.**
+**This guide explains how to create cron jobs to automate scheduled tasks on a web hosting plan.**
 
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- An [OVHcloud Web Hosting plan](/links/web/hosting)
+- An [OVHcloud web hosting plan](/links/web/hosting)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -57,62 +57,70 @@ On OVHcloud Web Hostings, you can use scripts to automate certain operations. Cr
 
 ## Instructions
 
-Log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action} in the top navigation bar. Click `Hosting plans`{.action}, then choose the Web Hosting plan concerned. Next, navigate to the `cron`{.action} tab by selecting it in the `More`{.action} submenu.
-
-In this section you will see an overview of your scheduled jobs and their settings.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Creating an automated task
 
-#### Step 1: Defining general settings
+Click on the tabs below to view each of the **5** steps.
 
-To create a new cron task, click on the `Add a scheduling`{.action} button on the right-hand side. You can customise the settings for the task in the new window.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Option|Description|   
-|---|---|   
-|Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|   
-|Language|Select the PHP version the script is using.|
-|Activation|Choose whether the task will be active after creation or activated later.| 
-|Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.| 
-|Description|Enter a description to keep track of what your tasks do.| 
-
-Click on `Next`{.action} to proceed to the second step.
-
-#### Step 2: Setting the frequency
-
-The interface offers two modes to configure the frequency of your task. Use the **Basic mode** for a beginner-friendly selection of scheduling options. If you prefer to directly enter a frequency, similar to a cron table format (*crontab*), choose the **Advanced mode**.
-
-|Basic mode|
-|---|
-|Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-|Advanced mode| 
-|---|
-|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
->
-> The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
->
-
-You can switch between the two modes during configuration to view the changes accordingly. Please also note the [limitations when scheduling a task on a Web Hosting](./#limitations-of-web-hosting-tasks).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Step 3: Finishing the setup
-
-The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
-
-![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `More`{.action} tab, then `Cron`{.action}. You will see an overview of your scheduled tasks and their settings.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> To create a cron job, click on the `Add a scheduling`{.action} button on the right-hand side.
+>>
+> **Step 3**
+>>
+>> Customise the task settings in the window that appears.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Option|Description|
+>> |---|---|
+>> |Command to be executed|Define the path to the file containing your script. Example: www/jobs/cron.php|
+>> |Language|Select the PHP version the script is using.|
+>> |Activation|Choose whether the task will be active after creation or activated later.|
+>> |Logs by email|If necessary, select a contact (admin or technical) to whom a report will be sent in case of an execution error. You can also provide an alternative email address.|
+>> |Description|Enter a description to keep track of what your tasks do.|
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 4**
+>>
+>> The interface offers two modes to configure the frequency of your task:
+>>
+>> - **Basic mode**: use the drop-down menus to specify the time of day, days of a month, week days and months for the task.
+>> - **Expert mode**: enter numeric values as you would in a *crontab*.
+>>
+>> |Basic mode|Expert mode|
+>> |---|---|
+>> |Use the drop-down menus to specify the time of day, days of a month, week days and months for the task.|Enter numeric values as you would in a *crontab*. The asterisk operator denotes "every value" of the time period, meaning the task would continuously run **once an hour every day** in this example.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > The `Days`{.action} form allows you to define execution frequencies on a monthly cycle.
+>> >
+>> > The `Days of the week`{.action} form allows you to define additional execution frequencies, but on a weekly cycle.
+>>
+>> You can switch between the two modes during configuration. Please also note the [limitations when scheduling a task on a web hosting plan](./#limitations-of-web-hosting-tasks).
+>>
+>> Click on `Next`{.action}.
+>>
+> **Step 5**
+>>
+>> The summary lists all your settings including the *crontab* notation of the execution frequency. If everything is correct, click on `Confirm`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> The task will be ready within a few minutes. You can then modify all of its settings or delete the task by clicking on `...`{.action} in the overview table in your OVHcloud Control Panel.
 
 ### Modify or delete a scheduled task
 
@@ -135,7 +143,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> Click on the `Edit`{.action} or `Delete`{.action} button, depending on the action you want to perform on the scheduled task.
 
-### Limitations of Web Hosting tasks
+### Limitations of web hosting tasks
 
 |Functionality|Description|
 |---|---|
@@ -155,10 +163,10 @@ A simple test to see if your script will produce an error is to run it in a web 
 #### Verifying the usage of absolute paths
 
 Always make sure to use absolute paths to files in your scripts. The "DIR" constant, for example, can help to receive the current path in PHP scripts ([PHP documentation](http://php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Checking your execution logs
 
-In your Web Hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
+In your web hosting's logs, accessible from the [OVHcloud Control Panel](/links/manager), you will see the log category labelled "cron".
 
 Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) for details.
 
@@ -167,35 +175,35 @@ Please refer to [this guide](/pages/web_cloud/web_hosting/logs_and_statistics) f
 - Example of a successfully finished execution output
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output due to exceeded execution time
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Example of a failed execution output because the script file was not found in the specified path
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Example of a failed execution output because of a permissions error (chmod) or incorrect configuration of the .ovhconfig file
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Go further <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Using automated tasks on a Web Hosting plan"
 excerpt: "Find out how to configure scheduled jobs on your Web Hosting"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Crear tareas automatizadas (CRON) en un alojamiento web"
 excerpt: "Descubra cómo crear tareas CRON para automatizar las tareas programadas en un alojamiento web"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,7 +29,7 @@ updated: 2025-02-20
 
 ## Objetivo
 
-En su alojamiento web de OVHcloud, puede utilizar scripts para automatizar determinadas operaciones. La creación de una tarea programada ("tarea CRON") es la forma más sencilla de garantizar que sus scripts se ejecutan en momentos específicos sin que usted tenga que realizar ninguna otra acción. 
+En su alojamiento web de OVHcloud, puede utilizar scripts para automatizar determinadas operaciones. Una tarea programada ("tarea CRON") permite que sus scripts se ejecuten en momentos específicos sin que usted tenga que realizar ninguna otra acción.
 
 **Esta guía explica cómo crear tareas CRON para automatizar las tareas programadas en un alojamiento web.**
 
@@ -37,7 +37,7 @@ En su alojamiento web de OVHcloud, puede utilizar scripts para automatizar deter
 >
 > La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
 >
-> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado ["Más información"](#go-further) de esta guía. 
+> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado ["Más información"](#go-further) de esta guía.
 >
 
 ## Requisitos
@@ -48,7 +48,7 @@ En su alojamiento web de OVHcloud, puede utilizar scripts para automatizar deter
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -56,64 +56,70 @@ En su alojamiento web de OVHcloud, puede utilizar scripts para automatizar deter
 
 ## Procedimiento
 
-Acceda al [área de cliente de OVHcloud](/links/manager). Haga clic en `Web Cloud`{.action} y seleccione `Alojamientos`{.action}.
-
-Seleccione el alojamiento correspondiente, abra la pestaña `Más`{.action} y haga clic en `Cron.`{.action}.
-
-En esta sección, tendrá un resumen de sus tareas planificadas y sus parámetros.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Creación de una tarea automatizada
 
-#### Etapa 1: Definición de la configuración general
+Haga clic en las fichas siguientes para ver cada una de las **5** etapas.
 
-Para crear una tarea CRON, haga clic en el botón `Añadir una planificación`{.action} a la derecha. Puede personalizar la configuración de la tarea en la nueva ventana.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Opción|Descripción|   
-|---|---|   
-|Orden a ejecutar|Establezca la ruta al archivo que contiene el script. Ejemplo: www/jobs/cron.php|   
-|Idioma|Seleccione la versión PHP del script.|
-|Activación|Seleccione si la tarea se activará después de crearla o se activará más adelante.| 
-|Logs por e-mail|Si es necesario, seleccione un contacto (administrador o técnico) al que se enviará un informe en caso de error de ejecución. También puede proporcionar otra dirección de correo electrónico.| 
-|Descripción|Introduzca una descripción para consultar el progreso en la ejecución de sus tareas.| 
-
-Haga clic en `Siguiente`{.action} para ir al paso 2.
-
-#### Etapa 2: Definición de frecuencia
-
-La interfaz ofrece dos modos para configurar la frecuencia de la tarea. Utilice el **Modo simple** para seleccionar opciones de planificación sencilla para principiantes. Si prefiere introducir directamente una frecuencia similar a un formato de tabla CRON (*crontab*), seleccione el **Modo experto**.
-
-|Modo simple|
-|---|
-|Utilice los menús desplegables para especificar la hora, los días de un mes, los días de la semana y los meses de la tarea.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> El formulario `Días`{.action} permite definir frecuencias de ejecución en un ciclo mensual.
->
-> El formulario `Días de la semana`{.action} permite definir frecuencias de ejecución adicionales, pero en un ciclo semanal.
->
-
-|Modo experto| 
-|---|
-|Introduzca valores numéricos como en una *crontab*. Los asteriscos indican cada valor del período, lo que significa que la tarea se ejecutaría continuamente **una vez por hora todos los días** en este ejemplo.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-Puede cambiar entre ambos modos durante la configuración para ver los cambios en consecuencia. Asimismo, tenga en cuenta las [limitaciones al planificar una tarea en un alojamiento web](./#limitaciones-de-las-tareas-planificadas-en-su-alojamiento-web).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Etapa 3: Fin de la instalación
-
-El resumen le recuerda los parámetros configurados, incluyendo la notación *crontab* sobre la frecuencia de ejecución. si lo son, haga clic en `Aceptar`{.action}.
-
-![cron de confirmación](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-La tarea estará lista en unos minutos. Podrá modificar todos los parámetros o eliminar la tarea haciendo clic en `...`{.action} en la tabla de presentación del panel de configuración de OVHcloud.
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `Más`{.action} y seleccione `Cron`{.action}. Tendrá un resumen de sus tareas planificadas y sus parámetros.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> Para crear una tarea CRON, haga clic en el botón `Añadir una planificación`{.action} a la derecha.
+>>
+> **Etapa 3**
+>>
+>> Personalice los parámetros de la tarea en la ventana que aparece.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Opción|Descripción|
+>> |---|---|
+>> |Orden a ejecutar|Establezca la ruta al archivo que contiene el script. Ejemplo: www/jobs/cron.php|
+>> |Idioma|Seleccione la versión PHP del script.|
+>> |Activación|Seleccione si la tarea se activará después de crearla o se activará más adelante.|
+>> |Logs por e-mail|Si es necesario, seleccione un contacto (administrador o técnico) al que se enviará un informe en caso de error de ejecución. También puede proporcionar otra dirección de correo electrónico.|
+>> |Descripción|Introduzca una descripción para consultar el progreso en la ejecución de sus tareas.|
+>>
+>> Haga clic en `Siguiente`{.action}.
+>>
+> **Etapa 4**
+>>
+>> La interfaz ofrece dos modos para configurar la frecuencia de la tarea:
+>>
+>> - **Modo simple**: utilice los menús desplegables para especificar la hora, los días de un mes, los días de la semana y los meses de la tarea.
+>> - **Modo experto**: introduzca valores numéricos como en una *crontab*.
+>>
+>> |Modo simple|Modo experto|
+>> |---|---|
+>> |Utilice los menús desplegables para especificar la hora, los días de un mes, los días de la semana y los meses de la tarea.|Introduzca valores numéricos como en una *crontab*. Los asteriscos indican cada valor del período, lo que significa que la tarea se ejecutaría continuamente **una vez por hora todos los días** en este ejemplo.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > El formulario `Días`{.action} permite definir frecuencias de ejecución en un ciclo mensual.
+>> >
+>> > El formulario `Días de la semana`{.action} permite definir frecuencias de ejecución adicionales, pero en un ciclo semanal.
+>>
+>> Puede cambiar entre ambos modos durante la configuración. Asimismo, tenga en cuenta las [limitaciones al planificar una tarea en un alojamiento web](./#limitaciones-de-las-tareas-planificadas-en-su-alojamiento-web).
+>>
+>> Haga clic en `Siguiente`{.action}.
+>>
+> **Etapa 5**
+>>
+>> El resumen le recuerda los parámetros configurados, incluyendo la notación *crontab* sobre la frecuencia de ejecución. Si todo es correcto, haga clic en `Aceptar`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> La tarea estará lista en unos minutos. Podrá modificar todos los parámetros o eliminar la tarea haciendo clic en `...`{.action} en la tabla de presentación del panel de configuración de OVHcloud.
 
 ### Modificar o eliminar una tarea programada
 
@@ -122,7 +128,7 @@ Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -156,7 +162,7 @@ Una prueba sencilla de si el script producirá un error es ejecutarlo en un nave
 #### Comprobación del uso de rutas absolutas
 
 Utilice siempre rutas de acceso absolutas a los archivos de sus scripts. La constante "DIR", por ejemplo, puede ayudar a obtener la ruta actual en los scripts PHP ([documentación PHP](https://www.php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Verificación de los logs de ejecución
 
 Podrá acceder a los logs de su alojamiento web desde su [área de cliente de OVHcloud](/links/manager) y ver la categoría de log denominada "CRON".
@@ -165,38 +171,38 @@ Para más información, consulte nuestra guía ["Consultar las estadísticas y l
 
 ##### **Ejemplo de logs**
 
-- Ejemplo de finalización de script correctamente ejecutado 
+- Ejemplo de finalización de script correctamente ejecutado
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Ejemplo de fallo al superar el tiempo de ejecución
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Ejemplo de error: no se puede encontrar el archivo de guión en la ruta de acceso especificada
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Ejemplo de error debido a un error de autorización (chmod) o a una configuración incorrecta del archivo .ovhconfig
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Más información <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Crear tareas automatizadas (CRON) en un alojamiento web"
 excerpt: "Descubra cómo crear tareas CRON para automatizar las tareas programadas en un alojamiento web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Crear tareas automatizadas (CRON) en un alojamiento web"
 excerpt: "Descubra cómo crear tareas CRON para automatizar las tareas programadas en un alojamiento web"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,7 +29,7 @@ updated: 2025-02-20
 
 ## Objetivo
 
-En su alojamiento web de OVHcloud, puede utilizar scripts para automatizar determinadas operaciones. La creación de una tarea programada ("tarea CRON") es la forma más sencilla de garantizar que sus scripts se ejecutan en momentos específicos sin que usted tenga que realizar ninguna otra acción. 
+En su alojamiento web de OVHcloud, puede utilizar scripts para automatizar determinadas operaciones. Una tarea programada ("tarea CRON") permite que sus scripts se ejecuten en momentos específicos sin que usted tenga que realizar ninguna otra acción.
 
 **Esta guía explica cómo crear tareas CRON para automatizar las tareas programadas en un alojamiento web.**
 
@@ -37,7 +37,7 @@ En su alojamiento web de OVHcloud, puede utilizar scripts para automatizar deter
 >
 > La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
 >
-> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado ["Más información"](#go-further) de esta guía. 
+> Esta guía le ayudará a realizar las operaciones más habituales. No obstante, si tiene alguna duda, le recomendamos que contacte con un proveedor de servicios especializado o con el editor del servicio. Nosotros no podremos asistirle. Para más información, consulte el apartado ["Más información"](#go-further) de esta guía.
 >
 
 ## Requisitos
@@ -48,7 +48,7 @@ En su alojamiento web de OVHcloud, puede utilizar scripts para automatizar deter
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -56,64 +56,70 @@ En su alojamiento web de OVHcloud, puede utilizar scripts para automatizar deter
 
 ## Procedimiento
 
-Acceda al [área de cliente de OVHcloud](/links/manager). Haga clic en `Web Cloud`{.action} y seleccione `Alojamientos`{.action}.
-
-Seleccione el alojamiento correspondiente, abra la pestaña `Más`{.action} y haga clic en `Cron.`{.action}.
-
-En esta sección, tendrá un resumen de sus tareas planificadas y sus parámetros.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Creación de una tarea automatizada
 
-#### Etapa 1: Definición de la configuración general
+Haga clic en las fichas siguientes para ver cada una de las **5** etapas.
 
-Para crear una tarea CRON, haga clic en el botón `Añadir una planificación`{.action} a la derecha. Puede personalizar la configuración de la tarea en la nueva ventana.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Opción|Descripción|   
-|---|---|   
-|Orden a ejecutar|Establezca la ruta al archivo que contiene el script. Ejemplo: www/jobs/cron.php|   
-|Idioma|Seleccione la versión PHP del script.|
-|Activación|Seleccione si la tarea se activará después de crearla o se activará más adelante.| 
-|Logs por e-mail|Si es necesario, seleccione un contacto (administrador o técnico) al que se enviará un informe en caso de error de ejecución. También puede proporcionar otra dirección de correo electrónico.| 
-|Descripción|Introduzca una descripción para consultar el progreso en la ejecución de sus tareas.| 
-
-Haga clic en `Siguiente`{.action} para ir al paso 2.
-
-#### Etapa 2: Definición de frecuencia
-
-La interfaz ofrece dos modos para configurar la frecuencia de la tarea. Utilice el **Modo simple** para seleccionar opciones de planificación sencilla para principiantes. Si prefiere introducir directamente una frecuencia similar a un formato de tabla CRON (*crontab*), seleccione el **Modo experto**.
-
-|Modo simple|
-|---|
-|Utilice los menús desplegables para especificar la hora, los días de un mes, los días de la semana y los meses de la tarea.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> El formulario `Días`{.action} permite definir frecuencias de ejecución en un ciclo mensual.
->
-> El formulario `Días de la semana`{.action} permite definir frecuencias de ejecución adicionales, pero en un ciclo semanal.
->
-
-|Modo experto| 
-|---|
-|Introduzca valores numéricos como en una *crontab*. Los asteriscos indican cada valor del período, lo que significa que la tarea se ejecutaría continuamente **una vez por hora todos los días** en este ejemplo.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-Puede cambiar entre ambos modos durante la configuración para ver los cambios en consecuencia. Asimismo, tenga en cuenta las [limitaciones al planificar una tarea en un alojamiento web](./#limitaciones-de-las-tareas-planificadas-en-su-alojamiento-web).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Etapa 3: Fin de la instalación
-
-El resumen le recuerda los parámetros configurados, incluyendo la notación *crontab* sobre la frecuencia de ejecución. si lo son, haga clic en `Aceptar`{.action}.
-
-![cron de confirmación](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-La tarea estará lista en unos minutos. Podrá modificar todos los parámetros o eliminar la tarea haciendo clic en `...`{.action} en la tabla de presentación del panel de configuración de OVHcloud.
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `Más`{.action} y seleccione `Cron`{.action}. Tendrá un resumen de sus tareas planificadas y sus parámetros.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> Para crear una tarea CRON, haga clic en el botón `Añadir una planificación`{.action} a la derecha.
+>>
+> **Etapa 3**
+>>
+>> Personalice los parámetros de la tarea en la ventana que aparece.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Opción|Descripción|
+>> |---|---|
+>> |Orden a ejecutar|Establezca la ruta al archivo que contiene el script. Ejemplo: www/jobs/cron.php|
+>> |Idioma|Seleccione la versión PHP del script.|
+>> |Activación|Seleccione si la tarea se activará después de crearla o se activará más adelante.|
+>> |Logs por e-mail|Si es necesario, seleccione un contacto (administrador o técnico) al que se enviará un informe en caso de error de ejecución. También puede proporcionar otra dirección de correo electrónico.|
+>> |Descripción|Introduzca una descripción para consultar el progreso en la ejecución de sus tareas.|
+>>
+>> Haga clic en `Siguiente`{.action}.
+>>
+> **Etapa 4**
+>>
+>> La interfaz ofrece dos modos para configurar la frecuencia de la tarea:
+>>
+>> - **Modo simple**: utilice los menús desplegables para especificar la hora, los días de un mes, los días de la semana y los meses de la tarea.
+>> - **Modo experto**: introduzca valores numéricos como en una *crontab*.
+>>
+>> |Modo simple|Modo experto|
+>> |---|---|
+>> |Utilice los menús desplegables para especificar la hora, los días de un mes, los días de la semana y los meses de la tarea.|Introduzca valores numéricos como en una *crontab*. Los asteriscos indican cada valor del período, lo que significa que la tarea se ejecutaría continuamente **una vez por hora todos los días** en este ejemplo.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > El formulario `Días`{.action} permite definir frecuencias de ejecución en un ciclo mensual.
+>> >
+>> > El formulario `Días de la semana`{.action} permite definir frecuencias de ejecución adicionales, pero en un ciclo semanal.
+>>
+>> Puede cambiar entre ambos modos durante la configuración. Asimismo, tenga en cuenta las [limitaciones al planificar una tarea en un alojamiento web](./#limitaciones-de-las-tareas-planificadas-en-su-alojamiento-web).
+>>
+>> Haga clic en `Siguiente`{.action}.
+>>
+> **Etapa 5**
+>>
+>> El resumen le recuerda los parámetros configurados, incluyendo la notación *crontab* sobre la frecuencia de ejecución. Si todo es correcto, haga clic en `Aceptar`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> La tarea estará lista en unos minutos. Podrá modificar todos los parámetros o eliminar la tarea haciendo clic en `...`{.action} en la tabla de presentación del panel de configuración de OVHcloud.
 
 ### Modificar o eliminar una tarea programada
 
@@ -122,7 +128,7 @@ Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -156,7 +162,7 @@ Una prueba sencilla de si el script producirá un error es ejecutarlo en un nave
 #### Comprobación del uso de rutas absolutas
 
 Utilice siempre rutas de acceso absolutas a los archivos de sus scripts. La constante "DIR", por ejemplo, puede ayudar a obtener la ruta actual en los scripts PHP ([documentación PHP](https://www.php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Verificación de los logs de ejecución
 
 Podrá acceder a los logs de su alojamiento web desde su [área de cliente de OVHcloud](/links/manager) y ver la categoría de log denominada "CRON".
@@ -165,38 +171,38 @@ Para más información, consulte nuestra guía ["Consultar las estadísticas y l
 
 ##### **Ejemplo de logs**
 
-- Ejemplo de finalización de script correctamente ejecutado 
+- Ejemplo de finalización de script correctamente ejecutado
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Ejemplo de fallo al superar el tiempo de ejecución
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Ejemplo de error: no se puede encontrar el archivo de guión en la ruta de acceso especificada
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Ejemplo de error debido a un error de autorización (chmod) o a una configuración incorrecta del archivo .ovhconfig
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Más información <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Crear tareas automatizadas (CRON) en un alojamiento web"
 excerpt: "Descubra cómo crear tareas CRON para automatizar las tareas programadas en un alojamiento web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Créer des tâches automatisées (CRON) sur votre hébergement web"
 excerpt: "Découvrez comment créer des tâches CRON pour automatiser vos tâches planifiées sur un hébergement web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Créer des tâches automatisées (CRON) sur votre hébergement web"
 excerpt: "Découvrez comment créer des tâches CRON pour automatiser vos tâches planifiées sur un hébergement web"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,7 +29,7 @@ updated: 2025-02-20
 
 ## Objectif
 
-Sur votre hébergement Web OVHcloud, vous pouvez utiliser des scripts pour automatiser certaines opérations. La création d'une tâche planifiée (« tâche CRON ») est le moyen le plus simple de s'assurer que vos scripts s'exécutent à des moments spécifiques sans que d'autres actions soient nécessaires de votre part. 
+Sur votre hébergement web OVHcloud, vous pouvez utiliser des scripts pour automatiser certaines opérations. Une tâche planifiée (« tâche CRON ») permet à vos scripts de s'exécuter à des moments spécifiques, sans action de votre part.
 
 **Découvrez comment créer des tâches CRON pour automatiser vos tâches planifiées sur un hébergement web.**
 
@@ -37,7 +37,7 @@ Sur votre hébergement Web OVHcloud, vous pouvez utiliser des scripts pour autom
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide. 
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
 >
 
 ## Prérequis
@@ -57,64 +57,70 @@ Sur votre hébergement Web OVHcloud, vous pouvez utiliser des scripts pour autom
 
 ## En pratique
 
-Rendez-vous dans votre [espace client OVHcloud](/links/manager). Cliquez sur l'onglet `Web Cloud`{.action}, puis sur `Hébergements`{.action}.
-
-Sélectionnez l'hébergement concerné, cliquez sur l'onglet `Plus`{.action} puis sur `Cron`{.action}.
-
-Dans cette section, vous aurez un aperçu de vos tâches planifiées et de leurs paramètres.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Création d'une tâche automatisée
 
-#### Étape 1 : Définition des paramètres généraux
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **5** étapes.
 
-Pour créer une tâche CRON, cliquez sur le bouton `Ajouter une planification`{.action} à droite. Vous pouvez personnaliser les paramètres de la tâche dans la nouvelle fenêtre.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Option|Description|   
-|---|---|   
-|Commande à exécuter|Définissez le chemin d'accès au fichier contenant votre script. Exemple : www/jobs/cron.php|   
-|Language|Sélectionnez la version PHP utilisée par le script.|
-|Activation|Choisissez si la tâche sera active après sa création ou activée ultérieurement.| 
-|Logs par e-mail|Si nécessaire, sélectionnez un contact (administrateur ou technicien) auquel un rapport sera envoyé en cas d'erreur d'exécution. Vous pouvez également fournir une autre adresse de messagerie.| 
-|Description|Saisissez une description pour suivre l'exécution de vos tâches.| 
-
-Cliquez sur `Suivant`{.action} pour passer à l'étape 2.
-
-#### Étape 2 : Définition de la fréquence
-
-L'interface offre deux modes pour configurer la fréquence de votre tâche. Utilisez le **Mode Simple** pour une sélection d'options de planification simplifiée pour les débutants. Si vous préférez entrer directement une fréquence, semblable à un format de table CRON (*crontab*), choisissez le **Mode expert**.
-
-|Mode simple|
-|---|
-|Utilisez les menus déroulants pour spécifier l'heure, les jours d'un mois, les jours de la semaine et les mois de la tâche.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> Le formulaire `Jours`{.action} permet de définir des fréquences d'exécution sur un cycle mensuel.
->
-> Le formulaire `Jours de la semaine`{.action} permet de définir des fréquences d'exécution complémentaires mais sur un cycle hebdomadaire.
->
-
-|Mode expert| 
-|---|
-|Entrez des valeurs numériques comme dans une *crontab*. Les astérisques indiquent chaque valeur de la période, ce qui signifie que la tâche s'exécuterait en continu **une fois par heure tous les jours** dans cet exemple.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-Vous pouvez basculer entre les deux modes pendant la configuration pour visualiser les modifications en conséquence. Notez également les [limitations lors de la planification d'une tâche sur un hébergement Web](./#limitations-des-taches-planifiees-sur-votre-hebergement-web).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Étape 3 : Fin de l'installation
-
-Le récapitulatif vous rappelle les paramètres configurés, y compris la notation *crontab* sur la fréquence d'exécution. Si tout est correct, cliquez sur `Valider`{.action}.
-
-![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-La tâche sera prête dans quelques minutes. Vous pouvez alors modifier tous ses paramètres ou supprimer la tâche en cliquant sur `...`{.action} dans la table de présentation de votre panneau de configuration OVHcloud.
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Plus`{.action} puis sur `Cron`{.action}. Vous aurez un aperçu de vos tâches planifiées et de leurs paramètres.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> Pour créer une tâche CRON, cliquez sur le bouton `Ajouter une planification`{.action} à droite.
+>>
+> **Étape 3**
+>>
+>> Personnalisez les paramètres de la tâche dans la fenêtre affichée.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Option|Description|
+>> |---|---|
+>> |Commande à exécuter|Définissez le chemin d'accès au fichier contenant votre script. Exemple : www/jobs/cron.php|
+>> |Langage|Sélectionnez la version PHP utilisée par le script.|
+>> |Activation|Choisissez si la tâche sera active après sa création ou activée ultérieurement.|
+>> |Logs par e-mail|Si nécessaire, sélectionnez un contact (administrateur ou technicien) auquel un rapport sera envoyé en cas d'erreur d'exécution. Vous pouvez également fournir une autre adresse de messagerie.|
+>> |Description|Saisissez une description pour suivre l'exécution de vos tâches.|
+>>
+>> Cliquez sur `Suivant`{.action}.
+>>
+> **Étape 4**
+>>
+>> L'interface offre deux modes pour configurer la fréquence de votre tâche :
+>>
+>> - **Mode simple** : utilisez les menus déroulants pour spécifier l'heure, les jours d'un mois, les jours de la semaine et les mois de la tâche.
+>> - **Mode expert** : entrez des valeurs numériques comme dans une *crontab*.
+>>
+>> |Mode simple|Mode expert|
+>> |---|---|
+>> |Utilisez les menus déroulants pour spécifier l'heure, les jours d'un mois, les jours de la semaine et les mois de la tâche.|Entrez des valeurs numériques comme dans une *crontab*. Les astérisques indiquent chaque valeur de la période, ce qui signifie que la tâche s'exécute en continu **une fois par heure tous les jours** dans cet exemple.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > Le formulaire `Jours`{.action} permet de définir des fréquences d'exécution sur un cycle mensuel.
+>> >
+>> > Le formulaire `Jours de la semaine`{.action} permet de définir des fréquences d'exécution complémentaires mais sur un cycle hebdomadaire.
+>>
+>> Vous pouvez basculer entre les deux modes pendant la configuration. Notez également les [limitations lors de la planification d'une tâche sur un hébergement Web](./#limitations-des-taches-planifiees-sur-votre-hebergement-web).
+>>
+>> Cliquez sur `Suivant`{.action}.
+>>
+> **Étape 5**
+>>
+>> Le récapitulatif vous rappelle les paramètres configurés, y compris la notation *crontab* sur la fréquence d'exécution. Si tout est correct, cliquez sur `Valider`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> La tâche sera prête dans quelques minutes. Vous pouvez alors modifier tous ses paramètres ou supprimer la tâche en cliquant sur `...`{.action} dans le tableau de votre espace client OVHcloud.
 
 ### Modifier ou supprimer une tâche planifiée
 
@@ -137,7 +143,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 >> Choisissez parmi les boutons `Modifier`{.action} ou `Supprimer`{.action} en fonction de l'action que vous souhaitez réaliser sur la tâche planifiée.
 
-### Limitations des tâches planifiées sur votre hébergement Web
+### Limitations des tâches planifiées sur votre hébergement web
 
 |Étape|Description|
 |---|---|
@@ -160,44 +166,44 @@ Veillez toujours à utiliser des chemins d'accès absolus aux fichiers de vos sc
  
 #### Vérification des logs d'éxecution
 
-Dans [les logs]  de votre hébergement Web, accessibles depuis votre [espace client OVHcloud](/links/manager), vous verrez la catégorie de log intitulée « CRON ».
+Dans les logs de votre hébergement Web, accessibles depuis votre [espace client OVHcloud](/links/manager), vous verrez la catégorie de log intitulée « CRON ».
 
-Consultez notre guide [« Consulter les statistiques et les logs de mon site hébergé sur une offre mutualisée »](/pages/web_cloud/web_hosting/logs_and_statistics#logs) pour plus de détails.
+Consultez notre guide [« Consulter les statistiques et les logs de mon site hébergé sur une offre mutualisée »](/pages/web_cloud/web_hosting/logs_and_statistics) pour plus de détails.
 
 ##### **Exemple de logs**
 
 - Exemple de fin de script correctement exécuté 
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01] 
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Exemple d'échec en raison d'un dépassement du temps d'exécution
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Exemple d'échec car le fichier de script est introuvable dans le chemin d'accès spécifié
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Exemple d'échec en raison d'une erreur d'autorisation (chmod) ou d'une configuration incorrecte du fichier .ovhconfig
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Aller plus loin <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Créer des tâches automatisées (CRON) sur votre hébergement web"
 excerpt: "Découvrez comment créer des tâches CRON pour automatiser vos tâches planifiées sur un hébergement web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.fr-fr.md
@@ -29,7 +29,7 @@ updated: 2026-03-26
 
 ## Objectif
 
-Sur votre hébergement Web OVHcloud, vous pouvez utiliser des scripts pour automatiser certaines opérations. La création d'une tâche planifiée (« tâche CRON ») est le moyen le plus simple de s'assurer que vos scripts s'exécutent à des moments spécifiques sans que d'autres actions soient nécessaires de votre part. 
+Sur votre hébergement web OVHcloud, vous pouvez utiliser des scripts pour automatiser certaines opérations. Une tâche planifiée (« tâche CRON ») permet à vos scripts de s'exécuter à des moments spécifiques, sans action de votre part.
 
 **Découvrez comment créer des tâches CRON pour automatiser vos tâches planifiées sur un hébergement web.**
 
@@ -37,7 +37,7 @@ Sur votre hébergement Web OVHcloud, vous pouvez utiliser des scripts pour autom
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide. 
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide.
 >
 
 ## Prérequis
@@ -78,14 +78,14 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **5*
 >>
 > **Étape 3**
 >>
->> Personnalisez les paramètres de la tâche dans la fenêtre qui s'affiche.
+>> Personnalisez les paramètres de la tâche dans la fenêtre affichée.
 >>
 >> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
 >>
 >> |Option|Description|
 >> |---|---|
 >> |Commande à exécuter|Définissez le chemin d'accès au fichier contenant votre script. Exemple : www/jobs/cron.php|
->> |Language|Sélectionnez la version PHP utilisée par le script.|
+>> |Langage|Sélectionnez la version PHP utilisée par le script.|
 >> |Activation|Choisissez si la tâche sera active après sa création ou activée ultérieurement.|
 >> |Logs par e-mail|Si nécessaire, sélectionnez un contact (administrateur ou technicien) auquel un rapport sera envoyé en cas d'erreur d'exécution. Vous pouvez également fournir une autre adresse de messagerie.|
 >> |Description|Saisissez une description pour suivre l'exécution de vos tâches.|
@@ -96,12 +96,12 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **5*
 >>
 >> L'interface offre deux modes pour configurer la fréquence de votre tâche :
 >>
->> - **Mode Simple** : utilisez les menus déroulants pour spécifier l'heure, les jours d'un mois, les jours de la semaine et les mois de la tâche.
+>> - **Mode simple** : utilisez les menus déroulants pour spécifier l'heure, les jours d'un mois, les jours de la semaine et les mois de la tâche.
 >> - **Mode expert** : entrez des valeurs numériques comme dans une *crontab*.
 >>
 >> |Mode simple|Mode expert|
 >> |---|---|
->> |Utilisez les menus déroulants pour spécifier l'heure, les jours d'un mois, les jours de la semaine et les mois de la tâche.|Entrez des valeurs numériques comme dans une *crontab*. Les astérisques indiquent chaque valeur de la période, ce qui signifie que la tâche s'exécuterait en continu **une fois par heure tous les jours** dans cet exemple.|
+>> |Utilisez les menus déroulants pour spécifier l'heure, les jours d'un mois, les jours de la semaine et les mois de la tâche.|Entrez des valeurs numériques comme dans une *crontab*. Les astérisques indiquent chaque valeur de la période, ce qui signifie que la tâche s'exécute en continu **une fois par heure tous les jours** dans cet exemple.|
 >> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
 >>
 >> > [!primary]
@@ -143,7 +143,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 >> Choisissez parmi les boutons `Modifier`{.action} ou `Supprimer`{.action} en fonction de l'action que vous souhaitez réaliser sur la tâche planifiée.
 
-### Limitations des tâches planifiées sur votre hébergement Web
+### Limitations des tâches planifiées sur votre hébergement web
 
 |Étape|Description|
 |---|---|
@@ -151,7 +151,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 |Durée|La durée d'exécution d'une tâche est de 60 minutes. Si un script dépasse cette durée d'exécution, il sera automatiquement arrêté par le système.|
 |Variables|Vous ne pouvez définir que des variables dans un script. Les ajouter à l'URL appelant le script ne fonctionnera pas (Exemple : www/jobs/cron.php?variable=value).|
 |Limite de données|Une tâche ne peut générer que 5 Mo de données (*stdin/stderr*). Par exemple, si un script écrit des données dans un fichier .txt, l'exécution s'arrête automatiquement lorsque le fichier atteint 5 Mo.|
-|Scripts produisant des erreurs|Si un script est défectueux, il sera automatiquement désactivé après 10 tentatives d'exécution échouées. Le rapport d'erreur ne sera envoyé que lorsque les 10 tentatives auront échoué.<br>Corrigez votre script en fonction du rapport d'erreur reçu puis réactivez la « tâche CRON » dans le panneau de configuration.|
+|Scripts produisant des erreurs|Si un script est défectueux, il sera automatiquement désactivé après 10 tentatives d'exécution échouées. Le rapport d'erreur ne sera envoyé que lorsque les 10 tentatives auront échoué.<br>Corrigez votre script en fonction du rapport d'erreur reçu puis réactivez la « tâche CRON » dans le panneau de configuration (cliquez sur `...`{.action} puis sur `Modifier`{.action}).|
 |Rapports d'exécution|Les rapports ne seront envoyés à l'adresse électronique sélectionnée qu'une fois par jour (pendant les heures de nuit).|
 
 ### Dépannage
@@ -175,35 +175,35 @@ Consultez notre guide [« Consulter les statistiques et les logs de mon site hé
 - Exemple de fin de script correctement exécuté 
 
 <pre class="bgwhite"><code>
-[2026-08-11 00:36:01] ## OVH ## START - 2026-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2026-08-11 00:36:01] 
-[2026-08-11 00:36:01] ## OVH ## END - 2026-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01] 
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Exemple d'échec en raison d'un dépassement du temps d'exécution
 
 <pre class="bgwhite"><code>
-[2026-08-11 00:36:01] ## OVH ## START - 2026-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2026-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2026-08-11 01:36:01] ## OVH ## END - 2026-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Exemple d'échec car le fichier de script est introuvable dans le chemin d'accès spécifié
 
 <pre class="bgwhite"><code>
-[2026-08-11 00:36:01] ## OVH ## START - 2026-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2026-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2026-08-11 00:36:01] ## OVH ## END - 2026-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Exemple d'échec en raison d'une erreur d'autorisation (chmod) ou d'une configuration incorrecte du fichier .ovhconfig
 
 <pre class="bgwhite"><code>
-[2026-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2026-08-11 18:07:10]
-[2026-08-11 18:07:10] ## OVH ## END - 2026-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Aller plus loin <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Créer des tâches automatisées (CRON) sur votre hébergement web"
 excerpt: "Découvrez comment créer des tâches CRON pour automatiser vos tâches planifiées sur un hébergement web"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -37,7 +37,7 @@ Sur votre hébergement Web OVHcloud, vous pouvez utiliser des scripts pour autom
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d’en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide. 
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l’éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d’informations dans la section [« Aller plus loin »](#go-further) de ce guide. 
 >
 
 ## Prérequis
@@ -57,64 +57,70 @@ Sur votre hébergement Web OVHcloud, vous pouvez utiliser des scripts pour autom
 
 ## En pratique
 
-Rendez-vous dans votre [espace client OVHcloud](/links/manager). Cliquez sur l'onglet `Web Cloud`{.action}, puis sur `Hébergements`{.action}.
-
-Sélectionnez l'hébergement concerné, cliquez sur l'onglet `Plus`{.action} puis sur `Cron`{.action}.
-
-Dans cette section, vous aurez un aperçu de vos tâches planifiées et de leurs paramètres.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Création d'une tâche automatisée
 
-#### Étape 1 : Définition des paramètres généraux
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **5** étapes.
 
-Pour créer une tâche CRON, cliquez sur le bouton `Ajouter une planification`{.action} à droite. Vous pouvez personnaliser les paramètres de la tâche dans la nouvelle fenêtre.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Option|Description|   
-|---|---|   
-|Commande à exécuter|Définissez le chemin d'accès au fichier contenant votre script. Exemple : www/jobs/cron.php|   
-|Language|Sélectionnez la version PHP utilisée par le script.|
-|Activation|Choisissez si la tâche sera active après sa création ou activée ultérieurement.| 
-|Logs par e-mail|Si nécessaire, sélectionnez un contact (administrateur ou technicien) auquel un rapport sera envoyé en cas d'erreur d'exécution. Vous pouvez également fournir une autre adresse de messagerie.| 
-|Description|Saisissez une description pour suivre l'exécution de vos tâches.| 
-
-Cliquez sur `Suivant`{.action} pour passer à l'étape 2.
-
-#### Étape 2 : Définition de la fréquence
-
-L'interface offre deux modes pour configurer la fréquence de votre tâche. Utilisez le **Mode Simple** pour une sélection d'options de planification simplifiée pour les débutants. Si vous préférez entrer directement une fréquence, semblable à un format de table CRON (*crontab*), choisissez le **Mode expert**.
-
-|Mode simple|
-|---|
-|Utilisez les menus déroulants pour spécifier l'heure, les jours d'un mois, les jours de la semaine et les mois de la tâche.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> Le formulaire `Jours`{.action} permet de définir des fréquences d'exécution sur un cycle mensuel.
->
-> Le formulaire `Jours de la semaine`{.action} permet de définir des fréquences d'exécution complémentaires mais sur un cycle hebdomadaire.
->
-
-|Mode expert| 
-|---|
-|Entrez des valeurs numériques comme dans une *crontab*. Les astérisques indiquent chaque valeur de la période, ce qui signifie que la tâche s'exécuterait en continu **une fois par heure tous les jours** dans cet exemple.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-Vous pouvez basculer entre les deux modes pendant la configuration pour visualiser les modifications en conséquence. Notez également les [limitations lors de la planification d'une tâche sur un hébergement Web](./#limitations-des-taches-planifiees-sur-votre-hebergement-web).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Étape 3 : Fin de l'installation
-
-Le récapitulatif vous rappelle les paramètres configurés, y compris la notation *crontab* sur la fréquence d'exécution. Si tout est correct, cliquez sur `Valider`{.action}.
-
-![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-La tâche sera prête dans quelques minutes. Vous pouvez alors modifier tous ses paramètres ou supprimer la tâche en cliquant sur `...`{.action} dans la table de présentation de votre panneau de configuration OVHcloud.
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Plus`{.action} puis sur `Cron`{.action}. Vous aurez un aperçu de vos tâches planifiées et de leurs paramètres.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> Pour créer une tâche CRON, cliquez sur le bouton `Ajouter une planification`{.action} à droite.
+>>
+> **Étape 3**
+>>
+>> Personnalisez les paramètres de la tâche dans la fenêtre qui s'affiche.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Option|Description|
+>> |---|---|
+>> |Commande à exécuter|Définissez le chemin d'accès au fichier contenant votre script. Exemple : www/jobs/cron.php|
+>> |Language|Sélectionnez la version PHP utilisée par le script.|
+>> |Activation|Choisissez si la tâche sera active après sa création ou activée ultérieurement.|
+>> |Logs par e-mail|Si nécessaire, sélectionnez un contact (administrateur ou technicien) auquel un rapport sera envoyé en cas d'erreur d'exécution. Vous pouvez également fournir une autre adresse de messagerie.|
+>> |Description|Saisissez une description pour suivre l'exécution de vos tâches.|
+>>
+>> Cliquez sur `Suivant`{.action}.
+>>
+> **Étape 4**
+>>
+>> L'interface offre deux modes pour configurer la fréquence de votre tâche :
+>>
+>> - **Mode Simple** : utilisez les menus déroulants pour spécifier l'heure, les jours d'un mois, les jours de la semaine et les mois de la tâche.
+>> - **Mode expert** : entrez des valeurs numériques comme dans une *crontab*.
+>>
+>> |Mode simple|Mode expert|
+>> |---|---|
+>> |Utilisez les menus déroulants pour spécifier l'heure, les jours d'un mois, les jours de la semaine et les mois de la tâche.|Entrez des valeurs numériques comme dans une *crontab*. Les astérisques indiquent chaque valeur de la période, ce qui signifie que la tâche s'exécuterait en continu **une fois par heure tous les jours** dans cet exemple.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > Le formulaire `Jours`{.action} permet de définir des fréquences d'exécution sur un cycle mensuel.
+>> >
+>> > Le formulaire `Jours de la semaine`{.action} permet de définir des fréquences d'exécution complémentaires mais sur un cycle hebdomadaire.
+>>
+>> Vous pouvez basculer entre les deux modes pendant la configuration. Notez également les [limitations lors de la planification d'une tâche sur un hébergement Web](./#limitations-des-taches-planifiees-sur-votre-hebergement-web).
+>>
+>> Cliquez sur `Suivant`{.action}.
+>>
+> **Étape 5**
+>>
+>> Le récapitulatif vous rappelle les paramètres configurés, y compris la notation *crontab* sur la fréquence d'exécution. Si tout est correct, cliquez sur `Valider`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> La tâche sera prête dans quelques minutes. Vous pouvez alors modifier tous ses paramètres ou supprimer la tâche en cliquant sur `...`{.action} dans le tableau de votre espace client OVHcloud.
 
 ### Modifier ou supprimer une tâche planifiée
 
@@ -145,7 +151,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 |Durée|La durée d'exécution d'une tâche est de 60 minutes. Si un script dépasse cette durée d'exécution, il sera automatiquement arrêté par le système.|
 |Variables|Vous ne pouvez définir que des variables dans un script. Les ajouter à l'URL appelant le script ne fonctionnera pas (Exemple : www/jobs/cron.php?variable=value).|
 |Limite de données|Une tâche ne peut générer que 5 Mo de données (*stdin/stderr*). Par exemple, si un script écrit des données dans un fichier .txt, l'exécution s'arrête automatiquement lorsque le fichier atteint 5 Mo.|
-|Scripts produisant des erreurs|Si un script est défectueux, il sera automatiquement désactivé après 10 tentatives d'exécution échouées. Le rapport d'erreur ne sera envoyé que lorsque les 10 tentatives auront échoué.<br>Corrigez votre script en fonction du rapport d'erreur reçu puis réactivez la « tâche CRON » dans le panneau de configuration (cliquez sur `...`{.action} puis sur `Modifier`{.action}).|
+|Scripts produisant des erreurs|Si un script est défectueux, il sera automatiquement désactivé après 10 tentatives d'exécution échouées. Le rapport d'erreur ne sera envoyé que lorsque les 10 tentatives auront échoué.<br>Corrigez votre script en fonction du rapport d'erreur reçu puis réactivez la « tâche CRON » dans le panneau de configuration.|
 |Rapports d'exécution|Les rapports ne seront envoyés à l'adresse électronique sélectionnée qu'une fois par jour (pendant les heures de nuit).|
 
 ### Dépannage
@@ -160,44 +166,44 @@ Veillez toujours à utiliser des chemins d'accès absolus aux fichiers de vos sc
  
 #### Vérification des logs d'éxecution
 
-Dans [les logs]  de votre hébergement Web, accessibles depuis votre [espace client OVHcloud](/links/manager), vous verrez la catégorie de log intitulée « CRON ».
+Dans les logs de votre hébergement Web, accessibles depuis votre [espace client OVHcloud](/links/manager), vous verrez la catégorie de log intitulée « CRON ».
 
-Consultez notre guide [« Consulter les statistiques et les logs de mon site hébergé sur une offre mutualisée »](/pages/web_cloud/web_hosting/logs_and_statistics#logs) pour plus de détails.
+Consultez notre guide [« Consulter les statistiques et les logs de mon site hébergé sur une offre mutualisée »](/pages/web_cloud/web_hosting/logs_and_statistics) pour plus de détails.
 
 ##### **Exemple de logs**
 
 - Exemple de fin de script correctement exécuté 
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-08-11 00:36:01] ## OVH ## START - 2026-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-08-11 00:36:01] 
+[2026-08-11 00:36:01] ## OVH ## END - 2026-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Exemple d'échec en raison d'un dépassement du temps d'exécution
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-08-11 00:36:01] ## OVH ## START - 2026-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-08-11 01:36:01] ## OVH ## END - 2026-08-11 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Exemple d'échec car le fichier de script est introuvable dans le chemin d'accès spécifié
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-08-11 00:36:01] ## OVH ## START - 2026-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-08-11 00:36:01] ## OVH ## END - 2026-08-11 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Exemple d'échec en raison d'une erreur d'autorisation (chmod) ou d'une configuration incorrecte du fichier .ovhconfig
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-08-11 18:07:10]
+[2026-08-11 18:07:10] ## OVH ## END - 2026-08-11 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Aller plus loin <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Crea task automatizzati (CRON) sul tuo hosting Web"
 excerpt: "Questa guida ti mostra come creare task CRON per automatizzare le operazioni pianificate su un hosting Web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Crea task automatizzati (CRON) sul tuo hosting Web"
 excerpt: "Questa guida ti mostra come creare task CRON per automatizzare le operazioni pianificate su un hosting Web"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,26 +29,26 @@ updated: 2025-02-20
 
 ## Obiettivo
 
-Sull'hosting Web OVHcloud è possibile utilizzare script per automatizzare alcune operazioni. La creazione di un task pianificato ("task CRON") è il modo più semplice per assicurarsi che i tuoi script si eseguano in momenti specifici senza che tu debba effettuare altre azioni. 
+Sull'hosting web OVHcloud è possibile utilizzare script per automatizzare alcune operazioni. Un task pianificato ("task CRON") permette ai tuoi script di eseguirsi in momenti specifici senza che tu debba effettuare altre azioni.
 
-**Questa guida ti mostra come creare task CRON per automatizzare le operazioni pianificate su un hosting Web.**
+**Questa guida ti mostra come creare task CRON per automatizzare le operazioni pianificate su un hosting web.**
 
 > [!warning]
 >
 > OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Spetta quindi a te garantirne il buon funzionamento.
 >
-> Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Per questo, ti suggeriamo di rivolgerti a un [provider specializzato](/links/partner) o di contattare l’amministratore del servizio nel caso in cui dovessi incontrare delle difficoltà. Non saremo effettivamente in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione [“Per saperne di più”](#go-further) di questa guida. 
+> Questa guida ti aiuta a realizzare le operazioni più ricorrenti. Per questo, ti suggeriamo di rivolgerti a un [provider specializzato](/links/partner) o di contattare l'amministratore del servizio nel caso in cui dovessi incontrare delle difficoltà. Non saremo effettivamente in grado di fornirti assistenza. Per maggiori informazioni consulta la sezione ["Per saperne di più"](#go-further) di questa guida.
 >
 
 ## Prerequisiti
 
-- Disporre di una soluzione di [hosting Web](/links/web/hosting) attiva
+- Disporre di una soluzione di [hosting web](/links/web/hosting) attiva
 <!-- CP-NAV-START:web-hosting -->
 ---
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -56,73 +56,79 @@ Sull'hosting Web OVHcloud è possibile utilizzare script per automatizzare alcun
 
 ## Procedura
 
-Accedi allo [Spazio Cliente OVHcloud](/links/manager). Clicca sulla scheda `Web Cloud`{.action} e poi su `Hosting`{.action}.
-
-Seleziona l'hosting, clicca sulla scheda `Più`{.action} e poi su `Cron`{.action}.
-
-In questa sezione, visualizzi i tuoi task pianificati e i loro parametri.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Crea un task automatizzato
 
-#### Step 1: Definizione dei parametri generali
-
-Per creare un task CRON, clicca sul pulsante `Aggiungi una pianificazione`{.action} a destra. Puoi personalizzare le impostazioni dell'operazione nella nuova finestra.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Opzione|Descrizione|   
-|---|---|   
-|Ordine da eseguire|Definisci il percorso per accedere al file che contiene il tuo script. Esempio: www/jobs/cron.php|   
-|Lingua|Seleziona la versione PHP utilizzata dallo script.|
-|Attivazione|Scegli se attivare il task dopo la sua creazione o attivarlo successivamente.| 
-|Log via email|Se necessario, seleziona un contatto (amministratore o tecnico) al quale verrà inviato un report in caso di errore di esecuzione. Puoi anche fornire un altro indirizzo email.| 
-|Descrizione|Inserisci una descrizione per seguire l'esecuzione dei tuoi compiti.| 
-
-Clicca su `Avanti`{.action} per passare allo Step 2.
-
-#### Step 2: Definizione della frequenza
-
-L'interfaccia offre due modalità per configurare la frequenza del tuo task. Utilizza la **Modalità Simple** per una selezione di opzioni di pianificazione semplificata per i principianti. Se preferisci utilizzare una frequenza, simile a un formato di tabella CRON (*crontab*), scegli la **Modalità esperto**.
-
-|Modalità semplice|
-|---|
-|Utilizza i menu a tendina per specificare l'ora, i giorni di un mese, i giorni della settimana e i mesi del task.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> Il modulo `Giorni`{.action} permette di definire le frequenze di esecuzione su un ciclo mensile.
->
-> Il modulo `Giorni della settimana`{.action} permette di definire frequenze di esecuzione complementari ma su un ciclo settimanale.
->
-
-|Modalità esperto| 
-|---|
-|Inserisci valori numerici come in un *crontab*. Gli asterischi indicano ogni valore del periodo, il che significa che il task si eseguirebbe in modo continuo **una volta all'ora ogni giorno** in questo esempio.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-Durante la configurazione è possibile passare da una modalità all'altra per visualizzare le modifiche di conseguenza. Annota anche i [limiti durante la pianificazione di un'operazione su un hosting Web](./#limitazioni-delle-attivita-pianificate-sul-tuo-hosting-web).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Step 3: Fine dell'installazione
-
-Il riepilogo ti ricorda i parametri configurati, inclusa la notazione *crontab* sulla frequenza di esecuzione. se tutto è corretto, clicca su `Conferma`{.action}.
-
-![cron di conferma](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-L'operazione sarà pronta tra pochi minuti. Per modificare tutte le impostazioni o eliminare l'operazione clicca sui tre puntini...` `{.action} nella tabella di presentazione del tuo pannello di configurazione OVHcloud.
-
-### Modificare o eliminare un'operazione pianificata
-
-Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passi.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **5** passaggi.
 
 > [!tabs]
 > **Passaggio 1**
 >>
->> Accedi alla pagina [Hosting plans](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting web interessato.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `Più`{.action} e poi su `Cron`{.action}. Visualizzi i tuoi task pianificati e i loro parametri.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> Per creare un task CRON, clicca sul pulsante `Aggiungi un intervento programmato`{.action} a destra.
+>>
+> **Passaggio 3**
+>>
+>> Personalizza le impostazioni del task nella finestra visualizzata.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Opzione|Descrizione|
+>> |---|---|
+>> |Ordine da eseguire|Definisci il percorso per accedere al file che contiene il tuo script. Esempio: www/jobs/cron.php|
+>> |Lingua|Seleziona la versione PHP utilizzata dallo script.|
+>> |Attivazione|Scegli se attivare il task dopo la sua creazione o attivarlo successivamente.|
+>> |Log via email|Se necessario, seleziona un contatto (amministratore o tecnico) al quale verrà inviato un report in caso di errore di esecuzione. Puoi anche fornire un altro indirizzo email.|
+>> |Descrizione|Inserisci una descrizione per seguire l'esecuzione dei tuoi compiti.|
+>>
+>> Clicca su `Avanti`{.action}.
+>>
+> **Passaggio 4**
+>>
+>> L'interfaccia offre due modalità per configurare la frequenza del tuo task:
+>>
+>> - **Modalità semplice**: utilizza i menu a tendina per specificare l'ora, i giorni di un mese, i giorni della settimana e i mesi del task.
+>> - **Modalità esperto**: inserisci valori numerici come in un *crontab*.
+>>
+>> |Modalità semplice|Modalità esperto|
+>> |---|---|
+>> |Utilizza i menu a tendina per specificare l'ora, i giorni di un mese, i giorni della settimana e i mesi del task.|Inserisci valori numerici come in un *crontab*. Gli asterischi indicano ogni valore del periodo, il che significa che il task si eseguirebbe in modo continuo **una volta all'ora ogni giorno** in questo esempio.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > Il modulo `Giorni`{.action} permette di definire le frequenze di esecuzione su un ciclo mensile.
+>> >
+>> > Il modulo `Giorni della settimana`{.action} permette di definire frequenze di esecuzione complementari ma su un ciclo settimanale.
+>>
+>> Durante la configurazione è possibile passare da una modalità all'altra. Annota anche i [limiti durante la pianificazione di un'operazione su un hosting web](./#limitazioni-delle-attivita-pianificate-sul-tuo-hosting-web).
+>>
+>> Clicca su `Avanti`{.action}.
+>>
+> **Passaggio 5**
+>>
+>> Il riepilogo ti ricorda i parametri configurati, inclusa la notazione *crontab* sulla frequenza di esecuzione. Se tutto è corretto, clicca su `Conferma`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> L'operazione sarà pronta tra pochi minuti. Per modificare tutte le impostazioni o eliminare l'operazione clicca su `...`{.action} nella tabella di presentazione del tuo pannello di configurazione OVHcloud.
+
+### Modificare o eliminare un'operazione pianificata
+
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting web interessato.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -132,11 +138,11 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
 >>
 > **Passaggio 3**
 >>
->> Nella tabella che appare, clicca sul pulsante `...`{.action} a destra dell’operazione pianificata in questione.
+>> Nella tabella che appare, clicca sul pulsante `...`{.action} a destra dell'operazione pianificata in questione.
 >>
->> Scegli tra i pulsanti `Modifica`{.action} o `Elimina`{.action} in base all’azione che vuoi effettuare sull’operazione pianificata.
+>> Scegli tra i pulsanti `Modifica`{.action} o `Elimina`{.action} in base all'azione che vuoi effettuare sull'operazione pianificata.
 
-### Limitazioni delle attività pianificate sul tuo hosting Web
+### Limitazioni delle attività pianificate sul tuo hosting web
 
 |Funzionalità|Descrizione|
 |---|---|
@@ -149,61 +155,61 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
 
 ### Intervento tecnico
 
-#### Test del vostro script con un browser Web
+#### Test del vostro script con un browser web
 
-Un semplice test per verificare se il tuo script produce un errore è eseguirlo su un browser Web. Ad esempio, se il percorso di accesso del vostro script è "www/cron.php" e il vostro dominio di hosting è "mypersonaldomain.ovh", dovrete utilizzare l'URL "http://<i></i>mypersonaldomain.ovh/cron.php". Se non si verificano errori ma lo script non funziona come previsto, segui i suggerimenti qui sotto.
+Un semplice test per verificare se il tuo script produce un errore è eseguirlo su un browser web. Ad esempio, se il percorso di accesso del vostro script è "www/cron.php" e il vostro dominio di hosting è "mypersonaldomain.ovh", dovrete utilizzare l'URL "http://<i></i>mypersonaldomain.ovh/cron.php". Se non si verificano errori ma lo script non funziona come previsto, segui i suggerimenti qui sotto.
 
 #### Verifica dell'utilizzo dei percorsi assoluti
 
 Ti consigliamo di utilizzare percorsi di accesso assoluti ai file dei tuoi script. La costante "DIR", ad esempio, può aiutare a ricevere il percorso corrente negli script PHP ([documentazione PHP](https://www.php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Verifica dei log di esecuzione
 
-Nei log del tuo hosting Web, accessibili dal tuo [Spazio Cliente OVHcloud](/links/manager), visualizzerai la categoria di log intitolata "CRON".
+Nei log del tuo hosting web, accessibili dal tuo [Spazio Cliente OVHcloud](/links/manager), visualizzerai la categoria di log intitolata "CRON".
 
 Consulta la nostra guida ["Consulta le statistiche e i log del tuo sito su un'offerta condivisa"](/pages/web_cloud/web_hosting/logs_and_statistics) per maggiori dettagli.
 
 ##### **Esempio di log**
 
-- Esempio di fine script correttamente eseguito 
+- Esempio di fine script correttamente eseguito
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Esempio di insuccesso dovuto al superamento del tempo di esecuzione
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] # OVH# ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceded the maximum permitted (3600 secondi)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Esempio di errore perché il file di script non è possibile trovare nel percorso di accesso specificato
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Esempio di mancato rispetto a causa di un errore di autorizzazione (chmod) o di una configurazione errata del file.ovhconfig
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Per saperne di più <a name="go-further"></a>
 
-[Configurare il file .ovhconfig di un hosting Web](/pages/web_cloud/web_hosting/configure_your_web_hosting)
+[Configurare il file .ovhconfig di un hosting web](/pages/web_cloud/web_hosting/configure_your_web_hosting)
 
-[Utilizza l'accesso SSH di un hosting Web](/pages/web_cloud/web_hosting/ssh_on_webhosting)
+[Utilizza l'accesso SSH di un hosting web](/pages/web_cloud/web_hosting/ssh_on_webhosting)
 
 Per prestazioni specializzate (referenziamento, sviluppo, ecc...), contatta i [partner OVHcloud](/links/partner).
 

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.it-it.md
@@ -89,7 +89,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **5** pa
 >> |Log via email|Se necessario, seleziona un contatto (amministratore o tecnico) al quale verrà inviato un report in caso di errore di esecuzione. Puoi anche fornire un altro indirizzo email.|
 >> |Descrizione|Inserisci una descrizione per seguire l'esecuzione dei tuoi compiti.|
 >>
->> Clicca su `Avanti`{.action}.
+>> Clicca su `Continua`{.action}.
 >>
 > **Passaggio 4**
 >>
@@ -111,7 +111,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **5** pa
 >>
 >> Durante la configurazione è possibile passare da una modalità all'altra. Annota anche i [limiti durante la pianificazione di un'operazione su un hosting web](./#limitazioni-delle-attivita-pianificate-sul-tuo-hosting-web).
 >>
->> Clicca su `Avanti`{.action}.
+>> Clicca su `Continua`{.action}.
 >>
 > **Passaggio 5**
 >>
@@ -140,7 +140,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
 >>
 >> Nella tabella che appare, clicca sul pulsante `...`{.action} a destra dell'operazione pianificata in questione.
 >>
->> Scegli tra i pulsanti `Modifica`{.action} o `Elimina`{.action} in base all'azione che vuoi effettuare sull'operazione pianificata.
+>> Scegli tra i pulsanti `Modificare`{.action} o `Eliminare`{.action} in base all'azione che vuoi effettuare sull'operazione pianificata.
 
 ### Limitazioni delle attività pianificate sul tuo hosting web
 
@@ -150,7 +150,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
 |Durata|La durata di esecuzione di un'operazione è di 60 minuti. Se uno script supera il tempo di esecuzione, viene automaticamente arrestato dal sistema.|
 |Variabile|Puoi definire solo delle variabili in uno script. Aggiungere all'URL che chiama lo script non funzionerà (esempio: www/jobs/cron.php?variabili=value).|
 |Limite di dati|Un task può generare solo 5 MB di dati (*stdin/stderr*). Ad esempio, se uno script scrive dati in un file .txt, l'esecuzione si interrompe automaticamente quando il file raggiunge 5 MB.|
-|Script che producono errori|Se uno script è difettoso, verrà automaticamente disattivato dopo 10 tentativi di esecuzione non andati a buon fine. La segnalazione degli errori verrà inviata solo quando tutti e 10 i tentativi avranno avuto esito negativo.<br>Correggi lo script in base alla segnalazione degli errori ricevuta e riattiva il "task CRON" nel pannello di controllo (clicca su `...`{.action} e poi su `Modifica`{.action}).|
+|Script che producono errori|Se uno script è difettoso, verrà automaticamente disattivato dopo 10 tentativi di esecuzione non andati a buon fine. La segnalazione degli errori verrà inviata solo quando tutti e 10 i tentativi avranno avuto esito negativo.<br>Correggi lo script in base alla segnalazione degli errori ricevuta e riattiva il "task CRON" nel pannello di controllo (clicca su `...`{.action} e poi su `Modificare`{.action}).|
 |Relazioni di attuazione|I rapporti saranno inviati all'indirizzo elettronico selezionato una volta al giorno (durante le ore notturne).|
 
 ### Intervento tecnico

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Tworzenie automatycznych zadań (CRON) na twoim hostingu"
 excerpt: "Dowiedz się, jak utworzyć zadania CRON do automatyzacji zaplanowanych zadań na hostingu"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>
@@ -37,7 +37,7 @@ Na twoim hostingu OVHcloud możesz użyć skryptów do automatyzacji niektórych
 >
 > OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Jesteś tym samym odpowiedzialny za ich prawidłowe funkcjonowanie.
 >
-> Oddajemy w twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [„Sprawdź również"](#go-further).
+> Oddajemy w twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji ["Sprawdź również"](#go-further).
 >
 
 ## Wymagania początkowe

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.pl-pl.md
@@ -29,7 +29,7 @@ updated: 2026-03-31
 
 ## Wprowadzenie
 
-Na twoim hostingu OVHcloud możesz użyć skryptów do automatyzacji niektórych operacji. Zaplanowane zadanie ("zadanie CRON") pozwala, aby twoje skrypty były wykonywane w określonych momentach, bez konieczności podejmowania dalszych działań.
+Na Twoim hostingu OVHcloud możesz użyć skryptów do automatyzacji niektórych operacji. Zaplanowane zadanie ("zadanie CRON") pozwala, aby Twoje skrypty były wykonywane w określonych momentach, bez konieczności podejmowania dalszych działań.
 
 **Dowiedz się, jak tworzyć zadania CRON do automatyzacji zaplanowanych zadań na hostingu.**
 
@@ -120,7 +120,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **5** kroków.
 >>
 >> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
 >>
->> Zadanie będzie gotowe za kilka minut. Możesz zmienić wszystkie parametry lub usunąć zadanie klikając na `...`{.action} w tabeli prezentacji twojego panelu konfiguracyjnego OVHcloud.
+>> Zadanie będzie gotowe za kilka minut. Możesz zmienić wszystkie parametry lub usunąć zadanie klikając na `...`{.action} w tabeli prezentacji Twojego panelu konfiguracyjnego OVHcloud.
 
 ### Zmień lub usuń zaplanowane zadanie
 
@@ -141,7 +141,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
 >>
 >> W tabeli, która się wyświetli kliknij przycisk `...`{.action} po prawej stronie planowanego zadania.
 >>
->> Wybierz przycisk `Zmień`{.action} lub `Usuń`{.action} w zależności od czynności, którą chcesz wykonać w odniesieniu do zaplanowanego zadania.
+>> Wybierz przycisk `Zmodyfikuj`{.action} lub `Usuń`{.action} w zależności od czynności, którą chcesz wykonać w odniesieniu do zaplanowanego zadania.
 
 ### Ograniczenia zaplanowanych zadań na twoim hostingu
 
@@ -151,7 +151,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
 |Czas trwania|Czas wykonywania zadania to 60 minut. Jeśli skrypt przekracza ten czas, zostanie automatycznie zatrzymany przez system.|
 |Zmienna|Możesz zdefiniować tylko zmienne w skrypcie. Dodanie ich do adresu URL wywołującego skrypt nie będzie działać (Przykład: www/jobs/cron.php?zmienna=value).|
 |Limit danych|Zadanie może generować tylko 5 MB danych (*stdin/stderr*). Na przykład, jeśli skrypt zapisuje dane w pliku .txt, wykonywanie automatycznie kończy się, gdy plik osiągnie 5 MB.|
-|Skrypty powodujące błędy|Jeśli skrypt jest uszkodzony, zostanie automatycznie wyłączony po 10 nieudanych próbach. Raport o błędach zostanie wysłany dopiero po 10 próbach zakończonych niepowodzeniem.<br>Popraw skrypt na podstawie otrzymanego raportu o błędzie, a następnie ponownie włącz "zadanie CRON" w panelu sterowania (kliknij opcję `...`{.action}, a następnie `Zmień`{.action}).|
+|Skrypty powodujące błędy|Jeśli skrypt jest uszkodzony, zostanie automatycznie wyłączony po 10 nieudanych próbach. Raport o błędach zostanie wysłany dopiero po 10 próbach zakończonych niepowodzeniem.<br>Popraw skrypt na podstawie otrzymanego raportu o błędzie, a następnie ponownie włącz "zadanie CRON" w panelu sterowania (kliknij opcję `...`{.action}, a następnie `Zmodyfikuj`{.action}).|
 |Sprawozdania z realizacji|Raporty będą wysyłane na wybrany adres e-mail tylko raz dziennie (w godzinach nocnych).|
 
 ### Naprawa

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Tworzenie automatycznych zadań (CRON) na twoim hostingu"
 excerpt: "Dowiedz się, jak utworzyć zadania CRON do automatyzacji zaplanowanych zadań na hostingu"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -27,9 +27,9 @@ updated: 2025-02-20
  }
 </style>
 
-## Wprowadzenie 
+## Wprowadzenie
 
-Na twoim hostingu OVHcloud możesz użyć skryptów do automatyzacji niektórych operacji. Utworzenie zaplanowanego zadania ("zadanie CRON") to najprostszy sposób, aby upewnić się, że twoje skrypty są wykonywane w określonych momentach, bez konieczności podejmowania dalszych działań. 
+Na twoim hostingu OVHcloud możesz użyć skryptów do automatyzacji niektórych operacji. Zaplanowane zadanie ("zadanie CRON") pozwala, aby twoje skrypty były wykonywane w określonych momentach, bez konieczności podejmowania dalszych działań.
 
 **Dowiedz się, jak tworzyć zadania CRON do automatyzacji zaplanowanych zadań na hostingu.**
 
@@ -37,7 +37,7 @@ Na twoim hostingu OVHcloud możesz użyć skryptów do automatyzacji niektórych
 >
 > OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Jesteś tym samym odpowiedzialny za ich prawidłowe funkcjonowanie.
 >
-> Oddajemy w twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [„Sprawdź również”](#go-further). 
+> Oddajemy w twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [„Sprawdź również"](#go-further).
 >
 
 ## Wymagania początkowe
@@ -49,7 +49,7 @@ Na twoim hostingu OVHcloud możesz użyć skryptów do automatyzacji niektórych
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -57,64 +57,70 @@ Na twoim hostingu OVHcloud możesz użyć skryptów do automatyzacji niektórych
 
 ## W praktyce
 
-Przejdź do Panelu [klienta OVHcloud](/links/manager). Kliknij kartę `Web Cloud`{.action}, a następnie `Hosting`{.action}.
-
-Wybierz odpowiedni hosting, kliknij zakładkę `Więcej`{.action}, a następnie `Cron`{.action}.
-
-W tej sekcji znajdziesz przegląd zaplanowanych zadań i ich parametrów.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Tworzenie zautomatyzowanego zadania
 
-#### Etap 1: Definicja parametrów ogólnych
+Kliknij poniższe zakładki, aby wyświetlić kolejne **5** kroków.
 
-Aby utworzyć zadanie CRON, kliknij przycisk `Dodaj harmonogram`{.action} po prawej stronie. W nowym oknie możesz spersonalizować ustawienia zadania.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Opcja|Opis|   
-|---|---|   
-|Zamówienie do wykonania|Zdefiniuj ścieżkę dostępu do pliku zawierającego Twój skrypt. Przykład: www/jobs/cron.php|   
-|Język|Wybierz wersję PHP używaną przez skrypt.|
-|Aktywacja|Wybierz, czy zadanie będzie aktywne po jego utworzeniu, czy też zostanie włączone w późniejszym terminie.| 
-|Logi na e-mail|W razie potrzeby wybierz kontakt (administrator lub technik), do którego zostanie wysłany raport w przypadku błędu w wykonaniu. Możesz również podać inny adres poczty elektronicznej.| 
-|Opis|Wpisz opis, aby śledzić wykonywanie zadań.| 
-
-Kliknij `Dalej`{.action}, aby przejść do etapu 2.
-
-#### Etap 2: Definicja częstotliwości
-
-Interfejs pozwala na skonfigurowanie częstotliwości zadania w dwóch trybach. Użyj **Tryb Prosty** do wyboru opcji planowania uproszczonego dla początkujących. Jeśli wolisz wprowadzić bezpośrednio częstotliwość, podobna do formatu tabeli CRON (*crontab*), wybierz **Tryb eksperta**.
-
-|Tryb prosty|
-|---|
-|Użyj rozwijanych menu, aby określić godzinę, dni miesiąca, dni tygodnia i miesiące zadania.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> Formularz `Dni`{.action} pozwala na zdefiniowanie częstotliwości wykonywania w cyklu miesięcznym.
->
-> Formularz `Dni tygodnia`{.action} pozwala na zdefiniowanie dodatkowych częstotliwości wykonywania, ale w cyklu tygodniowym.
->
-
-|Tryb zaawansowany| 
-|---|
-|Wprowadź wartości liczbowe jak w *crontab*. Gwiazdki wskazują każdą wartość okresu, co oznacza, że zadanie będzie wykonywane stale **raz na godzinę każdego dnia** w tym przykładzie.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-Możesz przełączyć między dwoma trybami podczas konfiguracji, aby wyświetlić odpowiednie zmiany. Pamiętaj również o [ograniczeniach podczas planowania zadania na hostingu WWW](./#ograniczenia-zaplanowanych-zadan-na-twoim-hostingu).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Etap 3: Koniec instalacji
-
-Podsumowanie zawiera informacje o skonfigurowanych parametrach, w tym *o ratingu crontab* częstotliwości wykonywania. Jeśli są poprawne, kliknij `Zatwierdź`{.action}.
-
-![cron](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-Zadanie będzie gotowe za kilka minut. Możesz zmienić wszystkie parametry lub usunąć zadanie klikając na `...`{.action} w tabeli prezentacji twojego panelu konfiguracyjnego OVHcloud.
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `Więcej`{.action}, a następnie `Cron`{.action}. Znajdziesz przegląd zaplanowanych zadań i ich parametrów.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> Aby utworzyć zadanie CRON, kliknij przycisk `Dodaj zadanie`{.action} po prawej stronie.
+>>
+> **Krok 3**
+>>
+>> Spersonalizuj ustawienia zadania w wyświetlonym oknie.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Opcja|Opis|
+>> |---|---|
+>> |Zamówienie do wykonania|Zdefiniuj ścieżkę dostępu do pliku zawierającego Twój skrypt. Przykład: www/jobs/cron.php|
+>> |Język|Wybierz wersję PHP używaną przez skrypt.|
+>> |Aktywacja|Wybierz, czy zadanie będzie aktywne po jego utworzeniu, czy też zostanie włączone w późniejszym terminie.|
+>> |Logi na e-mail|W razie potrzeby wybierz kontakt (administrator lub technik), do którego zostanie wysłany raport w przypadku błędu w wykonaniu. Możesz również podać inny adres poczty elektronicznej.|
+>> |Opis|Wpisz opis, aby śledzić wykonywanie zadań.|
+>>
+>> Kliknij `Dalej`{.action}.
+>>
+> **Krok 4**
+>>
+>> Interfejs pozwala na skonfigurowanie częstotliwości zadania w dwóch trybach:
+>>
+>> - **Tryb prosty**: użyj rozwijanych menu, aby określić godzinę, dni miesiąca, dni tygodnia i miesiące zadania.
+>> - **Tryb eksperta**: wprowadź wartości liczbowe jak w *crontab*.
+>>
+>> |Tryb prosty|Tryb eksperta|
+>> |---|---|
+>> |Użyj rozwijanych menu, aby określić godzinę, dni miesiąca, dni tygodnia i miesiące zadania.|Wprowadź wartości liczbowe jak w *crontab*. Gwiazdki wskazują każdą wartość okresu, co oznacza, że zadanie będzie wykonywane stale **raz na godzinę każdego dnia** w tym przykładzie.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > Formularz `Dni`{.action} pozwala na zdefiniowanie częstotliwości wykonywania w cyklu miesięcznym.
+>> >
+>> > Formularz `Dni tygodnia`{.action} pozwala na zdefiniowanie dodatkowych częstotliwości wykonywania, ale w cyklu tygodniowym.
+>>
+>> Możesz przełączyć między dwoma trybami podczas konfiguracji. Pamiętaj również o [ograniczeniach podczas planowania zadania na hostingu WWW](./#ograniczenia-zaplanowanych-zadan-na-twoim-hostingu).
+>>
+>> Kliknij `Dalej`{.action}.
+>>
+> **Krok 5**
+>>
+>> Podsumowanie zawiera informacje o skonfigurowanych parametrach, w tym notację *crontab* częstotliwości wykonywania. Jeśli wszystko jest poprawne, kliknij `Zatwierdź`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> Zadanie będzie gotowe za kilka minut. Możesz zmienić wszystkie parametry lub usunąć zadanie klikając na `...`{.action} w tabeli prezentacji twojego panelu konfiguracyjnego OVHcloud.
 
 ### Zmień lub usuń zaplanowane zadanie
 
@@ -123,7 +129,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
 > [!tabs]
 > **Krok 1**
 >>
->> Przejdź na stronę [Hosting plans](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -157,7 +163,7 @@ Prosty test, aby sprawdzić, czy Twój skrypt spowoduje błąd, to uruchomienie 
 #### Sprawdzanie wykorzystania ścieżek bezwzględnych
 
 Zawsze korzystaj z bezwzględnych ścieżek dostępu do plików skryptów. Stała "DIR", na przykład, może pomóc otrzymać bieżącą ścieżkę w skryptach PHP ([dokumentacja PHP](https://www.php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Weryfikacja logów wykonawczych
 
 W \[logach] twojego hostingu WWW, które są dostępne w [Panelu klienta OVHcloud](/links/manager), zobaczysz kategorię logów zatytułowaną "CRON".
@@ -166,38 +172,38 @@ Więcej informacji znajdziesz w przewodniku ["Sprawdź statystyki i logi strony 
 
 ##### **Przykład logów**
 
-- Przykład poprawnie wykonanego końca skryptu 
+- Przykład poprawnie wykonanego końca skryptu
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Przykład niepowodzenia z powodu przekroczenia czasu wykonywania
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] # OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maksymalna permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Przykład awarii, ponieważ plik skryptu nie może zostać znaleziony w określonej ścieżce dostępu
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Przykład niepowodzenia z powodu błędu autoryzacji (chmod) lub nieprawidłowej konfiguracji pliku .ovhconfig
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Sprawdź również <a name="go-further"></a>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.pt-pt.md
@@ -115,7 +115,7 @@ Clique nos separadores abaixo para visualizar cada uma das **5** etapas.
 >>
 > **Etapa 5**
 >>
->> O resumo lembra-lhe os parâmetros configurados, incluindo a notação *crontab* da frequência de execução. Se tudo estiver correto, clique em `Validar`{.action}.
+>> O resumo lembra-lhe os parâmetros configurados, incluindo a notação *crontab* da frequência de execução. Se tudo estiver correto, clique em `Confirmar`{.action}.
 >>
 >> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
 >>
@@ -215,4 +215,4 @@ Para serviços especializados (referenciamento, desenvolvimento, etc), contacte 
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 
-Fale com nossa [comunidade de utilizadores](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Criar tarefas automatizadas (CRON) no seu alojamento Web"
 excerpt: "Saiba como criar tarefas CRON para automatizar as tarefas programadas num alojamento web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/cron_tasks/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/cron_tasks/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Criar tarefas automatizadas (CRON) no seu alojamento Web"
 excerpt: "Saiba como criar tarefas CRON para automatizar as tarefas programadas num alojamento web"
-updated: 2025-02-20
+updated: 2026-03-26
 ---
 
 <style>
@@ -29,7 +29,7 @@ updated: 2025-02-20
 
 ## Objetivo
 
-No seu alojamento Web OVHcloud, pode utilizar scripts para automatizar certas operações. A criação de uma tarefa planificada ("tarefa CRON") é a forma mais simples de assegurar que os seus scripts são executados em momentos específicos sem que seja necessário mais ações da sua parte. 
+No seu alojamento web OVHcloud, pode utilizar scripts para automatizar certas operações. Uma tarefa planificada ("tarefa CRON") permite que os seus scripts sejam executados em momentos específicos sem que seja necessário mais ações da sua parte.
 
 **Saiba como criar tarefas CRON para automatizar as tarefas planeadas num alojamento web.**
 
@@ -37,18 +37,18 @@ No seu alojamento Web OVHcloud, pode utilizar scripts para automatizar certas op
 >
 > A responsabilidade sobre a configuração e a gestão dos serviços que a OVHcloud disponibiliza recai sobre o utilizador. Assim, deverá certificar-se de que estes funcionam corretamente.
 >
-> Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se tiver alguma dúvida, recomendamos que recorra a um fornecedor de serviços especializado e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção [“Quer saber mais?”](#go-further) deste manual. 
+> Este manual fornece as instruções necessárias para realizar as operações mais habituais. No entanto, se tiver alguma dúvida, recomendamos que recorra a um fornecedor de serviços especializado e/ou que contacte o editor do serviço. Não poderemos proporcionar-lhe assistência técnica. Para mais informações, aceda à secção ["Quer saber mais?"](#go-further) deste manual.
 >
 
 ## Requisitos
 
-- Ter um serviço de [alojamento Web da OVHcloud](/links/web/hosting).
+- Ter um serviço de [alojamento web da OVHcloud](/links/web/hosting).
 <!-- CP-NAV-START:web-hosting -->
 ---
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -56,64 +56,70 @@ No seu alojamento Web OVHcloud, pode utilizar scripts para automatizar certas op
 
 ## Instruções
 
-Aceda à [Área de Cliente OVHcloud](/links/manager). Clique no separador `Web Cloud`{.action} e, a seguir, em `Alojamentos`{.action}.
-
-Selecione o alojamento em causa, clique no separador `Mais`{.action} e, a seguir, em `Cron`{.action}.
-
-Nesta secção, terá uma visão geral das tarefas planeadas e dos respetivos parâmetros.
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
-
 ### Criação de uma tarefa automatizada
 
-#### Etapa 1: Definição dos parâmetros gerais
+Clique nos separadores abaixo para visualizar cada uma das **5** etapas.
 
-Para criar uma tarefa CRON, clique no botão `Adicionar um planeamento`{.action} à direita. Pode personalizar os parâmetros da tarefa na nova janela.
-
-![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
-
-|Opção|Descrição|   
-|---|---|   
-|Comando a executar|Defina o caminho de acesso ao ficheiro que contém o script. Exemplo: www/jobs/cron.php|   
-|Linguagem|Selecione a versão PHP utilizada pelo script.|
-|Ativação|Escolha se a tarefa será ativa após a sua criação ou ativada posteriormente.| 
-|Logs por e-mail|Se necessário, selecione um contacto (administrador ou técnico) ao qual será enviado um relatório em caso de erro de execução. Pode também fornecer outro endereço de e-mail.| 
-|Descrição|Introduza uma descrição para seguir a execução das suas tarefas.| 
-
-Clique em `Seguinte`{.action} para passar ao passo 2.
-
-#### Etapa 2: Definição da frequência
-
-A interface oferece dois modos para configurar a frequência da sua tarefa. Utilize o **Modo Simple** para uma seleção de opções de planeamento simplificado para os principiantes. Se prefere entrar diretamente uma frequência, semelhante a um formato de tabela CRON (*crontab*), escolha o **Modo expert**.
-
-|Modo simples|
-|---|
-|Utilize os menus pendente para especificar a hora, os dias de um mês, os dias da semana e os meses da tarefa.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|
-
-> [!primary]
->
-> O formulário `Dias`{.action} permite definir frequências de execução num ciclo mensal.
->
-> O formulário `Dias da semana`{.action} permite definir frequências de execução complementares mas com um ciclo semanal.
->
-
-|Modo expert| 
-|---|
-|Introduza valores numéricos como num *crontab*. Os asteriscos indicam cada valor do período, o que significa que a tarefa será realizada continuamente **uma vez por hora, todos os dias**, no exemplo.|
-|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
-
-Pode alternar entre os dois modos durante a configuração para visualizar as alterações em conformidade. Tenha em atenção as [limitações durante o planeamento de uma tarefa num alojamento Web](./#limitacoes-das-tarefas-planificadas-no-seu-alojamento-web).
-
-![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.gif){.thumbnail}
-
-#### Etapa 3: Fim da instalação
-
-O resumo lembra-lhe os parâmetros configurados, incluindo a notação *crontab* da frequência de execução. Se tudo estiver correto, clique em `Validar`{.action}.
-
-![cron confirmação](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
-
-A tarefa estará pronta dentro de alguns minutos. Pode alterar todos os seus parâmetros ou eliminar a tarefa clicando em `...`{.action} na tabela de apresentação do seu painel de configuração OVHcloud.
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Clique no separador `Mais`{.action} e, a seguir, em `Cron`{.action}. Terá uma visão geral das tarefas planeadas e dos respetivos parâmetros.
+>>
+>> ![cron control panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/schedule-jobs.png){.thumbnail}
+>>
+>> Para criar uma tarefa CRON, clique no botão `Adicionar uma ação programada`{.action} à direita.
+>>
+> **Etapa 3**
+>>
+>> Personalize os parâmetros da tarefa na janela apresentada.
+>>
+>> ![adding scheduling](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-1.png){.thumbnail}
+>>
+>> |Opção|Descrição|
+>> |---|---|
+>> |Comando a executar|Defina o caminho de acesso ao ficheiro que contém o script. Exemplo: www/jobs/cron.php|
+>> |Linguagem|Selecione a versão PHP utilizada pelo script.|
+>> |Ativação|Escolha se a tarefa será ativa após a sua criação ou ativada posteriormente.|
+>> |Logs por e-mail|Se necessário, selecione um contacto (administrador ou técnico) ao qual será enviado um relatório em caso de erro de execução. Pode também fornecer outro endereço de e-mail.|
+>> |Descrição|Introduza uma descrição para seguir a execução das suas tarefas.|
+>>
+>> Clique em `Seguinte`{.action}.
+>>
+> **Etapa 4**
+>>
+>> A interface oferece dois modos para configurar a frequência da sua tarefa:
+>>
+>> - **Modo simples**: utilize os menus pendente para especificar a hora, os dias de um mês, os dias da semana e os meses da tarefa.
+>> - **Modo expert**: introduza valores numéricos como num *crontab*.
+>>
+>> |Modo simples|Modo expert|
+>> |---|---|
+>> |Utilize os menus pendente para especificar a hora, os dias de um mês, os dias da semana e os meses da tarefa.|Introduza valores numéricos como num *crontab*. Os asteriscos indicam cada valor do período, o que significa que a tarefa será realizada continuamente **uma vez por hora, todos os dias**, no exemplo.|
+>> |![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-basic-mod-step-2.png){.thumbnail}|![cron frequency](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-expert-mod-step-2.png){.thumbnail}|
+>>
+>> > [!primary]
+>> >
+>> > O formulário `Dias`{.action} permite definir frequências de execução num ciclo mensal.
+>> >
+>> > O formulário `Dias da semana`{.action} permite definir frequências de execução complementares mas com um ciclo semanal.
+>>
+>> Pode alternar entre os dois modos durante a configuração. Tenha em atenção as [limitações durante o planeamento de uma tarefa num alojamento web](./#limitacoes-das-tarefas-planificadas-no-seu-alojamento-web).
+>>
+>> Clique em `Seguinte`{.action}.
+>>
+> **Etapa 5**
+>>
+>> O resumo lembra-lhe os parâmetros configurados, incluindo a notação *crontab* da frequência de execução. Se tudo estiver correto, clique em `Validar`{.action}.
+>>
+>> ![cron confirmation](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/cron/add-scheduling-step-3.png){.thumbnail}
+>>
+>> A tarefa estará pronta dentro de alguns minutos. Pode alterar todos os seus parâmetros ou eliminar a tarefa clicando em `...`{.action} na tabela de apresentação do seu painel de configuração OVHcloud.
 
 ### Modificar ou eliminar uma tarefa agendada
 
@@ -122,7 +128,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 > [!tabs]
 > **Etapa 1**
 >>
->> Aceda à página [Hosting plans](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -136,7 +142,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 >>
 >> Escolha entre os botões `Alterar`{.action} ou `Eliminar`{.action} em função da ação que pretende realizar na tarefa programada.
 
-### Limitações das tarefas planificadas no seu alojamento Web
+### Limitações das tarefas planificadas no seu alojamento web
 
 |Funcionalidade|Descrição|
 |---|---|
@@ -156,47 +162,47 @@ Um teste simples para ver se o script vai produzir um erro é executá-lo num br
 #### Verificação da utilização dos caminhos absolutos
 
 Tenha o cuidado de utilizar caminhos de acesso absolutos aos ficheiros dos seus scripts. A constante "DIR", por exemplo, pode ajudar a receber o caminho corrente nos scripts PHP ([documentação PHP](https://www.php.net/manual/en/language.constants.predefined.php)).
- 
+
 #### Verificação dos logs de execução
 
-No \[logs] do seu alojamento Web, acessível a partir da sua Área de [Cliente OVHcloud](/links/manager), poderá ver a categoria de log intitulada "CRON".
+No \[logs] do seu alojamento web, acessível a partir da sua Área de [Cliente OVHcloud](/links/manager), poderá ver a categoria de log intitulada "CRON".
 
 Para mais informações, consulte o nosso guia ["Consultar as estatísticas e os logs do meu site alojado numa oferta partilhada"](/pages/web_cloud/web_hosting/logs_and_statistics).
 
 ##### **Exemplo de logs**
 
-- Exemplo de fim de script corretamente executado 
+- Exemplo de fim de script corretamente executado
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
-[2023-08-11 00:36:01] 
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/myscript.sh
+[2026-03-30 00:36:01]
+[2026-03-30 00:36:01] ## OVH ## END - 2023-08-10 22:39:44.086166 exitcode: 0
 </code></pre>
 
 - Exemplo de insucesso devido a ultrapassagem do tempo de execução
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/sleep.sh
 
-[2023-08-11 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
-[2023-08-11 01:36:01] ## OVH ## END - 2023-08-11 01:36:01.086166 exitcode: 0
+[2026-03-30 01:36:01] ## OVH ## ERROR - CRON TASK INTERRUPTED BY OVH - reason: your script duration exceeded the maximum permitted (3600 seconds)
+[2026-03-30 01:36:01] ## OVH ## END - 2026-03-30 01:36:01.086166 exitcode: 0
 </code></pre>
 
 - Exemplo de falha porque o ficheiro de script não pode ser encontrado no caminho de acesso especificado
 
 <pre class="bgwhite"><code>
-[2023-08-11 00:36:01] ## OVH ## START - 2023-08-11 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
+[2026-03-30 00:36:01] ## OVH ## START - 2026-03-30 00:36:01.524384 executing: /usr/local/php7.2/bin/php /homez.161/myftpusername/www/noscript.sh
 
-[2023-08-11 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
-[2023-08-11 00:36:01] ## OVH ## END - 2023-08-11 00:36:01.086166 exitcode: 255
+[2026-03-30 00:36:01] ## OVH ## ERROR command '/homez.161/myftpusername/www/noscript.sh' not found
+[2026-03-30 00:36:01] ## OVH ## END - 2026-03-30 00:36:01.086166 exitcode: 255
 </code></pre>
 
 - Exemplo de falha devido a um erro de autorização (chmod) ou a uma configuração incorreta do ficheiro .ovhconfig
 
 <pre class="bgwhite"><code>
-[2023-08-11 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
-[2023-08-11 18:07:10]
-[2023-08-11 18:07:10] ## OVH ## END - 2023-08-11 18:07:10.969840 exitcode: 255
+[2026-03-30 18:07:10] ## OVH ## Your job could not be initiated for an unknown reason.
+[2026-03-30 18:07:10]
+[2026-03-30 18:07:10] ## OVH ## END - 2026-03-30 18:07:10.969840 exitcode: 255
 </code></pre>
 
 ## Quer saber mais? <a name="go-further"></a>
@@ -209,4 +215,4 @@ Para serviços especializados (referenciamento, desenvolvimento, etc), contacte 
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 
-Fale com nossa [comunidade de utilizadores](/links/community). 
+Fale com nossa [comunidade de utilizadores](/links/community).

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.de-de.md
@@ -1,10 +1,24 @@
 ---
 title: "Die häufigsten Datenbankfehler beheben"
 excerpt: "Erfahren Sie hier, wie Sie Fehler in Zusammenhang mit Datenbanken beheben"
-updated: 2026-02-11
+updated: 2026-03-26
 ---
 
-## Ziel 
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
+
+## Ziel
 
 Bei der Nutzung von Datenbanken können Unregelmäßigkeiten auftreten. Fehler beim Datenbankzugriff werden entweder direkt auf Ihrer Website oder in Ihrem [OVHcloud Kundencenter](/links/manager) sowie im [phpMyAdmin Interface](/pages/web_cloud/web_hosting/sql_create_database) angezeigt.
 
@@ -12,8 +26,8 @@ Bei der Nutzung von Datenbanken können Unregelmäßigkeiten auftreten. Fehler b
 
 > [!warning]
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-> 
-> Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
+>
+> Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren oder Ihre Fragen in der OVHcloud Community zu stellen, falls Sie Hilfe brauchen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
 >
 
 ## Voraussetzungen
@@ -42,14 +56,53 @@ Bei der Nutzung von Datenbanken können Unregelmäßigkeiten auftreten. Fehler b
 
 Überprüfen Sie zunächst auf der Seite [Web Cloud Status](https://web-cloud.status-ovhcloud.com/), ob Ihr Rechenzentrum, Ihr Web-Cluster, Ihr Web Cloud Databases Server oder Ihre Datenbank von einem Zwischenfall in der OVHcloud Infrastruktur betroffen ist.
 
-> [!primary]
->
-> Um die dazu nötigen Informationen einzusehen, loggen Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager) ein und gehen Sie zum Bereich `Web Cloud`{.action}.
->
-> - Um das `Rechenzentrum`{.action} Ihres Webhostings zu finden, wählen Sie `Hosting-Pakete`{.action} aus und dann das betreffende Webhosting. Diese Informationen finden Sie im Tab `Allgemeine Informationen`{.action}.
-> - Um **Cluster** und **Filer** (Dateiserver) Ihres Webhostings zu finden, konsultieren Sie [diese Anleitung](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - Um den Namen des **Web Cloud Databases** Servers zu finden, klicken Sie unter `Web Cloud Databases`{.action} auf den betreffenden Datenbankdienst. Die Server-Bezeichung (`Hostname`) befindet sich unter `SQL` im Feld `Verbindungsinformationen` des Tabs `Allgemeine Informationen`{.action}.
-> - Um den Server zu finden, auf dem sich Ihre integrierte oder über Ihr [Webhosting](/links/web/hosting) bestellte Datenbank befindet, konsultieren Sie [diese Anleitung](/pages/web_cloud/web_hosting/sql_find_server).
+**Klicken Sie auf die gewünschte Information, um den Inhalt anzuzeigen.**
+
+/// details | Rechenzentrum Ihres Webhostings finden
+
+Klicken Sie auf die Tabs, um die **2** Schritte nacheinander anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Im Tab `Allgemeine Informationen`{.action} finden Sie das `Rechenzentrum`.
+
+///
+
+/// details | Cluster und Filer Ihres Webhostings finden
+
+Lesen Sie unsere Anleitung „[Cluster und Filer Ihres Webhostings ermitteln](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Den Namen des Web Cloud Databases Servers finden
+
+Klicken Sie auf die Tabs, um die **2** Schritte nacheinander anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Web Cloud Databases](/links/control-panel/web-cloud-databases) und wählen Sie den betreffenden Dienst aus.
+>>
+>> ![Auswahl eines Web Cloud Databases Servers im OVHcloud Kundencenter](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Im Bereich `Verbindungsinformationen`, unter `SQL`, finden Sie den `Hostname`.
+
+///
+
+/// details | Den Server Ihrer Webhosting-Datenbank finden
+
+Lesen Sie unsere Anleitung „[Den Server Ihrer Datenbank ermitteln](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Verbindungsdaten Ihrer Datenbank überprüfen <a name="config_file"></a>
 
@@ -68,29 +121,40 @@ Stellen Sie anschließend die **exakte** Übereinstimmung zwischen den Verbindun
 
 #### Beispiel für WordPress
 
-Wenn Ihre Website einen Fehler des Typs **"Error establishing a database connection"** ausgibt und die zugehörige Infrastruktur nicht von einer [Störung](https://web-cloud.status-ovhcloud.com/) betroffen ist, loggen Sie sich mit [FTP](/pages/web_cloud/web_hosting/ftp_connection) ein und öffnen Sie dann das Verzeichnis in dem sich die Website befindet ("www" im Standardfall).
+Wenn Ihre Website einen Fehler des Typs **"Error establishing a database connection"** ausgibt und die zugehörige Infrastruktur nicht von einer [Störung](https://web-cloud.status-ovhcloud.com/) betroffen ist, loggen Sie sich mit [FTP](/pages/web_cloud/web_hosting/ftp_connection) ein und öffnen Sie dann das Verzeichnis in dem sich die Website befindet (`www` im Standardfall).
 
 Wenn es sich um eine WordPress Website handelt, öffnen Sie die Datei `wp-config.php`.
 
 ```php
 define('DB_NAME', 'my_database');
- 
+
 /** MySQL database username */
 define('DB_USER', 'my_user');
- 
+
 /** MySQL database password */
 define('DB_PASSWORD', 'my_password');
- 
+
 /** MySQL hostname */
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-In Ihrem [OVHcloud Kundencenter](/links/manager) klicken Sie im Bereich `Hosting-Pakete`{.action} auf Ihren Dienst und prüfen im Tab `Datenbanken`{.action} die Übereinstimmung der hier angezeigten Elemente mit den Daten in der Datei `wp-config.php`:
+Klicken Sie auf die Tabs, um die **2** Schritte nacheinander anzuzeigen.
 
-- **my_database** muss dem `Namen der Datenbank` entsprechen;
-- **my_user** muss dem `Benutzernamen` entsprechen;
-- **my_password** entspricht dem [Passwort Ihrer Datenbank](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** muss dem entsprechen, was unter `Server-Adresse` angegeben ist.
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `Datenbanken`{.action} und prüfen Sie die Übereinstimmung der hier angezeigten Elemente mit den Daten in der Datei `wp-config.php`:
+>>
+>> - **my_database** muss dem `Namen der Datenbank` entsprechen;
+>> - **my_user** muss dem `Benutzernamen` entsprechen;
+>> - **my_password** entspricht dem [Passwort Ihrer Datenbank](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** muss dem entsprechen, was unter `Server-Adresse` angegeben ist.
 
 > [!primary]
 >
@@ -120,7 +184,22 @@ Wenn Sie über ein Webhosting **Starter** oder **Basic** verfügen, empfehlen wi
 > Daher empfehlen wir Ihnen, falls Sie eine plötzliche Vergrößerung Ihrer Datenbank feststellen oder wenn Sie beispielsweise nur einen Blog betreiben, der nicht viel Datenvolumen verbraucht, sobald möglich einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren.
 >
 
-Loggen Sie sich in Ihr [OVHcloud Kundencenter](/links/manager) ein, klicken Sie auf `Hosting-Pakete`{.action} und anschließend auf das betreffende Hosting. Klicken Sie auf den Button `...`{.action} rechts im Bereich `Abo`{.action} unter `Angebot`{.action}, dann auf `Upgraden`{.action}.
+Um diese Änderung durchzuführen, klicken Sie auf die Tabs, um die **3** Schritte nacheinander anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Button `...`{.action} im Bereich `Angebot` auf der rechten Seite des Bildschirms.
+>>
+> **Schritt 3**
+>>
+>> Klicken Sie auf `Angebot wechseln`{.action}.
 
 Wenn Sie ein Webhosting **Performance** verwenden, gehen Sie zu [Methode 2](#method2).
 
@@ -141,7 +220,22 @@ Sie können Ihre Daten auch auf eine neue Datenbank migrieren:
 
 Loggen Sie sich nach einer [Sicherung Ihrer Datenbank](/pages/web_cloud/web_hosting/sql_database_export) über [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#auf-das-phpmyadmin-interface-zugreifen) ein, um unnötige Daten mithilfe der Befehle Drop, Delete und Truncate zu löschen.
 
-Lassen Sie dann die Quota im Tab `Datenbanken`{.action} des betreffenden Hostings neu berechnen: Klicken Sie auf `...`{.action} und dann auf `Das Quota neu berechnen`{.action}.
+Um die Quota neu zu berechnen, klicken Sie auf die Tabs, um die **3** Schritte nacheinander anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `Datenbanken`{.action}, dann auf den Button `...`{.action} neben der betreffenden Datenbank.
+>>
+> **Schritt 3**
+>>
+>> Klicken Sie auf `Quota neu berechnen`{.action}.
 
 > [!warning]
 >
@@ -150,7 +244,24 @@ Lassen Sie dann die Quota im Tab `Datenbanken`{.action} des betreffenden Hosting
 
 #### Methode 4: Ihre Datenbank optimieren
 
-Um Ihre Datenbank zu optimieren, folgen Sie den Anweisungen in unserer Anleitung "[Konfigurieren Ihres Datenbankservers](/pages/web_cloud/web_cloud_databases/configure-database-server#ihre-datenbanken-optimieren)". Lassen Sie dann die Quota im Tab `Datenbanken`{.action} des betreffenden Hostings neu berechnen: Klicken Sie auf `...`{.action} und dann auf `Das Quota neu berechnen`{.action}.
+Um Ihre Datenbank zu optimieren, folgen Sie den Anweisungen in unserer Anleitung „[Konfigurieren Ihres Datenbankservers](/pages/web_cloud/web_cloud_databases/configure-database-server#ihre-datenbanken-optimieren)".
+
+Um die Quota neu zu berechnen, klicken Sie auf die Tabs, um die **3** Schritte nacheinander anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `Datenbanken`{.action}, dann auf den Button `...`{.action} neben der betreffenden Datenbank.
+>>
+> **Schritt 3**
+>>
+>> Klicken Sie auf `Quota neu berechnen`{.action}.
 
 > [!warning]
 >
@@ -159,22 +270,35 @@ Um Ihre Datenbank zu optimieren, folgen Sie den Anweisungen in unserer Anleitung
 
 ### Überschreitungen der RAM-Kapazität (nur Web Cloud Databases)
 
-In der unten abgebildeten Nachricht im Bereich `Web Cloud Databases`{.action} in Ihrem [OVHcloud Kundencenter](/links/manager) wird darauf hingewiesen, dass Ihre [Web Cloud Databases](/links/web/databases) zu viele Ressourcen auf der OVHcloud Infrastruktur verbraucht hat:
+Die folgende Nachricht weist darauf hin, dass Ihr [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) Server zu viele Ressourcen auf der OVHcloud Infrastruktur verbraucht hat:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-In diesem Fall können Sie die [RAM-Kapazität](/pages/web_cloud/web_cloud_databases/configure-database-server#wechseln-des-datenbank-angebots) im Bereich `Web Cloud Databases`{.action} Ihres [OVHcloud Kundencenters](/links/manager) erhöhen. Klicken Sie im Tab `Allgemeine Informationen`{.action} auf die Schaltfläche `...`{.action} im Bereich `RAM`.
+Um die [RAM-Kapazität](/pages/web_cloud/web_cloud_databases/configure-database-server#wechseln-des-datenbank-angebots) zu erhöhen, klicken Sie auf die Tabs, um die **3** Schritte nacheinander anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Web Cloud Databases](/links/control-panel/web-cloud-databases) und wählen Sie den betreffenden Dienst aus.
+>>
+>> ![Auswahl eines Web Cloud Databases Servers im OVHcloud Kundencenter](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Im Tab `Allgemeine Informationen`{.action} finden Sie den Bereich `RAM`.
+>>
+> **Schritt 3**
+>>
+>> Klicken Sie auf den Button `...`{.action} im Bereich `RAM`, dann auf `RAM-Menge ändern`{.action}.
 
 > [!warning]
 >
 > Diese Erweiterung des RAM funktioniert nur bei einer Web Cloud Databases, die nicht Teil eines Performance Webhostings ist. Wenn Sie die RAM-Kapazität einer in den [Performance Angeboten](/links/web/hosting-performance-offer) enthaltenen Datenbank erhöhen möchten, müssen Sie diese zuerst abtrennen.
-> 
-> Loggen Sie sich zum Abtrennen der Datenbank in Ihr [OVHcloud Kundencenter](/links/manager) ein und öffnen Sie `Web Cloud`{.action}. Klicken Sie links auf `Hosting-Pakete`{.action} und wählen Sie das Webhosting mit der aktiven Web Cloud Databases aus.
 >
-> Klicken Sie im Bereich `Konfiguration` auf den Button `...`{.action} rechts neben `Web Cloud Databases`. Klicken Sie dann auf `Abtrennen`{.action}.
+> Lesen Sie dazu unsere Anleitung „[Eine Web Cloud Databases von Ihrem Webhosting abtrennen](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
 >
 
-Sie können Ihre Datenbank auch weiter optimieren, indem Sie die Anweisungen in unserer Anleitung "[Ihren Datenbankserver konfigurieren](/pages/web_cloud/web_cloud_databases/configure-database-server#uberprufung-der-ram-nutzung)" befolgen.
+Sie können Ihre Datenbank auch weiter optimieren, indem Sie die Anweisungen in unserer Anleitung „[Ihren Datenbankserver konfigurieren](/pages/web_cloud/web_cloud_databases/configure-database-server#ihre-datenbanken-optimieren)" befolgen.
 
 > [!primary]
 >
@@ -189,25 +313,41 @@ Sie können Ihre Datenbank auch weiter optimieren, indem Sie die Anweisungen in 
 > **"#1044 - Access denied for user to database"**
 >
 
-Diese Fehlermeldung bedeutet, dass die Datenbank, die Sie zu importieren versuchen, Elemente enthält, die auf der Shared Hosting Infrastruktur von OVHcloud nicht zulässig sind. 
+Diese Fehlermeldung bedeutet, dass die Datenbank, die Sie zu importieren versuchen, Elemente enthält, die auf der Shared Hosting Infrastruktur von OVHcloud nicht zulässig sind.
 
-Vergewissern Sie sich zunächst, dass Ihre Datenbank leer ist. Klicken Sie auf `...`{.action} und dann auf `Das Quota neu berechnen`{.action} im Tab `Datenbanken`{.action}. (Falls Sie zunächst die Daten sichern möchten, folgen Sie den Instruktionen zum [Datenbank-Backup](/pages/web_cloud/web_hosting/sql_database_export).)
+Vergewissern Sie sich zunächst, dass Ihre Datenbank leer ist. Klicken Sie dazu auf die Tabs, um die **3** Schritte nacheinander anzuzeigen.
 
-Sie können beim [Datenbank-Import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#eigene-backup-datei-uber-das-kundencenter-importieren) auch die Option `Datenbank leeren`{.action} anhaken. 
-
-![database-import](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `Datenbanken`{.action}, dann auf den Button `...`{.action} neben der betreffenden Datenbank und auf `Quota neu berechnen`{.action}.
+>>
+> **Schritt 3**
+>>
+>> Wenn die Datenbank nicht leer ist, [sichern Sie die vorhandenen Daten](/pages/web_cloud/web_hosting/sql_database_export) und löschen Sie diese, bevor Sie den Import erneut starten.
+>>
+>> Sie können beim [Datenbank-Import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#eigene-backup-datei-uber-das-kundencenter-importieren) auch die Option `Aktuelle Datenbank leeren`{.action} anhaken:
+>>
+>> ![database-import](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
 Kontaktieren Sie gegebenenfalls unsere [Community](/links/community) oder einen [spezialisierten Dienstleister](/links/partner). Wir werden Sie in diesem Fall nicht unterstützen können.
 
-> [!success]
+> [!primary]
 >
-> Sie können keinen **Trigger** im Importskript Ihrer Datenbank verwenden. Importieren Sie in diesem Fall Ihre Datenbank auf einen [Web Cloud Databases Dienst](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
->
+> **Welche Elemente im Importskript meiner Datenbank können einen Fehler „#1044 - Access denied for user to database" verursachen?**
+
+Sie können keinen **Trigger** im Importskript Ihrer Datenbank verwenden. Importieren Sie in diesem Fall Ihre Datenbank auf einen [Web Cloud Databases Dienst](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 
 Außerdem ist folgende Abfrage nicht zulässig:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 Ersetzen Sie sie mit der Zeile:
 
@@ -220,14 +360,29 @@ Ersetzen Sie `Database-Name` mit dem Namen der Datenbank aus Ihrem [OVHcloud Kun
 #### "MySQL server has gone away"
 
 >
-> **"404 ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
 Diese Fehlermeldung wird beim [Import einer Datenbank](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#eine-lokale-sicherung-importieren) auf [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) angezeigt. Dies hängt meist mit der Menge der zu importierenden Daten oder mit einer mangelnden Optimierung der SQL-Abfragen im Importskript zusammen.
 
 Um dieses Problem zu beheben können Sie Maßnahmen anwenden:
 
-- Erhöhung der [Arbeitsspeicherkapazität (RAM)](/pages/web_cloud/web_cloud_databases/configure-database-server#wechseln-des-datenbank-angebots). Gehen Sie hierzu zum [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) im Bereich `Datenbanken`{.action} Ihres [OVHcloud Kundencenters](/links/manager). Klicken Sie dann auf die Schaltfläche `...`{.action} im Bereich `RAM` und wählen Sie `RAM-Menge ändern`{.action}.
+- Erhöhung der [Arbeitsspeicherkapazität (RAM)](/pages/web_cloud/web_cloud_databases/configure-database-server#wechseln-des-datenbank-angebots). Klicken Sie dazu auf die Tabs, um die **3** Schritte nacheinander anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Web Cloud Databases](/links/control-panel/web-cloud-databases) und wählen Sie den betreffenden Dienst aus.
+>>
+>> ![Auswahl eines Web Cloud Databases Servers im OVHcloud Kundencenter](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Im Tab `Allgemeine Informationen`{.action} finden Sie den Bereich `RAM`.
+>>
+> **Schritt 3**
+>>
+>> Klicken Sie auf den Button `...`{.action} im Bereich `RAM`, dann auf `RAM-Menge ändern`{.action}.
 
 - Splitten Sie Ihre Datenbank, um sie dann über mehrere Operationen zu importieren. (Für Fragen zu den durchzuführenden Operationen kontaktieren Sie unsere [User Community](/links/community) oder die [OVHcloud Partner](/links/partner). Für externe Dienstleistungen können wir Ihnen leider keine Unterstützung anbieten.)
 
@@ -272,18 +427,47 @@ In dieser Situation müssen Sie [Ihre Datenbanken optimieren](/pages/web_cloud/w
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
 >
 
-Diese Fehlermeldung wird bei der [Verbindung über phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#auf-das-phpmyadmin-interface-zugreifen) angezeigt, wenn der angegebene Servername nicht korrekt ist.
+Diese Fehlermeldung wird bei der [Verbindung über phpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) angezeigt, wenn der angegebene Servername nicht korrekt ist.
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Überprüfen Sie den Servernamen des betroffenen Dienstes in Ihrem [OVHcloud Kundencenter](/links/manager).
+Überprüfen Sie den Servernamen des betroffenen Dienstes.
 
-> [!success]
->
-> Wenn sich die Datenbank, mit der Sie sich verbinden möchten, unter `Web Cloud`{.action} im Tab `Datenbanken`{.action} Ihres [OVHcloud Kundencenters](/links/manager) befindet, finden Sie den anzugebenen Namen in der Spalte `Server-Adresse`.
->
-> Wenn Sie sich mit einer Datenbank auf [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) verbinden möchten, finden Sie den einzugebenden Servernamen im Tab `Allgemeine Informationen`{.action} im Bereich `Verbindungsinformationen`{.action} unter `SQL`{.action}, hier bezeichnet als `Hostname`{.action}.
->
+**Klicken Sie auf die zutreffende Situation, um den Inhalt anzuzeigen.**
+
+/// details | Datenbank auf einem Webhosting
+
+Klicken Sie auf die Tabs, um die **2** Schritte nacheinander anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `Datenbanken`{.action}. Den einzugebenden Servernamen finden Sie in der Spalte `Server-Adresse`.
+
+///
+
+/// details | Datenbank auf einem Web Cloud Databases Server
+
+Klicken Sie auf die Tabs, um die **2** Schritte nacheinander anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Web Cloud Databases](/links/control-panel/web-cloud-databases) und wählen Sie den betreffenden Dienst aus.
+>>
+>> ![Auswahl eines Web Cloud Databases Servers im OVHcloud Kundencenter](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Im Tab `Allgemeine Informationen`{.action} finden Sie den einzugebenden Servernamen im Bereich `Verbindungsinformationen`, unter `SQL`, bezeichnet als `Hostname`.
+
+///
 
 ### Anmeldung bei einer Cloud Databases-Datenbank nicht möglich
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Die häufigsten Datenbankfehler beheben"
 excerpt: "Erfahren Sie hier, wie Sie Fehler in Zusammenhang mit Datenbanken beheben"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>
@@ -77,7 +77,7 @@ Klicken Sie auf die Tabs, um die **2** Schritte nacheinander anzuzeigen.
 
 /// details | Cluster und Filer Ihres Webhostings finden
 
-Lesen Sie unsere Anleitung „[Cluster und Filer Ihres Webhostings ermitteln](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+Lesen Sie unsere Anleitung "[Cluster und Filer Ihres Webhostings ermitteln](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
 
 ///
 
@@ -100,7 +100,7 @@ Klicken Sie auf die Tabs, um die **2** Schritte nacheinander anzuzeigen.
 
 /// details | Den Server Ihrer Webhosting-Datenbank finden
 
-Lesen Sie unsere Anleitung „[Den Server Ihrer Datenbank ermitteln](/pages/web_cloud/web_hosting/sql_find_server)".
+Lesen Sie unsere Anleitung "[Den Server Ihrer Datenbank ermitteln](/pages/web_cloud/web_hosting/sql_find_server)".
 
 ///
 
@@ -244,7 +244,7 @@ Um die Quota neu zu berechnen, klicken Sie auf die Tabs, um die **3** Schritte n
 
 #### Methode 4: Ihre Datenbank optimieren
 
-Um Ihre Datenbank zu optimieren, folgen Sie den Anweisungen in unserer Anleitung „[Konfigurieren Ihres Datenbankservers](/pages/web_cloud/web_cloud_databases/configure-database-server#ihre-datenbanken-optimieren)".
+Um Ihre Datenbank zu optimieren, folgen Sie den Anweisungen in unserer Anleitung "[Konfigurieren Ihres Datenbankservers](/pages/web_cloud/web_cloud_databases/configure-database-server#ihre-datenbanken-optimieren)".
 
 Um die Quota neu zu berechnen, klicken Sie auf die Tabs, um die **3** Schritte nacheinander anzuzeigen.
 
@@ -295,10 +295,10 @@ Um die [RAM-Kapazität](/pages/web_cloud/web_cloud_databases/configure-database-
 >
 > Diese Erweiterung des RAM funktioniert nur bei einer Web Cloud Databases, die nicht Teil eines Performance Webhostings ist. Wenn Sie die RAM-Kapazität einer in den [Performance Angeboten](/links/web/hosting-performance-offer) enthaltenen Datenbank erhöhen möchten, müssen Sie diese zuerst abtrennen.
 >
-> Lesen Sie dazu unsere Anleitung „[Eine Web Cloud Databases von Ihrem Webhosting abtrennen](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
+> Lesen Sie dazu unsere Anleitung "[Eine Web Cloud Databases von Ihrem Webhosting abtrennen](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
 >
 
-Sie können Ihre Datenbank auch weiter optimieren, indem Sie die Anweisungen in unserer Anleitung „[Ihren Datenbankserver konfigurieren](/pages/web_cloud/web_cloud_databases/configure-database-server#ihre-datenbanken-optimieren)" befolgen.
+Sie können Ihre Datenbank auch weiter optimieren, indem Sie die Anweisungen in unserer Anleitung "[Ihren Datenbankserver konfigurieren](/pages/web_cloud/web_cloud_databases/configure-database-server#ihre-datenbanken-optimieren)" befolgen.
 
 > [!primary]
 >
@@ -340,7 +340,7 @@ Kontaktieren Sie gegebenenfalls unsere [Community](/links/community) oder einen 
 
 > [!primary]
 >
-> **Welche Elemente im Importskript meiner Datenbank können einen Fehler „#1044 - Access denied for user to database" verursachen?**
+> **Welche Elemente im Importskript meiner Datenbank können einen Fehler "#1044 - Access denied for user to database" verursachen?**
 
 Sie können keinen **Trigger** im Importskript Ihrer Datenbank verwenden. Importieren Sie in diesem Fall Ihre Datenbank auf einen [Web Cloud Databases Dienst](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-asia.md
@@ -1,8 +1,22 @@
 ---
 title: "Troubleshooting common database errors"
 excerpt: "Find out how to diagnose the most common cases of database errors"
-updated: 2026-02-11
+updated: 2026-03-31
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -13,13 +27,13 @@ Your database usage may result in anomalies on your website or error messages in
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. However, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](/links/web/hosting)
-- an OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases)
+- An [OVHcloud Web Hosting plan](/links/web/hosting).
+- An OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases).
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -42,18 +56,57 @@ Your database usage may result in anomalies on your website or error messages in
 
 First, check on the [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) page whether your datacentre, your web hosting cluster, your Web Cloud Databases server, or your database is not affected by an incident on the OVHcloud infrastructure.
 
-> [!primary]
->
-> You can find these details in your [OVHcloud Control Panel](/links/manager), in the `Web Cloud`{.action} section:
->
-> - To find your Web Hosting plan's data centre, select `Hosting plans`{.action}, then the relevant web hosting. You will find this information in the `General Information`{.action} tab.
-> - To find the **cluster** of servers and **filer** (file server) of your web hosting, refer to [this guide](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - To retrieve the name of your **Web Cloud Databases** server, click on `Web Cloud Databases`{.action} in the left-hand menu, then on the relevant service. You can find the information concerned under the heading `Host name` in the `SQL` part of the `General information`{.action} tab.
-> - To find the server on which your included or additional database ordered via your [web hosting](/links/web/hosting) is located, refer to [this guide](/pages/web_cloud/web_hosting/sql_find_server).
+**Click on the information you are looking for to view the content.**
+
+/// details | Find the datacentre of your web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `Datacentre`.
+
+///
+
+/// details | Find the cluster and filer of your web hosting plan
+
+Refer to our guide "[Finding out the cluster and filer of your web hosting plan](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Find the Web Cloud Databases server name
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate `Host name` in the `SQL` section of `Login information`.
+
+///
+
+/// details | Find your web hosting database server
+
+Refer to our guide "[Finding your database server](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Verify login credentials for your database <a name="config_file"></a>
 
-Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website’s configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
+Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website's configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
 
 > [!warning]
 >
@@ -62,35 +115,46 @@ Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cl
 > We recommend that you contact the publisher of the [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) concerned or a [specialised service provider](/links/partner) if necessary. We will not be able to assist you with this.
 >
 
-Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website’s configuration file.
+Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website's configuration file.
 
 If necessary, change your [database password](/pages/web_cloud/web_hosting/sql_change_password).
 
 #### Example for WordPress
 
-If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the "www" folder).
+If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the `www` folder).
 
-If this is a WordPress site, open the file "wp-config.php".
+If this is a WordPress site, open the file `wp-config.php`.
 
 ```php
 define('DB_NAME', 'my_database');
- 
+
 /** MySQL database username */
 define('DB_USER', 'my_user');
- 
+
 /** MySQL database password */
 define('DB_PASSWORD', 'my_password');
- 
+
 /** MySQL hostname */
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-In your [OVHcloud Control Panel](/links/manager), open the `Hosting plans`{.action} section and click on the `Databases`{.action} tab. Check the correspondence between the elements displayed and those in the file `wp-config.php`:
+Click on the tabs below to view each of the **2** steps in succession.
 
-- **my_database** must match what is noted as `Database name`;
-- **my_user** must match what is noted as `User name`;
-- **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** must match the `Server address`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then check the correspondence between the elements displayed and those in the file `wp-config.php`:
+>>
+>> - **my_database** must match what is noted as `Database name`;
+>> - **my_user** must match what is noted as `User name`;
+>> - **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** must match the `Server address`.
 
 > [!primary]
 >
@@ -120,15 +184,30 @@ If you have a **Starter** or **Personal** Web Hosting plan, we recommend that yo
 > If you notice a sudden increase in the size of your database, or if you have a "blog" type site that normally does not use much data, we advise you to contact a [specialised service provider](/links/partner) as soon as possible. We will not be able to provide you with support on this matter.
 >
 
-To upgrade your subscription, log in to your [OVHcloud Control Panel](/links/manager) and open `Hosting plans`{.action} in the left-hand menu. Select the relevant service and click on the `...`{.action} button in the `Solution` section of the right-hand info box, then select `Upgrade`{.action}.
+To upgrade your subscription, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `...`{.action} button in the `Solution` section on the right-hand side of the screen.
+>>
+> **Step 3**
+>>
+>> Click `Change plan`{.action}.
 
 If you are already subscribing to a **Performance** offer, refer to [method 2](#method2).
 
-#### Method 2: Migrate your data to a larger database <a name=""method2"></a>
+#### Method 2: Migrate your data to a larger database <a name="method2"></a>
 
 You can also migrate your data to a new database:
 
-- Order a larger [database service](/links/web/databases) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
+- Order a larger [database service](/links/web/hosting-options-startsql) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
 - [Duplicate the content of the old database](/pages/web_cloud/web_hosting/copy_database) to the new database **or** perform an [export of your data](/pages/web_cloud/web_hosting/sql_database_export), then [import your data](/pages/web_cloud/web_hosting/sql_importing_mysql_database) in the new database;
 - Integrate the credentials of the new database into the [configuration file](#config_file) of your site.
 
@@ -141,7 +220,22 @@ You can also migrate your data to a new database:
 
 Once you have made a [database backup](/pages/web_cloud/web_hosting/sql_database_export), log in to your [phpMyAdmin interface](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) to delete any unnecessary data using the Drop, Delete and Truncate commands.
 
-Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -150,7 +244,24 @@ Then update the data usage from the `Databases`{.action} tab of the relevant ser
 
 #### Method 4: Optimise your database
 
-To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)". Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
+
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -159,20 +270,33 @@ To optimise your database, follow the instructions in our guide "[Configuring yo
 
 ### RAM overflows (Web Cloud Databases only)
 
-The following message in the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager) indicates that your [Web Cloud Databases](/links/web/databases) server has consumed too much resources on the OVHcloud infrastructure:
+The following message indicates that your [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server has consumed too much resources on the OVHcloud infrastructure:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-In this situation, you can increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution) available from the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager). In the `General information`{.action} tab, click on the `...`{.action} in the `RAM` section.
+To increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution), click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 > [!warning]
 >
 > To increase the amount of RAM, the database needs to be a standalone service and not one of those included with a Performance web hosting plan. If you want to increase the amount of RAM of a database included in the [Performance offers](/links/web/hosting-performance-offer), you first need to detach it.
-> 
-> To detach the database, log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action}. Click `Hosting plans`{.action}, then choose the web hosting plan that has the database activated.
 >
-> In the `Configuration` box, click the `...`{.action} button to the right of `Web Cloud Databases`, then click the `Detach`{.action} button.
-> 
+> To detach the database, refer to our guide "[Detaching a Web Cloud Databases from your web hosting plan](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
+>
 
 You can also optimise your database by following the instructions of our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
 
@@ -183,7 +307,7 @@ You can also optimise your database by following the instructions of our guide "
 
 ### Database import errors
 
-#### User access denied to database
+#### "Access denied for user to database"
 
 >
 > **"#1044 - Access denied for user to database"**
@@ -191,23 +315,39 @@ You can also optimise your database by following the instructions of our guide "
 
 This error message means that the database you are trying to import contains elements that are not authorised on the OVHcloud shared infrastructure.
 
-First make sure that your database is empty from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}. (If you need to save the existing data first, follow the [backup instructions](/pages/web_cloud/web_hosting/sql_database_export), then delete the data and relaunch the import operation.)
+First make sure that your database is empty. To do this, click on the tabs below to view each of the **3** steps in succession.
 
-You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>>
+> **Step 3**
+>>
+>> If the database is not empty, [back up the existing data](/pages/web_cloud/web_hosting/sql_database_export) then delete it before relaunching the import operation.
+>>
+>> You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+If necessary, contact our [user community](/links/community) or a [specialised service provider](/links/partner) for more information. We will not be able to assist you in correcting this issue.
 
-If necessary, contact our [user community](/links/community) or [OVHcloud partners](/links/partner) for more information. We will not be able to assist you in correcting this issue.
-
-> [!success]
+> [!primary]
 >
-> You cannot have a "**trigger**" in your database’s import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
->
+> **Which elements in my database import script can cause a "#1044 - Access denied for user to database" error?**
+
+You cannot have a **"trigger"** in your database's import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 
 The following query is also not allowed:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
 Use this line instead:
@@ -221,14 +361,29 @@ Replace `Database-Name` with the name of the database as displayed in your [OVHc
 #### "MySQL server has gone away"
 
 >
-> **"404 ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
-This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). I most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
+This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). In most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
 
-To resolve this issue, you can use the following methods:
+To resolve this issue, you can:
 
-- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution): go to the [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server concerned in the `Databases` section of your [OVHcloud Control Panel](/links/manager). Then click on the `...`{.action} button in the `RAM` section and select `Change the amount of RAM`{.action}.
+- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution). To do this, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 - Split your database in order to import it through multiple operations instead of one. (For any questions on the necessary steps, contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you with this.)
 
@@ -254,11 +409,11 @@ In this situation, [check the credentials entered](/pages/web_cloud/web_cloud_da
 > **"mysqli_real_connect(): (HY000/1040): Too many connections"**
 >
 
-The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/databases)) is **30**.
+The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/hosting-options-startsql)) is **30**.
 
 This number increases to **200** for the [Web Cloud Databases service](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (This setting can be modified in the `Configuration`{.action} section of your database service.)
 
-A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears, if this maximum number of connections is exceeded.
+A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears if this maximum number of connections is exceeded.
 
 In this situation, you will need to [optimise your databases](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases) in order to reduce the number of active connections.
 
@@ -267,7 +422,7 @@ In this situation, you will need to [optimise your databases](/pages/web_cloud/w
 > If you have any questions about the changes you need to make in order to reduce the number of active connections to your database, please contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you in this regard.
 >
 
-### "Name or service not known"
+#### "Name or service not known"
 
 >
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
@@ -277,28 +432,55 @@ This error message appears when [connecting to phpMyAdmin](/pages/web_cloud/web_
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Check the server name for the relevant database service in your [OVHcloud Control Panel](/links/manager).
+Check the server name for the relevant database service.
 
-> [!success]
->
-> If the database you would like to connect to appears in the `Databases`{.action} tab of the `Hosting plans`{.action} section of your [OVHcloud Control Panel](/links/manager), the name to enter is in the `Server address` column.
->
-> If you want to connect to a database on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), the server name can be retrieved from the tab `General information`{.action}, in the box `Login information`{.action} under `SQL`{.action} and labelled as `Host name`{.action}.
->
+**Click on the relevant situation to view the content.**
+
+/// details | Database on a web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab. The server name to enter is listed in the `Server address` column.
+
+///
+
+/// details | Database on a Web Cloud Databases server
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, the server name to enter is listed in the `Login information` section, under `SQL`, labelled as `Host name`.
+
+///
 
 ### Unable to connect to a Cloud Databases database
 
 Having a [Web Cloud Databases](/products/web-cloud-clouddb) server allows you to [connect to your databases](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) from your computer or a server outside of the OVHcloud infrastructure.
 
-If this connection is not possible, first check that you have [authorized your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) connected to the database server.
+If this connection is not possible, first check that you have [authorised your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) to connect to the database server.
 
 If this operation has been carried out, contact your ISP or the [OVHcloud partners](/links/partner). We will not be able to assist you in this situation.
 
 ## Go further <a name="go-further"></a>
 
 [Getting started with Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb)
-
-[Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-asia.md
@@ -326,7 +326,7 @@ First make sure that your database is empty. To do this, click on the tabs below
 >>
 > **Step 2**
 >>
->> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>> Click the `Databases`{.action} tab, then the `...`{.action} button next to the database, then `Recalculate the quota`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-au.md
@@ -1,8 +1,22 @@
 ---
 title: "Troubleshooting common database errors"
 excerpt: "Find out how to diagnose the most common cases of database errors"
-updated: 2026-02-11
+updated: 2026-03-31
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -13,13 +27,13 @@ Your database usage may result in anomalies on your website or error messages in
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. However, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](/links/web/hosting)
-- an OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases)
+- An [OVHcloud Web Hosting plan](/links/web/hosting).
+- An OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases).
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -42,18 +56,57 @@ Your database usage may result in anomalies on your website or error messages in
 
 First, check on the [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) page whether your datacentre, your web hosting cluster, your Web Cloud Databases server, or your database is not affected by an incident on the OVHcloud infrastructure.
 
-> [!primary]
->
-> You can find these details in your [OVHcloud Control Panel](/links/manager), in the `Web Cloud`{.action} section:
->
-> - To find your Web Hosting plan's data centre, select `Hosting plans`{.action}, then the relevant web hosting. You will find this information in the `General Information`{.action} tab.
-> - To find the **cluster** of servers and **filer** (file server) of your web hosting, refer to [this guide](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - To retrieve the name of your **Web Cloud Databases** server, click on `Web Cloud Databases`{.action} in the left-hand menu, then on the relevant service. You can find the information concerned under the heading `Host name` in the `SQL` part of the `General information`{.action} tab.
-> - To find the server on which your included or additional database ordered via your [web hosting](/links/web/hosting) is located, refer to [this guide](/pages/web_cloud/web_hosting/sql_find_server).
+**Click on the information you are looking for to view the content.**
+
+/// details | Find the datacentre of your web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `Datacentre`.
+
+///
+
+/// details | Find the cluster and filer of your web hosting plan
+
+Refer to our guide "[Finding out the cluster and filer of your web hosting plan](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Find the Web Cloud Databases server name
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate `Host name` in the `SQL` section of `Login information`.
+
+///
+
+/// details | Find your web hosting database server
+
+Refer to our guide "[Finding your database server](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Verify login credentials for your database <a name="config_file"></a>
 
-Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website’s configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
+Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website's configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
 
 > [!warning]
 >
@@ -62,35 +115,46 @@ Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cl
 > We recommend that you contact the publisher of the [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) concerned or a [specialised service provider](/links/partner) if necessary. We will not be able to assist you with this.
 >
 
-Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website’s configuration file.
+Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website's configuration file.
 
 If necessary, change your [database password](/pages/web_cloud/web_hosting/sql_change_password).
 
 #### Example for WordPress
 
-If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the "www" folder).
+If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the `www` folder).
 
-If this is a WordPress site, open the file "wp-config.php".
+If this is a WordPress site, open the file `wp-config.php`.
 
 ```php
 define('DB_NAME', 'my_database');
- 
+
 /** MySQL database username */
 define('DB_USER', 'my_user');
- 
+
 /** MySQL database password */
 define('DB_PASSWORD', 'my_password');
- 
+
 /** MySQL hostname */
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-In your [OVHcloud Control Panel](/links/manager), open the `Hosting plans`{.action} section and click on the `Databases`{.action} tab. Check the correspondence between the elements displayed and those in the file `wp-config.php`:
+Click on the tabs below to view each of the **2** steps in succession.
 
-- **my_database** must match what is noted as `Database name`;
-- **my_user** must match what is noted as `User name`;
-- **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** must match the `Server address`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then check the correspondence between the elements displayed and those in the file `wp-config.php`:
+>>
+>> - **my_database** must match what is noted as `Database name`;
+>> - **my_user** must match what is noted as `User name`;
+>> - **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** must match the `Server address`.
 
 > [!primary]
 >
@@ -120,15 +184,30 @@ If you have a **Starter** or **Personal** Web Hosting plan, we recommend that yo
 > If you notice a sudden increase in the size of your database, or if you have a "blog" type site that normally does not use much data, we advise you to contact a [specialised service provider](/links/partner) as soon as possible. We will not be able to provide you with support on this matter.
 >
 
-To upgrade your subscription, log in to your [OVHcloud Control Panel](/links/manager) and open `Hosting plans`{.action} in the left-hand menu. Select the relevant service and click on the `...`{.action} button in the `Solution` section of the right-hand info box, then select `Upgrade`{.action}.
+To upgrade your subscription, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `...`{.action} button in the `Solution` section on the right-hand side of the screen.
+>>
+> **Step 3**
+>>
+>> Click `Change plan`{.action}.
 
 If you are already subscribing to a **Performance** offer, refer to [method 2](#method2).
 
-#### Method 2: Migrate your data to a larger database <a name=""method2"></a>
+#### Method 2: Migrate your data to a larger database <a name="method2"></a>
 
 You can also migrate your data to a new database:
 
-- Order a larger [database service](/links/web/databases) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
+- Order a larger [database service](/links/web/hosting-options-startsql) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
 - [Duplicate the content of the old database](/pages/web_cloud/web_hosting/copy_database) to the new database **or** perform an [export of your data](/pages/web_cloud/web_hosting/sql_database_export), then [import your data](/pages/web_cloud/web_hosting/sql_importing_mysql_database) in the new database;
 - Integrate the credentials of the new database into the [configuration file](#config_file) of your site.
 
@@ -141,7 +220,22 @@ You can also migrate your data to a new database:
 
 Once you have made a [database backup](/pages/web_cloud/web_hosting/sql_database_export), log in to your [phpMyAdmin interface](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) to delete any unnecessary data using the Drop, Delete and Truncate commands.
 
-Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -150,7 +244,24 @@ Then update the data usage from the `Databases`{.action} tab of the relevant ser
 
 #### Method 4: Optimise your database
 
-To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)". Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
+
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -159,20 +270,33 @@ To optimise your database, follow the instructions in our guide "[Configuring yo
 
 ### RAM overflows (Web Cloud Databases only)
 
-The following message in the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager) indicates that your [Web Cloud Databases](/links/web/databases) server has consumed too much resources on the OVHcloud infrastructure:
+The following message indicates that your [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server has consumed too much resources on the OVHcloud infrastructure:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-In this situation, you can increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution) available from the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager). In the `General information`{.action} tab, click on the `...`{.action} in the `RAM` section.
+To increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution), click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 > [!warning]
 >
 > To increase the amount of RAM, the database needs to be a standalone service and not one of those included with a Performance web hosting plan. If you want to increase the amount of RAM of a database included in the [Performance offers](/links/web/hosting-performance-offer), you first need to detach it.
-> 
-> To detach the database, log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action}. Click `Hosting plans`{.action}, then choose the web hosting plan that has the database activated.
 >
-> In the `Configuration` box, click the `...`{.action} button to the right of `Web Cloud Databases`, then click the `Detach`{.action} button.
-> 
+> To detach the database, refer to our guide "[Detaching a Web Cloud Databases from your web hosting plan](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
+>
 
 You can also optimise your database by following the instructions of our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
 
@@ -183,7 +307,7 @@ You can also optimise your database by following the instructions of our guide "
 
 ### Database import errors
 
-#### User access denied to database
+#### "Access denied for user to database"
 
 >
 > **"#1044 - Access denied for user to database"**
@@ -191,23 +315,39 @@ You can also optimise your database by following the instructions of our guide "
 
 This error message means that the database you are trying to import contains elements that are not authorised on the OVHcloud shared infrastructure.
 
-First make sure that your database is empty from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}. (If you need to save the existing data first, follow the [backup instructions](/pages/web_cloud/web_hosting/sql_database_export), then delete the data and relaunch the import operation.)
+First make sure that your database is empty. To do this, click on the tabs below to view each of the **3** steps in succession.
 
-You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>>
+> **Step 3**
+>>
+>> If the database is not empty, [back up the existing data](/pages/web_cloud/web_hosting/sql_database_export) then delete it before relaunching the import operation.
+>>
+>> You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+If necessary, contact our [user community](/links/community) or a [specialised service provider](/links/partner) for more information. We will not be able to assist you in correcting this issue.
 
-If necessary, contact our [user community](/links/community) or [OVHcloud partners](/links/partner) for more information. We will not be able to assist you in correcting this issue.
-
-> [!success]
+> [!primary]
 >
-> You cannot have a "**trigger**" in your database’s import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
->
+> **Which elements in my database import script can cause a "#1044 - Access denied for user to database" error?**
+
+You cannot have a **"trigger"** in your database's import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 
 The following query is also not allowed:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
 Use this line instead:
@@ -221,14 +361,29 @@ Replace `Database-Name` with the name of the database as displayed in your [OVHc
 #### "MySQL server has gone away"
 
 >
-> **"404 ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
-This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). I most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
+This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). In most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
 
-To resolve this issue, you can use the following methods:
+To resolve this issue, you can:
 
-- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution): go to the [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server concerned in the `Databases` section of your [OVHcloud Control Panel](/links/manager). Then click on the `...`{.action} button in the `RAM` section and select `Change the amount of RAM`{.action}.
+- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution). To do this, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 - Split your database in order to import it through multiple operations instead of one. (For any questions on the necessary steps, contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you with this.)
 
@@ -254,11 +409,11 @@ In this situation, [check the credentials entered](/pages/web_cloud/web_cloud_da
 > **"mysqli_real_connect(): (HY000/1040): Too many connections"**
 >
 
-The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/databases)) is **30**.
+The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/hosting-options-startsql)) is **30**.
 
 This number increases to **200** for the [Web Cloud Databases service](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (This setting can be modified in the `Configuration`{.action} section of your database service.)
 
-A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears, if this maximum number of connections is exceeded.
+A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears if this maximum number of connections is exceeded.
 
 In this situation, you will need to [optimise your databases](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases) in order to reduce the number of active connections.
 
@@ -267,7 +422,7 @@ In this situation, you will need to [optimise your databases](/pages/web_cloud/w
 > If you have any questions about the changes you need to make in order to reduce the number of active connections to your database, please contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you in this regard.
 >
 
-### "Name or service not known"
+#### "Name or service not known"
 
 >
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
@@ -277,28 +432,55 @@ This error message appears when [connecting to phpMyAdmin](/pages/web_cloud/web_
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Check the server name for the relevant database service in your [OVHcloud Control Panel](/links/manager).
+Check the server name for the relevant database service.
 
-> [!success]
->
-> If the database you would like to connect to appears in the `Databases`{.action} tab of the `Hosting plans`{.action} section of your [OVHcloud Control Panel](/links/manager), the name to enter is in the `Server address` column.
->
-> If you want to connect to a database on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), the server name can be retrieved from the tab `General information`{.action}, in the box `Login information`{.action} under `SQL`{.action} and labelled as `Host name`{.action}.
->
+**Click on the relevant situation to view the content.**
+
+/// details | Database on a web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab. The server name to enter is listed in the `Server address` column.
+
+///
+
+/// details | Database on a Web Cloud Databases server
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, the server name to enter is listed in the `Login information` section, under `SQL`, labelled as `Host name`.
+
+///
 
 ### Unable to connect to a Cloud Databases database
 
 Having a [Web Cloud Databases](/products/web-cloud-clouddb) server allows you to [connect to your databases](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) from your computer or a server outside of the OVHcloud infrastructure.
 
-If this connection is not possible, first check that you have [authorized your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) connected to the database server.
+If this connection is not possible, first check that you have [authorised your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) to connect to the database server.
 
 If this operation has been carried out, contact your ISP or the [OVHcloud partners](/links/partner). We will not be able to assist you in this situation.
 
 ## Go further <a name="go-further"></a>
 
 [Getting started with Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb)
-
-[Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-au.md
@@ -326,7 +326,7 @@ First make sure that your database is empty. To do this, click on the tabs below
 >>
 > **Step 2**
 >>
->> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>> Click the `Databases`{.action} tab, then the `...`{.action} button next to the database, then `Recalculate the quota`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-ca.md
@@ -1,8 +1,22 @@
 ---
 title: "Troubleshooting common database errors"
 excerpt: "Find out how to diagnose the most common cases of database errors"
-updated: 2026-02-11
+updated: 2026-03-31
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -13,13 +27,13 @@ Your database usage may result in anomalies on your website or error messages in
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. However, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](/links/web/hosting)
-- an OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases)
+- An [OVHcloud Web Hosting plan](/links/web/hosting).
+- An OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases).
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -42,18 +56,57 @@ Your database usage may result in anomalies on your website or error messages in
 
 First, check on the [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) page whether your datacentre, your web hosting cluster, your Web Cloud Databases server, or your database is not affected by an incident on the OVHcloud infrastructure.
 
-> [!primary]
->
-> You can find these details in your [OVHcloud Control Panel](/links/manager), in the `Web Cloud`{.action} section:
->
-> - To find your Web Hosting plan's data centre, select `Hosting plans`{.action}, then the relevant web hosting. You will find this information in the `General Information`{.action} tab.
-> - To find the **cluster** of servers and **filer** (file server) of your web hosting, refer to [this guide](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - To retrieve the name of your **Web Cloud Databases** server, click on `Web Cloud Databases`{.action} in the left-hand menu, then on the relevant service. You can find the information concerned under the heading `Host name` in the `SQL` part of the `General information`{.action} tab.
-> - To find the server on which your included or additional database ordered via your [web hosting](/links/web/hosting) is located, refer to [this guide](/pages/web_cloud/web_hosting/sql_find_server).
+**Click on the information you are looking for to view the content.**
+
+/// details | Find the datacentre of your web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `Datacentre`.
+
+///
+
+/// details | Find the cluster and filer of your web hosting plan
+
+Refer to our guide "[Finding out the cluster and filer of your web hosting plan](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Find the Web Cloud Databases server name
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate `Host name` in the `SQL` section of `Login information`.
+
+///
+
+/// details | Find your web hosting database server
+
+Refer to our guide "[Finding your database server](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Verify login credentials for your database <a name="config_file"></a>
 
-Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website’s configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
+Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website's configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
 
 > [!warning]
 >
@@ -62,35 +115,46 @@ Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cl
 > We recommend that you contact the publisher of the [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) concerned or a [specialised service provider](/links/partner) if necessary. We will not be able to assist you with this.
 >
 
-Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website’s configuration file.
+Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website's configuration file.
 
 If necessary, change your [database password](/pages/web_cloud/web_hosting/sql_change_password).
 
 #### Example for WordPress
 
-If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the "www" folder).
+If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the `www` folder).
 
-If this is a WordPress site, open the file "wp-config.php".
+If this is a WordPress site, open the file `wp-config.php`.
 
 ```php
 define('DB_NAME', 'my_database');
- 
+
 /** MySQL database username */
 define('DB_USER', 'my_user');
- 
+
 /** MySQL database password */
 define('DB_PASSWORD', 'my_password');
- 
+
 /** MySQL hostname */
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-In your [OVHcloud Control Panel](/links/manager), open the `Hosting plans`{.action} section and click on the `Databases`{.action} tab. Check the correspondence between the elements displayed and those in the file `wp-config.php`:
+Click on the tabs below to view each of the **2** steps in succession.
 
-- **my_database** must match what is noted as `Database name`;
-- **my_user** must match what is noted as `User name`;
-- **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** must match the `Server address`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then check the correspondence between the elements displayed and those in the file `wp-config.php`:
+>>
+>> - **my_database** must match what is noted as `Database name`;
+>> - **my_user** must match what is noted as `User name`;
+>> - **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** must match the `Server address`.
 
 > [!primary]
 >
@@ -120,15 +184,30 @@ If you have a **Starter** or **Personal** Web Hosting plan, we recommend that yo
 > If you notice a sudden increase in the size of your database, or if you have a "blog" type site that normally does not use much data, we advise you to contact a [specialised service provider](/links/partner) as soon as possible. We will not be able to provide you with support on this matter.
 >
 
-To upgrade your subscription, log in to your [OVHcloud Control Panel](/links/manager) and open `Hosting plans`{.action} in the left-hand menu. Select the relevant service and click on the `...`{.action} button in the `Solution` section of the right-hand info box, then select `Upgrade`{.action}.
+To upgrade your subscription, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `...`{.action} button in the `Solution` section on the right-hand side of the screen.
+>>
+> **Step 3**
+>>
+>> Click `Change plan`{.action}.
 
 If you are already subscribing to a **Performance** offer, refer to [method 2](#method2).
 
-#### Method 2: Migrate your data to a larger database <a name=""method2"></a>
+#### Method 2: Migrate your data to a larger database <a name="method2"></a>
 
 You can also migrate your data to a new database:
 
-- Order a larger [database service](/links/web/databases) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
+- Order a larger [database service](/links/web/hosting-options-startsql) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
 - [Duplicate the content of the old database](/pages/web_cloud/web_hosting/copy_database) to the new database **or** perform an [export of your data](/pages/web_cloud/web_hosting/sql_database_export), then [import your data](/pages/web_cloud/web_hosting/sql_importing_mysql_database) in the new database;
 - Integrate the credentials of the new database into the [configuration file](#config_file) of your site.
 
@@ -141,7 +220,22 @@ You can also migrate your data to a new database:
 
 Once you have made a [database backup](/pages/web_cloud/web_hosting/sql_database_export), log in to your [phpMyAdmin interface](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) to delete any unnecessary data using the Drop, Delete and Truncate commands.
 
-Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -150,7 +244,24 @@ Then update the data usage from the `Databases`{.action} tab of the relevant ser
 
 #### Method 4: Optimise your database
 
-To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)". Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
+
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -159,20 +270,33 @@ To optimise your database, follow the instructions in our guide "[Configuring yo
 
 ### RAM overflows (Web Cloud Databases only)
 
-The following message in the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager) indicates that your [Web Cloud Databases](/links/web/databases) server has consumed too much resources on the OVHcloud infrastructure:
+The following message indicates that your [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server has consumed too much resources on the OVHcloud infrastructure:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-In this situation, you can increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution) available from the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager). In the `General information`{.action} tab, click on the `...`{.action} in the `RAM` section.
+To increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution), click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 > [!warning]
 >
 > To increase the amount of RAM, the database needs to be a standalone service and not one of those included with a Performance web hosting plan. If you want to increase the amount of RAM of a database included in the [Performance offers](/links/web/hosting-performance-offer), you first need to detach it.
-> 
-> To detach the database, log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action}. Click `Hosting plans`{.action}, then choose the web hosting plan that has the database activated.
 >
-> In the `Configuration` box, click the `...`{.action} button to the right of `Web Cloud Databases`, then click the `Detach`{.action} button.
-> 
+> To detach the database, refer to our guide "[Detaching a Web Cloud Databases from your web hosting plan](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
+>
 
 You can also optimise your database by following the instructions of our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
 
@@ -183,7 +307,7 @@ You can also optimise your database by following the instructions of our guide "
 
 ### Database import errors
 
-#### User access denied to database
+#### "Access denied for user to database"
 
 >
 > **"#1044 - Access denied for user to database"**
@@ -191,23 +315,39 @@ You can also optimise your database by following the instructions of our guide "
 
 This error message means that the database you are trying to import contains elements that are not authorised on the OVHcloud shared infrastructure.
 
-First make sure that your database is empty from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}. (If you need to save the existing data first, follow the [backup instructions](/pages/web_cloud/web_hosting/sql_database_export), then delete the data and relaunch the import operation.)
+First make sure that your database is empty. To do this, click on the tabs below to view each of the **3** steps in succession.
 
-You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>>
+> **Step 3**
+>>
+>> If the database is not empty, [back up the existing data](/pages/web_cloud/web_hosting/sql_database_export) then delete it before relaunching the import operation.
+>>
+>> You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+If necessary, contact our [user community](/links/community) or a [specialised service provider](/links/partner) for more information. We will not be able to assist you in correcting this issue.
 
-If necessary, contact our [user community](/links/community) or [OVHcloud partners](/links/partner) for more information. We will not be able to assist you in correcting this issue.
-
-> [!success]
+> [!primary]
 >
-> You cannot have a "**trigger**" in your database’s import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
->
+> **Which elements in my database import script can cause a "#1044 - Access denied for user to database" error?**
+
+You cannot have a **"trigger"** in your database's import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 
 The following query is also not allowed:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
 Use this line instead:
@@ -221,14 +361,29 @@ Replace `Database-Name` with the name of the database as displayed in your [OVHc
 #### "MySQL server has gone away"
 
 >
-> **"404 ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
-This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). I most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
+This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). In most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
 
-To resolve this issue, you can use the following methods:
+To resolve this issue, you can:
 
-- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution): go to the [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server concerned in the `Databases` section of your [OVHcloud Control Panel](/links/manager). Then click on the `...`{.action} button in the `RAM` section and select `Change the amount of RAM`{.action}.
+- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution). To do this, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 - Split your database in order to import it through multiple operations instead of one. (For any questions on the necessary steps, contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you with this.)
 
@@ -254,11 +409,11 @@ In this situation, [check the credentials entered](/pages/web_cloud/web_cloud_da
 > **"mysqli_real_connect(): (HY000/1040): Too many connections"**
 >
 
-The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/databases)) is **30**.
+The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/hosting-options-startsql)) is **30**.
 
 This number increases to **200** for the [Web Cloud Databases service](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (This setting can be modified in the `Configuration`{.action} section of your database service.)
 
-A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears, if this maximum number of connections is exceeded.
+A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears if this maximum number of connections is exceeded.
 
 In this situation, you will need to [optimise your databases](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases) in order to reduce the number of active connections.
 
@@ -267,7 +422,7 @@ In this situation, you will need to [optimise your databases](/pages/web_cloud/w
 > If you have any questions about the changes you need to make in order to reduce the number of active connections to your database, please contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you in this regard.
 >
 
-### "Name or service not known"
+#### "Name or service not known"
 
 >
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
@@ -277,28 +432,55 @@ This error message appears when [connecting to phpMyAdmin](/pages/web_cloud/web_
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Check the server name for the relevant database service in your [OVHcloud Control Panel](/links/manager).
+Check the server name for the relevant database service.
 
-> [!success]
->
-> If the database you would like to connect to appears in the `Databases`{.action} tab of the `Hosting plans`{.action} section of your [OVHcloud Control Panel](/links/manager), the name to enter is in the `Server address` column.
->
-> If you want to connect to a database on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), the server name can be retrieved from the tab `General information`{.action}, in the box `Login information`{.action} under `SQL`{.action} and labelled as `Host name`{.action}.
->
+**Click on the relevant situation to view the content.**
+
+/// details | Database on a web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab. The server name to enter is listed in the `Server address` column.
+
+///
+
+/// details | Database on a Web Cloud Databases server
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, the server name to enter is listed in the `Login information` section, under `SQL`, labelled as `Host name`.
+
+///
 
 ### Unable to connect to a Cloud Databases database
 
 Having a [Web Cloud Databases](/products/web-cloud-clouddb) server allows you to [connect to your databases](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) from your computer or a server outside of the OVHcloud infrastructure.
 
-If this connection is not possible, first check that you have [authorized your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) connected to the database server.
+If this connection is not possible, first check that you have [authorised your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) to connect to the database server.
 
 If this operation has been carried out, contact your ISP or the [OVHcloud partners](/links/partner). We will not be able to assist you in this situation.
 
 ## Go further <a name="go-further"></a>
 
 [Getting started with Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb)
-
-[Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-ca.md
@@ -326,7 +326,7 @@ First make sure that your database is empty. To do this, click on the tabs below
 >>
 > **Step 2**
 >>
->> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>> Click the `Databases`{.action} tab, then the `...`{.action} button next to the database, then `Recalculate the quota`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-gb.md
@@ -326,7 +326,7 @@ First make sure that your database is empty. To do this, click on the tabs below
 >>
 > **Step 2**
 >>
->> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>> Click the `Databases`{.action} tab, then the `...`{.action} button next to the database, then `Recalculate the quota`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting common database errors"
 excerpt: "Find out how to diagnose the most common cases of database errors"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-gb.md
@@ -1,8 +1,22 @@
 ---
 title: "Troubleshooting common database errors"
 excerpt: "Find out how to diagnose the most common cases of database errors"
-updated: 2026-02-11
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -13,13 +27,13 @@ Your database usage may result in anomalies on your website or error messages in
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. However, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](/links/web/hosting)
-- an OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases)
+- An [OVHcloud Web Hosting plan](/links/web/hosting).
+- An OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases).
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -42,18 +56,57 @@ Your database usage may result in anomalies on your website or error messages in
 
 First, check on the [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) page whether your datacentre, your web hosting cluster, your Web Cloud Databases server, or your database is not affected by an incident on the OVHcloud infrastructure.
 
-> [!primary]
->
-> You can find these details in your [OVHcloud Control Panel](/links/manager), in the `Web Cloud`{.action} section:
->
-> - To find your Web Hosting plan's data centre, select `Hosting plans`{.action}, then the relevant web hosting. You will find this information in the `General Information`{.action} tab.
-> - To find the **cluster** of servers and **filer** (file server) of your web hosting, refer to [this guide](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - To retrieve the name of your **Web Cloud Databases** server, click on `Web Cloud Databases`{.action} in the left-hand menu, then on the relevant service. You can find the information concerned under the heading `Host name` in the `SQL` part of the `General information`{.action} tab.
-> - To find the server on which your included or additional database ordered via your [web hosting](/links/web/hosting) is located, refer to [this guide](/pages/web_cloud/web_hosting/sql_find_server).
+**Click on the information you are looking for to view the content.**
+
+/// details | Find the datacentre of your web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `Datacentre`.
+
+///
+
+/// details | Find the cluster and filer of your web hosting plan
+
+Refer to our guide "[Finding out the cluster and filer of your web hosting plan](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Find the Web Cloud Databases server name
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate `Host name` in the `SQL` section of `Login information`.
+
+///
+
+/// details | Find your web hosting database server
+
+Refer to our guide "[Finding your database server](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Verify login credentials for your database <a name="config_file"></a>
 
-Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website’s configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
+Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website's configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
 
 > [!warning]
 >
@@ -62,35 +115,46 @@ Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cl
 > We recommend that you contact the publisher of the [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) concerned or a [specialised service provider](/links/partner) if necessary. We will not be able to assist you with this.
 >
 
-Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website’s configuration file.
+Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website's configuration file.
 
 If necessary, change your [database password](/pages/web_cloud/web_hosting/sql_change_password).
 
 #### Example for WordPress
 
-If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the "www" folder).
+If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the `www` folder).
 
-If this is a WordPress site, open the file "wp-config.php".
+If this is a WordPress site, open the file `wp-config.php`.
 
 ```php
 define('DB_NAME', 'my_database');
- 
+
 /** MySQL database username */
 define('DB_USER', 'my_user');
- 
+
 /** MySQL database password */
 define('DB_PASSWORD', 'my_password');
- 
+
 /** MySQL hostname */
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-In your [OVHcloud Control Panel](/links/manager), open the `Hosting plans`{.action} section and click on the `Databases`{.action} tab. Check the correspondence between the elements displayed and those in the file `wp-config.php`:
+Click on the tabs below to view each of the **2** steps in succession.
 
-- **my_database** must match what is noted as `Database name`;
-- **my_user** must match what is noted as `User name`;
-- **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** must match the `Server address`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then check the correspondence between the elements displayed and those in the file `wp-config.php`:
+>>
+>> - **my_database** must match what is noted as `Database name`;
+>> - **my_user** must match what is noted as `User name`;
+>> - **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** must match the `Server address`.
 
 > [!primary]
 >
@@ -120,15 +184,30 @@ If you have a **Starter** or **Personal** Web Hosting plan, we recommend that yo
 > If you notice a sudden increase in the size of your database, or if you have a "blog" type site that normally does not use much data, we advise you to contact a [specialised service provider](/links/partner) as soon as possible. We will not be able to provide you with support on this matter.
 >
 
-To upgrade your subscription, log in to your [OVHcloud Control Panel](/links/manager) and open `Hosting plans`{.action} in the left-hand menu. Select the relevant service and click on the `...`{.action} button in the `Solution` section of the right-hand info box, then select `Upgrade`{.action}.
+To upgrade your subscription, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `...`{.action} button in the `Solution` section on the right-hand side of the screen.
+>>
+> **Step 3**
+>>
+>> Click `Change plan`{.action}.
 
 If you are already subscribing to a **Performance** offer, refer to [method 2](#method2).
 
-#### Method 2: Migrate your data to a larger database <a name=""method2"></a>
+#### Method 2: Migrate your data to a larger database <a name="method2"></a>
 
 You can also migrate your data to a new database:
 
-- Order a larger [database service](/links/web/databases) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
+- Order a larger [database service](/links/web/hosting-options-startsql) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
 - [Duplicate the content of the old database](/pages/web_cloud/web_hosting/copy_database) to the new database **or** perform an [export of your data](/pages/web_cloud/web_hosting/sql_database_export), then [import your data](/pages/web_cloud/web_hosting/sql_importing_mysql_database) in the new database;
 - Integrate the credentials of the new database into the [configuration file](#config_file) of your site.
 
@@ -141,7 +220,22 @@ You can also migrate your data to a new database:
 
 Once you have made a [database backup](/pages/web_cloud/web_hosting/sql_database_export), log in to your [phpMyAdmin interface](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) to delete any unnecessary data using the Drop, Delete and Truncate commands.
 
-Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -150,7 +244,24 @@ Then update the data usage from the `Databases`{.action} tab of the relevant ser
 
 #### Method 4: Optimise your database
 
-To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)". Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
+
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -159,20 +270,33 @@ To optimise your database, follow the instructions in our guide "[Configuring yo
 
 ### RAM overflows (Web Cloud Databases only)
 
-The following message in the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager) indicates that your [Web Cloud Databases](/links/web/databases) server has consumed too much resources on the OVHcloud infrastructure:
+The following message indicates that your [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server has consumed too much resources on the OVHcloud infrastructure:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-In this situation, you can increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution) available from the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager). In the `General information`{.action} tab, click on the `...`{.action} in the `RAM` section.
+To increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution), click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 > [!warning]
 >
 > To increase the amount of RAM, the database needs to be a standalone service and not one of those included with a Performance web hosting plan. If you want to increase the amount of RAM of a database included in the [Performance offers](/links/web/hosting-performance-offer), you first need to detach it.
-> 
-> To detach the database, log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action}. Click `Hosting plans`{.action}, then choose the web hosting plan that has the database activated.
 >
-> In the `Configuration` box, click the `...`{.action} button to the right of `Web Cloud Databases`, then click the `Detach`{.action} button.
-> 
+> To detach the database, refer to our guide "[Detaching a Web Cloud Databases from your web hosting plan](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
+>
 
 You can also optimise your database by following the instructions of our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
 
@@ -183,7 +307,7 @@ You can also optimise your database by following the instructions of our guide "
 
 ### Database import errors
 
-#### User access denied to database
+#### "Access denied for user to database"
 
 >
 > **"#1044 - Access denied for user to database"**
@@ -191,23 +315,39 @@ You can also optimise your database by following the instructions of our guide "
 
 This error message means that the database you are trying to import contains elements that are not authorised on the OVHcloud shared infrastructure.
 
-First make sure that your database is empty from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}. (If you need to save the existing data first, follow the [backup instructions](/pages/web_cloud/web_hosting/sql_database_export), then delete the data and relaunch the import operation.)
+First make sure that your database is empty. To do this, click on the tabs below to view each of the **3** steps in succession.
 
-You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>>
+> **Step 3**
+>>
+>> If the database is not empty, [back up the existing data](/pages/web_cloud/web_hosting/sql_database_export) then delete it before relaunching the import operation.
+>>
+>> You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+If necessary, contact our [user community](/links/community) or a [specialised service provider](/links/partner) for more information. We will not be able to assist you in correcting this issue.
 
-If necessary, contact our [user community](/links/community) or [OVHcloud partners](/links/partner) for more information. We will not be able to assist you in correcting this issue.
-
-> [!success]
+> [!primary]
 >
-> You cannot have a "**trigger**" in your database’s import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
->
+> **Which elements in my database import script can cause a "#1044 - Access denied for user to database" error?**
+
+You cannot have a **"trigger"** in your database's import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 
 The following query is also not allowed:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
 Use this line instead:
@@ -221,14 +361,29 @@ Replace `Database-Name` with the name of the database as displayed in your [OVHc
 #### "MySQL server has gone away"
 
 >
-> **"404 ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
-This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). I most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
+This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). In most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
 
-To resolve this issue, you can use the following methods:
+To resolve this issue, you can:
 
-- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution): go to the [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server concerned in the `Databases` section of your [OVHcloud Control Panel](/links/manager). Then click on the `...`{.action} button in the `RAM` section and select `Change the amount of RAM`{.action}.
+- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution). To do this, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 - Split your database in order to import it through multiple operations instead of one. (For any questions on the necessary steps, contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you with this.)
 
@@ -254,11 +409,11 @@ In this situation, [check the credentials entered](/pages/web_cloud/web_cloud_da
 > **"mysqli_real_connect(): (HY000/1040): Too many connections"**
 >
 
-The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/databases)) is **30**.
+The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/hosting-options-startsql)) is **30**.
 
 This number increases to **200** for the [Web Cloud Databases service](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (This setting can be modified in the `Configuration`{.action} section of your database service.)
 
-A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears, if this maximum number of connections is exceeded.
+A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears if this maximum number of connections is exceeded.
 
 In this situation, you will need to [optimise your databases](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases) in order to reduce the number of active connections.
 
@@ -267,7 +422,7 @@ In this situation, you will need to [optimise your databases](/pages/web_cloud/w
 > If you have any questions about the changes you need to make in order to reduce the number of active connections to your database, please contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you in this regard.
 >
 
-### "Name or service not known"
+#### "Name or service not known"
 
 >
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
@@ -277,28 +432,55 @@ This error message appears when [connecting to phpMyAdmin](/pages/web_cloud/web_
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Check the server name for the relevant database service in your [OVHcloud Control Panel](/links/manager).
+Check the server name for the relevant database service.
 
-> [!success]
->
-> If the database you would like to connect to appears in the `Databases`{.action} tab of the `Hosting plans`{.action} section of your [OVHcloud Control Panel](/links/manager), the name to enter is in the `Server address` column.
->
-> If you want to connect to a database on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), the server name can be retrieved from the tab `General information`{.action}, in the box `Login information`{.action} under `SQL`{.action} and labelled as `Host name`{.action}.
->
+**Click on the relevant situation to view the content.**
+
+/// details | Database on a web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab. The server name to enter is listed in the `Server address` column.
+
+///
+
+/// details | Database on a Web Cloud Databases server
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, the server name to enter is listed in the `Login information` section, under `SQL`, labelled as `Host name`.
+
+///
 
 ### Unable to connect to a Cloud Databases database
 
 Having a [Web Cloud Databases](/products/web-cloud-clouddb) server allows you to [connect to your databases](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) from your computer or a server outside of the OVHcloud infrastructure.
 
-If this connection is not possible, first check that you have [authorized your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) connected to the database server.
+If this connection is not possible, first check that you have [authorised your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) to connect to the database server.
 
 If this operation has been carried out, contact your ISP or the [OVHcloud partners](/links/partner). We will not be able to assist you in this situation.
 
 ## Go further <a name="go-further"></a>
 
 [Getting started with Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb)
-
-[Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-ie.md
@@ -1,8 +1,22 @@
 ---
 title: "Troubleshooting common database errors"
 excerpt: "Find out how to diagnose the most common cases of database errors"
-updated: 2026-02-11
+updated: 2026-03-31
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -13,13 +27,13 @@ Your database usage may result in anomalies on your website or error messages in
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. However, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](/links/web/hosting)
-- an OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases)
+- An [OVHcloud Web Hosting plan](/links/web/hosting).
+- An OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases).
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -42,18 +56,57 @@ Your database usage may result in anomalies on your website or error messages in
 
 First, check on the [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) page whether your datacentre, your web hosting cluster, your Web Cloud Databases server, or your database is not affected by an incident on the OVHcloud infrastructure.
 
-> [!primary]
->
-> You can find these details in your [OVHcloud Control Panel](/links/manager), in the `Web Cloud`{.action} section:
->
-> - To find your Web Hosting plan's data centre, select `Hosting plans`{.action}, then the relevant web hosting. You will find this information in the `General Information`{.action} tab.
-> - To find the **cluster** of servers and **filer** (file server) of your web hosting, refer to [this guide](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - To retrieve the name of your **Web Cloud Databases** server, click on `Web Cloud Databases`{.action} in the left-hand menu, then on the relevant service. You can find the information concerned under the heading `Host name` in the `SQL` part of the `General information`{.action} tab.
-> - To find the server on which your included or additional database ordered via your [web hosting](/links/web/hosting) is located, refer to [this guide](/pages/web_cloud/web_hosting/sql_find_server).
+**Click on the information you are looking for to view the content.**
+
+/// details | Find the datacentre of your web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `Datacentre`.
+
+///
+
+/// details | Find the cluster and filer of your web hosting plan
+
+Refer to our guide "[Finding out the cluster and filer of your web hosting plan](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Find the Web Cloud Databases server name
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate `Host name` in the `SQL` section of `Login information`.
+
+///
+
+/// details | Find your web hosting database server
+
+Refer to our guide "[Finding your database server](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Verify login credentials for your database <a name="config_file"></a>
 
-Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website’s configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
+Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website's configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
 
 > [!warning]
 >
@@ -62,35 +115,46 @@ Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cl
 > We recommend that you contact the publisher of the [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) concerned or a [specialised service provider](/links/partner) if necessary. We will not be able to assist you with this.
 >
 
-Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website’s configuration file.
+Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website's configuration file.
 
 If necessary, change your [database password](/pages/web_cloud/web_hosting/sql_change_password).
 
 #### Example for WordPress
 
-If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the "www" folder).
+If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the `www` folder).
 
-If this is a WordPress site, open the file "wp-config.php".
+If this is a WordPress site, open the file `wp-config.php`.
 
 ```php
 define('DB_NAME', 'my_database');
- 
+
 /** MySQL database username */
 define('DB_USER', 'my_user');
- 
+
 /** MySQL database password */
 define('DB_PASSWORD', 'my_password');
- 
+
 /** MySQL hostname */
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-In your [OVHcloud Control Panel](/links/manager), open the `Hosting plans`{.action} section and click on the `Databases`{.action} tab. Check the correspondence between the elements displayed and those in the file `wp-config.php`:
+Click on the tabs below to view each of the **2** steps in succession.
 
-- **my_database** must match what is noted as `Database name`;
-- **my_user** must match what is noted as `User name`;
-- **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** must match the `Server address`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then check the correspondence between the elements displayed and those in the file `wp-config.php`:
+>>
+>> - **my_database** must match what is noted as `Database name`;
+>> - **my_user** must match what is noted as `User name`;
+>> - **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** must match the `Server address`.
 
 > [!primary]
 >
@@ -120,15 +184,30 @@ If you have a **Starter** or **Personal** Web Hosting plan, we recommend that yo
 > If you notice a sudden increase in the size of your database, or if you have a "blog" type site that normally does not use much data, we advise you to contact a [specialised service provider](/links/partner) as soon as possible. We will not be able to provide you with support on this matter.
 >
 
-To upgrade your subscription, log in to your [OVHcloud Control Panel](/links/manager) and open `Hosting plans`{.action} in the left-hand menu. Select the relevant service and click on the `...`{.action} button in the `Solution` section of the right-hand info box, then select `Upgrade`{.action}.
+To upgrade your subscription, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `...`{.action} button in the `Solution` section on the right-hand side of the screen.
+>>
+> **Step 3**
+>>
+>> Click `Change plan`{.action}.
 
 If you are already subscribing to a **Performance** offer, refer to [method 2](#method2).
 
-#### Method 2: Migrate your data to a larger database <a name=""method2"></a>
+#### Method 2: Migrate your data to a larger database <a name="method2"></a>
 
 You can also migrate your data to a new database:
 
-- Order a larger [database service](/links/web/databases) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
+- Order a larger [database service](/links/web/hosting-options-startsql) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
 - [Duplicate the content of the old database](/pages/web_cloud/web_hosting/copy_database) to the new database **or** perform an [export of your data](/pages/web_cloud/web_hosting/sql_database_export), then [import your data](/pages/web_cloud/web_hosting/sql_importing_mysql_database) in the new database;
 - Integrate the credentials of the new database into the [configuration file](#config_file) of your site.
 
@@ -141,7 +220,22 @@ You can also migrate your data to a new database:
 
 Once you have made a [database backup](/pages/web_cloud/web_hosting/sql_database_export), log in to your [phpMyAdmin interface](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) to delete any unnecessary data using the Drop, Delete and Truncate commands.
 
-Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -150,7 +244,24 @@ Then update the data usage from the `Databases`{.action} tab of the relevant ser
 
 #### Method 4: Optimise your database
 
-To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)". Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
+
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -159,20 +270,33 @@ To optimise your database, follow the instructions in our guide "[Configuring yo
 
 ### RAM overflows (Web Cloud Databases only)
 
-The following message in the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager) indicates that your [Web Cloud Databases](/links/web/databases) server has consumed too much resources on the OVHcloud infrastructure:
+The following message indicates that your [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server has consumed too much resources on the OVHcloud infrastructure:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-In this situation, you can increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution) available from the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager). In the `General information`{.action} tab, click on the `...`{.action} in the `RAM` section.
+To increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution), click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 > [!warning]
 >
 > To increase the amount of RAM, the database needs to be a standalone service and not one of those included with a Performance web hosting plan. If you want to increase the amount of RAM of a database included in the [Performance offers](/links/web/hosting-performance-offer), you first need to detach it.
-> 
-> To detach the database, log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action}. Click `Hosting plans`{.action}, then choose the web hosting plan that has the database activated.
 >
-> In the `Configuration` box, click the `...`{.action} button to the right of `Web Cloud Databases`, then click the `Detach`{.action} button.
-> 
+> To detach the database, refer to our guide "[Detaching a Web Cloud Databases from your web hosting plan](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
+>
 
 You can also optimise your database by following the instructions of our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
 
@@ -183,7 +307,7 @@ You can also optimise your database by following the instructions of our guide "
 
 ### Database import errors
 
-#### User access denied to database
+#### "Access denied for user to database"
 
 >
 > **"#1044 - Access denied for user to database"**
@@ -191,23 +315,39 @@ You can also optimise your database by following the instructions of our guide "
 
 This error message means that the database you are trying to import contains elements that are not authorised on the OVHcloud shared infrastructure.
 
-First make sure that your database is empty from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}. (If you need to save the existing data first, follow the [backup instructions](/pages/web_cloud/web_hosting/sql_database_export), then delete the data and relaunch the import operation.)
+First make sure that your database is empty. To do this, click on the tabs below to view each of the **3** steps in succession.
 
-You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>>
+> **Step 3**
+>>
+>> If the database is not empty, [back up the existing data](/pages/web_cloud/web_hosting/sql_database_export) then delete it before relaunching the import operation.
+>>
+>> You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+If necessary, contact our [user community](/links/community) or a [specialised service provider](/links/partner) for more information. We will not be able to assist you in correcting this issue.
 
-If necessary, contact our [user community](/links/community) or [OVHcloud partners](/links/partner) for more information. We will not be able to assist you in correcting this issue.
-
-> [!success]
+> [!primary]
 >
-> You cannot have a "**trigger**" in your database’s import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
->
+> **Which elements in my database import script can cause a "#1044 - Access denied for user to database" error?**
+
+You cannot have a **"trigger"** in your database's import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 
 The following query is also not allowed:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
 Use this line instead:
@@ -221,14 +361,29 @@ Replace `Database-Name` with the name of the database as displayed in your [OVHc
 #### "MySQL server has gone away"
 
 >
-> **"404 ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
-This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). I most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
+This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). In most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
 
-To resolve this issue, you can use the following methods:
+To resolve this issue, you can:
 
-- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution): go to the [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server concerned in the `Databases` section of your [OVHcloud Control Panel](/links/manager). Then click on the `...`{.action} button in the `RAM` section and select `Change the amount of RAM`{.action}.
+- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution). To do this, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 - Split your database in order to import it through multiple operations instead of one. (For any questions on the necessary steps, contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you with this.)
 
@@ -254,11 +409,11 @@ In this situation, [check the credentials entered](/pages/web_cloud/web_cloud_da
 > **"mysqli_real_connect(): (HY000/1040): Too many connections"**
 >
 
-The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/databases)) is **30**.
+The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/hosting-options-startsql)) is **30**.
 
 This number increases to **200** for the [Web Cloud Databases service](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (This setting can be modified in the `Configuration`{.action} section of your database service.)
 
-A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears, if this maximum number of connections is exceeded.
+A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears if this maximum number of connections is exceeded.
 
 In this situation, you will need to [optimise your databases](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases) in order to reduce the number of active connections.
 
@@ -267,7 +422,7 @@ In this situation, you will need to [optimise your databases](/pages/web_cloud/w
 > If you have any questions about the changes you need to make in order to reduce the number of active connections to your database, please contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you in this regard.
 >
 
-### "Name or service not known"
+#### "Name or service not known"
 
 >
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
@@ -277,28 +432,55 @@ This error message appears when [connecting to phpMyAdmin](/pages/web_cloud/web_
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Check the server name for the relevant database service in your [OVHcloud Control Panel](/links/manager).
+Check the server name for the relevant database service.
 
-> [!success]
->
-> If the database you would like to connect to appears in the `Databases`{.action} tab of the `Hosting plans`{.action} section of your [OVHcloud Control Panel](/links/manager), the name to enter is in the `Server address` column.
->
-> If you want to connect to a database on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), the server name can be retrieved from the tab `General information`{.action}, in the box `Login information`{.action} under `SQL`{.action} and labelled as `Host name`{.action}.
->
+**Click on the relevant situation to view the content.**
+
+/// details | Database on a web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab. The server name to enter is listed in the `Server address` column.
+
+///
+
+/// details | Database on a Web Cloud Databases server
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, the server name to enter is listed in the `Login information` section, under `SQL`, labelled as `Host name`.
+
+///
 
 ### Unable to connect to a Cloud Databases database
 
 Having a [Web Cloud Databases](/products/web-cloud-clouddb) server allows you to [connect to your databases](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) from your computer or a server outside of the OVHcloud infrastructure.
 
-If this connection is not possible, first check that you have [authorized your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) connected to the database server.
+If this connection is not possible, first check that you have [authorised your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) to connect to the database server.
 
 If this operation has been carried out, contact your ISP or the [OVHcloud partners](/links/partner). We will not be able to assist you in this situation.
 
 ## Go further <a name="go-further"></a>
 
 [Getting started with Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb)
-
-[Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-ie.md
@@ -326,7 +326,7 @@ First make sure that your database is empty. To do this, click on the tabs below
 >>
 > **Step 2**
 >>
->> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>> Click the `Databases`{.action} tab, then the `...`{.action} button next to the database, then `Recalculate the quota`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-sg.md
@@ -1,8 +1,22 @@
 ---
 title: "Troubleshooting common database errors"
 excerpt: "Find out how to diagnose the most common cases of database errors"
-updated: 2026-02-11
+updated: 2026-03-31
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -13,13 +27,13 @@ Your database usage may result in anomalies on your website or error messages in
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. However, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](/links/web/hosting)
-- an OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases)
+- An [OVHcloud Web Hosting plan](/links/web/hosting).
+- An OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases).
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -42,18 +56,57 @@ Your database usage may result in anomalies on your website or error messages in
 
 First, check on the [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) page whether your datacentre, your web hosting cluster, your Web Cloud Databases server, or your database is not affected by an incident on the OVHcloud infrastructure.
 
-> [!primary]
->
-> You can find these details in your [OVHcloud Control Panel](/links/manager), in the `Web Cloud`{.action} section:
->
-> - To find your Web Hosting plan's data centre, select `Hosting plans`{.action}, then the relevant web hosting. You will find this information in the `General Information`{.action} tab.
-> - To find the **cluster** of servers and **filer** (file server) of your web hosting, refer to [this guide](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - To retrieve the name of your **Web Cloud Databases** server, click on `Web Cloud Databases`{.action} in the left-hand menu, then on the relevant service. You can find the information concerned under the heading `Host name` in the `SQL` part of the `General information`{.action} tab.
-> - To find the server on which your included or additional database ordered via your [web hosting](/links/web/hosting) is located, refer to [this guide](/pages/web_cloud/web_hosting/sql_find_server).
+**Click on the information you are looking for to view the content.**
+
+/// details | Find the datacentre of your web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `Datacentre`.
+
+///
+
+/// details | Find the cluster and filer of your web hosting plan
+
+Refer to our guide "[Finding out the cluster and filer of your web hosting plan](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Find the Web Cloud Databases server name
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate `Host name` in the `SQL` section of `Login information`.
+
+///
+
+/// details | Find your web hosting database server
+
+Refer to our guide "[Finding your database server](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Verify login credentials for your database <a name="config_file"></a>
 
-Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website’s configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
+Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website's configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
 
 > [!warning]
 >
@@ -62,35 +115,46 @@ Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cl
 > We recommend that you contact the publisher of the [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) concerned or a [specialised service provider](/links/partner) if necessary. We will not be able to assist you with this.
 >
 
-Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website’s configuration file.
+Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website's configuration file.
 
 If necessary, change your [database password](/pages/web_cloud/web_hosting/sql_change_password).
 
 #### Example for WordPress
 
-If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the "www" folder).
+If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the `www` folder).
 
-If this is a WordPress site, open the file "wp-config.php".
+If this is a WordPress site, open the file `wp-config.php`.
 
 ```php
 define('DB_NAME', 'my_database');
- 
+
 /** MySQL database username */
 define('DB_USER', 'my_user');
- 
+
 /** MySQL database password */
 define('DB_PASSWORD', 'my_password');
- 
+
 /** MySQL hostname */
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-In your [OVHcloud Control Panel](/links/manager), open the `Hosting plans`{.action} section and click on the `Databases`{.action} tab. Check the correspondence between the elements displayed and those in the file `wp-config.php`:
+Click on the tabs below to view each of the **2** steps in succession.
 
-- **my_database** must match what is noted as `Database name`;
-- **my_user** must match what is noted as `User name`;
-- **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** must match the `Server address`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then check the correspondence between the elements displayed and those in the file `wp-config.php`:
+>>
+>> - **my_database** must match what is noted as `Database name`;
+>> - **my_user** must match what is noted as `User name`;
+>> - **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** must match the `Server address`.
 
 > [!primary]
 >
@@ -120,15 +184,30 @@ If you have a **Starter** or **Personal** Web Hosting plan, we recommend that yo
 > If you notice a sudden increase in the size of your database, or if you have a "blog" type site that normally does not use much data, we advise you to contact a [specialised service provider](/links/partner) as soon as possible. We will not be able to provide you with support on this matter.
 >
 
-To upgrade your subscription, log in to your [OVHcloud Control Panel](/links/manager) and open `Hosting plans`{.action} in the left-hand menu. Select the relevant service and click on the `...`{.action} button in the `Solution` section of the right-hand info box, then select `Upgrade`{.action}.
+To upgrade your subscription, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `...`{.action} button in the `Solution` section on the right-hand side of the screen.
+>>
+> **Step 3**
+>>
+>> Click `Change plan`{.action}.
 
 If you are already subscribing to a **Performance** offer, refer to [method 2](#method2).
 
-#### Method 2: Migrate your data to a larger database <a name=""method2"></a>
+#### Method 2: Migrate your data to a larger database <a name="method2"></a>
 
 You can also migrate your data to a new database:
 
-- Order a larger [database service](/links/web/databases) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
+- Order a larger [database service](/links/web/hosting-options-startsql) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
 - [Duplicate the content of the old database](/pages/web_cloud/web_hosting/copy_database) to the new database **or** perform an [export of your data](/pages/web_cloud/web_hosting/sql_database_export), then [import your data](/pages/web_cloud/web_hosting/sql_importing_mysql_database) in the new database;
 - Integrate the credentials of the new database into the [configuration file](#config_file) of your site.
 
@@ -141,7 +220,22 @@ You can also migrate your data to a new database:
 
 Once you have made a [database backup](/pages/web_cloud/web_hosting/sql_database_export), log in to your [phpMyAdmin interface](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) to delete any unnecessary data using the Drop, Delete and Truncate commands.
 
-Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -150,7 +244,24 @@ Then update the data usage from the `Databases`{.action} tab of the relevant ser
 
 #### Method 4: Optimise your database
 
-To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)". Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
+
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -159,20 +270,33 @@ To optimise your database, follow the instructions in our guide "[Configuring yo
 
 ### RAM overflows (Web Cloud Databases only)
 
-The following message in the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager) indicates that your [Web Cloud Databases](/links/web/databases) server has consumed too much resources on the OVHcloud infrastructure:
+The following message indicates that your [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server has consumed too much resources on the OVHcloud infrastructure:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-In this situation, you can increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution) available from the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager). In the `General information`{.action} tab, click on the `...`{.action} in the `RAM` section.
+To increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution), click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 > [!warning]
 >
 > To increase the amount of RAM, the database needs to be a standalone service and not one of those included with a Performance web hosting plan. If you want to increase the amount of RAM of a database included in the [Performance offers](/links/web/hosting-performance-offer), you first need to detach it.
-> 
-> To detach the database, log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action}. Click `Hosting plans`{.action}, then choose the web hosting plan that has the database activated.
 >
-> In the `Configuration` box, click the `...`{.action} button to the right of `Web Cloud Databases`, then click the `Detach`{.action} button.
-> 
+> To detach the database, refer to our guide "[Detaching a Web Cloud Databases from your web hosting plan](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
+>
 
 You can also optimise your database by following the instructions of our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
 
@@ -183,7 +307,7 @@ You can also optimise your database by following the instructions of our guide "
 
 ### Database import errors
 
-#### User access denied to database
+#### "Access denied for user to database"
 
 >
 > **"#1044 - Access denied for user to database"**
@@ -191,23 +315,39 @@ You can also optimise your database by following the instructions of our guide "
 
 This error message means that the database you are trying to import contains elements that are not authorised on the OVHcloud shared infrastructure.
 
-First make sure that your database is empty from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}. (If you need to save the existing data first, follow the [backup instructions](/pages/web_cloud/web_hosting/sql_database_export), then delete the data and relaunch the import operation.)
+First make sure that your database is empty. To do this, click on the tabs below to view each of the **3** steps in succession.
 
-You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>>
+> **Step 3**
+>>
+>> If the database is not empty, [back up the existing data](/pages/web_cloud/web_hosting/sql_database_export) then delete it before relaunching the import operation.
+>>
+>> You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+If necessary, contact our [user community](/links/community) or a [specialised service provider](/links/partner) for more information. We will not be able to assist you in correcting this issue.
 
-If necessary, contact our [user community](/links/community) or [OVHcloud partners](/links/partner) for more information. We will not be able to assist you in correcting this issue.
-
-> [!success]
+> [!primary]
 >
-> You cannot have a "**trigger**" in your database’s import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
->
+> **Which elements in my database import script can cause a "#1044 - Access denied for user to database" error?**
+
+You cannot have a **"trigger"** in your database's import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 
 The following query is also not allowed:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
 Use this line instead:
@@ -221,14 +361,29 @@ Replace `Database-Name` with the name of the database as displayed in your [OVHc
 #### "MySQL server has gone away"
 
 >
-> **"404 ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
-This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). I most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
+This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). In most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
 
-To resolve this issue, you can use the following methods:
+To resolve this issue, you can:
 
-- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution): go to the [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server concerned in the `Databases` section of your [OVHcloud Control Panel](/links/manager). Then click on the `...`{.action} button in the `RAM` section and select `Change the amount of RAM`{.action}.
+- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution). To do this, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 - Split your database in order to import it through multiple operations instead of one. (For any questions on the necessary steps, contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you with this.)
 
@@ -254,11 +409,11 @@ In this situation, [check the credentials entered](/pages/web_cloud/web_cloud_da
 > **"mysqli_real_connect(): (HY000/1040): Too many connections"**
 >
 
-The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/databases)) is **30**.
+The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/hosting-options-startsql)) is **30**.
 
 This number increases to **200** for the [Web Cloud Databases service](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (This setting can be modified in the `Configuration`{.action} section of your database service.)
 
-A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears, if this maximum number of connections is exceeded.
+A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears if this maximum number of connections is exceeded.
 
 In this situation, you will need to [optimise your databases](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases) in order to reduce the number of active connections.
 
@@ -267,7 +422,7 @@ In this situation, you will need to [optimise your databases](/pages/web_cloud/w
 > If you have any questions about the changes you need to make in order to reduce the number of active connections to your database, please contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you in this regard.
 >
 
-### "Name or service not known"
+#### "Name or service not known"
 
 >
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
@@ -277,28 +432,55 @@ This error message appears when [connecting to phpMyAdmin](/pages/web_cloud/web_
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Check the server name for the relevant database service in your [OVHcloud Control Panel](/links/manager).
+Check the server name for the relevant database service.
 
-> [!success]
->
-> If the database you would like to connect to appears in the `Databases`{.action} tab of the `Hosting plans`{.action} section of your [OVHcloud Control Panel](/links/manager), the name to enter is in the `Server address` column.
->
-> If you want to connect to a database on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), the server name can be retrieved from the tab `General information`{.action}, in the box `Login information`{.action} under `SQL`{.action} and labelled as `Host name`{.action}.
->
+**Click on the relevant situation to view the content.**
+
+/// details | Database on a web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab. The server name to enter is listed in the `Server address` column.
+
+///
+
+/// details | Database on a Web Cloud Databases server
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, the server name to enter is listed in the `Login information` section, under `SQL`, labelled as `Host name`.
+
+///
 
 ### Unable to connect to a Cloud Databases database
 
 Having a [Web Cloud Databases](/products/web-cloud-clouddb) server allows you to [connect to your databases](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) from your computer or a server outside of the OVHcloud infrastructure.
 
-If this connection is not possible, first check that you have [authorized your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) connected to the database server.
+If this connection is not possible, first check that you have [authorised your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) to connect to the database server.
 
 If this operation has been carried out, contact your ISP or the [OVHcloud partners](/links/partner). We will not be able to assist you in this situation.
 
 ## Go further <a name="go-further"></a>
 
 [Getting started with Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb)
-
-[Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-sg.md
@@ -326,7 +326,7 @@ First make sure that your database is empty. To do this, click on the tabs below
 >>
 > **Step 2**
 >>
->> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>> Click the `Databases`{.action} tab, then the `...`{.action} button next to the database, then `Recalculate the quota`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-us.md
@@ -1,8 +1,22 @@
 ---
 title: "Troubleshooting common database errors"
 excerpt: "Find out how to diagnose the most common cases of database errors"
-updated: 2026-02-11
+updated: 2026-03-31
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -13,13 +27,13 @@ Your database usage may result in anomalies on your website or error messages in
 > [!warning]
 > OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
->This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. However, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- an [OVHcloud Web Hosting plan](/links/web/hosting)
-- an OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases)
+- An [OVHcloud Web Hosting plan](/links/web/hosting).
+- An OVHcloud database service: [Start SQL](/links/web/hosting-options-startsql) or [Web Cloud Databases](/links/web/databases).
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -40,20 +54,59 @@ Your database usage may result in anomalies on your website or error messages in
 
 #### Check ongoing incidents
 
-First, check on the [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) page whether your datacentre, your web hosting cluster, your Web Cloud Databases server, or your database is not affected by an incident on the OVHcloud infrastructure.
+First, check on the [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) page whether your datacenter, your web hosting cluster, your Web Cloud Databases server, or your database is not affected by an incident on the OVHcloud infrastructure.
 
-> [!primary]
->
-> You can find these details in your [OVHcloud Control Panel](/links/manager), in the `Web Cloud`{.action} section:
->
-> - To find your Web Hosting plan's data centre, select `Hosting plans`{.action}, then the relevant web hosting. You will find this information in the `General Information`{.action} tab.
-> - To find the **cluster** of servers and **filer** (file server) of your web hosting, refer to [this guide](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - To retrieve the name of your **Web Cloud Databases** server, click on `Web Cloud Databases`{.action} in the left-hand menu, then on the relevant service. You can find the information concerned under the heading `Host name` in the `SQL` part of the `General information`{.action} tab.
-> - To find the server on which your included or additional database ordered via your [web hosting](/links/web/hosting) is located, refer to [this guide](/pages/web_cloud/web_hosting/sql_find_server).
+**Click on the information you are looking for to view the content.**
+
+/// details | Find the datacenter of your web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `Datacentre`.
+
+///
+
+/// details | Find the cluster and filer of your web hosting plan
+
+Refer to our guide "[Finding out the cluster and filer of your web hosting plan](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Find the Web Cloud Databases server name
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate `Host name` in the `SQL` section of `Login information`.
+
+///
+
+/// details | Find your web hosting database server
+
+Refer to our guide "[Finding your database server](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Verify login credentials for your database <a name="config_file"></a>
 
-Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website’s configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
+Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cloud/web_hosting/ftp_connection) and find your website's configuration file (for example, a WordPress website will have a **wp-config.php** file located in the folder containing your website).
 
 > [!warning]
 >
@@ -62,35 +115,46 @@ Log in to the file storage space of your Web Hosting plan by [FTP](/pages/web_cl
 > We recommend that you contact the publisher of the [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) concerned or a [specialised service provider](/links/partner) if necessary. We will not be able to assist you with this.
 >
 
-Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website’s configuration file.
+Then check the **exact** match between the login details for [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) and the login details for your website's configuration file.
 
 If necessary, change your [database password](/pages/web_cloud/web_hosting/sql_change_password).
 
 #### Example for WordPress
 
-If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the "www" folder).
+If your website displays an **"Error establishing a database connection"** message and your hosting cluster is not affected by an [incident](https://web-cloud.status-ovhcloud.com/), log in to the [FTP storage space](/pages/web_cloud/web_hosting/ftp_connection) of your hosting and open the directory containing your website (by default, this is the `www` folder).
 
-If this is a WordPress site, open the file "wp-config.php".
+If this is a WordPress site, open the file `wp-config.php`.
 
 ```php
 define('DB_NAME', 'my_database');
- 
+
 /** MySQL database username */
 define('DB_USER', 'my_user');
- 
+
 /** MySQL database password */
 define('DB_PASSWORD', 'my_password');
- 
+
 /** MySQL hostname */
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-In your [OVHcloud Control Panel](/links/manager), open the `Hosting plans`{.action} section and click on the `Databases`{.action} tab. Check the correspondence between the elements displayed and those in the file `wp-config.php`:
+Click on the tabs below to view each of the **2** steps in succession.
 
-- **my_database** must match what is noted as `Database name`;
-- **my_user** must match what is noted as `User name`;
-- **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** must match the `Server address`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then check the correspondence between the elements displayed and those in the file `wp-config.php`:
+>>
+>> - **my_database** must match what is noted as `Database name`;
+>> - **my_user** must match what is noted as `User name`;
+>> - **my_password** corresponds to your [database password](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** must match the `Server address`.
 
 > [!primary]
 >
@@ -120,15 +184,30 @@ If you have a **Starter** or **Personal** Web Hosting plan, we recommend that yo
 > If you notice a sudden increase in the size of your database, or if you have a "blog" type site that normally does not use much data, we advise you to contact a [specialised service provider](/links/partner) as soon as possible. We will not be able to provide you with support on this matter.
 >
 
-To upgrade your subscription, log in to your [OVHcloud Control Panel](/links/manager) and open `Hosting plans`{.action} in the left-hand menu. Select the relevant service and click on the `...`{.action} button in the `Solution` section of the right-hand info box, then select `Upgrade`{.action}.
+To upgrade your subscription, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `...`{.action} button in the `Solution` section on the right-hand side of the screen.
+>>
+> **Step 3**
+>>
+>> Click `Change plan`{.action}.
 
 If you are already subscribing to a **Performance** offer, refer to [method 2](#method2).
 
-#### Method 2: Migrate your data to a larger database <a name=""method2"></a>
+#### Method 2: Migrate your data to a larger database <a name="method2"></a>
 
 You can also migrate your data to a new database:
 
-- Order a larger [database service](/links/web/databases) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
+- Order a larger [database service](/links/web/hosting-options-startsql) if necessary, then [create the new database](/pages/web_cloud/web_hosting/sql_create_database);
 - [Duplicate the content of the old database](/pages/web_cloud/web_hosting/copy_database) to the new database **or** perform an [export of your data](/pages/web_cloud/web_hosting/sql_database_export), then [import your data](/pages/web_cloud/web_hosting/sql_importing_mysql_database) in the new database;
 - Integrate the credentials of the new database into the [configuration file](#config_file) of your site.
 
@@ -141,7 +220,22 @@ You can also migrate your data to a new database:
 
 Once you have made a [database backup](/pages/web_cloud/web_hosting/sql_database_export), log in to your [phpMyAdmin interface](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) to delete any unnecessary data using the Drop, Delete and Truncate commands.
 
-Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -150,7 +244,24 @@ Then update the data usage from the `Databases`{.action} tab of the relevant ser
 
 #### Method 4: Optimise your database
 
-To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)". Then update the data usage from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}.
+To optimise your database, follow the instructions in our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
+
+To recalculate the quota, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned.
+>>
+> **Step 3**
+>>
+>> Click `Recalculate the quota`{.action}.
 
 > [!warning]
 >
@@ -159,20 +270,33 @@ To optimise your database, follow the instructions in our guide "[Configuring yo
 
 ### RAM overflows (Web Cloud Databases only)
 
-The following message in the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager) indicates that your [Web Cloud Databases](/links/web/databases) server has consumed too much resources on the OVHcloud infrastructure:
+The following message indicates that your [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server has consumed too much resources on the OVHcloud infrastructure:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-In this situation, you can increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution) available from the `Web Cloud Databases`{.action} section of your [OVHcloud Control Panel](/links/manager). In the `General information`{.action} tab, click on the `...`{.action} in the `RAM` section.
+To increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution), click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 > [!warning]
 >
 > To increase the amount of RAM, the database needs to be a standalone service and not one of those included with a Performance web hosting plan. If you want to increase the amount of RAM of a database included in the [Performance offers](/links/web/hosting-performance-offer), you first need to detach it.
-> 
-> To detach the database, log in to your [OVHcloud Control Panel](/links/manager) and select `Web Cloud`{.action}. Click `Hosting plans`{.action}, then choose the web hosting plan that has the database activated.
 >
-> In the `Configuration` box, click the `...`{.action} button to the right of `Web Cloud Databases`, then click the `Detach`{.action} button.
-> 
+> To detach the database, refer to our guide "[Detaching a Web Cloud Databases from your web hosting plan](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
+>
 
 You can also optimise your database by following the instructions of our guide "[Configuring your database server](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases)".
 
@@ -183,7 +307,7 @@ You can also optimise your database by following the instructions of our guide "
 
 ### Database import errors
 
-#### User access denied to database
+#### "Access denied for user to database"
 
 >
 > **"#1044 - Access denied for user to database"**
@@ -191,23 +315,39 @@ You can also optimise your database by following the instructions of our guide "
 
 This error message means that the database you are trying to import contains elements that are not authorised on the OVHcloud shared infrastructure.
 
-First make sure that your database is empty from the `Databases`{.action} tab of the relevant service. Click on the `...`{.action} button next to the database concerned, then select `Recalculate the quota`{.action}. (If you need to save the existing data first, follow the [backup instructions](/pages/web_cloud/web_hosting/sql_database_export), then delete the data and relaunch the import operation.)
+First make sure that your database is empty. To do this, click on the tabs below to view each of the **3** steps in succession.
 
-You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>>
+> **Step 3**
+>>
+>> If the database is not empty, [back up the existing data](/pages/web_cloud/web_hosting/sql_database_export) then delete it before relaunching the import operation.
+>>
+>> You can also tick the `Empty the current database`{.action} box just before [launching the import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-your-own-backup-via-your-control-panel):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+If necessary, contact our [user community](/links/community) or a [specialised service provider](/links/partner) for more information. We will not be able to assist you in correcting this issue.
 
-If necessary, contact our [user community](/links/community) or [OVHcloud partners](/links/partner) for more information. We will not be able to assist you in correcting this issue.
-
-> [!success]
+> [!primary]
 >
-> You cannot have a "**trigger**" in your database’s import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
->
+> **Which elements in my database import script can cause a "#1044 - Access denied for user to database" error?**
+
+You cannot have a **"trigger"** in your database's import script on OVHcloud shared hosting servers. In this situation, import your database to a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 
 The following query is also not allowed:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
 Use this line instead:
@@ -221,14 +361,29 @@ Replace `Database-Name` with the name of the database as displayed in your [OVHc
 #### "MySQL server has gone away"
 
 >
-> **"404 ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
-This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). I most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
+This error message appears when [importing a database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importing-a-local-backup) on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). In most cases, it is caused by the quantity of data to be imported being too large or by non-optimised SQL queries in the import script.
 
-To resolve this issue, you can use the following methods:
+To resolve this issue, you can:
 
-- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution): go to the [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) server concerned in the `Databases` section of your [OVHcloud Control Panel](/links/manager). Then click on the `...`{.action} button in the `RAM` section and select `Change the amount of RAM`{.action}.
+- Increase the [amount of RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifying-the-database-server-solution). To do this, click on the tabs below to view each of the **3** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, locate the `RAM` section.
+>>
+> **Step 3**
+>>
+>> Click on the `...`{.action} button in the `RAM` section, then click `Change the amount of RAM`{.action}.
 
 - Split your database in order to import it through multiple operations instead of one. (For any questions on the necessary steps, contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you with this.)
 
@@ -254,11 +409,11 @@ In this situation, [check the credentials entered](/pages/web_cloud/web_cloud_da
 > **"mysqli_real_connect(): (HY000/1040): Too many connections"**
 >
 
-The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/databases)) is **30**.
+The maximum number of active connections for databases delivered with a shared hosting ([Start SQL](/links/web/hosting-options-startsql)) is **30**.
 
 This number increases to **200** for the [Web Cloud Databases service](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (This setting can be modified in the `Configuration`{.action} section of your database service.)
 
-A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears, if this maximum number of connections is exceeded.
+A "Too many connections" error when [connecting to phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accessing-the-phpmyadmin-interface) appears if this maximum number of connections is exceeded.
 
 In this situation, you will need to [optimise your databases](/pages/web_cloud/web_cloud_databases/configure-database-server#managing-your-databases) in order to reduce the number of active connections.
 
@@ -267,7 +422,7 @@ In this situation, you will need to [optimise your databases](/pages/web_cloud/w
 > If you have any questions about the changes you need to make in order to reduce the number of active connections to your database, please contact our [community](/links/community) or [OVHcloud partners](/links/partner). We will not be able to assist you in this regard.
 >
 
-### "Name or service not known"
+#### "Name or service not known"
 
 >
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
@@ -277,28 +432,55 @@ This error message appears when [connecting to phpMyAdmin](/pages/web_cloud/web_
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Check the server name for the relevant database service in your [OVHcloud Control Panel](/links/manager).
+Check the server name for the relevant database service.
 
-> [!success]
->
-> If the database you would like to connect to appears in the `Databases`{.action} tab of the `Hosting plans`{.action} section of your [OVHcloud Control Panel](/links/manager), the name to enter is in the `Server address` column.
->
-> If you want to connect to a database on a [Web Cloud Databases server](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), the server name can be retrieved from the tab `General information`{.action}, in the box `Login information`{.action} under `SQL`{.action} and labelled as `Host name`{.action}.
->
+**Click on the relevant situation to view the content.**
+
+/// details | Database on a web hosting plan
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the relevant web hosting plan.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Databases`{.action} tab. The server name to enter is listed in the `Server address` column.
+
+///
+
+/// details | Database on a Web Cloud Databases server
+
+Click on the tabs below to view each of the **2** steps in succession.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Web Cloud Databases](/links/control-panel/web-cloud-databases) page, then select the relevant service.
+>>
+>> ![Selecting a Web Cloud Databases server in the OVHcloud Control Panel](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, the server name to enter is listed in the `Login information` section, under `SQL`, labelled as `Host name`.
+
+///
 
 ### Unable to connect to a Cloud Databases database
 
 Having a [Web Cloud Databases](/products/web-cloud-clouddb) server allows you to [connect to your databases](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) from your computer or a server outside of the OVHcloud infrastructure.
 
-If this connection is not possible, first check that you have [authorized your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) connected to the database server.
+If this connection is not possible, first check that you have [authorised your public IP address](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) to connect to the database server.
 
 If this operation has been carried out, contact your ISP or the [OVHcloud partners](/links/partner). We will not be able to assist you in this situation.
 
 ## Go further <a name="go-further"></a>
 
 [Getting started with Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb)
-
-[Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.en-us.md
@@ -326,7 +326,7 @@ First make sure that your database is empty. To do this, click on the tabs below
 >>
 > **Step 2**
 >>
->> Click on the `Databases`{.action} tab, then on the `...`{.action} button next to the database concerned and on `Recalculate the quota`{.action}.
+>> Click the `Databases`{.action} tab, then the `...`{.action} button next to the database, then `Recalculate the quota`{.action}.
 >>
 > **Step 3**
 >>

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.es-es.md
@@ -1,8 +1,22 @@
 ---
 title: "Resolver los errores más frecuentes asociados a las bases de datos"
 excerpt: "Diagnóstico de los errores más comunes relacionados con las bases de datos"
-updated: 2026-02-11
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo
 
@@ -14,7 +28,7 @@ El uso de sus bases de datos puede dar lugar a una serie de anomalías en su sit
 >
 > La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
 >
-> Le ofrecemos esta guía para ayudarle a completar mejor las tareas más comunes. Sin embargo, le recomendamos que, si necesita ayuda, contacte con un proveedor de servicios especializado o con el editor del programa o la interfaz. Nosotros no podremos asistirle. Más información en la sección [Más información](#go-further) de esta guía.
+> Le ofrecemos esta guía para ayudarle a completar mejor las tareas más comunes. Sin embargo, le recomendamos que, si necesita ayuda, contacte con un [proveedor de servicios especializado](/links/partner) o con el editor del programa o la interfaz. Nosotros no podremos asistirle. Más información en la sección [Más información](#go-further) de esta guía.
 >
 
 ## Requisitos
@@ -27,7 +41,7 @@ El uso de sus bases de datos puede dar lugar a una serie de anomalías en su sit
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -43,14 +57,53 @@ El uso de sus bases de datos puede dar lugar a una serie de anomalías en su sit
 
 Compruebe en primer lugar en la página [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) que su centro de datos, su clúster de alojamiento web, su servidor Web Cloud Databases o su base de datos no estén afectados por un incidente en la infraestructura de OVHcloud.
 
-> [!primary]
->
-> Para encontrar esta información, conéctese a su [área de cliente de OVHcloud](/links/manager), en la sección `Web Cloud`{.action} :
->
-> - Para encontrar el `Datacenter` de su alojamiento web, seleccione `Alojamientos`{.action} y, a continuación, el alojamiento web correspondiente. Encontrará esta información en la pestaña `Información general`{.action}.
-> - Para encontrar el **clúster** de servidores y el **filer** (servidor de archivos) de su alojamiento web, consulte [este guía](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - Para encontrar el nombre de su servidor **Web Cloud Databases**, haga clic en `Web Cloud Databases`{.action} y seleccione el servicio correspondiente. Puede consultar esta información en la pestaña `Información general`{.action}.
-> - Para encontrar el servidor en el que se encuentra su base de datos incluida o adquirida como complemento a través de su [alojamiento web](/links/web/hosting), consulte [este guía](/pages/web_cloud/web_hosting/sql_find_server).
+**Haga clic en la información que busca para ver el contenido.**
+
+/// details | Encontrar el datacenter de su alojamiento web
+
+Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> En la pestaña `Información general`{.action}, localice el `Datacenter`.
+
+///
+
+/// details | Encontrar el clúster y el filer de su alojamiento web
+
+Consulte nuestra guía "[Conocer el clúster y el filer de su alojamiento web](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Encontrar el nombre del servidor Web Cloud Databases
+
+Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
+>>
+>> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Localice `Nombre del host` en el apartado `SQL` de la sección `Información de conexión`.
+
+///
+
+/// details | Encontrar el servidor de su base de datos de alojamiento web
+
+Consulte nuestra guía "[Encontrar el servidor de su base de datos](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Comprobar las claves de conexión a su base de datos <a name="config_file"></a>
 
@@ -69,33 +122,44 @@ Cambie, si es necesario, la [contraseña de su base de datos](/pages/web_cloud/w
 
 #### Ejemplo para WordPress
 
-Si su sitio web muestra un mensaje **"Error al conectarse a la base de datos"** y no se ve afectado por un [incidente](https://web-cloud.status-ovhcloud.com/), conéctese a [FTP](/pages/web_cloud/web_hosting/ftp_connection) a su alojamiento y abra el directorio que contiene su sitio web (por defecto es el directorio "www").
+Si su sitio web muestra un mensaje **"Error al conectarse a la base de datos"** y no se ve afectado por un [incidente](https://web-cloud.status-ovhcloud.com/), conéctese a [FTP](/pages/web_cloud/web_hosting/ftp_connection) a su alojamiento y abra el directorio que contiene su sitio web (por defecto es el directorio `www`).
 
-Si se trata de un sitio web WordPress, abra el archivo **wp-config.php**.
+Si se trata de un sitio web WordPress, abra el archivo `wp-config.php`.
 
 ```php
 define('DB_NAME', 'my_database');
- 
+
 /** MySQL database username */
 define('DB_USER', 'my_user');
- 
+
 /** MySQL database password */
 define('DB_PASSWORD', 'my_password');
- 
+
 /** MySQL hostname */
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-En el área de cliente de OVHcloud](/links/manager), haga clic en la pestaña `Bases de datos`{.action} y compruebe la correspondencia entre los elementos mostrados y los presentes en el archivo **wp-config.php**.
+Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
 
-- **my_database** debe coincidir con lo que se indica en el símbolo "Nombre de la base de datos" ;
-- **my_user** debe coincidir con lo que se indica en `Nombre de usuario`;
-- **my_password** corresponde a [contraseña de la base de datos](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** debe coincidir con lo que se indica en `Dirección del servidor`.
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action} y compruebe la correspondencia entre los elementos mostrados y los presentes en el archivo `wp-config.php`:
+>>
+>> - **my_database** debe coincidir con lo que se indica en `Nombre de la base de datos`;
+>> - **my_user** debe coincidir con lo que se indica en `Nombre de usuario`;
+>> - **my_password** corresponde a la [contraseña de la base de datos](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** debe coincidir con lo que se indica en `Dirección del servidor`.
 
 > [!primary]
 >
-> Si esta operación no le permite restablecer el acceso a su sitio web, [guarde su base de datos](/pages/web_cloud/web_hosting/sql_database_export) y después [restablezca-la a una fecha anterior](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#1-restaurar-una-copia-de-seguridad-existente) desde su [área de cliente OVHcloud](/links/manager).
+> Si esta operación no le permite restablecer el acceso a su sitio web, [guarde su base de datos](/pages/web_cloud/web_hosting/sql_database_export) y después [restablézcala a una fecha anterior](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#1-restaurar-una-copia-de-seguridad-existente) desde su [área de cliente OVHcloud](/links/manager).
 >
 > Contacte a continuación con un [proveedor especializado](/links/partner) si es necesario. No podremos asistirle en este asunto.
 >
@@ -110,7 +174,7 @@ Desbloquee la base de datos de tres formas distintas:
 
 #### Método 1: cambiar la suscripción a un plan superior
 
-Si dispone de una fórmula **Starter** o **Personal**, le recomendamos que cambie a [plan de hosting superior](/links/web/hosting). Este cambio de suscripción aumentará el tamaño de la base de datos, lo que la reabrirá automáticamente. Este método es el más sencillo y no necesita conocimientos técnicos específicos.
+Si dispone de una fórmula **Starter** o **Personal**, le recomendamos que cambie a un [plan de hosting superior](/links/web/hosting). Este cambio de suscripción aumentará el tamaño de la base de datos, lo que la reabrirá automáticamente. Este método es el más sencillo y no necesita conocimientos técnicos específicos.
 
 > [!warning]
 >
@@ -121,7 +185,22 @@ Si dispone de una fórmula **Starter** o **Personal**, le recomendamos que cambi
 > Si detecta un aumento repentino en el tamaño de su base de datos o si tiene un sitio web de tipo "blog" que normalmente no consume datos, le recomendamos que contacte inmediatamente con un [proveedor especializado](/links/partner). No podremos ofrecerle soporte sobre este tema.
 >
 
-Para ello, conéctese a su [área de cliente de OVHcloud](/links/manager), haga clic en `Alojamientos`{.action} y seleccione el alojamiento correspondiente. Haga clic en el botón `...`{.action} en el epígrafe `Producto` situado a la derecha de su pantalla y, seguidamente, en `Cambiar de plan`{.action}.
+Para realizar este cambio, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en el botón `...`{.action} en el apartado `Producto` situado a la derecha de su pantalla.
+>>
+> **Paso 3**
+>>
+>> Haga clic en `Cambiar de plan`{.action}.
 
 Si utiliza un plan **Performance**, consulte el [método 2](#methode2).
 
@@ -130,7 +209,7 @@ Si utiliza un plan **Performance**, consulte el [método 2](#methode2).
 También puede migrar sus datos a una nueva base de datos:
 
 - Contrate, si es necesario, una [base de datos](/links/web/hosting-options-startsql) de mayor tamaño y lance su [creación](/pages/web_cloud/web_hosting/sql_create_database).
-- [Duplique el contenido de la antigua base de datos](/pages/web_cloud/web_hosting/copy_database) en la nueva **o** realice un [exportar sus datos](/pages/web_cloud/web_hosting/sql_database_export) y a continuación [importar los](/pages/web_cloud/web_hosting/sql_importing_mysql_database) en la nueva base de datos;
+- [Duplique el contenido de la antigua base de datos](/pages/web_cloud/web_hosting/copy_database) en la nueva **o** realice una [exportación de sus datos](/pages/web_cloud/web_hosting/sql_database_export) y a continuación [impórtelos](/pages/web_cloud/web_hosting/sql_importing_mysql_database) en la nueva base de datos.
 - Integre las claves de la nueva base de datos en el [archivo de configuración](#config_file) de su sitio web.
 
 > [!primary]
@@ -142,7 +221,22 @@ También puede migrar sus datos a una nueva base de datos:
 
 Una vez realizada la [copia de seguridad de su base de datos](/pages/web_cloud/web_hosting/sql_database_export), conéctese a su interfaz [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) para eliminar los datos innecesarios con los comandos Drop, Delete y Truncate.
 
-Abra la pestaña `Bases de datos`{.action} del alojamiento correspondiente e inicie el cálculo de la cuota utilizada. pulse el botón `...`{.action} correspondiente y luego `Recalcular el espacio utilizado`{.action}.
+Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión.
+>>
+> **Paso 3**
+>>
+>> Haga clic en `Recalcular el espacio utilizado`{.action}.
 
 > [!warning]
 >
@@ -151,28 +245,58 @@ Abra la pestaña `Bases de datos`{.action} del alojamiento correspondiente e ini
 
 #### Método 4: optimizar la base de datos
 
-Para optimizar su base de datos, siga las instrucciones de nuestra guía "[Configurar su servidor de bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos)". Abra la pestaña `Bases de datos`{.action} de su alojamiento y haga clic en el botón `...`{.action} de la base de datos en cuestión.
+Para optimizar su base de datos, siga las instrucciones de nuestra guía "[Configurar su servidor de bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos)".
+
+Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión.
+>>
+> **Paso 3**
+>>
+>> Haga clic en `Recalcular el espacio utilizado`{.action}.
 
 > [!warning]
 >
-> Si el asesoramiento ofrecido sobre la optimización de su base de datos no bastaba para desbloquear el acceso a su sitio web, le recomendamos que se ponga en contacto con nuestra [comunidad de usuarios](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.
+> Si el asesoramiento ofrecido sobre la optimización de su base de datos no basta para desbloquear el acceso a su sitio web, le recomendamos que se ponga en contacto con nuestra [comunidad de usuarios](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.
 >
 
 ### Memoria RAM rebasada (solo Web Cloud Databases)
 
-El siguiente mensaje, situado en la sección `Web Cloud Databases`{.action} de su [área de cliente de OVHcloud](/links/manager), indica que su servidor [Web Cloud Databases](/links/web/databases) ha consumido una cantidad de recursos demasiado grande en la infraestructura de OVHcloud:
+El siguiente mensaje indica que su servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) ha consumido una cantidad de recursos demasiado grande en la infraestructura de OVHcloud:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-En ese caso, puede aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#cambiar-la-oferta-del-servidor-de-bases-de-datos) disponible desde la sección `Web Cloud Databases`{.action} de su [área de cliente OVHcloud](/links/manager). En la pestaña `Información general`{.action}, haga clic en el botón `...`{.action} en la sección `RAM`.
+Para aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#cambiar-la-oferta-del-servidor-de-bases-de-datos), haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
+>>
+>> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> En la pestaña `Información general`{.action}, localice el apartado `RAM`.
+>>
+> **Paso 3**
+>>
+>> Haga clic en el botón `...`{.action} en el apartado `RAM` y, a continuación, en `Cambiar la cantidad de RAM`{.action}.
 
 > [!warning]
 >
 > Para aumentar la RAM, el Web Cloud Databases no debe activarse a través de un hosting Performance. Si quiere aumentar la cantidad de memoria RAM de una base de datos incluida en los [planes Performance](/links/web/hosting-performance-offer), deberá desvincularla primero.
-> 
-> Para desvincular la base de datos, conéctese a su [área de cliente de OVHcloud](/links/manager) y seleccione `Web Cloud`{.action}. Haga clic en `Alojamientos`{.action} y seleccione el alojamiento web en el que esté activado el Web Cloud Databases.
 >
-> En el área de `Configuración`, haga clic en los `...`{.action} a la derecha de la mención `Web Cloud Databases` y haga clic en el botón `Desvincular`{.action}.
+> Para desvincular la base de datos, consulte nuestra guía "[Desvincular un Web Cloud Databases de su alojamiento web](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
 >
 
 También puede optimizar su base de datos siguiendo las instrucciones de nuestra guía "[Configurar su servidor de bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos)".
@@ -192,15 +316,28 @@ También puede optimizar su base de datos siguiendo las instrucciones de nuestra
 
 Este mensaje de error significa que la base de datos que está intentando importar contiene elementos no autorizados en la infraestructura compartida de OVHcloud.
 
-En primer lugar, asegúrese de que la base de datos esté vacía en la pestaña `Bases de datos`{.action} del alojamiento correspondiente (haga clic en el botón `...`{.action}) correspondiente y seleccione `Recalcular el espacio utilizado`{.action}.
+En primer lugar, asegúrese de que la base de datos esté vacía. Para ello, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
 
-En caso contrario, [guarde los datos presentes](/pages/web_cloud/web_hosting/sql_database_export) en la base de datos y después borre la base de datos antes de reanudar la operación de importación.
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión y en `Recalcular el espacio utilizado`{.action}.
+>>
+> **Paso 3**
+>>
+>> Si la base de datos no está vacía, [guarde los datos presentes](/pages/web_cloud/web_hosting/sql_database_export) y después elimínelos antes de reanudar la operación de importación.
+>>
+>> También puede marcar la casilla `Vaciar la base de datos actual`{.action} justo antes de [iniciar la importación](/pages/web_cloud/web_hosting/sql_importing_mysql_database#importar-una-copia-de-seguridad-desde-el-area-de-cliente):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-También puede marcar la casilla `Vaciar la base de datos actual`{.action} justo antes de [iniciar la importación](/pages/web_cloud/web_hosting/sql_importing_mysql_database#importar-una-copia-de-seguridad-desde-el-area-de-cliente):
-
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
-
-Este mensaje de error significa que la base de datos que está intentando importar contiene elementos no autorizados en la infraestructura compartida de OVHcloud. Si lo necesita, puede ponerse en contacto con nuestra [comunidad de usuarios](/links/community) o con un [proveedor especializado](/links/partner). No podremos asistirle en la corrección de esta anomalía.
+Si lo necesita, puede ponerse en contacto con nuestra [comunidad de usuarios](/links/community) o con un [proveedor especializado](/links/partner). No podremos asistirle en la corrección de esta anomalía.
 
 > [!primary]
 >
@@ -211,7 +348,7 @@ Tener un **"trigger"** en el script de importación de su base de datos no está
 Por otro lado, no está permitida la siguiente petición:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
 Sustituya por:
@@ -232,11 +369,26 @@ Este mensaje de error aparece durante [la importación de una base de datos](/pa
 
 Para resolver esta anomalía, puede:
 
-- Aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#seguimiento-de-la-ram-consumida). Para ello, acceda al servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) correspondiente en la sección `Bases de datos`{.action} de su [área de cliente OVHcloud](/links/manager). Haga clic en el botón `...`{.action} en la sección `RAM` y, seguidamente, en `Cambiar la cantidad de RAM`{.action}.
+- Aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#seguimiento-de-la-ram-consumida). Para ello, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
 
-- Fraccione su base de datos para importarla en varias operaciones en lugar de una (para cualquier duda sobre las operaciones a realizar, contacte con nuestra [comunidad](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
+>>
+>> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> En la pestaña `Información general`{.action}, localice el apartado `RAM`.
+>>
+> **Paso 3**
+>>
+>> Haga clic en el botón `...`{.action} en el apartado `RAM` y, a continuación, en `Cambiar la cantidad de RAM`{.action}.
 
-- [Optimice su base de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos) y luego repite las operaciones de exportación/importación.
+- Fraccione su base de datos para importarla en varias operaciones en lugar de una (para cualquier duda sobre las operaciones a realizar, contacte con nuestra [comunidad](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.)
+
+- [Optimice su base de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos) y luego repita las operaciones de exportación/importación.
 
 ### No se ha podido acceder a PhpMyAdmin
 
@@ -262,7 +414,7 @@ El número máximo de conexiones activas para las bases de datos entregadas con 
 
 Este número es de **200** para las bases de servidores [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (Puede cambiar este parámetro en la sección `Configuración`{.action} del servidor de la base de datos).
 
-Este mensaje aparece durante [conexión a PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) cuando se supera el número máximo de conexiones.
+Este mensaje aparece durante la [conexión a PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) cuando se supera el número máximo de conexiones.
 
 En ese caso, deberá [optimizar las bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos) para reducir el número de conexiones activas.
 
@@ -277,18 +429,47 @@ En ese caso, deberá [optimizar las bases de datos](/pages/web_cloud/web_cloud_d
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
 >
 
-Este mensaje de error aparece durante [conexión a PhpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#procedimiento) cuando el nombre del servidor introducido es incorrecto.
+Este mensaje de error aparece durante la [conexión a PhpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#procedimiento) cuando el nombre del servidor introducido es incorrecto.
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Compruebe el nombre del servidor que quiera registrar en su [área de cliente de OVHcloud](/links/manager).
+Compruebe el nombre del servidor correspondiente.
 
-> [!success]
->
-> Si la base de datos a la que desea conectarse aparece en la pestaña `Bases de datos`{.action} de la parte `Alojamientos`{.action} de su [área de cliente de OVHcloud](/links/manager), el nombre que debe introducir se indica en la columna `Dirección del servidor`.
->
-> Si desea conectarse a una base de datos en un servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), el nombre del servidor a introducir se inscribe en la pestaña `Información general`{.action}, parte `Datos de conexión`{.action}, `SQL`{.action} y en el `Nombre del host`{.action}.
->
+**Haga clic en la situación correspondiente para ver el contenido.**
+
+/// details | Base de datos en un alojamiento web
+
+Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action}. El nombre del servidor a introducir aparece en la columna `Dirección del servidor`.
+
+///
+
+/// details | Base de datos en un servidor Web Cloud Databases
+
+Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
+>>
+>> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> En la pestaña `Información general`{.action}, el nombre del servidor a introducir se encuentra en la sección `Información de conexión`, apartado `SQL`, mención `Nombre del host`.
+
+///
 
 ### No es posible conectarse a una base de datos Cloud Databases
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Resolver los errores más frecuentes asociados a las bases de datos"
 excerpt: "Diagnóstico de los errores más comunes relacionados con las bases de datos"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objetivo
 
-El uso de sus bases de datos puede dar lugar a una serie de anomalías en su sitio web o su [área de cliente OVHcloud](/links/manager), así como en la interfaz [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database).
+El uso de sus bases de datos puede dar lugar a una serie de anomalías en su sitio web o su [área de cliente OVHcloud](/links/manager), así como en la interfaz [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database).
 
 **Descubra cómo solucionar los errores relacionados con las bases de datos de los alojamientos compartidos de OVHcloud.**
 
@@ -95,7 +95,7 @@ Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
 >>
 > **Paso 2**
 >>
->> Localice `Nombre del host` en el apartado `SQL` de la sección `Información de conexión`.
+>> Localice `Nombre del host` en el apartado `SQL` de la sección `Datos de conexión`.
 
 ///
 
@@ -116,7 +116,7 @@ Conéctese al espacio de almacenamiento de archivos de su alojamiento mediante [
 > Si necesita ayuda, le recomendamos que se ponga en contacto con el editor del [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) utilizado para crear su sitio web o con un [proveedor especializado](/links/partner). No podremos asistirle en este asunto.
 >
 
-Compruebe la coincidencia **exacta** entre los identificadores de conexión a [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceso-a-la-interfaz-phpmyadmin) y los del fichero de configuración de su sitio web.
+Compruebe la coincidencia **exacta** entre los identificadores de conexión a [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceso-a-la-interfaz-phpmyadmin) y los del fichero de configuración de su sitio web.
 
 Cambie, si es necesario, la [contraseña de su base de datos](/pages/web_cloud/web_hosting/sql_change_password).
 
@@ -196,7 +196,7 @@ Para realizar este cambio, haga clic en las pestañas para ver sucesivamente cad
 >>
 > **Paso 2**
 >>
->> Haga clic en el botón `...`{.action} en el apartado `Producto` situado a la derecha de su pantalla.
+>> Haga clic en el botón `...`{.action} en el apartado `Solución` situado a la derecha de su pantalla.
 >>
 > **Paso 3**
 >>
@@ -219,7 +219,7 @@ También puede migrar sus datos a una nueva base de datos:
 
 #### Método 3: eliminar datos innecesarios
 
-Una vez realizada la [copia de seguridad de su base de datos](/pages/web_cloud/web_hosting/sql_database_export), conéctese a su interfaz [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) para eliminar los datos innecesarios con los comandos Drop, Delete y Truncate.
+Una vez realizada la [copia de seguridad de su base de datos](/pages/web_cloud/web_hosting/sql_database_export), conéctese a su interfaz [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) para eliminar los datos innecesarios con los comandos Drop, Delete y Truncate.
 
 Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
 
@@ -362,7 +362,7 @@ USE `Database-Name`;
 #### "MySQL server has gone away"
 
 >
-> **"ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
 Este mensaje de error aparece durante [la importación de una base de datos](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#2-importar-una-copia-de-seguridad-local) en un servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). La mayor parte del tiempo se debe a la cantidad excesiva de datos que se van a importar o a la falta de optimización de las peticiones SQL en el script de importación.
@@ -390,7 +390,7 @@ Para resolver esta anomalía, puede:
 
 - [Optimice su base de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos) y luego repita las operaciones de exportación/importación.
 
-### No se ha podido acceder a PhpMyAdmin
+### No se ha podido acceder a phpMyAdmin
 
 #### "Access denied for user"
 
@@ -398,7 +398,7 @@ Para resolver esta anomalía, puede:
 > **"mysqli::real_connect(): (HY000/1045): Access denied for user"**
 >
 
-Este mensaje de error puede aparecer al conectarse a la base de datos por [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin). Indica que los identificadores introducidos son incorrectos.
+Este mensaje de error puede aparecer al conectarse a la base de datos por [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin). Indica que los identificadores introducidos son incorrectos.
 
 ![access_denied_for_user](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-1045.png){.thumbnail}
 
@@ -414,7 +414,7 @@ El número máximo de conexiones activas para las bases de datos entregadas con 
 
 Este número es de **200** para las bases de servidores [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (Puede cambiar este parámetro en la sección `Configuración`{.action} del servidor de la base de datos).
 
-Este mensaje aparece durante la [conexión a PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) cuando se supera el número máximo de conexiones.
+Este mensaje aparece durante la [conexión a phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) cuando se supera el número máximo de conexiones.
 
 En ese caso, deberá [optimizar las bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos) para reducir el número de conexiones activas.
 
@@ -429,7 +429,7 @@ En ese caso, deberá [optimizar las bases de datos](/pages/web_cloud/web_cloud_d
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
 >
 
-Este mensaje de error aparece durante la [conexión a PhpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#procedimiento) cuando el nombre del servidor introducido es incorrecto.
+Este mensaje de error aparece durante la [conexión a phpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#procedimiento) cuando el nombre del servidor introducido es incorrecto.
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
@@ -467,7 +467,7 @@ Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
 >>
 > **Paso 2**
 >>
->> En la pestaña `Información general`{.action}, el nombre del servidor a introducir se encuentra en la sección `Información de conexión`, apartado `SQL`, mención `Nombre del host`.
+>> En la pestaña `Información general`{.action}, el nombre del servidor a introducir se encuentra en la sección `Datos de conexión`, apartado `SQL`, mención `Nombre del host`.
 
 ///
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.es-es.md
@@ -61,16 +61,16 @@ Compruebe en primer lugar en la página [Web Cloud Status](https://web-cloud.sta
 
 /// details | Encontrar el datacenter de su alojamiento web
 
-Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+Haga clic en las pestañas para ver sucesivamente cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la pestaña `Información general`{.action}, localice el `Datacenter`.
 
@@ -84,16 +84,16 @@ Consulte nuestra guía "[Conocer el clúster y el filer de su alojamiento web](/
 
 /// details | Encontrar el nombre del servidor Web Cloud Databases
 
-Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+Haga clic en las pestañas para ver sucesivamente cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
 >>
 >> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Localice `Nombre del host` en el apartado `SQL` de la sección `Datos de conexión`.
 
@@ -139,16 +139,16 @@ define('DB_PASSWORD', 'my_password');
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+Haga clic en las pestañas para ver sucesivamente cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action} y compruebe la correspondencia entre los elementos mostrados y los presentes en el archivo `wp-config.php`:
 >>
@@ -185,20 +185,20 @@ Si dispone de una fórmula **Starter** o **Personal**, le recomendamos que cambi
 > Si detecta un aumento repentino en el tamaño de su base de datos o si tiene un sitio web de tipo "blog" que normalmente no consume datos, le recomendamos que contacte inmediatamente con un [proveedor especializado](/links/partner). No podremos ofrecerle soporte sobre este tema.
 >
 
-Para realizar este cambio, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+Para realizar este cambio, haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en el botón `...`{.action} en el apartado `Solución` situado a la derecha de su pantalla.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en `Cambiar de plan`{.action}.
 
@@ -221,20 +221,20 @@ También puede migrar sus datos a una nueva base de datos:
 
 Una vez realizada la [copia de seguridad de su base de datos](/pages/web_cloud/web_hosting/sql_database_export), conéctese a su interfaz [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) para eliminar los datos innecesarios con los comandos Drop, Delete y Truncate.
 
-Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en `Recalcular el espacio utilizado`{.action}.
 
@@ -247,20 +247,20 @@ Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesi
 
 Para optimizar su base de datos, siga las instrucciones de nuestra guía "[Configurar su servidor de bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos)".
 
-Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en `Recalcular el espacio utilizado`{.action}.
 
@@ -275,20 +275,20 @@ El siguiente mensaje indica que su servidor [Web Cloud Databases](/pages/web_clo
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-Para aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#cambiar-la-oferta-del-servidor-de-bases-de-datos), haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+Para aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#cambiar-la-oferta-del-servidor-de-bases-de-datos), haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
 >>
 >> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la pestaña `Información general`{.action}, localice el apartado `RAM`.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en el botón `...`{.action} en el apartado `RAM` y, a continuación, en `Cambiar la cantidad de RAM`{.action}.
 
@@ -316,20 +316,20 @@ También puede optimizar su base de datos siguiendo las instrucciones de nuestra
 
 Este mensaje de error significa que la base de datos que está intentando importar contiene elementos no autorizados en la infraestructura compartida de OVHcloud.
 
-En primer lugar, asegúrese de que la base de datos esté vacía. Para ello, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+En primer lugar, asegúrese de que la base de datos esté vacía. Para ello, haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión y en `Recalcular el espacio utilizado`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Si la base de datos no está vacía, [guarde los datos presentes](/pages/web_cloud/web_hosting/sql_database_export) y después elimínelos antes de reanudar la operación de importación.
 >>
@@ -369,24 +369,24 @@ Este mensaje de error aparece durante [la importación de una base de datos](/pa
 
 Para resolver esta anomalía, puede:
 
-- Aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#seguimiento-de-la-ram-consumida). Para ello, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+- Aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#seguimiento-de-la-ram-consumida). Para ello, haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
 >>
 >> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la pestaña `Información general`{.action}, localice el apartado `RAM`.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en el botón `...`{.action} en el apartado `RAM` y, a continuación, en `Cambiar la cantidad de RAM`{.action}.
 
-- Fraccione su base de datos para importarla en varias operaciones en lugar de una (para cualquier duda sobre las operaciones a realizar, contacte con nuestra [comunidad](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.)
+- Fraccione su base de datos para importarla en varias operaciones en lugar de una (para cualquier duda sobre las operaciones a realizar, contacte con nuestra [comunidad](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.
 
 - [Optimice su base de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos) y luego repita las operaciones de exportación/importación.
 
@@ -439,16 +439,16 @@ Compruebe el nombre del servidor correspondiente.
 
 /// details | Base de datos en un alojamiento web
 
-Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+Haga clic en las pestañas para ver sucesivamente cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action}. El nombre del servidor a introducir aparece en la columna `Dirección del servidor`.
 
@@ -456,16 +456,16 @@ Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
 
 /// details | Base de datos en un servidor Web Cloud Databases
 
-Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+Haga clic en las pestañas para ver sucesivamente cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
 >>
 >> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la pestaña `Información general`{.action}, el nombre del servidor a introducir se encuentra en la sección `Datos de conexión`, apartado `SQL`, mención `Nombre del host`.
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.es-us.md
@@ -1,12 +1,26 @@
 ---
 title: "Resolver los errores más frecuentes asociados a las bases de datos"
 excerpt: "Diagnóstico de los errores más comunes relacionados con las bases de datos"
-updated: 2026-02-11
+updated: 2026-03-31
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo
 
-El uso de sus bases de datos puede dar lugar a una serie de anomalías en su sitio web o su [área de cliente OVHcloud](/links/manager), así como en la interfaz [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database).
+El uso de sus bases de datos puede dar lugar a una serie de anomalías en su sitio web o su [área de cliente OVHcloud](/links/manager), así como en la interfaz [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database).
 
 **Descubra cómo solucionar los errores relacionados con las bases de datos de los alojamientos compartidos de OVHcloud.**
 
@@ -14,7 +28,7 @@ El uso de sus bases de datos puede dar lugar a una serie de anomalías en su sit
 >
 > La configuración, la gestión y la responsabilidad de los servicios que OVHcloud pone a su disposición recaen sobre usted. Por lo tanto, usted deberá asegurarse de que estos funcionan correctamente.
 >
-> Le ofrecemos esta guía para ayudarle a completar mejor las tareas más comunes. Sin embargo, le recomendamos que, si necesita ayuda, contacte con un proveedor de servicios especializado o con el editor del programa o la interfaz. Nosotros no podremos asistirle. Más información en la sección [Más información](#go-further) de esta guía.
+> Le ofrecemos esta guía para ayudarle a completar mejor las tareas más comunes. Sin embargo, le recomendamos que, si necesita ayuda, contacte con un [proveedor de servicios especializado](/links/partner) o con el editor del programa o la interfaz. Nosotros no podremos asistirle. Más información en la sección [Más información](#go-further) de esta guía.
 >
 
 ## Requisitos
@@ -27,7 +41,7 @@ El uso de sus bases de datos puede dar lugar a una serie de anomalías en su sit
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -43,14 +57,53 @@ El uso de sus bases de datos puede dar lugar a una serie de anomalías en su sit
 
 Compruebe en primer lugar en la página [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) que su centro de datos, su clúster de alojamiento web, su servidor Web Cloud Databases o su base de datos no estén afectados por un incidente en la infraestructura de OVHcloud.
 
-> [!primary]
->
-> Para encontrar esta información, conéctese a su [área de cliente de OVHcloud](/links/manager), en la sección `Web Cloud`{.action} :
->
-> - Para encontrar el `Datacenter` de su alojamiento web, seleccione `Alojamientos`{.action} y, a continuación, el alojamiento web correspondiente. Encontrará esta información en la pestaña `Información general`{.action}.
-> - Para encontrar el **clúster** de servidores y el **filer** (servidor de archivos) de su alojamiento web, consulte [este guía](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - Para encontrar el nombre de su servidor **Web Cloud Databases**, haga clic en `Web Cloud Databases`{.action} y seleccione el servicio correspondiente. Puede consultar esta información en la pestaña `Información general`{.action}.
-> - Para encontrar el servidor en el que se encuentra su base de datos incluida o adquirida como complemento a través de su [alojamiento web](/links/web/hosting), consulte [este guía](/pages/web_cloud/web_hosting/sql_find_server).
+**Haga clic en la información que busca para ver el contenido.**
+
+/// details | Encontrar el datacenter de su alojamiento web
+
+Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> En la pestaña `Información general`{.action}, localice el `Datacenter`.
+
+///
+
+/// details | Encontrar el clúster y el filer de su alojamiento web
+
+Consulte nuestra guía "[Conocer el clúster y el filer de su alojamiento web](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Encontrar el nombre del servidor Web Cloud Databases
+
+Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
+>>
+>> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Localice `Nombre del host` en el apartado `SQL` de la sección `Datos de conexión`.
+
+///
+
+/// details | Encontrar el servidor de su base de datos de alojamiento web
+
+Consulte nuestra guía "[Encontrar el servidor de su base de datos](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Comprobar las claves de conexión a su base de datos <a name="config_file"></a>
 
@@ -63,39 +116,50 @@ Conéctese al espacio de almacenamiento de archivos de su alojamiento mediante [
 > Si necesita ayuda, le recomendamos que se ponga en contacto con el editor del [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) utilizado para crear su sitio web o con un [proveedor especializado](/links/partner). No podremos asistirle en este asunto.
 >
 
-Compruebe la coincidencia **exacta** entre los identificadores de conexión a [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceso-a-la-interfaz-phpmyadmin) y los del fichero de configuración de su sitio web.
+Compruebe la coincidencia **exacta** entre los identificadores de conexión a [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceso-a-la-interfaz-phpmyadmin) y los del fichero de configuración de su sitio web.
 
 Cambie, si es necesario, la [contraseña de su base de datos](/pages/web_cloud/web_hosting/sql_change_password).
 
 #### Ejemplo para WordPress
 
-Si su sitio web muestra un mensaje **"Error al conectarse a la base de datos"** y no se ve afectado por un [incidente](https://web-cloud.status-ovhcloud.com/), conéctese a [FTP](/pages/web_cloud/web_hosting/ftp_connection) a su alojamiento y abra el directorio que contiene su sitio web (por defecto es el directorio "www").
+Si su sitio web muestra un mensaje **"Error al conectarse a la base de datos"** y no se ve afectado por un [incidente](https://web-cloud.status-ovhcloud.com/), conéctese a [FTP](/pages/web_cloud/web_hosting/ftp_connection) a su alojamiento y abra el directorio que contiene su sitio web (por defecto es el directorio `www`).
 
-Si se trata de un sitio web WordPress, abra el archivo **wp-config.php**.
+Si se trata de un sitio web WordPress, abra el archivo `wp-config.php`.
 
 ```php
 define('DB_NAME', 'my_database');
- 
+
 /** MySQL database username */
 define('DB_USER', 'my_user');
- 
+
 /** MySQL database password */
 define('DB_PASSWORD', 'my_password');
- 
+
 /** MySQL hostname */
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-En el área de cliente de OVHcloud](/links/manager), haga clic en la pestaña `Bases de datos`{.action} y compruebe la correspondencia entre los elementos mostrados y los presentes en el archivo **wp-config.php**.
+Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
 
-- **my_database** debe coincidir con lo que se indica en el símbolo "Nombre de la base de datos" ;
-- **my_user** debe coincidir con lo que se indica en `Nombre de usuario`;
-- **my_password** corresponde a [contraseña de la base de datos](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** debe coincidir con lo que se indica en `Dirección del servidor`.
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action} y compruebe la correspondencia entre los elementos mostrados y los presentes en el archivo `wp-config.php`:
+>>
+>> - **my_database** debe coincidir con lo que se indica en `Nombre de la base de datos`;
+>> - **my_user** debe coincidir con lo que se indica en `Nombre de usuario`;
+>> - **my_password** corresponde a la [contraseña de la base de datos](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** debe coincidir con lo que se indica en `Dirección del servidor`.
 
 > [!primary]
 >
-> Si esta operación no le permite restablecer el acceso a su sitio web, [guarde su base de datos](/pages/web_cloud/web_hosting/sql_database_export) y después [restablezca-la a una fecha anterior](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#1-restaurar-una-copia-de-seguridad-existente) desde su [área de cliente OVHcloud](/links/manager).
+> Si esta operación no le permite restablecer el acceso a su sitio web, [guarde su base de datos](/pages/web_cloud/web_hosting/sql_database_export) y después [restablézcala a una fecha anterior](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#1-restaurar-una-copia-de-seguridad-existente) desde su [área de cliente OVHcloud](/links/manager).
 >
 > Contacte a continuación con un [proveedor especializado](/links/partner) si es necesario. No podremos asistirle en este asunto.
 >
@@ -110,7 +174,7 @@ Desbloquee la base de datos de tres formas distintas:
 
 #### Método 1: cambiar la suscripción a un plan superior
 
-Si dispone de una fórmula **Starter** o **Personal**, le recomendamos que cambie a [plan de hosting superior](/links/web/hosting). Este cambio de suscripción aumentará el tamaño de la base de datos, lo que la reabrirá automáticamente. Este método es el más sencillo y no necesita conocimientos técnicos específicos.
+Si dispone de una fórmula **Starter** o **Personal**, le recomendamos que cambie a un [plan de hosting superior](/links/web/hosting). Este cambio de suscripción aumentará el tamaño de la base de datos, lo que la reabrirá automáticamente. Este método es el más sencillo y no necesita conocimientos técnicos específicos.
 
 > [!warning]
 >
@@ -121,7 +185,22 @@ Si dispone de una fórmula **Starter** o **Personal**, le recomendamos que cambi
 > Si detecta un aumento repentino en el tamaño de su base de datos o si tiene un sitio web de tipo "blog" que normalmente no consume datos, le recomendamos que contacte inmediatamente con un [proveedor especializado](/links/partner). No podremos ofrecerle soporte sobre este tema.
 >
 
-Para ello, conéctese a su [área de cliente de OVHcloud](/links/manager), haga clic en `Alojamientos`{.action} y seleccione el alojamiento correspondiente. Haga clic en el botón `...`{.action} en el epígrafe `Producto` situado a la derecha de su pantalla y, seguidamente, en `Cambiar de plan`{.action}.
+Para realizar este cambio, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en el botón `...`{.action} en el apartado `Solución` situado a la derecha de su pantalla.
+>>
+> **Paso 3**
+>>
+>> Haga clic en `Cambiar de plan`{.action}.
 
 Si utiliza un plan **Performance**, consulte el [método 2](#methode2).
 
@@ -130,7 +209,7 @@ Si utiliza un plan **Performance**, consulte el [método 2](#methode2).
 También puede migrar sus datos a una nueva base de datos:
 
 - Contrate, si es necesario, una [base de datos](/links/web/hosting-options-startsql) de mayor tamaño y lance su [creación](/pages/web_cloud/web_hosting/sql_create_database).
-- [Duplique el contenido de la antigua base de datos](/pages/web_cloud/web_hosting/copy_database) en la nueva **o** realice un [exportar sus datos](/pages/web_cloud/web_hosting/sql_database_export) y a continuación [importar los](/pages/web_cloud/web_hosting/sql_importing_mysql_database) en la nueva base de datos;
+- [Duplique el contenido de la antigua base de datos](/pages/web_cloud/web_hosting/copy_database) en la nueva **o** realice una [exportación de sus datos](/pages/web_cloud/web_hosting/sql_database_export) y a continuación [impórtelos](/pages/web_cloud/web_hosting/sql_importing_mysql_database) en la nueva base de datos.
 - Integre las claves de la nueva base de datos en el [archivo de configuración](#config_file) de su sitio web.
 
 > [!primary]
@@ -140,9 +219,24 @@ También puede migrar sus datos a una nueva base de datos:
 
 #### Método 3: eliminar datos innecesarios
 
-Una vez realizada la [copia de seguridad de su base de datos](/pages/web_cloud/web_hosting/sql_database_export), conéctese a su interfaz [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) para eliminar los datos innecesarios con los comandos Drop, Delete y Truncate.
+Una vez realizada la [copia de seguridad de su base de datos](/pages/web_cloud/web_hosting/sql_database_export), conéctese a su interfaz [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) para eliminar los datos innecesarios con los comandos Drop, Delete y Truncate.
 
-Abra la pestaña `Bases de datos`{.action} del alojamiento correspondiente e inicie el cálculo de la cuota utilizada. pulse el botón `...`{.action} correspondiente y luego `Recalcular el espacio utilizado`{.action}.
+Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión.
+>>
+> **Paso 3**
+>>
+>> Haga clic en `Recalcular el espacio utilizado`{.action}.
 
 > [!warning]
 >
@@ -151,28 +245,58 @@ Abra la pestaña `Bases de datos`{.action} del alojamiento correspondiente e ini
 
 #### Método 4: optimizar la base de datos
 
-Para optimizar su base de datos, siga las instrucciones de nuestra guía "[Configurar su servidor de bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos)". Abra la pestaña `Bases de datos`{.action} de su alojamiento y haga clic en el botón `...`{.action} de la base de datos en cuestión.
+Para optimizar su base de datos, siga las instrucciones de nuestra guía "[Configurar su servidor de bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos)".
+
+Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión.
+>>
+> **Paso 3**
+>>
+>> Haga clic en `Recalcular el espacio utilizado`{.action}.
 
 > [!warning]
 >
-> Si el asesoramiento ofrecido sobre la optimización de su base de datos no bastaba para desbloquear el acceso a su sitio web, le recomendamos que se ponga en contacto con nuestra [comunidad de usuarios](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.
+> Si el asesoramiento ofrecido sobre la optimización de su base de datos no basta para desbloquear el acceso a su sitio web, le recomendamos que se ponga en contacto con nuestra [comunidad de usuarios](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.
 >
 
 ### Memoria RAM rebasada (solo Web Cloud Databases)
 
-El siguiente mensaje, situado en la sección `Web Cloud Databases`{.action} de su [área de cliente de OVHcloud](/links/manager), indica que su servidor [Web Cloud Databases](/links/web/databases) ha consumido una cantidad de recursos demasiado grande en la infraestructura de OVHcloud:
+El siguiente mensaje indica que su servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) ha consumido una cantidad de recursos demasiado grande en la infraestructura de OVHcloud:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-En ese caso, puede aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#cambiar-la-oferta-del-servidor-de-bases-de-datos) disponible desde la sección `Web Cloud Databases`{.action} de su [área de cliente OVHcloud](/links/manager). En la pestaña `Información general`{.action}, haga clic en el botón `...`{.action} en la sección `RAM`.
+Para aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#cambiar-la-oferta-del-servidor-de-bases-de-datos), haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
+>>
+>> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> En la pestaña `Información general`{.action}, localice el apartado `RAM`.
+>>
+> **Paso 3**
+>>
+>> Haga clic en el botón `...`{.action} en el apartado `RAM` y, a continuación, en `Cambiar la cantidad de RAM`{.action}.
 
 > [!warning]
 >
 > Para aumentar la RAM, el Web Cloud Databases no debe activarse a través de un hosting Performance. Si quiere aumentar la cantidad de memoria RAM de una base de datos incluida en los [planes Performance](/links/web/hosting-performance-offer), deberá desvincularla primero.
-> 
-> Para desvincular la base de datos, conéctese a su [área de cliente de OVHcloud](/links/manager) y seleccione `Web Cloud`{.action}. Haga clic en `Alojamientos`{.action} y seleccione el alojamiento web en el que esté activado el Web Cloud Databases.
 >
-> En el área de `Configuración`, haga clic en los `...`{.action} a la derecha de la mención `Web Cloud Databases` y haga clic en el botón `Desvincular`{.action}.
+> Para desvincular la base de datos, consulte nuestra guía "[Desvincular un Web Cloud Databases de su alojamiento web](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
 >
 
 También puede optimizar su base de datos siguiendo las instrucciones de nuestra guía "[Configurar su servidor de bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos)".
@@ -192,15 +316,28 @@ También puede optimizar su base de datos siguiendo las instrucciones de nuestra
 
 Este mensaje de error significa que la base de datos que está intentando importar contiene elementos no autorizados en la infraestructura compartida de OVHcloud.
 
-En primer lugar, asegúrese de que la base de datos esté vacía en la pestaña `Bases de datos`{.action} del alojamiento correspondiente (haga clic en el botón `...`{.action}) correspondiente y seleccione `Recalcular el espacio utilizado`{.action}.
+En primer lugar, asegúrese de que la base de datos esté vacía. Para ello, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
 
-En caso contrario, [guarde los datos presentes](/pages/web_cloud/web_hosting/sql_database_export) en la base de datos y después borre la base de datos antes de reanudar la operación de importación.
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión y en `Recalcular el espacio utilizado`{.action}.
+>>
+> **Paso 3**
+>>
+>> Si la base de datos no está vacía, [guarde los datos presentes](/pages/web_cloud/web_hosting/sql_database_export) y después elimínelos antes de reanudar la operación de importación.
+>>
+>> También puede marcar la casilla `Vaciar la base de datos actual`{.action} justo antes de [iniciar la importación](/pages/web_cloud/web_hosting/sql_importing_mysql_database#importar-una-copia-de-seguridad-desde-el-area-de-cliente):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-También puede marcar la casilla `Vaciar la base de datos actual`{.action} justo antes de [iniciar la importación](/pages/web_cloud/web_hosting/sql_importing_mysql_database#importar-una-copia-de-seguridad-desde-el-area-de-cliente):
-
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
-
-Este mensaje de error significa que la base de datos que está intentando importar contiene elementos no autorizados en la infraestructura compartida de OVHcloud. Si lo necesita, puede ponerse en contacto con nuestra [comunidad de usuarios](/links/community) o con un [proveedor especializado](/links/partner). No podremos asistirle en la corrección de esta anomalía.
+Si lo necesita, puede ponerse en contacto con nuestra [comunidad de usuarios](/links/community) o con un [proveedor especializado](/links/partner). No podremos asistirle en la corrección de esta anomalía.
 
 > [!primary]
 >
@@ -211,7 +348,7 @@ Tener un **"trigger"** en el script de importación de su base de datos no está
 Por otro lado, no está permitida la siguiente petición:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
 Sustituya por:
@@ -225,20 +362,35 @@ USE `Database-Name`;
 #### "MySQL server has gone away"
 
 >
-> **"ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
 Este mensaje de error aparece durante [la importación de una base de datos](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#2-importar-una-copia-de-seguridad-local) en un servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). La mayor parte del tiempo se debe a la cantidad excesiva de datos que se van a importar o a la falta de optimización de las peticiones SQL en el script de importación.
 
 Para resolver esta anomalía, puede:
 
-- Aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#seguimiento-de-la-ram-consumida). Para ello, acceda al servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) correspondiente en la sección `Bases de datos`{.action} de su [área de cliente OVHcloud](/links/manager). Haga clic en el botón `...`{.action} en la sección `RAM` y, seguidamente, en `Cambiar la cantidad de RAM`{.action}.
+- Aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#seguimiento-de-la-ram-consumida). Para ello, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
 
-- Fraccione su base de datos para importarla en varias operaciones en lugar de una (para cualquier duda sobre las operaciones a realizar, contacte con nuestra [comunidad](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
+>>
+>> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> En la pestaña `Información general`{.action}, localice el apartado `RAM`.
+>>
+> **Paso 3**
+>>
+>> Haga clic en el botón `...`{.action} en el apartado `RAM` y, a continuación, en `Cambiar la cantidad de RAM`{.action}.
 
-- [Optimice su base de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos) y luego repite las operaciones de exportación/importación.
+- Fraccione su base de datos para importarla en varias operaciones en lugar de una (para cualquier duda sobre las operaciones a realizar, contacte con nuestra [comunidad](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.)
 
-### No se ha podido acceder a PhpMyAdmin
+- [Optimice su base de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos) y luego repita las operaciones de exportación/importación.
+
+### No se ha podido acceder a phpMyAdmin
 
 #### "Access denied for user"
 
@@ -246,7 +398,7 @@ Para resolver esta anomalía, puede:
 > **"mysqli::real_connect(): (HY000/1045): Access denied for user"**
 >
 
-Este mensaje de error puede aparecer al conectarse a la base de datos por [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin). Indica que los identificadores introducidos son incorrectos.
+Este mensaje de error puede aparecer al conectarse a la base de datos por [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin). Indica que los identificadores introducidos son incorrectos.
 
 ![access_denied_for_user](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-1045.png){.thumbnail}
 
@@ -262,7 +414,7 @@ El número máximo de conexiones activas para las bases de datos entregadas con 
 
 Este número es de **200** para las bases de servidores [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (Puede cambiar este parámetro en la sección `Configuración`{.action} del servidor de la base de datos).
 
-Este mensaje aparece durante [conexión a PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) cuando se supera el número máximo de conexiones.
+Este mensaje aparece durante la [conexión a phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) cuando se supera el número máximo de conexiones.
 
 En ese caso, deberá [optimizar las bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos) para reducir el número de conexiones activas.
 
@@ -277,18 +429,47 @@ En ese caso, deberá [optimizar las bases de datos](/pages/web_cloud/web_cloud_d
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
 >
 
-Este mensaje de error aparece durante [conexión a PhpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#procedimiento) cuando el nombre del servidor introducido es incorrecto.
+Este mensaje de error aparece durante la [conexión a phpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#procedimiento) cuando el nombre del servidor introducido es incorrecto.
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Compruebe el nombre del servidor que quiera registrar en su [área de cliente de OVHcloud](/links/manager).
+Compruebe el nombre del servidor correspondiente.
 
-> [!success]
->
-> Si la base de datos a la que desea conectarse aparece en la pestaña `Bases de datos`{.action} de la parte `Alojamientos`{.action} de su [área de cliente de OVHcloud](/links/manager), el nombre que debe introducir se indica en la columna `Dirección del servidor`.
->
-> Si desea conectarse a una base de datos en un servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), el nombre del servidor a introducir se inscribe en la pestaña `Información general`{.action}, parte `Datos de conexión`{.action}, `SQL`{.action} y en el `Nombre del host`{.action}.
->
+**Haga clic en la situación correspondiente para ver el contenido.**
+
+/// details | Base de datos en un alojamiento web
+
+Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> Haga clic en la pestaña `Bases de datos`{.action}. El nombre del servidor a introducir aparece en la columna `Dirección del servidor`.
+
+///
+
+/// details | Base de datos en un servidor Web Cloud Databases
+
+Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+
+> [!tabs]
+> **Paso 1**
+>>
+>> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
+>>
+>> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Paso 2**
+>>
+>> En la pestaña `Información general`{.action}, el nombre del servidor a introducir se encuentra en la sección `Datos de conexión`, apartado `SQL`, mención `Nombre del host`.
+
+///
 
 ### No es posible conectarse a una base de datos Cloud Databases
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.es-us.md
@@ -61,16 +61,16 @@ Compruebe en primer lugar en la página [Web Cloud Status](https://web-cloud.sta
 
 /// details | Encontrar el datacenter de su alojamiento web
 
-Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+Haga clic en las pestañas para ver sucesivamente cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la pestaña `Información general`{.action}, localice el `Datacenter`.
 
@@ -84,16 +84,16 @@ Consulte nuestra guía "[Conocer el clúster y el filer de su alojamiento web](/
 
 /// details | Encontrar el nombre del servidor Web Cloud Databases
 
-Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+Haga clic en las pestañas para ver sucesivamente cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
 >>
 >> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Localice `Nombre del host` en el apartado `SQL` de la sección `Datos de conexión`.
 
@@ -139,16 +139,16 @@ define('DB_PASSWORD', 'my_password');
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+Haga clic en las pestañas para ver sucesivamente cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action} y compruebe la correspondencia entre los elementos mostrados y los presentes en el archivo `wp-config.php`:
 >>
@@ -185,20 +185,20 @@ Si dispone de una fórmula **Starter** o **Personal**, le recomendamos que cambi
 > Si detecta un aumento repentino en el tamaño de su base de datos o si tiene un sitio web de tipo "blog" que normalmente no consume datos, le recomendamos que contacte inmediatamente con un [proveedor especializado](/links/partner). No podremos ofrecerle soporte sobre este tema.
 >
 
-Para realizar este cambio, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+Para realizar este cambio, haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en el botón `...`{.action} en el apartado `Solución` situado a la derecha de su pantalla.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en `Cambiar de plan`{.action}.
 
@@ -221,20 +221,20 @@ También puede migrar sus datos a una nueva base de datos:
 
 Una vez realizada la [copia de seguridad de su base de datos](/pages/web_cloud/web_hosting/sql_database_export), conéctese a su interfaz [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-la-interfaz-phpmyadmin) para eliminar los datos innecesarios con los comandos Drop, Delete y Truncate.
 
-Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en `Recalcular el espacio utilizado`{.action}.
 
@@ -247,20 +247,20 @@ Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesi
 
 Para optimizar su base de datos, siga las instrucciones de nuestra guía "[Configurar su servidor de bases de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos)".
 
-Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+Para recalcular el espacio utilizado, haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en `Recalcular el espacio utilizado`{.action}.
 
@@ -275,20 +275,20 @@ El siguiente mensaje indica que su servidor [Web Cloud Databases](/pages/web_clo
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-Para aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#cambiar-la-oferta-del-servidor-de-bases-de-datos), haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+Para aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#cambiar-la-oferta-del-servidor-de-bases-de-datos), haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
 >>
 >> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la pestaña `Información general`{.action}, localice el apartado `RAM`.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en el botón `...`{.action} en el apartado `RAM` y, a continuación, en `Cambiar la cantidad de RAM`{.action}.
 
@@ -316,20 +316,20 @@ También puede optimizar su base de datos siguiendo las instrucciones de nuestra
 
 Este mensaje de error significa que la base de datos que está intentando importar contiene elementos no autorizados en la infraestructura compartida de OVHcloud.
 
-En primer lugar, asegúrese de que la base de datos esté vacía. Para ello, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+En primer lugar, asegúrese de que la base de datos esté vacía. Para ello, haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action} y, a continuación, en el botón `...`{.action} a la derecha de la base de datos en cuestión y en `Recalcular el espacio utilizado`{.action}.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Si la base de datos no está vacía, [guarde los datos presentes](/pages/web_cloud/web_hosting/sql_database_export) y después elimínelos antes de reanudar la operación de importación.
 >>
@@ -369,24 +369,24 @@ Este mensaje de error aparece durante [la importación de una base de datos](/pa
 
 Para resolver esta anomalía, puede:
 
-- Aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#seguimiento-de-la-ram-consumida). Para ello, haga clic en las pestañas para ver sucesivamente cada uno de los **3** pasos.
+- Aumentar la [cantidad de memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#seguimiento-de-la-ram-consumida). Para ello, haga clic en las pestañas para ver sucesivamente cada una de las **3** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
 >>
 >> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la pestaña `Información general`{.action}, localice el apartado `RAM`.
 >>
-> **Paso 3**
+> **Etapa 3**
 >>
 >> Haga clic en el botón `...`{.action} en el apartado `RAM` y, a continuación, en `Cambiar la cantidad de RAM`{.action}.
 
-- Fraccione su base de datos para importarla en varias operaciones en lugar de una (para cualquier duda sobre las operaciones a realizar, contacte con nuestra [comunidad](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.)
+- Fraccione su base de datos para importarla en varias operaciones en lugar de una (para cualquier duda sobre las operaciones a realizar, contacte con nuestra [comunidad](/links/community) o con los [partners de OVHcloud](/links/partner). Nosotros no podremos asistirle en este asunto.
 
 - [Optimice su base de datos](/pages/web_cloud/web_cloud_databases/configure-database-server#gestionar-las-bases-de-datos) y luego repita las operaciones de exportación/importación.
 
@@ -439,16 +439,16 @@ Compruebe el nombre del servidor correspondiente.
 
 /// details | Base de datos en un alojamiento web
 
-Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+Haga clic en las pestañas para ver sucesivamente cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> Haga clic en la pestaña `Bases de datos`{.action}. El nombre del servidor a introducir aparece en la columna `Dirección del servidor`.
 
@@ -456,16 +456,16 @@ Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
 
 /// details | Base de datos en un servidor Web Cloud Databases
 
-Haga clic en las pestañas para ver sucesivamente cada uno de los **2** pasos.
+Haga clic en las pestañas para ver sucesivamente cada una de las **2** etapas.
 
 > [!tabs]
-> **Paso 1**
+> **Etapa 1**
 >>
 >> Acceda a la página [Web Cloud Databases](/links/control-panel/web-cloud-databases) y seleccione el servicio correspondiente.
 >>
 >> ![Selección de un servidor Web Cloud Databases en el área de cliente de OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Paso 2**
+> **Etapa 2**
 >>
 >> En la pestaña `Información general`{.action}, el nombre del servidor a introducir se encuentra en la sección `Datos de conexión`, apartado `SQL`, mención `Nombre del host`.
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.fr-ca.md
@@ -1,8 +1,22 @@
 ---
 title: "Résoudre les erreurs les plus fréquentes liées aux bases de données"
 excerpt: "Diagnostiquez les cas les plus courants d'erreurs liées aux bases de données"
-updated: 2026-02-11
+updated: 2026-03-31
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objectif
 
@@ -14,7 +28,7 @@ L'utilisation de vos bases de données peut entraîner un certain nombre d'anoma
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
+> Ce guide vous accompagne sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
 >
 
 ## Prérequis
@@ -43,14 +57,53 @@ L'utilisation de vos bases de données peut entraîner un certain nombre d'anoma
 
 Vérifiez tout d'abord sur la page [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) que votre datacentre, votre cluster d'hébergement web, votre serveur Web Cloud Databases ou votre base de données ne sont pas concernés par un incident sur l'infrastructure OVHcloud.
 
-> [!primary]
->
-> Pour retrouver ces informations, connectez-vous à votre [espace client OVHcloud](/links/manager), dans la partie `Web Cloud`{.action} :
->
-> - Pour retrouver le `Datacentre` de votre hébergement web, choisissez `Hébergements`{.action}, puis l'hébergement web concerné. Vous trouverez ces informations dans l'onglet `Informations générales`{.action}.
-> - Pour retrouver le **cluster** de serveurs et le **filer** (serveur de fichier) de votre hébergement web, consultez [ce guide](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - Pour retrouver le nom de votre serveur **Web Cloud Databases**, cliquez sur `Web Cloud Databases`{.action} puis sur l'offre concernée. Vous trouverez cette information sous la mention `Nom d'hôte` dans la rubrique `SQL` de `Informations de connexion`.
-> - Pour retrouver le serveur sur lequel se trouve votre base de données incluse ou commandée en complément via votre [hébergement web](/links/web/hosting), consultez [ce guide](/pages/web_cloud/web_hosting/sql_find_server).
+**Cliquez sur l'information recherchée pour afficher le contenu.**
+
+/// details | Retrouver le Datacentre de votre hébergement web
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `Informations générales`{.action}, repérez le `Datacentre`.
+
+///
+
+/// details | Retrouver le cluster et le filer de votre hébergement web
+
+Consultez notre guide « [Connaître le cluster et le filer de votre hébergement web](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer) ».
+
+///
+
+/// details | Retrouver le nom du serveur Web Cloud Databases
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez l'offre concernée.
+>>
+>> ![Sélection d'un serveur Web Cloud Databases dans l'espace client OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Repérez la mention `Nom d'hôte` dans la rubrique `SQL` de `Informations de connexion`.
+
+///
+
+/// details | Retrouver le serveur de votre base de données d'hébergement web
+
+Consultez notre guide « [Retrouver le serveur de sa base de données](/pages/web_cloud/web_hosting/sql_find_server) ».
+
+///
 
 #### Vérifier les identifiants de connexion à votre base de données <a name="config_file"></a>
 
@@ -86,12 +139,23 @@ define('DB_PASSWORD', 'my_password');
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-Dans votre [espace client OVHcloud](/links/manager), dans la partie `Hébergements`{.action}, cliquez sur l'onglet `Bases de données`{.action} puis vérifiez la correspondance entre les éléments affichés et ceux présents dans le fichier `wp-config.php` :
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
-- **my_database** doit correspondre à ce qui est noté dans `Nom de la base`;
-- **my_user** doit correspondre à ce qui est noté dans `Nom d'utilisateur`;
-- **my_password** correspond au [mot de passe de votre base de données](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** doit correspondre à ce qui est noté dans `Adresse du serveur`.
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action} puis vérifiez la correspondance entre les éléments affichés et ceux présents dans le fichier `wp-config.php` :
+>>
+>> - **my_database** doit correspondre à ce qui est noté dans `Nom de la base`;
+>> - **my_user** doit correspondre à ce qui est noté dans `Nom d'utilisateur`;
+>> - **my_password** correspond au [mot de passe de votre base de données](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** doit correspondre à ce qui est noté dans `Adresse du serveur`.
 
 > [!primary]
 >
@@ -102,7 +166,7 @@ Dans votre [espace client OVHcloud](/links/manager), dans la partie `Hébergemen
 
 ### Dépassement du quota autorisé de la base de données
 
-Vous avez reçu un e-mail de nos services indiquant que la quantité de données sur votre base dépasse la limite autorisée. Votre base est donc passée en lecture seule. Ceci empêche toute modification de votre site.
+Vous avez reçu un e-mail indiquant que votre base de données dépasse la limite autorisée. Passée en lecture seule, elle empêche toute modification de votre site.
 
 ![database-overquota-notification-email](/pages/assets/screens/email-sending-to-customer/databases/overquota-db.png){.thumbnail}
 
@@ -121,7 +185,22 @@ Si vous disposez d'une formule **Starter** ou **Perso**, nous vous conseillons d
 > Nous vous conseillons donc, si vous constatez une augmentation soudaine de la taille de votre base de données ou si vous disposez d'un site de type « blog » normalement peu consommateur de données, de contacter immédiatement un [prestataire spécialisé](/links/partner). Nous ne serons pas en mesure de vous apporter un support sur ce sujet.
 >
 
-Pour effectuer ce changement, connectez-vous à votre [espace client OVHcloud](/links/manager) puis cliquez sur `Hébergements`{.action}, puis sur l'hébergement concerné. Cliquez sur le bouton `...`{.action} dans la rubrique `Offre` sur la droite de votre écran puis sur `Changer d'offre`{.action}.
+Pour effectuer ce changement, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur le bouton `...`{.action} dans la rubrique `Offre` sur la droite de votre écran.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur `Changer d'offre`{.action}.
 
 #### Méthode 2 : migrer vos données sur une base de taille supérieure <a name="methode2"></a>
 
@@ -140,7 +219,22 @@ Vous pouvez également migrer vos données sur une nouvelle base :
 
 Après avoir effectué une [sauvegarde de votre base de données](/pages/web_cloud/web_hosting/sql_database_export), connectez-vous à votre interface [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-linterface-phpmyadmin) afin de supprimer les données inutiles grâce aux commandes Drop, Delete et Truncate.
 
-Relancez ensuite le calcul du quota utilisé depuis l'onglet `Bases de données`{.action} de l'hébergement concerné : cliquez sur le bouton `...`{.action} concerné puis sur `Recalculer le quota`{.action}.
+Pour relancer le calcul du quota, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action}, puis sur le bouton `...`{.action} à droite de la base de données concernée.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur `Recalculer le quota`{.action}.
 
 > [!warning]
 >
@@ -149,7 +243,24 @@ Relancez ensuite le calcul du quota utilisé depuis l'onglet `Bases de données`
 
 #### Méthode 4 : optimiser votre base de données
 
-Pour optimiser votre base de données, suivez les instructions de notre guide « [Configurer votre serveur de bases de données](/pages/web_cloud/web_cloud_databases/configure-database-server#optimiser-vos-bases-de-donnees) ». Relancez ensuite le calcul du quota utilisé depuis l'onglet `Bases de données`{.action} de votre hébergement, en cliquant sur le bouton `...`{.action} de la base de données concernée.
+Pour optimiser votre base de données, suivez les instructions de notre guide « [Configurer votre serveur de bases de données](/pages/web_cloud/web_cloud_databases/configure-database-server#optimiser-vos-bases-de-donnees) ».
+
+Pour relancer le calcul du quota, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action}, puis sur le bouton `...`{.action} à droite de la base de données concernée.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur `Recalculer le quota`{.action}.
 
 > [!warning]
 >
@@ -158,19 +269,32 @@ Pour optimiser votre base de données, suivez les instructions de notre guide «
 
 ### Dépassements de la mémoire RAM (Web Cloud Databases uniquement)
 
-Le message suivant dans la partie `Web Cloud Databases`{.action} de votre [espace client OVHcloud](/links/manager) indique que votre serveur [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) a consommé une quantité de ressources trop importantes sur l'infrastructure OVHcloud :
+Le message suivant indique que votre serveur [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) a consommé une quantité de ressources trop importantes sur l'infrastructure OVHcloud :
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-Dans cette situation, vous pouvez augmenter la [quantité de mémoire RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifier-loffre-du-serveur-de-bases-de-donnees) disponible depuis la partie `Web Cloud Databases`{.action} de votre [espace client OVHcloud](/links/manager). Dans l'onglet `Informations générales`{.action}, cliquez sur le bouton `...`{.action} dans la rubrique `RAM`.
+Pour augmenter la [quantité de mémoire RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifier-loffre-du-serveur-de-bases-de-donnees), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez la solution concernée.
+>>
+>> ![Sélection d'un serveur Web Cloud Databases dans l'espace client OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `Informations générales`{.action}, repérez la rubrique `RAM`.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur le bouton `...`{.action} dans la rubrique `RAM`, puis sur `Changer la quantité de la RAM`{.action}.
 
 > [!warning]
 >
 > Pour augmenter sa RAM, le Web Cloud Databases ne doit pas avoir été activé via un hébergement Performance. Si vous souhaitez augmenter la quantité de mémoire vive d'une base de données incluse dans les [offres performance](/links/web/hosting-performance-offer), il vous faut d'abord en délier cette base de données.
 >
-> Pour délier la base de données, connectez-vous à votre [espace client OVHcloud](/links/manager) et sélectionnez l'onglet `Web Cloud`{.action}. Cliquez sur `Hébergements`{.action} puis choisissez l'hébergement web sur lequel le Web Cloud Databases est activé.
->
-> Dans la zone `Configuration`, cliquez sur le bouton `...`{.action} à droite de la mention `Web Cloud Databases`, puis cliquez sur le bouton `Délier`{.action}.
+> Pour délier la base de données, consultez notre guide « [Détacher un Web Cloud Databases de votre hébergement web](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting) ».
 >
 
 Vous pouvez également optimiser votre base de données en suivant les instructions de notre guide « [Configurer votre serveur de bases de données](/pages/web_cloud/web_cloud_databases/configure-database-server#optimiser-vos-bases-de-donnees) ».
@@ -190,13 +314,26 @@ Vous pouvez également optimiser votre base de données en suivant les instructi
 
 Ce message d'erreur signifie que la base de données que vous tentez d'importer contient des éléments non autorisés sur l'infrastructure mutualisée OVHcloud.
 
-Assurez-vous tout d'abord que votre base de données est vide depuis l'onglet `Bases de données`{.action} de l'hébergement concerné (cliquez sur le bouton `...`{.action} concerné puis sur `Recalculer le quota`{.action}).
+Vérifiez d'abord que votre base de données est vide. Pour cela, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-Dans le cas contraire, [sauvegardez les données présentes](/pages/web_cloud/web_hosting/sql_database_export) dans votre base puis supprimez-les avant de relancer l'opération d'import.
-
-Vous pouvez également cocher la case `Vider la base de données actuelle`{.action} juste avant de [lancer l'import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#importer-votre-propre-sauvegarde-depuis-lespace-client) :
-
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action}, puis sur le bouton `...`{.action} à droite de la base de données concernée et sur `Recalculer le quota`{.action}.
+>>
+> **Étape 3**
+>>
+>> Si la base de données n'est pas vide, [sauvegardez les données présentes](/pages/web_cloud/web_hosting/sql_database_export) puis supprimez-les avant de relancer l'opération d'import.
+>>
+>> Vous pouvez également cocher la case `Vider la base de données actuelle`{.action} juste avant de [lancer l'import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#importer-votre-propre-sauvegarde-depuis-lespace-client) :
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
 Contactez si besoin notre [communauté d'utilisateurs](/links/community) ou un [prestataire spécialisé](/links/partner) à ce sujet. Nous ne serons pas en mesure de vous fournir une assistance sur la correction de cette anomalie.
 
@@ -230,7 +367,22 @@ Ce message d'erreur apparaît lors de [l'import d'une base de données](/pages/w
 
 Pour résoudre cette anomalie, vous pouvez :
 
-- Augmenter la [quantité de mémoire vive (RAM)](/pages/web_cloud/web_cloud_databases/configure-database-server#suivre-la-ram-consommee). Pour cela, rendez vous sur le serveur [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) concerné dans la rubrique `Bases de données`{.action} de votre [espace client OVHcloud](/links/manager). Cliquez ensuite sur le bouton `...`{.action} dans la partie `RAM`, puis sur `Changer la quantité de RAM`{.action}.
+- Augmenter la [quantité de mémoire vive (RAM)](/pages/web_cloud/web_cloud_databases/configure-database-server#suivre-la-ram-consommee). Pour cela, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez la solution concernée.
+>>
+>> ![Sélection d'un serveur Web Cloud Databases dans l'espace client OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `Informations générales`{.action}, repérez la rubrique `RAM`.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur le bouton `...`{.action} dans la rubrique `RAM`, puis sur `Changer la quantité de la RAM`{.action}.
 
 - Fractionner votre base de données, afin de l'importer en plusieurs opérations au lieu d'une seule (pour toute question sur les manipulations à réaliser, contactez notre [communauté d'utilisateurs](/links/community) ou les [partenaires OVHcloud](/links/partner). En effet, nous ne serons pas en mesure de vous fournir une assistance sur ce sujet.)
 
@@ -244,7 +396,7 @@ Pour résoudre cette anomalie, vous pouvez :
 > **« mysqli::real_connect(): (HY000/1045): Access denied for user »**
 >
 
-Ce message d'erreur peut apparaître lors de la connexion à votre base de données par [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-linterface-phpmyadmin). Elle indique que les identifiants renseignés sont erronés.
+Ce message d'erreur peut apparaître lors de la connexion à votre base de données par [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-linterface-phpmyadmin). Il indique que les identifiants renseignés sont erronés.
 
 ![access_denied_for_user](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-1045.png){.thumbnail}
 
@@ -258,7 +410,7 @@ Dans cette situation, [vérifiez les identifiants renseignés](/pages/web_cloud/
 
 Le nombre maximal de connexions actives pour les bases de données livrées avec les hébergements mutualisés ([StartSQL](/links/web/hosting-options-startsql)) est de **30**.
 
-Ce nombre est de **200** pour les bases des serveurs [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) et [Cloud Databases](/links/web/databases)  (Ce paramètre est modifiable dans la partie `Configuration`{.action} de votre serveur de base de données).
+Ce nombre est de **200** pour les bases des serveurs [Web Cloud Databases](/links/web/databases) (ce paramètre est modifiable dans les [paramètres de configuration](/pages/web_cloud/web_cloud_databases/configure-database-server) de votre serveur de base de données).
 
 Ce message apparaît lors de la [connexion à PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-linterface-phpmyadmin) lorsque ce nombre maximal de connexions est dépassé.
 
@@ -279,14 +431,43 @@ Ce message d'erreur apparaît lors de la [connexion à PhpMyAdmin](/pages/web_cl
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Vérifiez le nom du serveur à inscrire dans votre [espace client OVHcloud](/links/manager).
+Vérifiez le nom du serveur à inscrire.
 
-> [!success]
->
-> Si la base à laquelle vous souhaitez vous connecter apparaît dans l'onglet `Bases de données`{.action} de la partie `Hébergements`{.action} de votre [espace client OVHcloud](/links/manager), le nom à renseigner est inscrit dans la colonne `Adresse du serveur`.
->
-> Si vous souhaitez vous connecter à une base de données sur un serveur [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), le nom de serveur à renseigner est inscrit dans l'onglet `Informations générales`{.action}, partie `Informations de connexions`{.action}, `SQL`{.action} et dans la rubrique `Nom d'hôte`{.action}.
->
+**Cliquez sur la situation de votre choix pour afficher le contenu.**
+
+/// details | Base de données sur un hébergement web
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action}. Le nom du serveur à renseigner est inscrit dans la colonne `Adresse du serveur`.
+
+///
+
+/// details | Base de données sur un serveur Web Cloud Databases
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez la solution concernée.
+>>
+>> ![Sélection d'un serveur Web Cloud Databases dans l'espace client OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `Informations générales`{.action}, le nom du serveur à renseigner est inscrit dans la partie `Informations de connexion`, rubrique `SQL`, mention `Nom d'hôte`.
+
+///
 
 ### Connexion impossible sur une base de données Cloud Databases
 
@@ -294,12 +475,12 @@ Disposer d'un serveur [Web Cloud Databases](/products/web-cloud-clouddb) vous pe
 
 Si cette connexion s'avère impossible, commencez par vérifier que vous avez bien [autorisé votre adresse IP publique](/pages/web_cloud/web_cloud_databases/starting_with_clouddb#autoriser-une-adresse-ip) à se connecter au serveur de bases de données.
 
-Si cette opération a bien été réalisée, contactez votre Fournisseur d'Accès à Internet ou les [partenaires OVHcloud](/links/partner). Nous ne serons pas en mesure de vous fournir une assistance dans cette situation.
+Si cette opération a bien été réalisée, contactez votre fournisseur d'accès à Internet ou les [partenaires OVHcloud](/links/partner). Nous ne serons pas en mesure de vous fournir une assistance dans cette situation.
 
 ## Aller plus loin <a name="go-further"></a>
 
 [Premiers pas avec le service Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
+Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.fr-fr.md
@@ -28,7 +28,7 @@ L'utilisation de vos bases de données peut entraîner un certain nombre d'anoma
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
+> Ce guide vous accompagne sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
 >
 
 ## Prérequis
@@ -68,7 +68,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2*
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -91,7 +91,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2*
 >>
 >> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez l'offre concernée.
 >>
->> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>> ![Sélection d'un serveur Web Cloud Databases dans l'espace client OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -146,7 +146,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2*
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -192,7 +192,7 @@ Pour effectuer ce changement, cliquez sur les onglets ci-dessous pour afficher s
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -226,7 +226,7 @@ Pour relancer le calcul du quota, cliquez sur les onglets ci-dessous pour affich
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -252,7 +252,7 @@ Pour relancer le calcul du quota, cliquez sur les onglets ci-dessous pour affich
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -273,14 +273,14 @@ Le message suivant indique que votre serveur [Web Cloud Databases](/pages/web_cl
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-Dans cette situation, vous pouvez augmenter la [quantité de mémoire RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifier-loffre-du-serveur-de-bases-de-donnees). Pour cela, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+Pour augmenter la [quantité de mémoire RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifier-loffre-du-serveur-de-bases-de-donnees), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
 > [!tabs]
 > **Étape 1**
 >>
 >> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez la solution concernée.
 >>
->> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>> ![Sélection d'un serveur Web Cloud Databases dans l'espace client OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -321,7 +321,7 @@ Vérifiez d'abord que votre base de données est vide. Pour cela, cliquez sur le
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -374,7 +374,7 @@ Pour résoudre cette anomalie, vous pouvez :
 >>
 >> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez la solution concernée.
 >>
->> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>> ![Sélection d'un serveur Web Cloud Databases dans l'espace client OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -444,7 +444,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2*
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -461,7 +461,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2*
 >>
 >> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez la solution concernée.
 >>
->> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>> ![Sélection d'un serveur Web Cloud Databases dans l'espace client OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
 > **Étape 2**
 >>

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Résoudre les erreurs les plus fréquentes liées aux bases de données"
 excerpt: "Diagnostiquez les cas les plus courants d'erreurs liées aux bases de données"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.fr-fr.md
@@ -1,8 +1,22 @@
 ---
 title: "Résoudre les erreurs les plus fréquentes liées aux bases de données"
 excerpt: "Diagnostiquez les cas les plus courants d'erreurs liées aux bases de données"
-updated: 2026-02-11
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objectif
 
@@ -14,7 +28,7 @@ L'utilisation de vos bases de données peut entraîner un certain nombre d'anoma
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
 >
 
 ## Prérequis
@@ -43,14 +57,53 @@ L'utilisation de vos bases de données peut entraîner un certain nombre d'anoma
 
 Vérifiez tout d'abord sur la page [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) que votre datacentre, votre cluster d'hébergement web, votre serveur Web Cloud Databases ou votre base de données ne sont pas concernés par un incident sur l'infrastructure OVHcloud.
 
-> [!primary]
->
-> Pour retrouver ces informations, connectez-vous à votre [espace client OVHcloud](/links/manager), dans la partie `Web Cloud`{.action} :
->
-> - Pour retrouver le `Datacentre` de votre hébergement web, choisissez `Hébergements`{.action}, puis l'hébergement web concerné. Vous trouverez ces informations dans l'onglet `Informations générales`{.action}.
-> - Pour retrouver le **cluster** de serveurs et le **filer** (serveur de fichier) de votre hébergement web, consultez [ce guide](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - Pour retrouver le nom de votre serveur **Web Cloud Databases**, cliquez sur `Web Cloud Databases`{.action} puis sur l'offre concernée. Vous trouverez cette information sous la mention `Nom d'hôte` dans la rubrique `SQL` de `Informations de connexion`.
-> - Pour retrouver le serveur sur lequel se trouve votre base de données incluse ou commandée en complément via votre [hébergement web](/links/web/hosting), consultez [ce guide](/pages/web_cloud/web_hosting/sql_find_server).
+**Cliquez sur l'information recherchée pour afficher le contenu.**
+
+/// details | Retrouver le Datacentre de votre hébergement web
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `Informations générales`{.action}, repérez le `Datacentre`.
+
+///
+
+/// details | Retrouver le cluster et le filer de votre hébergement web
+
+Consultez notre guide « [Connaître le cluster et le filer de votre hébergement web](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer) ».
+
+///
+
+/// details | Retrouver le nom du serveur Web Cloud Databases
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez l'offre concernée.
+>>
+>> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Repérez la mention `Nom d'hôte` dans la rubrique `SQL` de `Informations de connexion`.
+
+///
+
+/// details | Retrouver le serveur de votre base de données d'hébergement web
+
+Consultez notre guide « [Retrouver le serveur de sa base de données](/pages/web_cloud/web_hosting/sql_find_server) ».
+
+///
 
 #### Vérifier les identifiants de connexion à votre base de données <a name="config_file"></a>
 
@@ -86,12 +139,23 @@ define('DB_PASSWORD', 'my_password');
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-Dans votre [espace client OVHcloud](/links/manager), dans la partie `Hébergements`{.action}, cliquez sur l'onglet `Bases de données`{.action} puis vérifiez la correspondance entre les éléments affichés et ceux présents dans le fichier `wp-config.php` :
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
-- **my_database** doit correspondre à ce qui est noté dans `Nom de la base`;
-- **my_user** doit correspondre à ce qui est noté dans `Nom d'utilisateur`;
-- **my_password** correspond au [mot de passe de votre base de données](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** doit correspondre à ce qui est noté dans `Adresse du serveur`.
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action} puis vérifiez la correspondance entre les éléments affichés et ceux présents dans le fichier `wp-config.php` :
+>>
+>> - **my_database** doit correspondre à ce qui est noté dans `Nom de la base`;
+>> - **my_user** doit correspondre à ce qui est noté dans `Nom d'utilisateur`;
+>> - **my_password** correspond au [mot de passe de votre base de données](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** doit correspondre à ce qui est noté dans `Adresse du serveur`.
 
 > [!primary]
 >
@@ -102,7 +166,7 @@ Dans votre [espace client OVHcloud](/links/manager), dans la partie `Hébergemen
 
 ### Dépassement du quota autorisé de la base de données
 
-Vous avez reçu un e-mail de nos services indiquant que la quantité de données sur votre base dépasse la limite autorisée. Votre base est donc passée en lecture seule. Ceci empêche toute modification de votre site.
+Vous avez reçu un e-mail indiquant que votre base de données dépasse la limite autorisée. Passée en lecture seule, elle empêche toute modification de votre site.
 
 ![database-overquota-notification-email](/pages/assets/screens/email-sending-to-customer/databases/overquota-db.png){.thumbnail}
 
@@ -121,7 +185,22 @@ Si vous disposez d'une formule **Starter** ou **Perso**, nous vous conseillons d
 > Nous vous conseillons donc, si vous constatez une augmentation soudaine de la taille de votre base de données ou si vous disposez d'un site de type « blog » normalement peu consommateur de données, de contacter immédiatement un [prestataire spécialisé](/links/partner). Nous ne serons pas en mesure de vous apporter un support sur ce sujet.
 >
 
-Pour effectuer ce changement, connectez-vous à votre [espace client OVHcloud](/links/manager) puis cliquez sur `Hébergements`{.action}, puis sur l'hébergement concerné. Cliquez sur le bouton `...`{.action} dans la rubrique `Offre` sur la droite de votre écran puis sur `Changer d'offre`{.action}.
+Pour effectuer ce changement, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur le bouton `...`{.action} dans la rubrique `Offre` sur la droite de votre écran.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur `Changer d'offre`{.action}.
 
 #### Méthode 2 : migrer vos données sur une base de taille supérieure <a name="methode2"></a>
 
@@ -140,7 +219,22 @@ Vous pouvez également migrer vos données sur une nouvelle base :
 
 Après avoir effectué une [sauvegarde de votre base de données](/pages/web_cloud/web_hosting/sql_database_export), connectez-vous à votre interface [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-linterface-phpmyadmin) afin de supprimer les données inutiles grâce aux commandes Drop, Delete et Truncate.
 
-Relancez ensuite le calcul du quota utilisé depuis l'onglet `Bases de données`{.action} de l'hébergement concerné : cliquez sur le bouton `...`{.action} concerné puis sur `Recalculer le quota`{.action}.
+Pour relancer le calcul du quota, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action}, puis sur le bouton `...`{.action} à droite de la base de données concernée.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur `Recalculer le quota`{.action}.
 
 > [!warning]
 >
@@ -149,7 +243,24 @@ Relancez ensuite le calcul du quota utilisé depuis l'onglet `Bases de données`
 
 #### Méthode 4 : optimiser votre base de données
 
-Pour optimiser votre base de données, suivez les instructions de notre guide « [Configurer votre serveur de bases de données](/pages/web_cloud/web_cloud_databases/configure-database-server#optimiser-vos-bases-de-donnees) ». Relancez ensuite le calcul du quota utilisé depuis l'onglet `Bases de données`{.action} de votre hébergement, en cliquant sur le bouton `...`{.action} de la base de données concernée.
+Pour optimiser votre base de données, suivez les instructions de notre guide « [Configurer votre serveur de bases de données](/pages/web_cloud/web_cloud_databases/configure-database-server#optimiser-vos-bases-de-donnees) ».
+
+Pour relancer le calcul du quota, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action}, puis sur le bouton `...`{.action} à droite de la base de données concernée.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur `Recalculer le quota`{.action}.
 
 > [!warning]
 >
@@ -158,19 +269,32 @@ Pour optimiser votre base de données, suivez les instructions de notre guide «
 
 ### Dépassements de la mémoire RAM (Web Cloud Databases uniquement)
 
-Le message suivant dans la partie `Web Cloud Databases`{.action} de votre [espace client OVHcloud](/links/manager) indique que votre serveur [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) a consommé une quantité de ressources trop importantes sur l'infrastructure OVHcloud :
+Le message suivant indique que votre serveur [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) a consommé une quantité de ressources trop importantes sur l'infrastructure OVHcloud :
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-Dans cette situation, vous pouvez augmenter la [quantité de mémoire RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifier-loffre-du-serveur-de-bases-de-donnees) disponible depuis la partie `Web Cloud Databases`{.action} de votre [espace client OVHcloud](/links/manager). Dans l'onglet `Informations générales`{.action}, cliquez sur le bouton `...`{.action} dans la rubrique `RAM`.
+Dans cette situation, vous pouvez augmenter la [quantité de mémoire RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#modifier-loffre-du-serveur-de-bases-de-donnees). Pour cela, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez la solution concernée.
+>>
+>> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `Informations générales`{.action}, repérez la rubrique `RAM`.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur le bouton `...`{.action} dans la rubrique `RAM`, puis sur `Changer la quantité de la RAM`{.action}.
 
 > [!warning]
 >
 > Pour augmenter sa RAM, le Web Cloud Databases ne doit pas avoir été activé via un hébergement Performance. Si vous souhaitez augmenter la quantité de mémoire vive d'une base de données incluse dans les [offres performance](/links/web/hosting-performance-offer), il vous faut d'abord en délier cette base de données.
 >
-> Pour délier la base de données, connectez-vous à votre [espace client OVHcloud](/links/manager) et sélectionnez l'onglet `Web Cloud`{.action}. Cliquez sur `Hébergements`{.action} puis choisissez l'hébergement web sur lequel le Web Cloud Databases est activé.
->
-> Dans la zone `Configuration`, cliquez sur le bouton `...`{.action} à droite de la mention `Web Cloud Databases`, puis cliquez sur le bouton `Délier`{.action}.
+> Pour délier la base de données, consultez notre guide « [Détacher un Web Cloud Databases de votre hébergement web](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting) ».
 >
 
 Vous pouvez également optimiser votre base de données en suivant les instructions de notre guide « [Configurer votre serveur de bases de données](/pages/web_cloud/web_cloud_databases/configure-database-server#optimiser-vos-bases-de-donnees) ».
@@ -190,13 +314,26 @@ Vous pouvez également optimiser votre base de données en suivant les instructi
 
 Ce message d'erreur signifie que la base de données que vous tentez d'importer contient des éléments non autorisés sur l'infrastructure mutualisée OVHcloud.
 
-Assurez-vous tout d'abord que votre base de données est vide depuis l'onglet `Bases de données`{.action} de l'hébergement concerné (cliquez sur le bouton `...`{.action} concerné puis sur `Recalculer le quota`{.action}).
+Vérifiez d'abord que votre base de données est vide. Pour cela, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-Dans le cas contraire, [sauvegardez les données présentes](/pages/web_cloud/web_hosting/sql_database_export) dans votre base puis supprimez-les avant de relancer l'opération d'import.
-
-Vous pouvez également cocher la case `Vider la base de données actuelle`{.action} juste avant de [lancer l'import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#importer-votre-propre-sauvegarde-depuis-lespace-client) :
-
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action}, puis sur le bouton `...`{.action} à droite de la base de données concernée et sur `Recalculer le quota`{.action}.
+>>
+> **Étape 3**
+>>
+>> Si la base de données n'est pas vide, [sauvegardez les données présentes](/pages/web_cloud/web_hosting/sql_database_export) puis supprimez-les avant de relancer l'opération d'import.
+>>
+>> Vous pouvez également cocher la case `Vider la base de données actuelle`{.action} juste avant de [lancer l'import](/pages/web_cloud/web_hosting/sql_importing_mysql_database#importer-votre-propre-sauvegarde-depuis-lespace-client) :
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
 Contactez si besoin notre [communauté d'utilisateurs](/links/community) ou un [prestataire spécialisé](/links/partner) à ce sujet. Nous ne serons pas en mesure de vous fournir une assistance sur la correction de cette anomalie.
 
@@ -230,7 +367,22 @@ Ce message d'erreur apparaît lors de [l'import d'une base de données](/pages/w
 
 Pour résoudre cette anomalie, vous pouvez :
 
-- Augmenter la [quantité de mémoire vive (RAM)](/pages/web_cloud/web_cloud_databases/configure-database-server#suivre-la-ram-consommee). Pour cela, rendez vous sur le serveur [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) concerné dans la rubrique `Bases de données`{.action} de votre [espace client OVHcloud](/links/manager). Cliquez ensuite sur le bouton `...`{.action} dans la partie `RAM`, puis sur `Changer la quantité de RAM`{.action}.
+- Augmenter la [quantité de mémoire vive (RAM)](/pages/web_cloud/web_cloud_databases/configure-database-server#suivre-la-ram-consommee). Pour cela, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez la solution concernée.
+>>
+>> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `Informations générales`{.action}, repérez la rubrique `RAM`.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur le bouton `...`{.action} dans la rubrique `RAM`, puis sur `Changer la quantité de la RAM`{.action}.
 
 - Fractionner votre base de données, afin de l'importer en plusieurs opérations au lieu d'une seule (pour toute question sur les manipulations à réaliser, contactez notre [communauté d'utilisateurs](/links/community) ou les [partenaires OVHcloud](/links/partner). En effet, nous ne serons pas en mesure de vous fournir une assistance sur ce sujet.)
 
@@ -244,7 +396,7 @@ Pour résoudre cette anomalie, vous pouvez :
 > **« mysqli::real_connect(): (HY000/1045): Access denied for user »**
 >
 
-Ce message d'erreur peut apparaître lors de la connexion à votre base de données par [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-linterface-phpmyadmin). Elle indique que les identifiants renseignés sont erronés.
+Ce message d'erreur peut apparaître lors de la connexion à votre base de données par [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-linterface-phpmyadmin). Il indique que les identifiants renseignés sont erronés.
 
 ![access_denied_for_user](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-1045.png){.thumbnail}
 
@@ -258,7 +410,7 @@ Dans cette situation, [vérifiez les identifiants renseignés](/pages/web_cloud/
 
 Le nombre maximal de connexions actives pour les bases de données livrées avec les hébergements mutualisés ([StartSQL](/links/web/hosting-options-startsql)) est de **30**.
 
-Ce nombre est de **200** pour les bases des serveurs [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) et [Cloud Databases](/links/web/databases)  (Ce paramètre est modifiable dans la partie `Configuration`{.action} de votre serveur de base de données).
+Ce nombre est de **200** pour les bases des serveurs [Web Cloud Databases](/links/web/databases) (ce paramètre est modifiable dans les [paramètres de configuration](/pages/web_cloud/web_cloud_databases/configure-database-server) de votre serveur de base de données).
 
 Ce message apparaît lors de la [connexion à PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acceder-a-linterface-phpmyadmin) lorsque ce nombre maximal de connexions est dépassé.
 
@@ -279,14 +431,43 @@ Ce message d'erreur apparaît lors de la [connexion à PhpMyAdmin](/pages/web_cl
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Vérifiez le nom du serveur à inscrire dans votre [espace client OVHcloud](/links/manager).
+Vérifiez le nom du serveur à inscrire.
 
-> [!success]
->
-> Si la base à laquelle vous souhaitez vous connecter apparaît dans l'onglet `Bases de données`{.action} de la partie `Hébergements`{.action} de votre [espace client OVHcloud](/links/manager), le nom à renseigner est inscrit dans la colonne `Adresse du serveur`.
->
-> Si vous souhaitez vous connecter à une base de données sur un serveur [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), le nom de serveur à renseigner est inscrit dans l'onglet `Informations générales`{.action}, partie `Informations de connexions`{.action}, `SQL`{.action} et dans la rubrique `Nom d'hôte`{.action}.
->
+**Cliquez sur la situation de votre choix pour afficher le contenu.**
+
+/// details | Base de données sur un hébergement web
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Bases de données`{.action}. Le nom du serveur à renseigner est inscrit dans la colonne `Adresse du serveur`.
+
+///
+
+/// details | Base de données sur un serveur Web Cloud Databases
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Web Cloud Databases](/links/control-panel/web-cloud-databases), puis choisissez la solution concernée.
+>>
+>> ![Web Cloud Databases](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `Informations générales`{.action}, le nom du serveur à renseigner est inscrit dans la partie `Informations de connexion`, rubrique `SQL`, mention `Nom d'hôte`.
+
+///
 
 ### Connexion impossible sur une base de données Cloud Databases
 
@@ -294,12 +475,12 @@ Disposer d'un serveur [Web Cloud Databases](/products/web-cloud-clouddb) vous pe
 
 Si cette connexion s'avère impossible, commencez par vérifier que vous avez bien [autorisé votre adresse IP publique](/pages/web_cloud/web_cloud_databases/starting_with_clouddb#autoriser-une-adresse-ip) à se connecter au serveur de bases de données.
 
-Si cette opération a bien été réalisée, contactez votre Fournisseur d'Accès à Internet ou les [partenaires OVHcloud](/links/partner). Nous ne serons pas en mesure de vous fournir une assistance dans cette situation.
+Si cette opération a bien été réalisée, contactez votre fournisseur d'accès à Internet ou les [partenaires OVHcloud](/links/partner). Nous ne serons pas en mesure de vous fournir une assistance dans cette situation.
 
 ## Aller plus loin <a name="go-further"></a>
 
 [Premiers pas avec le service Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
+Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.it-it.md
@@ -150,7 +150,7 @@ Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2**
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action} e verifica la corrispondenza tra gli elementi visualizzati e quelli presenti nel file `wp-config.php`:
+>> Clicca sulla scheda `Databases`{.action} e verifica la corrispondenza tra gli elementi visualizzati e quelli presenti nel file `wp-config.php`:
 >>
 >> - **my_database** deve corrispondere a quanto indicato in `Nome del database`;
 >> - **my_user** deve corrispondere a quanto riportato in `Nome utente`;
@@ -232,7 +232,7 @@ Per ricalcolare la quota, clicca sulle schede qui sotto per visualizzare in succ
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}, poi sul pulsante `...`{.action} accanto al database interessato.
+>> Clicca sulla scheda `Databases`{.action}, poi sul pulsante `...`{.action} accanto al database interessato.
 >>
 > **Passaggio 3**
 >>
@@ -258,7 +258,7 @@ Per ricalcolare la quota, clicca sulle schede qui sotto per visualizzare in succ
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}, poi sul pulsante `...`{.action} accanto al database interessato.
+>> Clicca sulla scheda `Databases`{.action}, poi sul pulsante `...`{.action} accanto al database interessato.
 >>
 > **Passaggio 3**
 >>
@@ -327,7 +327,7 @@ Per prima cosa, assicurati che il database sia vuoto. Per farlo, clicca sulle sc
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}, poi sul pulsante `...`{.action} accanto al database interessato e su `Ricalcola la quota`{.action}.
+>> Clicca sulla scheda `Databases`{.action}, poi sul pulsante `...`{.action} accanto al database interessato e su `Ricalcola la quota`{.action}.
 >>
 > **Passaggio 3**
 >>
@@ -450,7 +450,7 @@ Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2**
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `Database`{.action}. Il nome del server da inserire è indicato nella colonna `Indirizzo del server`.
+>> Clicca sulla scheda `Databases`{.action}. Il nome del server da inserire è indicato nella colonna `Indirizzo del server`.
 
 ///
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Risolvi gli errori più frequenti associati ai database"
 excerpt: "Diagnostica i casi di errore più frequenti associati ai database"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Obiettivo
 
-L'utilizzo dei database può provocare alcune anomalie sul tuo sito o sul tuo [Spazio Cliente OVHcloud](/links/manager), così come sull'interfaccia [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database).
+L'utilizzo dei database può provocare alcune anomalie sul tuo sito o sul tuo [Spazio Cliente OVHcloud](/links/manager), così come sull'interfaccia [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database).
 
 **Scopri come risolvere gli errori associati ai database sugli hosting condivisi OVHcloud.**
 
@@ -95,7 +95,7 @@ Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2**
 >>
 > **Passaggio 2**
 >>
->> Individua il `Nome host` nella sezione `SQL` delle `Informazioni di connessione`.
+>> Individua il `Nome host` nella sezione `SQL` delle `Informazioni di login`.
 
 ///
 
@@ -116,7 +116,7 @@ Accedi in [FTP](/pages/web_cloud/web_hosting/ftp_connection) allo spazio di arch
 > In caso di necessità, ti consigliamo di rivolgerti all'editor del [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) utilizzato per creare il tuo sito o di rivolgerti a un [fornitore specializzato](/links/partner). Non saremo in grado di fornirti assistenza al riguardo.
 >
 
-Verifica la corrispondenza **esatta** tra le credenziali di connessione a [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database) e quelle del file di configurazione del tuo sito.
+Verifica la corrispondenza **esatta** tra le credenziali di connessione a [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accedere-all-interfaccia-phpmyadmin) e quelle del file di configurazione del tuo sito.
 
 Modifica, se necessario, la [password del tuo database](/pages/web_cloud/web_hosting/sql_change_password).
 
@@ -196,7 +196,7 @@ Per effettuare questa modifica, clicca sulle schede qui sotto per visualizzare i
 >>
 > **Passaggio 2**
 >>
->> Clicca sul pulsante `...`{.action} nella sezione `Offerta` sulla destra dello schermo.
+>> Clicca sul pulsante `...`{.action} nella sezione `Piano` sulla destra dello schermo.
 >>
 > **Passaggio 3**
 >>
@@ -219,7 +219,7 @@ Puoi anche migrare i tuoi dati su un nuovo database:
 
 #### Metodo 3: eliminare i dati non necessari
 
-Dopo aver effettuato un [backup del tuo database](/pages/web_cloud/web_hosting/sql_database_export), accedi alla tua interfaccia [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database) per eliminare i dati inutili grazie ai comandi Drop, Delete e Truncate.
+Dopo aver effettuato un [backup del tuo database](/pages/web_cloud/web_hosting/sql_database_export), accedi alla tua interfaccia [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accedere-all-interfaccia-phpmyadmin) per eliminare i dati inutili grazie ai comandi Drop, Delete e Truncate.
 
 Per ricalcolare la quota, clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **3** passaggi.
 
@@ -333,7 +333,7 @@ Per prima cosa, assicurati che il database sia vuoto. Per farlo, clicca sulle sc
 >>
 >> Se il database non è vuoto, [salva i dati presenti](/pages/web_cloud/web_hosting/sql_database_export) e poi eliminali prima di riavviare l'operazione di importazione.
 >>
->> Puoi anche selezionare la casella `Elimina tutti i file dal tuo database attuale`{.action} immediatamente prima di [avviare l'importazione](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server):
+>> Puoi anche selezionare la casella `Elimina tutti i file dal tuo database attuale`{.action} immediatamente prima di [avviare l'importazione](/pages/web_cloud/web_hosting/sql_importing_mysql_database#importare-il-backup-personale-dallo-spazio-cliente-ovhcloud):
 >>
 >> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
@@ -390,7 +390,7 @@ Per risolvere questa anomalia, puoi:
 
 - [Ottimizza il tuo database](/pages/web_cloud/web_cloud_databases/configure-database-server#ottimizza-i-tuoi-database) e ripeti le operazioni di esportazione/importazione.
 
-### Impossibile accedere a PhpMyAdmin
+### Impossibile accedere a phpMyAdmin
 
 #### "Access denied for user"
 
@@ -398,11 +398,11 @@ Per risolvere questa anomalia, puoi:
 > **"mysqli::real_connect(): (HY000/1045): Access denied for user"**
 >
 
-Questo messaggio di errore può comparire durante la connessione al tuo database da [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database). Indica che gli identificativi inseriti sono errati.
+Questo messaggio di errore può comparire durante la connessione al tuo database da [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accedere-all-interfaccia-phpmyadmin). Indica che gli identificativi inseriti sono errati.
 
 ![access_denied_for_user](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-1045.png){.thumbnail}
 
-In questa situazione, [verifica le credenziali inserite](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) e, se necessario, modifica la [password del tuo database](/pages/web_cloud/web_hosting/sql_change_password).
+In questa situazione, [verifica le credenziali inserite](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#procedura) e, se necessario, modifica la [password del tuo database](/pages/web_cloud/web_hosting/sql_change_password).
 
 #### "Too many connections"
 
@@ -414,7 +414,7 @@ Il numero massimo di connessioni attive per i database consegnati con hosting co
 
 Questo numero è di **200** per i database dei server [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (Questo parametro è modificabile nella sezione `Configurazione`{.action} del tuo server database).
 
-Questo messaggio compare durante la [connessione a PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database) quando viene superato il numero massimo di connessioni.
+Questo messaggio compare durante la [connessione a phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#accedere-all-interfaccia-phpmyadmin) quando viene superato il numero massimo di connessioni.
 
 Per ridurre il numero di connessioni attive, è necessario [ottimizzare i tuoi database](/pages/web_cloud/web_cloud_databases/configure-database-server#ottimizza-i-tuoi-database).
 
@@ -429,7 +429,7 @@ Per ridurre il numero di connessioni attive, è necessario [ottimizzare i tuoi d
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
 >
 
-Questo messaggio di errore compare durante la [connessione a PhpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) quando il nome del server inserito non è corretto.
+Questo messaggio di errore compare durante la [connessione a phpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#procedura) quando il nome del server inserito non è corretto.
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
@@ -467,7 +467,7 @@ Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2**
 >>
 > **Passaggio 2**
 >>
->> Nella scheda `Informazioni generali`{.action}, il nome del server da inserire è indicato nella sezione `Informazioni di connessione`, sotto `SQL`, alla voce `Nome host`.
+>> Nella scheda `Informazioni generali`{.action}, il nome del server da inserire è indicato nella sezione `Informazioni di login`, sotto `SQL`, alla voce `Nome host`.
 
 ///
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.it-it.md
@@ -1,8 +1,22 @@
 ---
 title: "Risolvi gli errori più frequenti associati ai database"
 excerpt: "Diagnostica i casi di errore più frequenti associati ai database"
-updated: 2026-02-11
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Obiettivo
 
@@ -12,9 +26,9 @@ L'utilizzo dei database può provocare alcune anomalie sul tuo sito o sul tuo [S
 
 > [!warning]
 >
-> OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
+> OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell'utente.
 >
-> Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l’amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) su questa guida.
+> Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un [fornitore specializzato](/links/partner) o l'amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) su questa guida.
 >
 
 ## Prerequisiti
@@ -27,7 +41,7 @@ L'utilizzo dei database può provocare alcune anomalie sul tuo sito o sul tuo [S
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -41,25 +55,65 @@ L'utilizzo dei database può provocare alcune anomalie sul tuo sito o sul tuo [S
 
 #### Verifica gli incidenti in corso
 
-Verificate innanzitutto sulla pagina [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) che il vostro datacenter, il vostro cluster di hosting web, il vostro server Web Cloud Database o la vostra base di dati non siano interessati da un incidente sull'infrastruttura OVHcloud.
+Verifica innanzitutto sulla pagina [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) che il tuo datacenter, il tuo cluster di hosting web, il tuo server Web Cloud Databases o il tuo database non siano interessati da un incidente sull'infrastruttura OVHcloud.
 
-> [!primary]
-> Per maggiori informazioni, accedi allo [Spazio Cliente OVHcloud](/links/manager), sezione `Web Cloud`{.action}:
->
-> - Per trovare il `Datacenter` del vostro hosting web, selezionate `Hosting`{.action}, quindi l'hosting web desiderato. Troverete queste informazioni nella scheda `Informazioni generali`{.action}.
-> - Per trovare il **cluster** di server e il **filer** (server file) del vostro hosting web, consultate [questa guida](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - Per recuperare il nome del tuo server **Web Cloud Databases**, clicca su `Web Cloud Databases`{.action} e seleziona l'offerta corrispondente. Questa informazione è disponibile nella scheda `Informazioni generali`{.action}.
-> - Per trovare il server su cui si trova la vostra base di dati inclusa o acquistata come complemento tramite il vostro [hosting web](/links/web/hosting), consultate [questa guida](/pages/web_cloud/web_hosting/sql_find_server).
+**Clicca sull'informazione che cerchi per visualizzare il contenuto.**
+
+/// details | Trovare il datacenter del tuo hosting web
+
+Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Nella scheda `Informazioni generali`{.action}, individua il `Datacenter`.
+
+///
+
+/// details | Trovare il cluster e il filer del tuo hosting web
+
+Consulta la nostra guida "[Conoscere il cluster e il filer del tuo hosting web](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Trovare il nome del server Web Cloud Databases
+
+Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona il servizio interessato.
+>>
+>> ![Selezione di un server Web Cloud Databases nello Spazio Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Individua il `Nome host` nella sezione `SQL` delle `Informazioni di connessione`.
+
+///
+
+/// details | Trovare il server del tuo database di hosting web
+
+Consulta la nostra guida "[Trovare il server del tuo database](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Verifica le credenziali di connessione al tuo database <a name="config_file"></a>
 
-Accedi in [FTP](/pages/web_cloud/web_hosting/ftp_connection) allo spazio di archiviazione dei file sul tuo hosting e ritrova il file di configurazione del tuo sito (ad esempio, per un sito WordPress, si tratta del file **wp-config.php***, che contiene il tuo sito).
+Accedi in [FTP](/pages/web_cloud/web_hosting/ftp_connection) allo spazio di archiviazione dei file sul tuo hosting e ritrova il file di configurazione del tuo sito (ad esempio, per un sito WordPress, si tratta del file **wp-config.php** situato nella cartella che contiene il tuo sito).
 
 > [!warning]
 >
-> La scelta e la configurazione del file contenente le informazioni di connessione al database sono inerenti al mittente del contenuto (CMS) interessato e non a OVHcloud.
+> La scelta e la configurazione del file contenente le informazioni di connessione al database sono inerenti all'editor del contenuto (CMS) interessato e non a OVHcloud.
 >
-> In caso di necessità, ti consigliamo di rivolgerti all'editor del [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) utilizzato per creare il tuo sito o di rivolgerti a uno specialista del settore(/links/partner). Non saremo in grado di fornirti assistenza al riguardo.
+> In caso di necessità, ti consigliamo di rivolgerti all'editor del [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) utilizzato per creare il tuo sito o di rivolgerti a un [fornitore specializzato](/links/partner). Non saremo in grado di fornirti assistenza al riguardo.
 >
 
 Verifica la corrispondenza **esatta** tra le credenziali di connessione a [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database) e quelle del file di configurazione del tuo sito.
@@ -68,34 +122,46 @@ Modifica, se necessario, la [password del tuo database](/pages/web_cloud/web_hos
 
 #### Esempio per WordPress
 
-Se il tuo sito visualizza un messaggio **"Errore durante la connessione al database"** e non è interessato da un [incidente](https://web-cloud.status-ovhcloud.com/), accedi al tuo hosting e apri la directory contenente il tuo sito (di default la cartella `wwww`) ...
+Se il tuo sito visualizza un messaggio **"Errore durante la connessione al database"** e non è interessato da un [incidente](https://web-cloud.status-ovhcloud.com/), accedi in [FTP](/pages/web_cloud/web_hosting/ftp_connection) al tuo hosting e apri la directory contenente il tuo sito (di default la cartella `www`).
 
 Se il tuo sito è WordPress, apri il file `wp-config.php`.
 
 ```php
 define('DB_NAME', 'my_database');
- 
+
 /** MySQL database username */
 define('DB_USER', 'my_user');
- 
+
 /** MySQL database password */
 define('DB_PASSWORD', 'my_password');
- 
+
 /** MySQL hostname */
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-Nello Spazio Cliente OVHcloud (/links/manager), sezione `Hosting`{.action}, clicca su `Database`{.action} e verifica la corrispondenza tra gli elementi visualizzati e quelli presenti nel file `wp-config.php`:
+Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2** passaggi.
 
-- **my_database** deve corrispondere a quanto indicato in `Nome del database`
-- **my_user** deve corrispondere a quanto riportato nella `Nome utente`
-- **my_password** corrisponde alla [password del tuo database](/pages/web_cloud/web_hosting/sql_change_password)
-- **my_server.mysql.db** deve corrispondere a quanto riportato su `Indirizzo del server`.
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `Database`{.action} e verifica la corrispondenza tra gli elementi visualizzati e quelli presenti nel file `wp-config.php`:
+>>
+>> - **my_database** deve corrispondere a quanto indicato in `Nome del database`;
+>> - **my_user** deve corrispondere a quanto riportato in `Nome utente`;
+>> - **my_password** corrisponde alla [password del tuo database](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** deve corrispondere a quanto riportato in `Indirizzo del server`.
 
 > [!primary]
-> Se queste operazioni non ti permettono di ripristinare l'accesso al tuo sito, [salva il tuo database](/pages/web_cloud/web_hosting/sql_database_export) e [ripristina il database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#ripristina-e-importa-un-database-dallo-spazio-cliente) dal tuo [Spazio Cliente OVHcloud](/links/manager).
 >
-> Contatta uno specialista del settore (/links/partner) se necessario. Non saremo in grado di fornirti assistenza al riguardo.
+> Se queste operazioni non ti permettono di ripristinare l'accesso al tuo sito, [salva il tuo database](/pages/web_cloud/web_hosting/sql_database_export) e [ripristinalo a una data precedente](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#ripristina-e-importa-un-database-dallo-spazio-cliente) dal tuo [Spazio Cliente OVHcloud](/links/manager).
+>
+> Contatta un [fornitore specializzato](/links/partner) se necessario. Non saremo in grado di fornirti assistenza al riguardo.
 >
 
 ### Superamento della quota autorizzata del database
@@ -116,22 +182,38 @@ Se disponi di una formula **Starter** o **Personale**, ti consigliamo di passare
 >
 > Un'anomalia può provocare un aumento permanente della dimensione del tuo database, nel qual caso la modifica dell'offerta di hosting risulterebbe inefficace.
 >
-> Ti consigliamo quindi di contattare immediatamente uno specialista (/links/partner) se riscontri un improvviso aumento nella dimensione del tuo database o se disponi di un sito di tipo "blog" normalmente a basso consumo di dati. Non saremo in grado di fornirti assistenza in merito.
+> Ti consigliamo quindi di contattare immediatamente un [fornitore specializzato](/links/partner) se riscontri un improvviso aumento nella dimensione del tuo database o se disponi di un sito di tipo "blog" normalmente a basso consumo di dati. Non saremo in grado di fornirti assistenza in merito.
 >
 
-Accedi allo [Spazio Cliente OVHcloud](/links/manager) e clicca su `Hosting`{.action} > 'hosting interessato'. Clicca sul pulsante `...`{.action} nella sezione `Offre` sulla destra dello schermo e su `Modifica dell'offerta`{.action}.
+Per effettuare questa modifica, clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **3** passaggi.
 
-Se utilizzi un'offerta **Performance**, consulta la sezione [metodo 2](#methode2).
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sul pulsante `...`{.action} nella sezione `Offerta` sulla destra dello schermo.
+>>
+> **Passaggio 3**
+>>
+>> Clicca su `Modificare soluzione`{.action}.
+
+Se utilizzi un'offerta **Performance**, consulta il [metodo 2](#methode2).
 
 #### Metodo 2: migrare i tuoi dati su un database di dimensione superiore <a name="methode2"></a>
 
 Puoi anche migrare i tuoi dati su un nuovo database:
 
-- Ordinare, se necessario, una [database](/links/web/hosting-options-startsql) di dimensione superiore e avviarne la [creazione](/pages/web_cloud/web_hosting/sql_create_database);
-- [Duplicare il contenuto del vecchio database](/pages/web_cloud/web_hosting/copy_database) nel nuovo **o** effettua un [export dei tuoi dati](/pages/web_cloud/web_hosting/sql_database_export), poi [importali](/pages/web_cloud/web_hosting/sql_importing_mysql_database) nel nuovo database;
+- Ordina, se necessario, un [database](/links/web/hosting-options-startsql) di dimensione superiore e avviane la [creazione](/pages/web_cloud/web_hosting/sql_create_database).
+- [Duplica il contenuto del vecchio database](/pages/web_cloud/web_hosting/copy_database) nel nuovo **o** effettua un [export dei tuoi dati](/pages/web_cloud/web_hosting/sql_database_export), poi [importali](/pages/web_cloud/web_hosting/sql_importing_mysql_database) nel nuovo database.
 - Inserisci gli identificativi del nuovo database nel [file di configurazione](#config_file) del tuo sito.
 
 > [!primary]
+>
 > Se disponi di un hosting **Performance**, puoi anche [attivare gratuitamente un server Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 >
 
@@ -139,16 +221,48 @@ Puoi anche migrare i tuoi dati su un nuovo database:
 
 Dopo aver effettuato un [backup del tuo database](/pages/web_cloud/web_hosting/sql_database_export), accedi alla tua interfaccia [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database) per eliminare i dati inutili grazie ai comandi Drop, Delete e Truncate.
 
-Esegui il calcolo della quota utilizzando la scheda `Database`{.action} dell'hosting in questione: clicca sul pulsante `...`{.action} interessata e seleziona `Ricalcola la quota`{.action}.
+Per ricalcolare la quota, clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **3** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `Database`{.action}, poi sul pulsante `...`{.action} accanto al database interessato.
+>>
+> **Passaggio 3**
+>>
+>> Clicca su `Ricalcola la quota`{.action}.
 
 > [!warning]
 >
-> Questa operazione richiede competenze tecniche molto elevate. In caso di necessità, ti consigliamo di rivolgerti a uno specialista del settore (/links/partner). Non saremo in grado di fornirvi assistenza in merito.
+> Questa operazione richiede competenze tecniche elevate. In caso di necessità, ti consigliamo di rivolgerti a un [fornitore specializzato](/links/partner). Non saremo in grado di fornirti assistenza in merito.
 >
 
 #### Metodo 4: ottimizzare il tuo database
 
-Per ottimizzare il tuo database, segui le istruzioni della nostra guida [Configura il tuo server di database](/pages/web_cloud/web_cloud_databases/configure-database-server#ottimizza-i-tuoi-database). Clicca sulla scheda `Database`{.action} del tuo hosting e poi riavvia il calcolo della quota `...`{.action} del database in questione.
+Per ottimizzare il tuo database, segui le istruzioni della nostra guida "[Configurare il tuo server di database](/pages/web_cloud/web_cloud_databases/configure-database-server#ottimizza-i-tuoi-database)".
+
+Per ricalcolare la quota, clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **3** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `Database`{.action}, poi sul pulsante `...`{.action} accanto al database interessato.
+>>
+> **Passaggio 3**
+>>
+>> Clicca su `Ricalcola la quota`{.action}.
 
 > [!warning]
 >
@@ -157,24 +271,38 @@ Per ottimizzare il tuo database, segui le istruzioni della nostra guida [Configu
 
 ### Superamento della capacità della RAM (solo Web Cloud Databases)
 
-Nella sezione `Web Cloud Databases`{.action} del tuo [Spazio Cliente OVHcloud](/links/manager) è riportato che il tuo server [Web Cloud Databases](/links/web/databases) ha consumato troppe risorse sull'infrastruttura OVHcloud:
+Il seguente messaggio indica che il tuo server [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) ha consumato troppe risorse sull'infrastruttura OVHcloud:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-In questa situazione è possibile aumentare la [quantità di memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#monitora-la-ram-consumata) disponibile nella sezione `Web Cloud Databases`{.action} del tuo [Spazio Cliente OVHcloud](/links/manager). Nella scheda `Informazioni generali`{.action}, clicca sul pulsante `...`{.action} nella sezione `RAM`.
+Per aumentare la [quantità di memoria RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#monitora-la-ram-consumata), clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **3** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona il servizio interessato.
+>>
+>> ![Selezione di un server Web Cloud Databases nello Spazio Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Nella scheda `Informazioni generali`{.action}, individua la sezione `RAM`.
+>>
+> **Passaggio 3**
+>>
+>> Clicca sul pulsante `...`{.action} nella sezione `RAM`, poi su `Modifica la quantità di RAM`{.action}.
 
 > [!warning]
 >
-> Per aumentare la RAM, il Web Cloud Databases non deve essere attivato tramite un hosting Performance. Per aumentare la quantità di RAM di un database incluso nelle [offerte performance](/links/web/hosting-performance-offer), è necessario scollegarla prima.
-> 
-> Accedi allo [Spazio Cliente OVHcloud](/links/manager) e seleziona `Web Cloud`{.action}. Clicca su `Hosting`{.action} e seleziona l'hosting Web su cui è attivo il Web Cloud Databases.
+> Per aumentare la RAM, il Web Cloud Databases non deve essere attivato tramite un hosting Performance. Per aumentare la quantità di RAM di un database incluso nelle [offerte performance](/links/web/hosting-performance-offer), è necessario prima scollegarlo.
 >
-> Nella zona `Configurazione`, clicca sui `...`{.action} in corrispondenza dell'menzione `Web Cloud Databases` e clicca su `Scollega`{.action}.
+> Per scollegare il database, consulta la nostra guida "[Scollegare un Web Cloud Databases dal tuo hosting web](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
 >
 
 Per ottimizzare il tuo database, segui le istruzioni della nostra guida "[Configurare il tuo server di database](/pages/web_cloud/web_cloud_databases/configure-database-server#ottimizza-i-tuoi-database)".
 
 > [!primary]
+>
 > Se riscontri difficoltà nell'utilizzo delle risorse sul tuo server di database e non desideri aumentarle, contatta la nostra [Community di utenti](/links/community) o i [partner OVHcloud](/links/partner). Non saremo in grado di fornirti assistenza al riguardo.
 >
 
@@ -186,23 +314,41 @@ Per ottimizzare il tuo database, segui le istruzioni della nostra guida "[Config
 > **"#1044 - Access denied for user to database"**
 >
 
-Per prima cosa, assicurati che il database sia vuoto dalla scheda `Database`{.action} dell'hosting interessato (clicca sul pulsante `...`{.action} in questione e su `Ricalcola la quota`{.action}) per [salvare i dati presenti](/pages/web_cloud/web_hosting/sql_database_export).
+Questo messaggio di errore significa che il database che stai cercando di importare contiene elementi non autorizzati sull'infrastruttura condivisa OVHcloud.
 
-Seleziona la casella `Svuota il database attuale`{.action} immediatamente prima di [avviare l'importazione](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server):
+Per prima cosa, assicurati che il database sia vuoto. Per farlo, clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **3** passaggi.
 
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `Database`{.action}, poi sul pulsante `...`{.action} accanto al database interessato e su `Ricalcola la quota`{.action}.
+>>
+> **Passaggio 3**
+>>
+>> Se il database non è vuoto, [salva i dati presenti](/pages/web_cloud/web_hosting/sql_database_export) e poi eliminali prima di riavviare l'operazione di importazione.
+>>
+>> Puoi anche selezionare la casella `Elimina tutti i file dal tuo database attuale`{.action} immediatamente prima di [avviare l'importazione](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-Questo messaggio di errore significa che il database che stai cercando di importare contiene elementi non autorizzati sull'infrastruttura condivisa OVHcloud. Contatta, se necessario, la nostra [Community di utenti](/links/community) o un [provider specializzato](/links/partner). Non saremo in grado di fornirti assistenza sulla correzione di questa anomalia.
+Contatta, se necessario, la nostra [Community di utenti](/links/community) o un [fornitore specializzato](/links/partner). Non saremo in grado di fornirti assistenza sulla correzione di questa anomalia.
 
-> [!success]
+> [!primary]
 >
-> Avere un "**trigger**" nello script di importazione del tuo database non è autorizzato sui server di hosting condiviso OVHcloud. importa il tuo database su un server [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
->
+> **Quali elementi nello script di importazione del database possono causare un errore "#1044 - Access denied for user to database"?**
+
+Avere un **"trigger"** nello script di importazione del tuo database non è autorizzato sui server di hosting condiviso OVHcloud. In questo caso, importa il tuo database su un server [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb).
 
 Inoltre, la seguente richiesta non è autorizzata:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
 Sostituiscila con:
@@ -216,18 +362,33 @@ USE `Database-Name`;
 #### "MySQL server has gone away"
 
 >
-> **"404 ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
 Questo messaggio di errore compare durante l'[importazione di un database](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#importa-un-backup-locale) su un server [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). È legato per la maggior parte del tempo alla quantità troppo elevata di dati da importare o alla mancanza di ottimizzazione delle richieste SQL nello script di importazione.
 
 Per risolvere questa anomalia, puoi:
 
-- Aumentare la [quantità di RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#monitora-la-ram-consumata). accedendo alla sezione `Database` del tuo [Spazio Cliente OVHcloud](/links/manager). Clicca sul pulsante `...`{.action} nella sezione `RAM` e clicca su `Modifica la quantità di RAM`{.action}.
+- Aumentare la [quantità di RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#monitora-la-ram-consumata). Per farlo, clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **3** passaggi.
 
-- Per importare il tuo database in più operazioni anziché in una sola pagina (per maggiori informazioni sulle operazioni da effettuare, contatta la nostra [Community di utenti](/links/community) o i [partner OVHcloud](/links/partner) OVHcloud non potrà fornirti alcuna assistenza al riguardo).
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona il servizio interessato.
+>>
+>> ![Selezione di un server Web Cloud Databases nello Spazio Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Nella scheda `Informazioni generali`{.action}, individua la sezione `RAM`.
+>>
+> **Passaggio 3**
+>>
+>> Clicca sul pulsante `...`{.action} nella sezione `RAM`, poi su `Modifica la quantità di RAM`{.action}.
 
-- [Ottimizza il tuo database](/pages/web_cloud/web_cloud_databases/configure-database-server) e ripeti le operazioni di esportazione/importazione.
+- Frazionare il tuo database per importarlo in più operazioni anziché in una sola (per maggiori informazioni sulle operazioni da effettuare, contatta la nostra [Community di utenti](/links/community) o i [partner OVHcloud](/links/partner). OVHcloud non potrà fornirti alcuna assistenza al riguardo).
+
+- [Ottimizza il tuo database](/pages/web_cloud/web_cloud_databases/configure-database-server#ottimizza-i-tuoi-database) e ripeti le operazioni di esportazione/importazione.
 
 ### Impossibile accedere a PhpMyAdmin
 
@@ -237,7 +398,7 @@ Per risolvere questa anomalia, puoi:
 > **"mysqli::real_connect(): (HY000/1045): Access denied for user"**
 >
 
-Questo messaggio di errore può comparire durante la connessione al tuo database da [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database). Essa indica che gli identificativi indicati sono errati.
+Questo messaggio di errore può comparire durante la connessione al tuo database da [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database). Indica che gli identificativi inseriti sono errati.
 
 ![access_denied_for_user](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-1045.png){.thumbnail}
 
@@ -249,13 +410,13 @@ In questa situazione, [verifica le credenziali inserite](/pages/web_cloud/web_cl
 > **"mysqli_real_connect(): (HY000/1040): Too many connections"**
 >
 
-Il numero massimo di connessioni attive per i database consegnati con hosting condivisi ([StartSQL](/links/web/hosting-options-startsql) è di **30**.
+Il numero massimo di connessioni attive per i database consegnati con hosting condivisi ([StartSQL](/links/web/hosting-options-startsql)) è di **30**.
 
-Questo numero è di **200** per i database dei server [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (Questo parametro è modificabile nella sezione `Configuration`{.action} del tuo server database).
+Questo numero è di **200** per i database dei server [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (Questo parametro è modificabile nella sezione `Configurazione`{.action} del tuo server database).
 
 Questo messaggio compare durante la [connessione a PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database) quando viene superato il numero massimo di connessioni.
 
-Per ridurre il numero di connessioni attive, è necessario [ottimizzare i tuoi database](/pages/web_cloud/web_cloud_databases/configure-database-server).
+Per ridurre il numero di connessioni attive, è necessario [ottimizzare i tuoi database](/pages/web_cloud/web_cloud_databases/configure-database-server#ottimizza-i-tuoi-database).
 
 > [!warning]
 >
@@ -272,22 +433,51 @@ Questo messaggio di errore compare durante la [connessione a PhpMyAdmin](/pages/
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Verifica il nome del server da iscrivere nel tuo [Spazio Cliente OVHcloud](/links/manager).
+Verifica il nome del server corrispondente.
 
-> [!success]
->
-> Se il database a cui vuoi connetterti compare nella scheda `Database`{.action} della sezione `Hosting`{.action} del tuo [Spazio Cliente OVHcloud](/links/manager), il nome da inserire è indicato nella colonna `Indirizzo del server`.
->
-> Se vuoi connetterti a un database su un server [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) il nome del server da inserire è iscritto nella scheda `Informazioni generali`{.action}, `Informazioni di connessione`{.action}, `SQL`{.action} e nella sezione `Nome host`{.action}.
->
+**Clicca sulla situazione corrispondente per visualizzare il contenuto.**
+
+/// details | Database su un hosting web
+
+Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `Database`{.action}. Il nome del server da inserire è indicato nella colonna `Indirizzo del server`.
+
+///
+
+/// details | Database su un server Web Cloud Databases
+
+Clicca sulle schede qui sotto per visualizzare in successione ciascuno dei **2** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Web Cloud Databases](/links/control-panel/web-cloud-databases), poi seleziona il servizio interessato.
+>>
+>> ![Selezione di un server Web Cloud Databases nello Spazio Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Nella scheda `Informazioni generali`{.action}, il nome del server da inserire è indicato nella sezione `Informazioni di connessione`, sotto `SQL`, alla voce `Nome host`.
+
+///
 
 ### Connessione impossibile su un database Cloud Databases
 
-Disporre di un server [Web Cloud Databases](/products/web-cloud-clouddb) permette di [accedere ai propri database](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) dal proprio computer o da un server esterno all’infrastruttura OVHcloud.
+Disporre di un server [Web Cloud Databases](/products/web-cloud-clouddb) permette di [accedere ai propri database](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) dal proprio computer o da un server esterno all'infrastruttura OVHcloud.
 
 Se non riesci a effettuare questa connessione, verifica innanzitutto di aver [autorizzato il tuo indirizzo IP pubblico](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) a connettersi al server di database.
 
-Se l’operazione è stata effettuata correttamente, contatta il tuo ISP o i [partner OVHcloud](/links/partner). OVHcloud non sarà in grado di fornirti assistenza in questa situazione.
+Se l'operazione è stata effettuata correttamente, contatta il tuo ISP o i [partner OVHcloud](/links/partner). OVHcloud non sarà in grado di fornirti assistenza in questa situazione.
 
 ## Per saperne di più <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.pl-pl.md
@@ -1,10 +1,24 @@
 ---
 title: "Rozwiąż najczęstsze błędy związane z bazami danych"
 excerpt: "Zdiagnozuj najczęstsze przypadki błędów związanych z bazami danych"
-updated: 2026-02-11
+updated: 2026-03-26
 ---
 
-## Wprowadzenie 
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
+
+## Wprowadzenie
 
 Korzystanie z baz danych może spowodować pewne nieprawidłowości na Twojej stronie WWW lub w [Panelu klienta OVHcloud](/links/manager), jak również w interfejsie [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database).
 
@@ -14,20 +28,20 @@ Korzystanie z baz danych może spowodować pewne nieprawidłowości na Twojej st
 >
 > OVHcloud udostępnia różnorodne usługi, jednak to Ty odpowiadasz za ich konfigurację i zarządzanie nimi. Ponosisz więc odpowiedzialność za ich prawidłowe funkcjonowanie.
 >
-> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. W przypadku trudności zalecamy skorzystanie z pomocy wyspecjalizowanego webmastera lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) ten przewodnik.
+> Oddajemy w Twoje ręce niniejszy przewodnik, którego celem jest pomoc w wykonywaniu bieżących zadań. Jednakże w przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub kontakt z producentem oprogramowania. Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie. Więcej informacji znajduje się w sekcji [Sprawdź również](#go-further) tego przewodnika.
 >
 
 ## Wymagania początkowe
 
 - Posiadanie [hostingu www OVHcloud](/links/web/hosting).
-- Korzystanie z jednej z naszych ofert baz danych [Web Cloud](/links/web/hosting-options-startsql) lub [Web Cloud Databases](/links/web/databases)
+- Korzystanie z jednej z naszych ofert baz danych [Web Cloud](/links/web/hosting-options-startsql) lub [Web Cloud Databases](/links/web/databases).
 
 <!-- CP-NAV-START:web-hosting -->
 ---
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -43,14 +57,53 @@ Korzystanie z baz danych może spowodować pewne nieprawidłowości na Twojej st
 
 Sprawdź najpierw na stronie [Web Cloud Status](https://web-cloud.status-ovhcloud.com/), czy Twój datacenter, klaster hostingu sieciowego, serwer Web Cloud Databases lub baza danych nie są dotknięte awarią infrastruktury OVHcloud.
 
-> [!primary]
->
-> Aby odnaleźć te informacje, zaloguj się do [Panelu klienta OVHcloud](/links/manager), w części `Web Cloud`{.action} :
->
-> - Aby znaleźć `Data center` dla Twojego hostingu sieciowego, wybierz `Hosting`{.action}, a następnie odpowiedni hosting sieciowy. Te informacje znajdziesz na karcie `Informacje ogólne`{.action}.
-> - Aby znaleźć **klaster** serwerów i **filer** (serwer plików) dla Twojego hostingu sieciowego, zapoznaj się z [tym przewodnikiem](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - Aby odnaleźć nazwę serwera **Web Cloud Databases**, kliknij przycisk `Web Cloud Databases`{.action}, a następnie wybierz odpowiednią ofertę. Informacja ta znajduje się pod pozycją `Nazwa hosta` w polu `SQL` `Informacje na temat połączenia`.
-> - Aby znaleźć serwer, na którym znajduje się Twoja baza danych włączona lub zamówiona jako dodatek do Twojego [hostingu sieciowego](/links/web/hosting), zapoznaj się z [tym przewodnikiem](/pages/web_cloud/web_hosting/sql_find_server).
+**Kliknij poszukiwaną informację, aby wyświetlić treść.**
+
+/// details | Znaleźć datacenter Twojego hostingu
+
+Kliknij na poniższe karty, aby wyświetlić kolejno każdy z **2** kroków.
+
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), a następnie wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> W zakładce `Informacje ogólne`{.action} odszukaj `Data center`.
+
+///
+
+/// details | Znaleźć klaster i filer Twojego hostingu
+
+Zapoznaj się z naszym przewodnikiem „[Poznaj klaster i filer Twojego hostingu](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Znaleźć nazwę serwera Web Cloud Databases
+
+Kliknij na poniższe karty, aby wyświetlić kolejno każdy z **2** kroków.
+
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Web Cloud Databases](/links/control-panel/web-cloud-databases), a następnie wybierz odpowiednią usługę.
+>>
+>> ![Wybór serwera Web Cloud Databases w Panelu klienta OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Odszukaj `Nazwa hosta` w sekcji `SQL` w polu `Informacje na temat połączenia`.
+
+///
+
+/// details | Znaleźć serwer bazy danych hostingu
+
+Zapoznaj się z naszym przewodnikiem „[Odnaleźć serwer bazy danych](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Sprawdź dane do logowania do bazy danych <a name="config_file"></a>
 
@@ -60,10 +113,10 @@ Zaloguj się przez [FTP](/pages/web_cloud/web_hosting/ftp_connection) do przestr
 >
 > Wybór i konfiguracja pliku zawierającego dane do logowania do bazy danych jest ściśle związana z wybranym edytorem treści, a nie z OVHcloud.
 >
-> Zalecamy zatem skontaktowanie się z wydawcą [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) używanym do założenia strony lub do skorzystania z pomocy [[wyspecjalizowanego usługodawcy](/links/partner)](/links/partner) w razie potrzeby. Nie będziemy w stanie udzielić wsparcia w tym zakresie.
+> Zalecamy zatem skontaktowanie się z wydawcą [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) używanym do założenia strony lub skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) w razie potrzeby. Nie będziemy w stanie udzielić wsparcia w tym zakresie.
 >
 
-Następnie sprawdź zgodność **dokładna** między identyfikatorami logowania do [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#dostep-do-interfejsu-phpmyadmin) a danymi w pliku konfiguracyjnym Twojej strony.
+Następnie sprawdź **dokładną** zgodność między identyfikatorami logowania do [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#dostep-do-interfejsu-phpmyadmin) a danymi w pliku konfiguracyjnym Twojej strony.
 
 W razie potrzeby zmień [hasło do Twojej bazy danych](/pages/web_cloud/web_hosting/sql_change_password).
 
@@ -86,18 +139,29 @@ define('DB_PASSWORD', 'my_password');
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-W [Panelu klienta OVHcloud](/links/manager), w części `Hosting`{.action}, kliknij zakładkę `Bazy danych`{.action}, następnie sprawdź zgodność między elementami wyświetlanymi i znajdującymi się w pliku `wp-config.php`:
+Kliknij na poniższe karty, aby wyświetlić kolejno każdy z **2** kroków.
 
-- **my_database** musi odpowiadać temu, co jest zapisane w `Nazwa bazy`;
-- **my_user** musi odpowiadać temu, co jest zapisane w `Nazwa użytkownika`;
-- **my_password** odnosi się do [hasło do bazy danych](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** musi odpowiadać temu, co jest zapisane w `Adres serwera`.
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), a następnie wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `Bazy danych`{.action}, następnie sprawdź zgodność między elementami wyświetlanymi a znajdującymi się w pliku `wp-config.php`:
+>>
+>> - **my_database** musi odpowiadać temu, co jest zapisane w `Nazwa bazy`;
+>> - **my_user** musi odpowiadać temu, co jest zapisane w `Nazwa użytkownika`;
+>> - **my_password** odnosi się do [hasła bazy danych](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** musi odpowiadać temu, co jest zapisane w `Adres serwera`.
 
 > [!primary]
 >
-> Jeśli operacje te nie pozwalają przywrócić dostępu do Twojej strony WWW, [zapisz bazę danych](/pages/web_cloud/web_hosting/sql_database_export), a następnie [przywróć ją w wcześniejszej dacie](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#1-przywroc-istniejaca-kopie-zapasowa) w [Panelu klienta OVHcloud](/links/manager).
+> Jeśli operacje te nie pozwalają przywrócić dostępu do Twojej strony WWW, [zapisz bazę danych](/pages/web_cloud/web_hosting/sql_database_export), a następnie [przywróć ją do wcześniejszej daty](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#1-przywroc-istniejaca-kopie-zapasowa) w [Panelu klienta OVHcloud](/links/manager).
 >
-> W razie potrzeby należy skontaktować się z [wyspecjalizowanym dostawcą usług](/links/partner). Nie będziemy w stanie udzielić wsparcia w tym zakresie.
+> W razie potrzeby skontaktuj się z [wyspecjalizowanym dostawcą usług](/links/partner). Nie będziemy w stanie udzielić wsparcia w tym zakresie.
 >
 
 ### Przekroczenie dozwolonego rozmiaru bazy danych
@@ -110,7 +174,7 @@ Odblokuj bazę danych na trzy sposoby:
 
 #### Metoda 1: przejdź na wyższą ofertę
 
-Jeśli posiadasz wzór **Starter** lub **Perso**, w tej sytuacji zalecamy przejście na górną [ofertę hostingową](/links/web/hosting). Zmiana abonamentu zwiększy rozmiar bazy danych, dzięki czemu będzie ona automatycznie odnawiana. Metoda ta jest najprostsza i nie wymaga szczególnych kompetencji technicznych.
+Jeśli posiadasz formułę **Starter** lub **Perso**, w tej sytuacji zalecamy przejście na [wyższą ofertę hostingową](/links/web/hosting). Zmiana abonamentu zwiększy rozmiar bazy danych, dzięki czemu będzie ona automatycznie odblokowana. Metoda ta jest najprostsza i nie wymaga szczególnych kompetencji technicznych.
 
 > [!warning]
 >
@@ -118,19 +182,34 @@ Jeśli posiadasz wzór **Starter** lub **Perso**, w tej sytuacji zalecamy przej�
 >
 > Nieprawidłowości mogą spowodować stały wzrost rozmiaru bazy danych. W takim przypadku zmiana oferty hostingowej byłaby nieskuteczna.
 >
-> Zalecamy zatem, aby w przypadku zaobserwowania nagłego wzrostu rozmiaru bazy danych lub gdy posiadasz stronę typu "blog", która w normalnych warunkach nie jest konsumentem danych, niezwłocznie skontaktował się z [wyspecjalizowanym dostawcą](/links/partner). Nie będziemy w stanie udzielić Ci wsparcia w tym zakresie.
+> Zalecamy zatem, aby w przypadku zaobserwowania nagłego wzrostu rozmiaru bazy danych lub gdy posiadasz stronę typu "blog", która w normalnych warunkach nie jest konsumentem danych, niezwłocznie skontaktować się z [wyspecjalizowanym dostawcą](/links/partner). Nie będziemy w stanie udzielić Ci wsparcia w tym zakresie.
 >
 
-W celu dokonania tej zmiany zaloguj się do [Panelu klienta OVHcloud](/links/manager), następnie kliknij przycisk `Hosting`{.action}, a następnie wybierz odpowiedni hosting. Kliknij przycisk `...`{.action} w rubryce `Pakiet` po prawej stronie ekranu, a następnie kliknij `Zmień ofertę`{.action}.
+Aby dokonać tej zmiany, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
-Jeśli korzystasz z oferty **Performance**, sprawdź [metoda 2](#methode2).
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), a następnie wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij przycisk `...`{.action} w rubryce `Pakiet` po prawej stronie ekranu.
+>>
+> **Krok 3**
+>>
+>> Kliknij `Zmień ofertę`{.action}.
+
+Jeśli korzystasz z oferty **Performance**, sprawdź [metodę 2](#methode2).
 
 #### Metoda 2: migracja danych na wyższą bazę danych <a name="methode2"></a>
 
 Możesz również przenieść dane na nową bazę:
 
-- Zamów w razie potrzeby [bazę danych](/links/web/hosting-options-startsql) o wyższej wielkości, a następnie uruchom [kreacja](/pages/web_cloud/web_hosting/sql_create_database);
-- [Zduplikuj zawartość starej bazy danych](/pages/web_cloud/web_hosting/copy_database) w nowej **lub** wykonaj [eksport swoich danych](/pages/web_cloud/web_hosting/sql_database_export), następnie [je importować](/pages/web_cloud/web_hosting/sql_importing_mysql_database) w nowej bazie;
+- Zamów w razie potrzeby [bazę danych](/links/web/hosting-options-startsql) o wyższej wielkości, a następnie uruchom [tworzenie](/pages/web_cloud/web_hosting/sql_create_database).
+- [Zduplikuj zawartość starej bazy danych](/pages/web_cloud/web_hosting/copy_database) w nowej **lub** wykonaj [eksport swoich danych](/pages/web_cloud/web_hosting/sql_database_export), następnie [zaimportuj je](/pages/web_cloud/web_hosting/sql_importing_mysql_database) w nowej bazie.
 - Wprowadź dane dostępowe nowej bazy danych do [pliku konfiguracyjnego](#config_file) swojej strony.
 
 > [!primary]
@@ -142,44 +221,89 @@ Możesz również przenieść dane na nową bazę:
 
 Po utworzeniu [kopii zapasowej bazy danych](/pages/web_cloud/web_hosting/sql_database_export) zaloguj się do swojego interfejsu [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#dostep-do-interfejsu-phpmyadmin), aby usunąć niepotrzebne dane za pomocą poleceń Drop, Delete i Truncate.
 
-Następnie upamiętaj obliczenie rozmiaru używanego w zakładce `Bazy danych`{.action} dla wybranego hostingu: kliknij przycisk `...`{.action} a następnie na `Przelicz rozmiar`{.action}.
+Aby ponownie przeliczyć rozmiar, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
+
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), a następnie wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `Bazy danych`{.action}, a następnie przycisk `...`{.action} obok odpowiedniej bazy danych.
+>>
+> **Krok 3**
+>>
+>> Kliknij `Przelicz rozmiar bazy`{.action}.
 
 > [!warning]
 >
-> Operacja ta wymaga wysokich umiejętności technicznych. W razie potrzeby zalecamy skorzystanie z pomocy [[wyspecjalizowanego usługodawcy](/links/partner)](/links/partner). Nie będziemy w stanie udzielić wsparcia w tym zakresie.
+> Operacja ta wymaga wysokich umiejętności technicznych. W razie potrzeby zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner). Nie będziemy w stanie udzielić wsparcia w tym zakresie.
 >
 
 #### Metoda 4: zoptymalizuj bazę danych
 
-Aby zoptymalizować bazę danych, postępuj zgodnie z instrukcjami zawartymi w przewodniku "[Konfiguracja serwera baz danych](/pages/web_cloud/web_cloud_databases/configure-database-server#optymalizacja-baz-danych)". Następnie ponownie zastosuj rozmiar w zakładce `Bazy danych`{.action} Twojego hostingu, klikając przycisk `...`{.action} odpowiedniej bazy danych.
+Aby zoptymalizować bazę danych, postępuj zgodnie z instrukcjami zawartymi w przewodniku „[Konfiguracja serwera baz danych](/pages/web_cloud/web_cloud_databases/configure-database-server#optymalizacja-baz-danych)".
+
+Aby ponownie przeliczyć rozmiar, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
+
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), a następnie wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `Bazy danych`{.action}, a następnie przycisk `...`{.action} obok odpowiedniej bazy danych.
+>>
+> **Krok 3**
+>>
+>> Kliknij `Przelicz rozmiar bazy`{.action}.
 
 > [!warning]
 >
-> Jeśli dostarczone porady dotyczące optymalizacji Twojej bazy danych nie wystarczą, aby odblokować dostęp do Twojej strony, zalecamy kontakt z naszym [społecznością użytkowników](/links/community) lub [partnerami OVHcloud](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
+> Jeśli dostarczone porady dotyczące optymalizacji Twojej bazy danych nie wystarczą, aby odblokować dostęp do Twojej strony, zalecamy kontakt z naszą [społecznością użytkowników](/links/community) lub [partnerami OVHcloud](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.
 >
 
 ### Przekroczenie pojemności pamięci RAM (tylko Web Cloud Databases)
 
-Poniższy komunikat w części `Web Cloud Databases`{.action} Twojego [Panelu klienta OVHcloud](/links/manager) wskazuje, że Twój serwer [Web Cloud Databases](/links/web/databases) wykorzystał zbyt dużą ilość zasobów w infrastrukturze OVHcloud:
+Poniższy komunikat wskazuje, że Twój serwer [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) wykorzystał zbyt dużą ilość zasobów w infrastrukturze OVHcloud:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-W tej sytuacji możesz zwiększyć [ilość pamięci RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#zmiana-oferty-serwera-baz-danych) dostępny w części `Web Cloud Databases`{.action} [Panelu klienta OVHcloud](/links/manager). W karcie `Informacje ogólne`{.action} kliknij przycisk `...`{.action} w rubryce `RAM`.
+Aby zwiększyć [ilość pamięci RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#zmiana-oferty-serwera-baz-danych), kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
+
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Web Cloud Databases](/links/control-panel/web-cloud-databases), a następnie wybierz odpowiednią usługę.
+>>
+>> ![Wybór serwera Web Cloud Databases w Panelu klienta OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> W zakładce `Informacje ogólne`{.action} odszukaj rubrykę `RAM`.
+>>
+> **Krok 3**
+>>
+>> Kliknij przycisk `...`{.action} w rubryce `RAM`, a następnie `Zmień ilość pamięci RAM`{.action}.
 
 > [!warning]
 >
-> Aby zwiększyć pamięć RAM, nie należy włączać usługi Web Cloud Databases za pomocą hostingu Performance. Jeśli chcesz zwiększyć ilość pamięci RAM bazy danych zawartej w [ofertach wydajności](/links/web/hosting-performance-offer), musisz ją odłączyć.
-> 
-> Aby odłączyć bazę danych, zaloguj się do [Panelu klienta OVHcloud](/links/manager) i wybierz `Web Cloud`{.action}. Kliknij polecenie `Hosting`{.action}, następnie wybierz hosting, na którym aktywowana jest usługa Web Cloud Databases.
+> Aby zwiększyć pamięć RAM, nie należy włączać usługi Web Cloud Databases za pomocą hostingu Performance. Jeśli chcesz zwiększyć ilość pamięci RAM bazy danych zawartej w [ofertach Performance](/links/web/hosting-performance-offer), musisz ją odłączyć.
 >
-> W obszarze `Konfiguracja` kliknij na `...`{.action} po prawej stronie pozycji `Web Cloud Databases`, następnie kliknij przycisk `Odłącz`{.action}.
+> Aby odłączyć bazę danych, zapoznaj się z naszym przewodnikiem „[Odłączenie Web Cloud Databases od hostingu](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
 >
 
-Możesz również zoptymalizować bazę danych, postępując zgodnie z instrukcjami zawartymi w przewodniku "[Konfiguracja serwera baz danych](/pages/web_cloud/web_cloud_databases/configure-database-server#optymalizacja-bazy-danych)".
+Możesz również zoptymalizować bazę danych, postępując zgodnie z instrukcjami zawartymi w przewodniku „[Konfiguracja serwera baz danych](/pages/web_cloud/web_cloud_databases/configure-database-server#optymalizacja-bazy-danych)".
 
 > [!primary]
 >
-> Jeśli napotkasz trudności z ograniczeniem wykorzystania zasobów na serwerze baz danych i nie chcesz ich zwiększać, skontaktuj się z naszym [społecznością użytkowników](/links/community) lub [partnerami OVHcloud](/links/partner). Nie będziemy w stanie udzielić wsparcia w tym zakresie.
+> Jeśli napotkasz trudności z ograniczeniem wykorzystania zasobów na serwerze baz danych i nie chcesz ich zwiększać, skontaktuj się z naszą [społecznością użytkowników](/links/community) lub [partnerami OVHcloud](/links/partner). Nie będziemy w stanie udzielić wsparcia w tym zakresie.
 >
 
 ### Błędy w imporcie baz danych
@@ -190,13 +314,30 @@ Możesz również zoptymalizować bazę danych, postępując zgodnie z instrukcj
 > **"#1044 - Access denied for user to database"**
 >
 
-Upewnij się, że baza danych jest pusta w zakładce `Bazy danych`{.action} odpowiedniego hostingu (kliknij przycisk `...`{.action} a następnie na `Przelicz kwotę`{.action}) w celu [zapisz obecne dane](/pages/web_cloud/web_hosting/sql_database_export).
+Ten komunikat błędu oznacza, że baza danych, którą chcesz importować, zawiera nieautoryzowane elementy na infrastrukturze współdzielonej OVHcloud.
 
-Możesz również zaznaczyć kratkę `Wyczyść aktualną bazę danych`{.action} tuż przed [uruchomieniem importu](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-twojej-kopii-zapasowej-w-panelu-klienta):
+Upewnij się najpierw, że baza danych jest pusta. W tym celu kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), a następnie wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `Bazy danych`{.action}, a następnie przycisk `...`{.action} obok odpowiedniej bazy danych i `Przelicz rozmiar bazy`{.action}.
+>>
+> **Krok 3**
+>>
+>> Jeśli baza danych nie jest pusta, [zapisz obecne dane](/pages/web_cloud/web_hosting/sql_database_export) i usuń je przed ponownym uruchomieniem importu.
+>>
+>> Możesz również zaznaczyć kratkę `Usuń aktualną zawartość bazy danych`{.action} tuż przed [uruchomieniem importu](/pages/web_cloud/web_hosting/sql_importing_mysql_database#import-twojej-kopii-zapasowej-w-panelu-klienta):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-Ten komunikat błędu oznacza, że baza danych, którą chcesz importować zawiera nieautoryzowane elementy na infrastrukturze współdzielonej OVHcloud. W razie potrzeby skontaktuj się z [społecznością użytkowników](/links/community) lub [wyspecjalizowanym dostawcą](/links/partner). Nie będziemy w stanie udzielić wsparcia w zakresie korekty tej nieprawidłowości.
+W razie potrzeby skontaktuj się z naszą [społecznością użytkowników](/links/community) lub [wyspecjalizowanym dostawcą](/links/partner). Nie będziemy w stanie udzielić wsparcia w zakresie korekty tej nieprawidłowości.
 
 > [!primary]
 >
@@ -207,7 +348,7 @@ Posiadanie **"trigger"** w skrypcie importu bazy danych nie jest dozwolone na se
 Ponadto nie zezwala się na następujące zapytanie:
 
 ```sql
-CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET LATIN1 COLLATE LATIN1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
 Zastąp ją:
@@ -216,23 +357,38 @@ Zastąp ją:
 USE `Database-Name`;
 ```
 
-(`Database-Name`: wpisz nazwę bazy danych [Panel klienta OVHcloud](/links/manager)
+(`Database-Name`: wpisz nazwę bazy danych z [Panelu klienta OVHcloud](/links/manager))
 
 #### "MySQL server has gone away"
 
 >
-> **"ERROR MySQL server has gone away"**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
-Ten komunikat błędu pojawia się podczas [importu bazy danych](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#1-przywroc-istniejaca-kopie-zapasowa) na serwerze [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). Wiąże się to głównie z zbyt dużą ilością danych do importu lub z brakiem optymalizacji zapytań SQL w skrypcie importu.
+Ten komunikat błędu pojawia się podczas [importu bazy danych](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#1-przywroc-istniejaca-kopie-zapasowa) na serwerze [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). Wiąże się to głównie ze zbyt dużą ilością danych do importu lub z brakiem optymalizacji zapytań SQL w skrypcie importu.
 
 Aby usunąć tę anomalię, możesz:
 
-- Zwiększyć [ilość pamięci RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#monitoruj-zuzyta-pamiec-ram). W tym celu przejdź do [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) w sekcji `Bazy danych`{.action} twojego [Panel klienta OVHcloud](/links/manager). Następnie kliknij przycisk `...`{.action} w części `RAM`, a następnie na `Zmień ilość pamięci RAM`{.action}.
+- Zwiększyć [ilość pamięci RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#monitoruj-zuzyta-pamiec-ram). W tym celu kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
+
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Web Cloud Databases](/links/control-panel/web-cloud-databases), a następnie wybierz odpowiednią usługę.
+>>
+>> ![Wybór serwera Web Cloud Databases w Panelu klienta OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> W zakładce `Informacje ogólne`{.action} odszukaj rubrykę `RAM`.
+>>
+> **Krok 3**
+>>
+>> Kliknij przycisk `...`{.action} w rubryce `RAM`, a następnie `Zmień ilość pamięci RAM`{.action}.
 
 - Podziel bazę danych, aby ją importować na kilka operacji zamiast jednej (w przypadku pytań dotyczących operacji, które należy przeprowadzić, skontaktuj się z naszą [społecznością użytkowników](/links/community) lub [partnerami OVHcloud](/links/partner). Niestety firma OVHcloud nie będzie mogła udzielić wsparcia w tym zakresie.)
 
-- [Zoptymalizuj bazę danych](/pages/web_cloud/web_cloud_databases/configure-database-server#optymalizacja-bazy-danych), a następnie powtórzyć operacje eksportu / importu.
+- [Zoptymalizuj bazę danych](/pages/web_cloud/web_cloud_databases/configure-database-server#optymalizacja-bazy-danych), a następnie powtórz operacje eksportu/importu.
 
 ### Nie można uzyskać dostępu do PhpMyAdmin
 
@@ -242,7 +398,7 @@ Aby usunąć tę anomalię, możesz:
 > **"mysqli::real_connect(): (HY000/1045): Access denied for user"**
 >
 
-Ten komunikat błędu może pojawić się podczas logowania do bazy danych przez [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#dostep-do-interfejsu-phpmyadmin). Wskazuje ona, że dane identyfikacyjne są błędne.
+Ten komunikat błędu może pojawić się podczas logowania do bazy danych przez [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#dostep-do-interfejsu-phpmyadmin). Wskazuje, że dane identyfikacyjne są błędne.
 
 ![access_denied_for_user](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-1045.png){.thumbnail}
 
@@ -256,7 +412,7 @@ W takiej sytuacji [sprawdź wpisane dane](/pages/web_cloud/web_cloud_databases/c
 
 Maksymalna liczba aktywnych połączeń dla baz danych dostarczanych na hostingu ([StartSQL](/links/web/hosting-options-startsql)) wynosi **30**.
 
-Liczba ta wynosi **200** dla baz serwerów [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) (Ten parametr można zmienić w części `Konfiguracja`{.action} twojego serwera bazy danych).
+Liczba ta wynosi **200** dla baz serwerów [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (Ten parametr można zmienić w części `Konfiguracja`{.action} twojego serwera bazy danych).
 
 Wiadomość ta pojawia się podczas [logowania do phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#dostep-do-interfejsu-phpmyadmin), gdy ta maksymalna liczba połączeń jest przekroczona.
 
@@ -277,14 +433,43 @@ Ten komunikat błędu pojawia się podczas [logowania do phpMyAdmin](/pages/web_
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Sprawdź nazwę serwera, który chcesz zarejestrować w [Panelu klienta OVHcloud](/links/manager).
+Sprawdź nazwę odpowiedniego serwera.
 
-> [!success]
->
-> Jeśli baza danych, do której chcesz się zalogować, wyświetla się w zakładce `Bazy danych`{.action} w części `Hosting`{.action} w Twoim [Panelu klienta OVHcloud](/links/manager), nazwa, którą należy wpisać jest wpisana w kolumnie `Adres serwera`.
->
-> Jeśli chcesz zalogować się do bazy danych na serwerze [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), nazwa serwera, która ma zostać wprowadzona jest w zakładce `Informacje ogólne`{.action}, w części `Informacje na temat połączenia`{.action}, `SQL`{.action} i w sekcji `Nazwa hosta`{.action}.
->
+**Kliknij odpowiednią sytuację, aby wyświetlić treść.**
+
+/// details | Baza danych na hostingu
+
+Kliknij na poniższe karty, aby wyświetlić kolejno każdy z **2** kroków.
+
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), a następnie wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `Bazy danych`{.action}. Nazwa serwera, którą należy wpisać, jest zapisana w kolumnie `Adres serwera`.
+
+///
+
+/// details | Baza danych na serwerze Web Cloud Databases
+
+Kliknij na poniższe karty, aby wyświetlić kolejno każdy z **2** kroków.
+
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Web Cloud Databases](/links/control-panel/web-cloud-databases), a następnie wybierz odpowiednią usługę.
+>>
+>> ![Wybór serwera Web Cloud Databases w Panelu klienta OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> W zakładce `Informacje ogólne`{.action} nazwa serwera do wpisania znajduje się w sekcji `Informacje na temat połączenia`, pod `SQL`, w polu `Nazwa hosta`.
+
+///
 
 ### Nie można nawiązać połączenia z bazą danych Cloud Databases
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Rozwiąż najczęstsze błędy związane z bazami danych"
 excerpt: "Zdiagnozuj najczęstsze przypadki błędów związanych z bazami danych"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>
@@ -78,7 +78,7 @@ Kliknij na poniższe karty, aby wyświetlić kolejno każdy z **2** kroków.
 
 /// details | Znaleźć klaster i filer Twojego hostingu
 
-Zapoznaj się z naszym przewodnikiem „[Poznaj klaster i filer Twojego hostingu](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+Zapoznaj się z naszym przewodnikiem "[Poznaj klaster i filer Twojego hostingu](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
 
 ///
 
@@ -101,7 +101,7 @@ Kliknij na poniższe karty, aby wyświetlić kolejno każdy z **2** kroków.
 
 /// details | Znaleźć serwer bazy danych hostingu
 
-Zapoznaj się z naszym przewodnikiem „[Odnaleźć serwer bazy danych](/pages/web_cloud/web_hosting/sql_find_server)".
+Zapoznaj się z naszym przewodnikiem "[Odnaleźć serwer bazy danych](/pages/web_cloud/web_hosting/sql_find_server)".
 
 ///
 
@@ -245,7 +245,7 @@ Aby ponownie przeliczyć rozmiar, kliknij na poniższe karty, aby wyświetlić k
 
 #### Metoda 4: zoptymalizuj bazę danych
 
-Aby zoptymalizować bazę danych, postępuj zgodnie z instrukcjami zawartymi w przewodniku „[Konfiguracja serwera baz danych](/pages/web_cloud/web_cloud_databases/configure-database-server#optymalizacja-baz-danych)".
+Aby zoptymalizować bazę danych, postępuj zgodnie z instrukcjami zawartymi w przewodniku "[Konfiguracja serwera baz danych](/pages/web_cloud/web_cloud_databases/configure-database-server#optymalizacja-baz-danych)".
 
 Aby ponownie przeliczyć rozmiar, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
@@ -296,10 +296,10 @@ Aby zwiększyć [ilość pamięci RAM](/pages/web_cloud/web_cloud_databases/conf
 >
 > Aby zwiększyć pamięć RAM, nie należy włączać usługi Web Cloud Databases za pomocą hostingu Performance. Jeśli chcesz zwiększyć ilość pamięci RAM bazy danych zawartej w [ofertach Performance](/links/web/hosting-performance-offer), musisz ją odłączyć.
 >
-> Aby odłączyć bazę danych, zapoznaj się z naszym przewodnikiem „[Odłączenie Web Cloud Databases od hostingu](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
+> Aby odłączyć bazę danych, zapoznaj się z naszym przewodnikiem "[Odłączenie Web Cloud Databases od hostingu](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
 >
 
-Możesz również zoptymalizować bazę danych, postępując zgodnie z instrukcjami zawartymi w przewodniku „[Konfiguracja serwera baz danych](/pages/web_cloud/web_cloud_databases/configure-database-server#optymalizacja-bazy-danych)".
+Możesz również zoptymalizować bazę danych, postępując zgodnie z instrukcjami zawartymi w przewodniku "[Konfiguracja serwera baz danych](/pages/web_cloud/web_cloud_databases/configure-database-server#optymalizacja-bazy-danych)".
 
 > [!primary]
 >
@@ -390,7 +390,7 @@ Aby usunąć tę anomalię, możesz:
 
 - [Zoptymalizuj bazę danych](/pages/web_cloud/web_cloud_databases/configure-database-server#optymalizacja-bazy-danych), a następnie powtórz operacje eksportu/importu.
 
-### Nie można uzyskać dostępu do PhpMyAdmin
+### Nie można uzyskać dostępu do phpMyAdmin
 
 #### "Access denied for user"
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.pt-pt.md
@@ -61,16 +61,16 @@ Verifique, em primeiro lugar, na página [Web Cloud Status](https://web-cloud.st
 
 /// details | Encontrar o datacenter do seu alojamento web
 
-Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** passos.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
 >>
 >> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> No separador `Informações gerais`{.action}, localize o `Datacenter`.
 
@@ -84,16 +84,16 @@ Consulte o nosso guia "[Conhecer o cluster e o filer do seu alojamento web](/pag
 
 /// details | Encontrar o nome do servidor Web Cloud Databases
 
-Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** passos.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e selecione o serviço em questão.
 >>
 >> ![Seleção de um servidor Web Cloud Databases na Área de Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Localize o `Nome do host` na secção `SQL` de `Informações da ligação`.
 
@@ -139,16 +139,16 @@ define('DB_PASSWORD', 'my_password');
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** passos.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
 >>
 >> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Bases de dados`{.action} e verifique a correspondência entre os elementos apresentados e os presentes no ficheiro `wp-config.php`:
 >>
@@ -185,20 +185,20 @@ Se dispõe de uma fórmula **Starter** ou **Perso**, aconselhamos-o a passar par
 > Se verificar um aumento súbito da dimensão da sua base de dados, ou se dispuser de um site do tipo "blog" normalmente pouco consumidor de dados, aconselhamos que contacte imediatamente um [fornecedor especializado](/links/partner). Não poderemos dar-lhe apoio nesta matéria.
 >
 
-Para efetuar esta alteração, clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
+Para efetuar esta alteração, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
 >>
 >> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no botão `...`{.action} na rubrica `Plano`, à direita do seu ecrã.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique em `Mudar de oferta`{.action}.
 
@@ -221,20 +221,20 @@ Também pode migrar os seus dados para uma nova base:
 
 Depois de realizar um [backup da sua base de dados](/pages/web_cloud/web_hosting/sql_database_export), aceda à interface [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin) para eliminar os dados inúteis graças aos comandos Drop, Delete e Truncate.
 
-Para recalcular o limite, clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
+Para recalcular o limite, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
 >>
 >> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Bases de dados`{.action} e, a seguir, no botão `...`{.action} junto à base de dados em questão.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique em `Recalcular o limite`{.action}.
 
@@ -247,20 +247,20 @@ Para recalcular o limite, clique nos separadores abaixo para visualizar sucessiv
 
 Para otimizar a sua base de dados, siga as instruções do nosso guia "[Configurar o seu servidor de bases de dados](/pages/web_cloud/web_cloud_databases/configure-database-server#otimizar-as-bases-de-dados)".
 
-Para recalcular o limite, clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
+Para recalcular o limite, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
 >>
 >> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Bases de dados`{.action} e, a seguir, no botão `...`{.action} junto à base de dados em questão.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique em `Recalcular o limite`{.action}.
 
@@ -275,20 +275,20 @@ A seguinte mensagem indica que o seu servidor [Web Cloud Databases](/pages/web_c
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-Para aumentar a [quantidade de memória RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#acompanhar-a-ram-consumida), clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
+Para aumentar a [quantidade de memória RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#acompanhar-a-ram-consumida), clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e selecione o serviço em questão.
 >>
 >> ![Seleção de um servidor Web Cloud Databases na Área de Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> No separador `Informações gerais`{.action}, localize a rubrica `RAM`.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique no botão `...`{.action} na rubrica `RAM` e, a seguir, em `Alterar quantidade de RAM`{.action}.
 
@@ -316,20 +316,20 @@ Também pode otimizar a sua base de dados seguindo as instruções do nosso guia
 
 Esta mensagem de erro significa que a base de dados que está a tentar importar contém elementos não autorizados na infraestrutura partilhada da OVHcloud.
 
-Em primeiro lugar, certifique-se de que a sua base de dados está vazia. Para isso, clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
+Em primeiro lugar, certifique-se de que a sua base de dados está vazia. Para isso, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
 >>
 >> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Bases de dados`{.action} e, a seguir, no botão `...`{.action} junto à base de dados em questão e em `Recalcular o limite`{.action}.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Se a base de dados não estiver vazia, [guarde os dados presentes](/pages/web_cloud/web_hosting/sql_database_export) e elimine-os antes de voltar a importar.
 >>
@@ -369,20 +369,20 @@ Esta mensagem de erro aparece aquando da [importação de uma base de dados](/pa
 
 Para resolver esta anomalia, pode:
 
-- Aumentar a [quantidade de memória viva (RAM)](/pages/web_cloud/web_cloud_databases/configure-database-server#acompanhar-a-ram-consumida). Para isso, clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
+- Aumentar a [quantidade de memória viva (RAM)](/pages/web_cloud/web_cloud_databases/configure-database-server#acompanhar-a-ram-consumida). Para isso, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e selecione o serviço em questão.
 >>
 >> ![Seleção de um servidor Web Cloud Databases na Área de Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> No separador `Informações gerais`{.action}, localize a rubrica `RAM`.
 >>
-> **Passo 3**
+> **Etapa 3**
 >>
 >> Clique no botão `...`{.action} na rubrica `RAM` e, a seguir, em `Alterar quantidade de RAM`{.action}.
 
@@ -439,16 +439,16 @@ Verifique o nome do servidor correspondente.
 
 /// details | Base de dados num alojamento web
 
-Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** passos.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
 >>
 >> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> Clique no separador `Bases de dados`{.action}. O nome do servidor a introduzir está inscrito na coluna `Endereço do servidor`.
 
@@ -456,16 +456,16 @@ Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** p
 
 /// details | Base de dados num servidor Web Cloud Databases
 
-Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** passos.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
 > [!tabs]
-> **Passo 1**
+> **Etapa 1**
 >>
 >> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e selecione o serviço em questão.
 >>
 >> ![Seleção de um servidor Web Cloud Databases na Área de Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
 >>
-> **Passo 2**
+> **Etapa 2**
 >>
 >> No separador `Informações gerais`{.action}, o nome do servidor a introduzir está inscrito na secção `Informações da ligação`, parte `SQL`, rubrica `Nome do host`.
 

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.pt-pt.md
@@ -1,14 +1,28 @@
 ---
-title: "Resolver os erros mais frequentes associados às bases de dados" 
+title: "Resolver os erros mais frequentes associados às bases de dados"
 excerpt: "Diagnosticar os casos mais comuns de erros associados às bases de dados"
-updated: 2026-02-11
+updated: 2026-03-26
 ---
 
-**Objetivo**
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
-A utilização das suas bases de dados pode dar origem a um certo número de anomalias no seu site ou no seu [Área de Cliente OVHcloud](/links/manager), bem como na interface [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database).
+## Objetivo
 
-**Descubra como resolver os erros associados às bases de dados sobre os alojamentos partilhados OVHcloud.**
+A utilização das suas bases de dados pode dar origem a um certo número de anomalias no seu site ou na sua [Área de Cliente OVHcloud](/links/manager), bem como na interface [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database).
+
+**Descubra como resolver os erros associados às bases de dados nos alojamentos partilhados OVHcloud.**
 
 > [!warning]
 >
@@ -27,7 +41,7 @@ A utilização das suas bases de dados pode dar origem a um certo número de ano
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -43,24 +57,63 @@ A utilização das suas bases de dados pode dar origem a um certo número de ano
 
 Verifique, em primeiro lugar, na página [Web Cloud Status](https://web-cloud.status-ovhcloud.com/) se o seu datacenter, o seu cluster de alojamento web, o seu servidor Web Cloud Databases ou a sua base de dados não estão afetados por um incidente na infraestrutura OVHcloud.
 
-> [!primary]
->
-> Para encontrar estas informações, aceda à [Área de Cliente OVHcloud](/links/manager), na parte `Web Cloud`{.action}:
->
-> - Para encontrar o `Datacenter` do seu alojamento web, selecione `Alojamentos`{.action}, depois o alojamento web em questão. Encontrará esta informação no separador `Informações gerais`{.action}.
-> - Para encontrar o **cluster** de servidores e o **filer** (servidor de ficheiros) do seu alojamento web, consulte [este guia](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer).
-> - Para encontrar o nome do seu servidor **Web Cloud Databases**, clique em `Web Cloud Databases`{.action} e, a seguir, na oferta em causa. Encontrará esta informação no separador `Informações gerais`{.action}.
-> - Para encontrar o servidor onde se encontra a sua base de dados incluída ou adquirida como complemento através do seu [alojamento web](/links/web/hosting), consulte [este guia](/pages/web_cloud/web_hosting/sql_find_server).
+**Clique na informação que procura para ver o conteúdo.**
+
+/// details | Encontrar o datacenter do seu alojamento web
+
+Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** passos.
+
+> [!tabs]
+> **Passo 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passo 2**
+>>
+>> No separador `Informações gerais`{.action}, localize o `Datacenter`.
+
+///
+
+/// details | Encontrar o cluster e o filer do seu alojamento web
+
+Consulte o nosso guia "[Conhecer o cluster e o filer do seu alojamento web](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)".
+
+///
+
+/// details | Encontrar o nome do servidor Web Cloud Databases
+
+Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** passos.
+
+> [!tabs]
+> **Passo 1**
+>>
+>> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e selecione o serviço em questão.
+>>
+>> ![Seleção de um servidor Web Cloud Databases na Área de Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Passo 2**
+>>
+>> Localize o `Nome do host` na secção `SQL` de `Informações de ligação`.
+
+///
+
+/// details | Encontrar o servidor da sua base de dados de alojamento web
+
+Consulte o nosso guia "[Encontrar o servidor da sua base de dados](/pages/web_cloud/web_hosting/sql_find_server)".
+
+///
 
 #### Verificar os dados de acesso à sua base de dados <a name="config_file"></a>
 
-Ligue-se ao espaço de armazenamento de ficheiros com [FTP](/pages/web_cloud/web_hosting/ftp_connection) ao espaço de armazenamento de ficheiros no seu alojamento e encontre o ficheiro de configuração do seu site (por exemplo, para um site WordPress, trata-se do ficheiro **wp-config.php** situado na pasta que contém o seu site).
+Ligue-se ao espaço de armazenamento de ficheiros com [FTP](/pages/web_cloud/web_hosting/ftp_connection) no seu alojamento e encontre o ficheiro de configuração do seu site (por exemplo, para um site WordPress, trata-se do ficheiro **wp-config.php** situado na pasta que contém o seu site).
 
 > [!warning]
 >
 > A escolha e a configuração do ficheiro com as informações de ligação à base de dados é inerente ao editor de conteúdo (CMS) em causa e não à OVHcloud.
 >
-> Recomendamos que contacte o editor do [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) utilizado para criar o seu site ou que recorra a um [fornecedor especializado](/links/partner) em caso de necessidade. De facto, a OVHcloud não lhe poderá fornecer assistência.
+> Recomendamos que contacte o editor do [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) utilizado para criar o seu site ou que recorra a um [fornecedor especializado](/links/partner) em caso de necessidade. A OVHcloud não lhe poderá fornecer assistência.
 >
 
 De seguida, verifique a correspondência **exata** entre os identificadores de ligação ao [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin) e os do ficheiro de configuração do seu site.
@@ -69,7 +122,7 @@ Altere, se necessário, a [palavra-passe da sua base de dados](/pages/web_cloud/
 
 #### Exemplo para WordPress
 
-Se o seu website apresentar uma mensagem **"Erro durante a ligação à base de dados"** e que este não é afetado por [incidente](https://web-cloud.status-ovhcloud.com/), ligue-se em [FTP](/pages/web_cloud/web_hosting/ftp_connection) ao seu alojamento e abra o diretório que contém o seu website (por predefinição, trata-se do dossier `www`).
+Se o seu website apresentar uma mensagem **"Erro durante a ligação à base de dados"** e que este não é afetado por um [incidente](https://web-cloud.status-ovhcloud.com/), ligue-se em [FTP](/pages/web_cloud/web_hosting/ftp_connection) ao seu alojamento e abra o diretório que contém o seu website (por predefinição, trata-se do dossier `www`).
 
 Se se tratar de um site WordPress, abra o ficheiro `wp-config.php`.
 
@@ -86,23 +139,34 @@ define('DB_PASSWORD', 'my_password');
 define('DB_HOST', 'my_server.mysql.db:port');
 ```
 
-No seu [Espaço Cliente OVHcloud](/links/manager), na parte `Alojamentos`{.action}, clique no separador `Bases de dados`{.action} e verifique a correspondência entre os elementos apresentados e os presentes no ficheiro `wp-config.php`:
+Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** passos.
 
-- **my_database** deve corresponder ao que é notado no `Nome da base de dados`;
-- **my_user** deve corresponder ao que é notado no `Nome do utilizador`;
-- **my_password** corresponde à [palavra-passe da sua base de dados](/pages/web_cloud/web_hosting/sql_change_password);
-- **my_server.mysql.db** deve corresponder ao que é notado no `Endereço do servidor`.
+> [!tabs]
+> **Passo 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passo 2**
+>>
+>> Clique no separador `Bases de dados`{.action} e verifique a correspondência entre os elementos apresentados e os presentes no ficheiro `wp-config.php`:
+>>
+>> - **my_database** deve corresponder ao que é indicado em `Nome da base de dados`;
+>> - **my_user** deve corresponder ao que é indicado em `Nome do utilizador`;
+>> - **my_password** corresponde à [palavra-passe da sua base de dados](/pages/web_cloud/web_hosting/sql_change_password);
+>> - **my_server.mysql.db** deve corresponder ao que é indicado em `Endereço do servidor`.
 
 > [!primary]
 >
-> Se estas manipulações não lhe permitem restabelecer o acesso ao seu website, [salvaguarde a sua base de dados](/pages/web_cloud/web_hosting/sql_database_export) e depois [restaure-a numa data anterior](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server) a partir do seu [Espaço Cliente OVHcloud](/links/manager).
+> Se estas manipulações não lhe permitem restabelecer o acesso ao seu website, [salvaguarde a sua base de dados](/pages/web_cloud/web_hosting/sql_database_export) e depois [restaure-a numa data anterior](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server) a partir da sua [Área de Cliente OVHcloud](/links/manager).
 >
-> Contacte um [fornecedor especializado](/links/partner) se necessário. De facto, a OVHcloud não lhe poderá fornecer assistência.
+> Contacte um [fornecedor especializado](/links/partner) se necessário. A OVHcloud não lhe poderá fornecer assistência.
 >
 
 ### Excesso do limite autorizado da base de dados
 
-Recebeu um e-mail dos nossos serviços indicando que a quantidade de dados na sua base de dados ultrapassa o limite autorizado. A sua base de dados passou então a ler sozinha. Isto impede qualquer modificação do seu site.
+Recebeu um e-mail dos nossos serviços indicando que a quantidade de dados na sua base de dados ultrapassa o limite autorizado. A sua base de dados passou então para modo de leitura. Isto impede qualquer modificação do seu site.
 
 ![database-overquota-notification-email](/pages/assets/screens/email-sending-to-customer/databases/overquota-db.png){.thumbnail}
 
@@ -121,7 +185,22 @@ Se dispõe de uma fórmula **Starter** ou **Perso**, aconselhamos-o a passar par
 > Se verificar um aumento súbito da dimensão da sua base de dados, ou se dispuser de um site do tipo "blog" normalmente pouco consumidor de dados, aconselhamos que contacte imediatamente um [fornecedor especializado](/links/partner). Não poderemos dar-lhe apoio nesta matéria.
 >
 
-Para efetuar esta alteração, aceda à Área de Cliente OVHcloud (/links/manager) e clique em `Alojamentos`{.action} e no alojamento em causa. Clique no botão `...`{.action} na rubrica `Oferta`, à direita do seu ecrã, e depois `alterer d'oferta`{.action}.
+Para efetuar esta alteração, clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
+
+> [!tabs]
+> **Passo 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passo 2**
+>>
+>> Clique no botão `...`{.action} na rubrica `Oferta`, à direita do seu ecrã.
+>>
+> **Passo 3**
+>>
+>> Clique em `Mudar de oferta`{.action}.
 
 Se utiliza uma oferta **Performance**, consulte o [método 2](#methode2).
 
@@ -129,8 +208,8 @@ Se utiliza uma oferta **Performance**, consulte o [método 2](#methode2).
 
 Também pode migrar os seus dados para uma nova base:
 
-- Encomende, se necessário, uma [base de dados](/links/web/hosting-options-startsql) de tamanho superior e lance a sua [criação](/pages/web_cloud/web_hosting/sql_create_database);
-- [Duplique o conteúdo da antiga base de dados](/pages/web_cloud/web_hosting/copy_database) na nova **ou** efetue uma [exportação dos seus dados](/pages/web_cloud/web_hosting/sql_database_export) e depois [importe-os](/pages/web_cloud/web_hosting/sql_importing_mysql_database) na nova base de dados;
+- Encomende, se necessário, uma [base de dados](/links/web/hosting-options-startsql) de tamanho superior e lance a sua [criação](/pages/web_cloud/web_hosting/sql_create_database).
+- [Duplique o conteúdo da antiga base de dados](/pages/web_cloud/web_hosting/copy_database) na nova **ou** efetue uma [exportação dos seus dados](/pages/web_cloud/web_hosting/sql_database_export) e depois [importe-os](/pages/web_cloud/web_hosting/sql_importing_mysql_database) na nova base de dados.
 - Integre os identificadores da nova base de dados no [ficheiro de configuração](#config_file) do seu site.
 
 > [!primary]
@@ -140,46 +219,91 @@ Também pode migrar os seus dados para uma nova base:
 
 #### Método 3: eliminar dados desnecessários
 
-Depois de realizar um backup da sua base de dados, aceda à interface [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin) para eliminar os dados inúteis graças aos comandos Drop, Delete e Truncate.
+Depois de realizar um [backup da sua base de dados](/pages/web_cloud/web_hosting/sql_database_export), aceda à interface [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin) para eliminar os dados inúteis graças aos comandos Drop, Delete e Truncate.
 
-De seguida, volte a analisar o cálculo da quota utilizado a partir do separador `Bases de dados`{.action} do alojamento em causa: clique no botão `...`{.action} em causa e depois `Recalcular o limite`{.action}.
+Para recalcular o limite, clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
+
+> [!tabs]
+> **Passo 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passo 2**
+>>
+>> Clique no separador `Bases de dados`{.action} e, a seguir, no botão `...`{.action} junto à base de dados em questão.
+>>
+> **Passo 3**
+>>
+>> Clique em `Recalcular o limite`{.action}.
 
 > [!warning]
 >
-> Esta operação requer grandes competências técnicas. Se necessário, recomendamos que recorra a um [prestador de serviços especializado](/links/partner) (/links/partner). De facto, a OVHcloud não lhe poderá fornecer assistência.
+> Esta operação requer grandes competências técnicas. Se necessário, recomendamos que recorra a um [prestador de serviços especializado](/links/partner). A OVHcloud não lhe poderá fornecer assistência.
 >
 
 #### Método 4: otimizar a sua base de dados
 
-Para otimizar a sua base de dados, siga as instruções do nosso guia "[Configurar o seu servidor de bases de dados](/pages/web_cloud/web_cloud_databases/configure-database-server#otimizar-as-bases-de-dados)". De seguida, volte a analisar o cálculo da quota utilizado a partir do separador `Bases de dados`{.action} do seu alojamento, clicando no botão `...`{.action} da base de dados em questão.
+Para otimizar a sua base de dados, siga as instruções do nosso guia "[Configurar o seu servidor de bases de dados](/pages/web_cloud/web_cloud_databases/configure-database-server#otimizar-as-bases-de-dados)".
+
+Para recalcular o limite, clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
+
+> [!tabs]
+> **Passo 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passo 2**
+>>
+>> Clique no separador `Bases de dados`{.action} e, a seguir, no botão `...`{.action} junto à base de dados em questão.
+>>
+> **Passo 3**
+>>
+>> Clique em `Recalcular o limite`{.action}.
 
 > [!warning]
 >
-> Se os conselhos fornecidos sobre a otimização da sua base de dados não bastam para desbloquear o acesso ao seu website, aconselhamos que contacte a nossa [comunidade](/links/community) ou os [parceiros da OVHcloud](/links/partner). De facto, a OVHcloud não lhe poderá fornecer assistência.
+> Se os conselhos fornecidos sobre a otimização da sua base de dados não bastam para desbloquear o acesso ao seu website, aconselhamos que contacte a nossa [comunidade](/links/community) ou os [parceiros da OVHcloud](/links/partner). A OVHcloud não lhe poderá fornecer assistência.
 >
 
 ### Capacidade de RAM excedida (Web Cloud Databases apenas)
 
-A seguinte mensagem na parte `Web Cloud Databases`{.action} do seu [Área de Cliente OVHcloud](/links/manager) indica que o seu servidor [Web Cloud Databases](/links/web/databases) consumiu uma quantidade de recursos demasiado importante na infraestrutura OVHcloud:
+A seguinte mensagem indica que o seu servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) consumiu uma quantidade de recursos demasiado importante na infraestrutura OVHcloud:
 
 ![ram-exceeded](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases/general-information/ram-exceeded.png){.thumbnail}
 
-Nesta situação, pode aumentar a [quantidade de memória RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#acompanhar-a-ram-consumida) disponível a partir da parte `Web Cloud Databases`{.action} do seu [Área de Cliente OVHcloud](/links/manager). No separador `Informações gerais`{.action}, clique no botão `...`{.action} na rubrica `RAM`.
+Para aumentar a [quantidade de memória RAM](/pages/web_cloud/web_cloud_databases/configure-database-server#acompanhar-a-ram-consumida), clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
+
+> [!tabs]
+> **Passo 1**
+>>
+>> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e selecione o serviço em questão.
+>>
+>> ![Seleção de um servidor Web Cloud Databases na Área de Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Passo 2**
+>>
+>> No separador `Informações gerais`{.action}, localize a rubrica `RAM`.
+>>
+> **Passo 3**
+>>
+>> Clique no botão `...`{.action} na rubrica `RAM` e, a seguir, em `Alterar quantidade de RAM`{.action}.
 
 > [!warning]
 >
 > Para aumentar a RAM, o Web Cloud Databases não deve ser ativado através de um alojamento Performance. Se deseja aumentar a quantidade de memória RAM de uma base de dados incluída nas [ofertas performance](/links/web/hosting-performance-offer), primeiro tem de a desassociar.
-> 
-> Para desassociar a base de dados, aceda à [Área de Cliente OVHcloud](/links/manager) e selecione `Web Cloud`{.action}. Clique em `Alojamentos`{.action} e escolha o alojamento web no qual o Web Cloud Databases está ativo.
 >
-> Na zona `Configuration`, clique em as o `...`{.action} à direita da menção `Web Cloud Databases`, e clique no botão `Desassociar`{.action}.
+> Para desassociar a base de dados, consulte o nosso guia "[Desassociar um Web Cloud Databases do seu alojamento web](/pages/web_cloud/web_cloud_databases/detach-from-web-hosting)".
 >
 
 Também pode otimizar a sua base de dados seguindo as instruções do nosso guia "[Configurar o seu servidor de bases de dados](/pages/web_cloud/web_cloud_databases/configure-database-server#otimizar-as-bases-de-dados)".
 
 > [!primary]
 >
-> Se encontrar dificuldades em diminuir a utilização dos recursos no seu servidor de bases de dados e não pretender aumentá-las, contacte a nossa [comunidade](/links/community) ou os [parceiros OVHcloud](/links/partner). De facto, a OVHcloud não lhe poderá fornecer assistência.
+> Se encontrar dificuldades em diminuir a utilização dos recursos no seu servidor de bases de dados e não pretender aumentá-las, contacte a nossa [comunidade](/links/community) ou os [parceiros OVHcloud](/links/partner). A OVHcloud não lhe poderá fornecer assistência.
 >
 
 ### Erros de importação de bases de dados
@@ -192,15 +316,28 @@ Também pode otimizar a sua base de dados seguindo as instruções do nosso guia
 
 Esta mensagem de erro significa que a base de dados que está a tentar importar contém elementos não autorizados na infraestrutura partilhada da OVHcloud.
 
-Em primeiro lugar, certifique-se de que a sua base de dados está vazia no separador `Bases de dados`{.action} do alojamento em causa (clique no botão `...`{.action} em causa e depois `Recalculer o limite`{.action}).
+Em primeiro lugar, certifique-se de que a sua base de dados está vazia. Para isso, clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
 
-Caso contrário, [guarde os dados presentes](/pages/web_cloud/web_hosting/sql_database_export) na sua base de dados e elimine-os antes de voltar a importar os dados.
+> [!tabs]
+> **Passo 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passo 2**
+>>
+>> Clique no separador `Bases de dados`{.action} e, a seguir, no botão `...`{.action} junto à base de dados em questão e em `Recalcular o limite`{.action}.
+>>
+> **Passo 3**
+>>
+>> Se a base de dados não estiver vazia, [guarde os dados presentes](/pages/web_cloud/web_hosting/sql_database_export) e elimine-os antes de voltar a importar.
+>>
+>> Também pode selecionar a opção `Limpar a base de dados atual`{.action} imediatamente antes de [lançar a importação](/pages/web_cloud/web_hosting/sql_importing_mysql_database#importar-o-seu-proprio-backup-a-partir-da-area-de-cliente):
+>>
+>> ![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
 
-Também pode selecionar a casa `Limpar a base de dados atual`{.action} imediatamente antes de [lançar a importação](/pages/web_cloud/web_hosting/sql_importing_mysql_database#importar-o-seu-proprio-backup-a-partir-da-area-de-cliente):
-
-![import-empty-current-db](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/databases/import-empty-current-db.png){.thumbnail}
-
-Contacte, se necessário, a nossa [comunidade](/links/community) ou um [fornecedor especializado](/links/partner) sobre este assumpto. Não poderemos prestar-lhe assistência na correção desta anomalia.
+Contacte, se necessário, a nossa [comunidade](/links/community) ou um [fornecedor especializado](/links/partner). Não poderemos prestar-lhe assistência na correção desta anomalia.
 
 > [!primary]
 >
@@ -211,30 +348,45 @@ Ter um **"trigger"** no script de importação da sua base de dados não é auto
 Além disso, não é autorizado o seguinte pedido:
 
 ```sql
-CREATE DATABASE IF NOT EXISTENTE `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci; 
+CREATE DATABASE IF NOT EXISTS `Database-Name` DEFAULT CHARACTER SET latin1 COLLATE latin1_swedish_ci;
 ```
 
-Substitua-a por:
+Substitua-o por:
 
 ```sql
 USE `Database-Name`;
 ```
 
-(`Database-Name`: indique o nome da base de dados indicado no seu [Área de Cliente OVHcloud](/links/manager)
+(`Database-Name`: indique o nome da base de dados indicado na sua [Área de Cliente OVHcloud](/links/manager))
 
-### "MySQL server has gone away"
+#### "MySQL server has gone away"
 
 >
-> **« ERROR 2006 : MySQL server has gone away »**
+> **"ERROR 2006 : MySQL server has gone away"**
 >
 
 Esta mensagem de erro aparece aquando da [importação de uma base de dados](/pages/web_cloud/web_cloud_databases/restore-import-on-database-server#2-importar-um-backup-local) num servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). Está ligado, na maior parte dos casos, à quantidade excessiva de dados a importar ou à falta de otimização dos pedidos SQL no script de importação.
 
 Para resolver esta anomalia, pode:
 
-- Aumentar a [quantidade de memória viva (RAM)](/pages/web_cloud/web_cloud_databases/configure-database-server#acompanhar-a-ram-consumida). Para isso, aceda ao servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) afetado na rubrica `Bases de dados`{.action} do seu [Área de Cliente OVHcloud](/links/manager). A seguir, clique no botão `...`{.action} na parte `RAM`, e `Alterar quantidade de RAM`{.action}.
+- Aumentar a [quantidade de memória viva (RAM)](/pages/web_cloud/web_cloud_databases/configure-database-server#acompanhar-a-ram-consumida). Para isso, clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
 
-- Transferir a base de dados para várias operações em vez de uma (para qualquer questão relativa às operações a realizar, contacte a nossa [comunidade](/links/community) ou os [parceiros da OVHcloud](/links/partner). De facto, a OVHcloud não lhe poderá fornecer assistência).
+> [!tabs]
+> **Passo 1**
+>>
+>> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e selecione o serviço em questão.
+>>
+>> ![Seleção de um servidor Web Cloud Databases na Área de Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Passo 2**
+>>
+>> No separador `Informações gerais`{.action}, localize a rubrica `RAM`.
+>>
+> **Passo 3**
+>>
+>> Clique no botão `...`{.action} na rubrica `RAM` e, a seguir, em `Alterar quantidade de RAM`{.action}.
+
+- Transferir a base de dados para várias operações em vez de uma (para qualquer questão relativa às operações a realizar, contacte a nossa [comunidade](/links/community) ou os [parceiros da OVHcloud](/links/partner). A OVHcloud não lhe poderá fornecer assistência).
 
 - [Otimize a sua base de dados](/pages/web_cloud/web_cloud_databases/configure-database-server#otimizar-as-bases-de-dados) e depois repita as operações de exportação/importação.
 
@@ -243,7 +395,7 @@ Para resolver esta anomalia, pode:
 #### "Access denied for user"
 
 >
-> **« mysqli::real_connect(): (HY000/1045): Acesso denied for user**
+> **"mysqli::real_connect(): (HY000/1045): Access denied for user"**
 >
 
 Esta mensagem de erro pode aparecer no acesso à sua base de dados por [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin). Indica que os dados de identificação introduzidos estão errados.
@@ -260,48 +412,77 @@ Nesta situação, [verifique os identificadores introduzidos](/pages/web_cloud/w
 
 O número máximo de ligações ativas para as bases de dados entregues com os alojamentos partilhados ([StartSQL](/links/web/hosting-options-startsql)) é de **30**.
 
-Este número é de **200** para as bases dos servidores [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (Este parâmetro pode ser modificado na secção `Configuration`{.action} do seu servidor de base de dados).
+Este número é de **200** para as bases dos servidores [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (Este parâmetro pode ser modificado na secção `Configuração`{.action} do seu servidor de base de dados).
 
-Esta mensagem aparece na [ligação ao PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#acaceder-a-interface-phpmyadmin) quando o número máximo de ligações é ultrapassado.
+Esta mensagem aparece na [ligação ao PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin) quando o número máximo de ligações é ultrapassado.
 
 Nesta situação, deverá [otimizar as suas bases de dados](/pages/web_cloud/web_cloud_databases/configure-database-server#otimizar-as-bases-de-dados) de forma a reduzir o número de ligações ativas.
 
 > [!warning]
 >
-> Para qualquer questão relativa às operações a realizar para reduzir o número de ligações ativas na sua base de dados, contacte a nossa [comunidade](/links/community) ou os [parceiros da OVHcloud](/links/partner). De facto, a OVHcloud não lhe poderá fornecer assistência.
+> Para qualquer questão relativa às operações a realizar para reduzir o número de ligações ativas na sua base de dados, contacte a nossa [comunidade](/links/community) ou os [parceiros da OVHcloud](/links/partner). A OVHcloud não lhe poderá fornecer assistência.
 >
 
-### "Name or service not known"
+#### "Name or service not known"
 
 >
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
 >
 
-Esta mensagem de erro aparece na [ligação a PhpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#instrucoes) quando o nome do servidor indicado está incorreto.
+Esta mensagem de erro aparece na [ligação ao PhpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#instrucoes) quando o nome do servidor indicado está incorreto.
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
-Verifique o nome do servidor a inscrever no seu [Área de Cliente OVHcloud](/links/manager).
+Verifique o nome do servidor correspondente.
 
-> [!success]
->
-> Se a base de dados à qual deseja aceder aparecer no separador `Bases de dados`{.action} da parte `Alojamentos`{.action} do seu [Espaço Cliente OVHcloud](/links/manager), o nome a inserir está inscrito na coluna `Endereço do servidor`.
->
-> Se pretender ligar-se a uma base de dados num servidor [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb), o nome do servidor a introduzir está inscrito no separador `Informações gerais`{.action}, parte `Informações da ligação`{.action}, `SQL`{.action} e na rubrica `Nome do host`{.action}.
->
+**Clique na situação correspondente para ver o conteúdo.**
+
+/// details | Base de dados num alojamento web
+
+Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** passos.
+
+> [!tabs]
+> **Passo 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em questão.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passo 2**
+>>
+>> Clique no separador `Bases de dados`{.action}. O nome do servidor a introduzir está inscrito na coluna `Endereço do servidor`.
+
+///
+
+/// details | Base de dados num servidor Web Cloud Databases
+
+Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** passos.
+
+> [!tabs]
+> **Passo 1**
+>>
+>> Aceda à página [Web Cloud Databases](/links/control-panel/web-cloud-databases) e selecione o serviço em questão.
+>>
+>> ![Seleção de um servidor Web Cloud Databases na Área de Cliente OVHcloud](/pages/assets/screens/control_panel/product-selection/web-cloud/web-cloud-databases.png){.thumbnail}
+>>
+> **Passo 2**
+>>
+>> No separador `Informações gerais`{.action}, o nome do servidor a introduzir está inscrito na secção `Informações de ligação`, parte `SQL`, rubrica `Nome do host`.
+
+///
 
 ### Não é possível estabelecer ligação a uma base de dados Cloud Databases
 
 Dispor de um servidor [Web Cloud Databases](/products/web-cloud-clouddb) permite-lhe [ligar às suas bases de dados](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server) a partir do seu computador ou de um servidor externo à infraestrutura da OVHcloud.
 
-Se esta ligação se revelar impossível, comece por verificar que autorizou [o seu endereço IP público](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) a ligar-se ao servidor de bases de dados.
+Se esta ligação se revelar impossível, comece por verificar que [autorizou o seu endereço IP público](/pages/web_cloud/web_cloud_databases/starting_with_clouddb) a ligar-se ao servidor de bases de dados.
 
-Se esta operação tiver sido realizada com sucesso, contacte o seu Fornecedor de Serviços Internet (ISP) ou [parceiros da OVHcloud](/links/partner). Nesta situação, não poderemos fornecer-lhe assistência.
+Se esta operação tiver sido realizada com sucesso, contacte o seu Fornecedor de Serviços Internet (ISP) ou os [parceiros da OVHcloud](/links/partner). Nesta situação, não poderemos fornecer-lhe assistência.
 
 ## Quer saber mais? <a name="go-further"></a>
 
 [Primeiros passos com o serviço Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb)
 
-Para serviços especializados (referenciamento, desenvolvimento, etc), contacte os [parceiros OVHcloud](/links/partner).
+Para serviços especializados (referenciamento, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 
-Fale com nossa [comunidade de utilizadores](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnosis_database_errors/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Resolver os erros mais frequentes associados às bases de dados"
 excerpt: "Diagnosticar os casos mais comuns de erros associados às bases de dados"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objetivo
 
-A utilização das suas bases de dados pode dar origem a um certo número de anomalias no seu site ou na sua [Área de Cliente OVHcloud](/links/manager), bem como na interface [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database).
+A utilização das suas bases de dados pode dar origem a um certo número de anomalias no seu site ou na sua [Área de Cliente OVHcloud](/links/manager), bem como na interface [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database).
 
 **Descubra como resolver os erros associados às bases de dados nos alojamentos partilhados OVHcloud.**
 
@@ -95,7 +95,7 @@ Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** p
 >>
 > **Passo 2**
 >>
->> Localize o `Nome do host` na secção `SQL` de `Informações de ligação`.
+>> Localize o `Nome do host` na secção `SQL` de `Informações da ligação`.
 
 ///
 
@@ -116,7 +116,7 @@ Ligue-se ao espaço de armazenamento de ficheiros com [FTP](/pages/web_cloud/web
 > Recomendamos que contacte o editor do [CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules) utilizado para criar o seu site ou que recorra a um [fornecedor especializado](/links/partner) em caso de necessidade. A OVHcloud não lhe poderá fornecer assistência.
 >
 
-De seguida, verifique a correspondência **exata** entre os identificadores de ligação ao [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin) e os do ficheiro de configuração do seu site.
+De seguida, verifique a correspondência **exata** entre os identificadores de ligação ao [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin) e os do ficheiro de configuração do seu site.
 
 Altere, se necessário, a [palavra-passe da sua base de dados](/pages/web_cloud/web_hosting/sql_change_password).
 
@@ -196,7 +196,7 @@ Para efetuar esta alteração, clique nos separadores abaixo para visualizar suc
 >>
 > **Passo 2**
 >>
->> Clique no botão `...`{.action} na rubrica `Oferta`, à direita do seu ecrã.
+>> Clique no botão `...`{.action} na rubrica `Plano`, à direita do seu ecrã.
 >>
 > **Passo 3**
 >>
@@ -219,7 +219,7 @@ Também pode migrar os seus dados para uma nova base:
 
 #### Método 3: eliminar dados desnecessários
 
-Depois de realizar um [backup da sua base de dados](/pages/web_cloud/web_hosting/sql_database_export), aceda à interface [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin) para eliminar os dados inúteis graças aos comandos Drop, Delete e Truncate.
+Depois de realizar um [backup da sua base de dados](/pages/web_cloud/web_hosting/sql_database_export), aceda à interface [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin) para eliminar os dados inúteis graças aos comandos Drop, Delete e Truncate.
 
 Para recalcular o limite, clique nos separadores abaixo para visualizar sucessivamente cada um dos **3** passos.
 
@@ -390,7 +390,7 @@ Para resolver esta anomalia, pode:
 
 - [Otimize a sua base de dados](/pages/web_cloud/web_cloud_databases/configure-database-server#otimizar-as-bases-de-dados) e depois repita as operações de exportação/importação.
 
-### Não é possível aceder ao PhpMyAdmin
+### Não é possível aceder ao phpMyAdmin
 
 #### "Access denied for user"
 
@@ -398,7 +398,7 @@ Para resolver esta anomalia, pode:
 > **"mysqli::real_connect(): (HY000/1045): Access denied for user"**
 >
 
-Esta mensagem de erro pode aparecer no acesso à sua base de dados por [PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin). Indica que os dados de identificação introduzidos estão errados.
+Esta mensagem de erro pode aparecer no acesso à sua base de dados por [phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin). Indica que os dados de identificação introduzidos estão errados.
 
 ![access_denied_for_user](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-1045.png){.thumbnail}
 
@@ -414,7 +414,7 @@ O número máximo de ligações ativas para as bases de dados entregues com os a
 
 Este número é de **200** para as bases dos servidores [Web Cloud Databases](/pages/web_cloud/web_cloud_databases/starting_with_clouddb). (Este parâmetro pode ser modificado na secção `Configuração`{.action} do seu servidor de base de dados).
 
-Esta mensagem aparece na [ligação ao PhpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin) quando o número máximo de ligações é ultrapassado.
+Esta mensagem aparece na [ligação ao phpMyAdmin](/pages/web_cloud/web_hosting/sql_create_database#aceder-a-interface-phpmyadmin) quando o número máximo de ligações é ultrapassado.
 
 Nesta situação, deverá [otimizar as suas bases de dados](/pages/web_cloud/web_cloud_databases/configure-database-server#otimizar-as-bases-de-dados) de forma a reduzir o número de ligações ativas.
 
@@ -429,7 +429,7 @@ Nesta situação, deverá [otimizar as suas bases de dados](/pages/web_cloud/web
 > **"mysqli::real_connect(): (HY000/2002): php_network_getaddresses: getaddrinfo failed: Name or service not known"**
 >
 
-Esta mensagem de erro aparece na [ligação ao PhpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#instrucoes) quando o nome do servidor indicado está incorreto.
+Esta mensagem de erro aparece na [ligação ao phpMyAdmin](/pages/web_cloud/web_cloud_databases/connecting-to-database-on-database-server#instrucoes) quando o nome do servidor indicado está incorreto.
 
 ![name_or_service_not_known](/pages/assets/screens/other/web-tools/phpmyadmin/pma-error-hy000-2002.png){.thumbnail}
 
@@ -467,7 +467,7 @@ Clique nos separadores abaixo para visualizar sucessivamente cada um dos **2** p
 >>
 > **Passo 2**
 >>
->> No separador `Informações gerais`{.action}, o nome do servidor a introduzir está inscrito na secção `Informações de ligação`, parte `SQL`, rubrica `Nome do host`.
+>> No separador `Informações gerais`{.action}, o nome do servidor a introduzir está inscrito na secção `Informações da ligação`, parte `SQL`, rubrica `Nome do host`.
 
 ///
 

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.de-de.md
@@ -155,7 +155,7 @@ Das bedeutet, dass dieser Domainname nicht in diesem [OVHcloud Kunden-Account](/
 
 Überprüfen Sie, ob er zu einem Ihrer anderen [OVHcloud Kunden-Accounts](/links/manager) gehört, falls Sie mehrere davon erstellt haben.
 
-Sie können auch, um den Registrar Ihres Domainnamens herauszufinden sowie die tatsächlich verwendeten DNS-Server zu überprüfen, das [WHOIS Tool](https://www.ovh.de/support/werkzeuge/check_whois.pl) verwenden.
+Sie können auch, um den Registrar Ihres Domainnamens herauszufinden sowie die tatsächlich verwendeten DNS-Server zu überprüfen, das [WHOIS Tool](/links/web/domains-whois) verwenden.
 
 Falls nötig kontaktieren Sie Ihren Webmaster oder einen [OVHcloud Partner](/links/partner).
 

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Was tun bei dem Fehler "Dies ist keine sichere Verbindung"?
 excerpt: Erfahren Sie hier, wie Sie bei sicherheitsrelevanten Fehlermeldungen auf Ihrer Website vorgehen
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.de-de.md
@@ -1,12 +1,26 @@
 ---
 title: Was tun bei dem Fehler "Dies ist keine sichere Verbindung"?
 excerpt: Erfahren Sie hier, wie Sie bei sicherheitsrelevanten Fehlermeldungen auf Ihrer Website vorgehen
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
-## Ziel  <a name="objective"></a>
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
-Es können verschiedene Fehlermeldungen auftreten, wenn Ihre Website nicht erreichbar ist. Die nachfolgenden Beispiele zeigen an, dass Ihr Webhosting kein [SSL-Zertifikat](/pages/web_cloud/web_hosting/ssl_on_webhosting) enthält (wenn Ihre Website keine der in dieser Anleitung beschriebenen Fehlermeldungen anzeigt, gehen Sie zum Abschnitt [“Weiterführende Informationen“](#go-further) in dieser Anleitung): 
+## Ziel <a name="objective"></a>
+
+Es können verschiedene Fehlermeldungen auftreten, wenn Ihre Website nicht erreichbar ist. Die nachfolgenden Beispiele zeigen an, dass Ihr Webhosting kein [SSL-Zertifikat](/pages/web_cloud/web_hosting/ssl_on_webhosting) enthält (wenn Ihre Website keine der in dieser Anleitung beschriebenen Fehlermeldungen anzeigt, gehen Sie zum Abschnitt ["Weiterführende Informationen"](#go-further) in dieser Anleitung):
 
 |Browser|Betreffende Fehlermeldung|
 |-|---|
@@ -19,7 +33,7 @@ Es können verschiedene Fehlermeldungen auftreten, wenn Ihre Website nicht errei
 
 > [!warning]
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-> 
+>
 > Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
 >
 
@@ -45,7 +59,7 @@ Um die Problemursache zu beheben müssen Sie:
 1. Das korrekte Hosting identifizieren, mit dem Ihre Domain verbunden ist.
 2. Auf dem betreffenden Hosting ein [SSL-Zertifikat](/pages/web_cloud/web_hosting/ssl_on_webhosting) für Ihre Domain erstellen, aktivieren oder verlängern.
 
-### 1: Überprüfen des Webhostings der betroffenen Domain
+### 1 - Überprüfen des Webhostings der betroffenen Domain
 
 #### Die IP-Adresse des Hostings überprüfen
 
@@ -58,13 +72,13 @@ Um die IP-Adresse Ihres [OVHcloud Webhostings](/links/web/hosting) herauszufinde
 >>
 >> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting), und wählen Sie das betreffende Webhosting aus.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hosting-Pakete Seite](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Schritt 2**
 >>
 >> Im Feld **Allgemeine Informationen** finden Sie die Adressen unter **IPv4** und **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![IPv4- und IPv6-Adressen](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Notieren Sie die IPv4- und/oder IPv6-Adresse und folgen Sie der Anleitung weiter.
 
@@ -72,28 +86,97 @@ Um die IP-Adresse Ihres [OVHcloud Webhostings](/links/web/hosting) herauszufinde
 
 Überprüfen Sie nun, ob die in der [DNS-Zone](/pages/web_cloud/domains/dns_zone_edit) hinterlegte IP-Adresse der Adresse Ihres [Webhostings](/links/web/hosting) entspricht.
 
-Loggen Sie sich in Ihr [OVHcloud Kundencenter](/links/manager) ein und gehen Sie in den Bereich `Web Cloud`{.action}. Klicken Sie auf das Menü `DNS-Zone`{.action} und wählen Sie den Domainnamen aus.
+Klicken Sie auf die Tabs, um die **2** Schritte anzuzeigen.
 
-Notieren Sie das "Ziel" des Eintrags vom Typ `A` Ihres Domainnamens:
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [DNS-Zone](/links/control-panel/web-dns-zone), und wählen Sie den Domainnamen aus.
+>>
+>> ![DNS-Zone Seite](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Notieren Sie das "Ziel" des Eintrags vom Typ `A` Ihres Domainnamens:
+>>
+>> ![A-Eintrag Ziel in der DNS-Zone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Die notwendigen Aktionen durchführen
 
-|Szenario|Nächster Schritt|
-|---|---|
-|Die in der [DNS-Zone](/pages/web_cloud/domains/dns_zone_edit) gelistete IP-Adresse entspricht der IP-Adresse Ihres Webhostings.|Fortfahren mit [Schritt 2](#step2)|
-|Die in der Zone angegebene IP-Adresse betrifft keines der Webhostings in Ihrem [OVHcloud Kundencenter](/links/manager), aber erscheint in der [Adressliste unserer Web Server](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Überprüfen Sie, ob die betreffende IP Adresse zu einem Ihrer Webhostings in einem anderen [OVHcloud Kunden-Account](/links/manager) gehört, falls Sie mehrere haben. Für mehr Informationen kontaktieren Sie Ihren Webmaster oder einen [OVHcloud Partner](/links/partner).|
-|Die in der Zone eingertragene IP-Adresse ist nicht die Ihres Webhostings und erscheint auch nicht in der [Adressliste unserer Web Server](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Kontaktieren Sie Ihren Webmaster oder einen [OVHcloud Partner](/links/partner) für mehr Informationen.|
-|Im Tab `DNS-Zone`{.action} gibt ein Warnhinweis an, dass Ihre Domain andere [DNS-Server](/pages/web_cloud/domains/dns_zone_edit) verwendet. Diese werden in der Form "ns **?** .ovh.net" oder "dns **?** .ovh.net" angezeigt ("**?**" zu ersetzen mit der entsprechenden DNS-Servernummer):<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|Sie müssen die DNS-Server Ihrer Domain bearbeiten, damit sie mit den `NS`-Einträgen der DNS-Zone übereinstimmen. Befolgen Sie hierzu die Anweisungen in [dieser Anleitung](/pages/web_cloud/domains/dns_server_edit).|
-|Im Tab `DNS-Zone`{.action} gibt eine Nachricht an, dass Ihre Domain andere [DNS-Server](/pages/web_cloud/domains/dns_zone_edit) verwendet, die nicht dem Format "ns **?** .ovh.net" oder "dns **?** .ovh.net" entsprechen :<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Kontaktieren Sie Ihren Webmaster oder einen [OVHcloud Partner](/links/partner) für mehr Informationen.|
-|Ihre Domain ist nicht im Bereich `Domainnamen`{.action} im [OVHcloud Kundencenter](/links/manager) aufgelistet.<br><br>Oder der Tab `DNS-Zone`{.action} Ihrer Domainname erscheint wie folgt:<br><br>![dns](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|Das bedeutet, dass dieser Domainname nicht in diesem [OVHcloud Kunden-Account](/links/manager) verwaltet wird.<br><br>Überprüfen Sie, ob er zu einem Ihrer anderen [OVHcloud Kunden-Accounts](/links/manager) gehört, falls Sie mehrere davon erstellt haben.<br><br>Sie können auch, um den Registrar Ihres Domainnamens herauszufinden sowie die tatsächlich verwendeten DNS-Server zu überprüfen, das [WHOIS Tool](https://www.ovh.de/support/werkzeuge/check_whois.pl) verwenden.<br><br>Falls nötig kontaktieren Sie Ihren Webmaster oder einen [OVHcloud Partner](/links/partner).|
+**Klicken Sie auf das Szenario, das Ihrer Situation entspricht, um den Inhalt anzuzeigen.**
 
-### 2: Das SSL-Zertifikat Ihres Hostings überprüfen <a name="step2"></a>
+/// details | Die IP-Adresse entspricht der IP-Adresse Ihres Webhostings
 
-Überprüfen Sie im Tab `Allgemeine Informationen`{.action} Ihres OVHcloud Hostings den Abschnitt `SSL-Zertifikat`:
+Die in der [DNS-Zone](/pages/web_cloud/domains/dns_zone_edit) gelistete IP-Adresse entspricht der IP-Adresse Ihres Webhostings. Gehen Sie zu [Teil 2](#step2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
+
+/// details | Die IP-Adresse betrifft keines der Webhostings in Ihrem Account, erscheint aber in der Adressliste unserer Web Server
+
+Die in der Zone angegebene IP-Adresse betrifft keines der Webhostings in Ihrem [OVHcloud Kundencenter](/links/manager), aber erscheint in der [Adressliste unserer Web Server](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Überprüfen Sie, ob die betreffende IP-Adresse zu einem Ihrer Webhostings in einem anderen [OVHcloud Kunden-Account](/links/manager) gehört, falls Sie mehrere haben. Falls nötig kontaktieren Sie Ihren Webmaster oder einen [OVHcloud Partner](/links/partner).
+
+///
+
+/// details | Die IP-Adresse ist nicht die Ihres Webhostings und erscheint nicht in der Adressliste unserer Web Server
+
+Die in der Zone eingetragene IP-Adresse ist nicht die Ihres Webhostings und erscheint auch nicht in der [Adressliste unserer Web Server](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Kontaktieren Sie Ihren Webmaster oder einen [OVHcloud Partner](/links/partner) für mehr Informationen.
+
+///
+
+/// details | Ihre Domain verwendet andere OVHcloud DNS-Server (ns?.ovh.net / dns?.ovh.net)
+
+Über der DNS-Zone in Ihrem OVHcloud Kundencenter gibt ein Warnhinweis an, dass Ihre Domain andere [DNS-Server](/pages/web_cloud/domains/dns_zone_edit) verwendet. Diese werden in der Form "ns **?** .ovh.net" oder "dns **?** .ovh.net" angezeigt ("**?**" zu ersetzen mit der entsprechenden DNS-Servernummer):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+Sie müssen die DNS-Server Ihrer Domain bearbeiten, damit sie mit den `NS`-Einträgen der DNS-Zone übereinstimmen. Befolgen Sie hierzu die Anweisungen in [dieser Anleitung](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Ihre Domain verwendet externe (nicht OVHcloud) DNS-Server
+
+Über der DNS-Zone in Ihrem OVHcloud Kundencenter gibt eine Nachricht an, dass Ihre Domain andere [DNS-Server](/pages/web_cloud/domains/dns_zone_edit) verwendet, die nicht dem Format "ns **?** .ovh.net" oder "dns **?** .ovh.net" entsprechen:
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Kontaktieren Sie Ihren Webmaster oder einen [OVHcloud Partner](/links/partner) für mehr Informationen.
+
+///
+
+/// details | Ihre Domain ist nicht in Ihrem OVHcloud Kundencenter aufgelistet
+
+Ihre Domain erscheint nicht auf der Seite [Domainnamen](/links/control-panel/web-domains) in Ihrem OVHcloud Kundencenter.
+
+Das bedeutet, dass dieser Domainname nicht in diesem [OVHcloud Kunden-Account](/links/manager) verwaltet wird.
+
+Überprüfen Sie, ob er zu einem Ihrer anderen [OVHcloud Kunden-Accounts](/links/manager) gehört, falls Sie mehrere davon erstellt haben.
+
+Sie können auch, um den Registrar Ihres Domainnamens herauszufinden sowie die tatsächlich verwendeten DNS-Server zu überprüfen, das [WHOIS Tool](https://www.ovh.de/support/werkzeuge/check_whois.pl) verwenden.
+
+Falls nötig kontaktieren Sie Ihren Webmaster oder einen [OVHcloud Partner](/links/partner).
+
+///
+
+### 2 - Das SSL-Zertifikat Ihres Hostings überprüfen <a name="step2"></a>
+
+Klicken Sie auf die Tabs, um die **2** Schritte anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting), und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete Seite](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Überprüfen Sie im Tab `Allgemeine Informationen`{.action} den Abschnitt `SSL-Zertifikat`:
+>>
+>> ![SSL-Zertifikat im Tab Allgemeine Informationen](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
 
 #### Szenario 1: Ihr Hosting enthält kein SSL-Zertifikat
 
@@ -103,13 +186,14 @@ Aktivieren Sie ein [SSL-Zertifikat](/links/web/hosting-options-ssl) auf Ihrem We
 
 Wenn Sie ein **"Let's Encrypt" SSL-Zertifikat** generiert haben, aktivieren Sie die SSL-Option Ihres Hosting-Pakets, indem Sie die Anweisungen in [dieser Anleitung](/pages/web_cloud/web_hosting/ssl_on_webhosting) befolgen.
 
-Wenn Sie eines der **kostenpflichtigen SSL-Zertifikate** unseres Partners [SECTIGO](https://sectigo.com/) bestellt haben, kontaktieren Sie den [SECTIGO Support](https://sectigo.com/support).
+Wenn Sie über ein **importiertes SSL-Zertifikat** verfügen und es nicht funktioniert, kontaktieren Sie den entsprechenden Anbieter.
 
-Wenn Sie über ein **importiertes SSL-Zertifikat** verfügen, kontaktieren Sie den entsprechenden Anbieter.
+Wenn Sie eines der **kostenpflichtigen SSL-Zertifikate** unseres Partners [SECTIGO](https://sectigo.com/) bestellt haben, überprüfen Sie, ob Sie eine E-Mail zur Verlängerung erhalten haben.
+<br>Falls nötig kontaktieren Sie den [SECTIGO Support](https://sectigo.com/support).
 
->[!primary]
+> [!primary]
 >
-> Um alle von unseren Diensten versendeten E-Mails einzusehen, klicken Sie oben rechts in Ihrem [OVHcloud Kundencenter](/links/manager) und dann auf `Meine Kommunikation`{.action}.
+> Um alle von unseren Diensten versendeten E-Mails einzusehen, gehen Sie auf die Seite [Meine Kommunikation](/links/control-panel/account-messages).
 
 ## Weiterführende Informationen <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-asia.md
@@ -1,12 +1,26 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2025-10-28
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective <a name="objective"></a>
 
-Several error messages may appear if your website is inaccessible. The examples below indicate that your web hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
+Several error messages may appear if your website is inaccessible. The examples below indicate that your Web Hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
 
 |Browser|Error message concerned|
 |-|---|
@@ -18,15 +32,14 @@ Several error messages may appear if your website is inaccessible. The examples 
 **Find out how to solve SSL-related error messages on your website.**
 
 > [!warning]
+> OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
->
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the "[Go further](#go-further)" section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- Administrative rights to manage your domain name’s [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
+- Administrative rights to manage your domain name's [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -46,7 +59,7 @@ To solve this issue, you will need to:
 1. Determine the hosting plan to which your domain name is linked, in order to intervene on the correct server.
 2. Create, activate or renew a [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) for your domain name on the concerned hosting plan.
 
-### 1: check the hosting plan attached to your domain name
+### 1 - Check the hosting plan attached to your domain name
 
 #### Check the hosting IP address
 
@@ -59,59 +72,128 @@ To find the IP address of your [OVHcloud hosting plan](/links/web/hosting), clic
 >>
 >> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Step 2**
 >>
 >> In the **General information** box, you will see the addresses under **IPv4** and **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![IPv4 and IPv6 addresses](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Note the IPv4 and/or IPv6 address, then continue reading the guide.
 
 #### Check the IP address in the DNS zone
 
-You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [Web Cloud hosting plan](/links/web/hosting).
+You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [OVHcloud Web Hosting plan](/links/web/hosting).
 
-Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section. Click the `DNS zones`{.action} menu, then choose the domain name concerned.
+Click on the tabs below to view each of the **2** steps.
 
-Note the target of the `A` record for your domain name:
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones page](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Note the target of the `A` record for your domain name:
+>>
+>> ![A record target in DNS zone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Perform the necessary actions
 
-|Scenario|What to do|
-|---|---|
-|The IP address listed in the [DNS Zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan’s IP address.|Proceed to [Step 2](#step2).|
-|The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|The IP address entered in the zone is not your hosting plan’s one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|In the `DNS Zone`{.action} tab, a warning indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).|
-|In the `DNS Zone`{.action} tab, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?**.ovh.net" :<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|Your domain name does not appear in the `Domain names`{.action} section of your [OVHcloud Control Panel](/links/manager).<br><br>Or your domain's `DNS Zone`{.action} tab appears as follows:<br><br>![dns](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|It means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).<br><br>Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.<br><br>You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).<br><br>If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.|
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check your hosting plan’s SSL certificate <a name="step2"></a>
+/// details | The IP address corresponds to that of your shared hosting plan
 
-In the `General information`{.action} tab of the concerned hosting plan within your [OVHcloud Control Panel](/links/manager), check the `SSL certificate` section:
+The IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan's IP address. Proceed to [part 2](#step2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
 
-#### Scenario 1: your web hosting plan does not contain any SSL certificate
+/// details | The IP address does not concern any of the hosting plans within your account but appears in the Web Cloud server list
+
+The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | The IP address is not your hosting plan's one, nor does it appear in the Web Cloud server list
+
+The IP address entered in the zone is not your hosting plan's one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain uses other OVHcloud DNS servers (ns?.ovh.net / dns?.ovh.net)
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Your domain uses external (non-OVHcloud) DNS servers
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain name does not appear in your OVHcloud Control Panel
+
+Your domain name does not appear on the [Domain names](/links/control-panel/web-domains) page of your OVHcloud Control Panel.
+
+This means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).
+
+Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.
+
+You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).
+
+If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.
+
+///
+
+### 2 - Check your Web Hosting plan's SSL certificate <a name="step2"></a>
+
+Click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, check the `SSL certificate` section:
+>>
+>> ![SSL certificate in general tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+
+#### Scenario 1: Your Web Hosting plan does not contain any SSL certificate
 
 Activate an [SSL certificate](/links/web/hosting-options-ssl) on your Web Hosting plan by following the instructions in this [guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-#### Scenario 2: the SSL certificate on your Web hosting plan does not work
+#### Scenario 2: The SSL certificate on your Web Hosting plan does not work
 
 If you have generated a **Let's Encrypt SSL certificate**, enable the SSL option on your hosting by following the instructions in [this guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-If you **ordered a SSL certificate** of our partner [SECTIGO](https://sectigo.com/), check if you have received an e-mail offering to renew it.
-<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more informations.
+If you have **imported a SSL certificate** from another provider and it does not work, contact the appropriate support team.
 
-If you **imported a SSL certificate** from another provider, contact its support team.
+If you have **ordered a SSL certificate** from our partner [SECTIGO](https://sectigo.com/), check if you have received an email offering to renew it.
+<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more information.
 
 > [!primary]
 >
-> To check all the emails sent by OVHcloud teams, click on the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then on `My messages`{.action}.
+> To check all the emails sent by OVHcloud, go to the [My communications](/links/control-panel/account-messages) page.
 
 ## Go further <a name="go-further"></a>
 
@@ -119,14 +201,14 @@ If you **imported a SSL certificate** from another provider, contact its support
 
 [Activating HTTPS on your website with an SSL certificate](/pages/web_cloud/web_hosting/ssl-activate-https-website)
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
-For specialized service providers (SEO, IT development, etc.), contact the [OVHcloud partners](/links/partner).
 
-If you need assistance using and configuring your OVHcloud solutions, please refer to our [support offers page](/links/support).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-au.md
@@ -1,12 +1,26 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2025-10-28
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective <a name="objective"></a>
 
-Several error messages may appear if your website is inaccessible. The examples below indicate that your web hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
+Several error messages may appear if your website is inaccessible. The examples below indicate that your Web Hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
 
 |Browser|Error message concerned|
 |-|---|
@@ -18,15 +32,14 @@ Several error messages may appear if your website is inaccessible. The examples 
 **Find out how to solve SSL-related error messages on your website.**
 
 > [!warning]
+> OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
->
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the "[Go further](#go-further)" section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- Administrative rights to manage your domain name’s [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
+- Administrative rights to manage your domain name's [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -46,7 +59,7 @@ To solve this issue, you will need to:
 1. Determine the hosting plan to which your domain name is linked, in order to intervene on the correct server.
 2. Create, activate or renew a [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) for your domain name on the concerned hosting plan.
 
-### 1: check the hosting plan attached to your domain name
+### 1 - Check the hosting plan attached to your domain name
 
 #### Check the hosting IP address
 
@@ -59,59 +72,128 @@ To find the IP address of your [OVHcloud hosting plan](/links/web/hosting), clic
 >>
 >> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Step 2**
 >>
 >> In the **General information** box, you will see the addresses under **IPv4** and **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![IPv4 and IPv6 addresses](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Note the IPv4 and/or IPv6 address, then continue reading the guide.
 
 #### Check the IP address in the DNS zone
 
-You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [Web Cloud hosting plan](/links/web/hosting).
+You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [OVHcloud Web Hosting plan](/links/web/hosting).
 
-Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section. Click the `DNS zones`{.action} menu, then choose the domain name concerned.
+Click on the tabs below to view each of the **2** steps.
 
-Note the target of the `A` record for your domain name:
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones page](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Note the target of the `A` record for your domain name:
+>>
+>> ![A record target in DNS zone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Perform the necessary actions
 
-|Scenario|What to do|
-|---|---|
-|The IP address listed in the [DNS Zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan’s IP address.|Proceed to [Step 2](#step2).|
-|The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|The IP address entered in the zone is not your hosting plan’s one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|In the `DNS Zone`{.action} tab, a warning indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).|
-|In the `DNS Zone`{.action} tab, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?**.ovh.net" :<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|Your domain name does not appear in the `Domain names`{.action} section of your [OVHcloud Control Panel](/links/manager).<br><br>Or your domain's `DNS Zone`{.action} tab appears as follows:<br><br>![dns](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|It means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).<br><br>Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.<br><br>You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).<br><br>If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.|
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check your hosting plan’s SSL certificate <a name="step2"></a>
+/// details | The IP address corresponds to that of your shared hosting plan
 
-In the `General information`{.action} tab of the concerned hosting plan within your [OVHcloud Control Panel](/links/manager), check the `SSL certificate` section:
+The IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan's IP address. Proceed to [part 2](#step2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
 
-#### Scenario 1: your web hosting plan does not contain any SSL certificate
+/// details | The IP address does not concern any of the hosting plans within your account but appears in the Web Cloud server list
+
+The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | The IP address is not your hosting plan's one, nor does it appear in the Web Cloud server list
+
+The IP address entered in the zone is not your hosting plan's one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain uses other OVHcloud DNS servers (ns?.ovh.net / dns?.ovh.net)
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Your domain uses external (non-OVHcloud) DNS servers
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain name does not appear in your OVHcloud Control Panel
+
+Your domain name does not appear on the [Domain names](/links/control-panel/web-domains) page of your OVHcloud Control Panel.
+
+This means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).
+
+Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.
+
+You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).
+
+If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.
+
+///
+
+### 2 - Check your Web Hosting plan's SSL certificate <a name="step2"></a>
+
+Click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, check the `SSL certificate` section:
+>>
+>> ![SSL certificate in general tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+
+#### Scenario 1: Your Web Hosting plan does not contain any SSL certificate
 
 Activate an [SSL certificate](/links/web/hosting-options-ssl) on your Web Hosting plan by following the instructions in this [guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-#### Scenario 2: the SSL certificate on your Web hosting plan does not work
+#### Scenario 2: The SSL certificate on your Web Hosting plan does not work
 
 If you have generated a **Let's Encrypt SSL certificate**, enable the SSL option on your hosting by following the instructions in [this guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-If you **ordered a SSL certificate** of our partner [SECTIGO](https://sectigo.com/), check if you have received an e-mail offering to renew it.
-<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more informations.
+If you have **imported a SSL certificate** from another provider and it does not work, contact the appropriate support team.
 
-If you **imported a SSL certificate** from another provider, contact its support team.
+If you have **ordered a SSL certificate** from our partner [SECTIGO](https://sectigo.com/), check if you have received an email offering to renew it.
+<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more information.
 
 > [!primary]
 >
-> To check all the emails sent by OVHcloud teams, click on the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then on `My messages`{.action}.
+> To check all the emails sent by OVHcloud, go to the [My communications](/links/control-panel/account-messages) page.
 
 ## Go further <a name="go-further"></a>
 
@@ -119,14 +201,14 @@ If you **imported a SSL certificate** from another provider, contact its support
 
 [Activating HTTPS on your website with an SSL certificate](/pages/web_cloud/web_hosting/ssl-activate-https-website)
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
-For specialized service providers (SEO, IT development, etc.), contact the [OVHcloud partners](/links/partner).
 
-If you need assistance using and configuring your OVHcloud solutions, please refer to our [support offers page](/links/support).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-ca.md
@@ -1,12 +1,26 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2025-10-28
+updated: 2026-03-26
 ---
- 
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
+
 ## Objective <a name="objective"></a>
 
-Several error messages may appear if your website is inaccessible. The examples below indicate that your web hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
+Several error messages may appear if your website is inaccessible. The examples below indicate that your Web Hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
 
 |Browser|Error message concerned|
 |-|---|
@@ -18,15 +32,14 @@ Several error messages may appear if your website is inaccessible. The examples 
 **Find out how to solve SSL-related error messages on your website.**
 
 > [!warning]
+> OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
->
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the "[Go further](#go-further)" section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- Administrative rights to manage your domain name’s [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
+- Administrative rights to manage your domain name's [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -46,7 +59,7 @@ To solve this issue, you will need to:
 1. Determine the hosting plan to which your domain name is linked, in order to intervene on the correct server.
 2. Create, activate or renew a [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) for your domain name on the concerned hosting plan.
 
-### 1: check the hosting plan attached to your domain name
+### 1 - Check the hosting plan attached to your domain name
 
 #### Check the hosting IP address
 
@@ -59,59 +72,128 @@ To find the IP address of your [OVHcloud hosting plan](/links/web/hosting), clic
 >>
 >> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Step 2**
 >>
 >> In the **General information** box, you will see the addresses under **IPv4** and **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![IPv4 and IPv6 addresses](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Note the IPv4 and/or IPv6 address, then continue reading the guide.
 
 #### Check the IP address in the DNS zone
 
-You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [Web Cloud hosting plan](/links/web/hosting).
+You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [OVHcloud Web Hosting plan](/links/web/hosting).
 
-Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section. Click the `DNS zones`{.action} menu, then choose the domain name concerned.
+Click on the tabs below to view each of the **2** steps.
 
-Note the target of the `A` record for your domain name:
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones page](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Note the target of the `A` record for your domain name:
+>>
+>> ![A record target in DNS zone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Perform the necessary actions
 
-|Scenario|What to do|
-|---|---|
-|The IP address listed in the [DNS Zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan’s IP address.|Proceed to [Step 2](#step2).|
-|The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|The IP address entered in the zone is not your hosting plan’s one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|In the `DNS Zone`{.action} tab, a warning indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).|
-|In the `DNS Zone`{.action} tab, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?**.ovh.net" :<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|Your domain name does not appear in the `Domain names`{.action} section of your [OVHcloud Control Panel](/links/manager).<br><br>Or your domain's `DNS Zone`{.action} tab appears as follows:<br><br>![dns](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|It means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).<br><br>Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.<br><br>You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).<br><br>If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.|
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check your hosting plan’s SSL certificate <a name="step2"></a>
+/// details | The IP address corresponds to that of your shared hosting plan
 
-In the `General information`{.action} tab of the concerned hosting plan within your [OVHcloud Control Panel](/links/manager), check the `SSL certificate` section:
+The IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan's IP address. Proceed to [part 2](#step2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
 
-#### Scenario 1: your web hosting plan does not contain any SSL certificate
+/// details | The IP address does not concern any of the hosting plans within your account but appears in the Web Cloud server list
+
+The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | The IP address is not your hosting plan's one, nor does it appear in the Web Cloud server list
+
+The IP address entered in the zone is not your hosting plan's one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain uses other OVHcloud DNS servers (ns?.ovh.net / dns?.ovh.net)
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Your domain uses external (non-OVHcloud) DNS servers
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain name does not appear in your OVHcloud Control Panel
+
+Your domain name does not appear on the [Domain names](/links/control-panel/web-domains) page of your OVHcloud Control Panel.
+
+This means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).
+
+Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.
+
+You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).
+
+If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.
+
+///
+
+### 2 - Check your Web Hosting plan's SSL certificate <a name="step2"></a>
+
+Click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, check the `SSL certificate` section:
+>>
+>> ![SSL certificate in general tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+
+#### Scenario 1: Your Web Hosting plan does not contain any SSL certificate
 
 Activate an [SSL certificate](/links/web/hosting-options-ssl) on your Web Hosting plan by following the instructions in this [guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-#### Scenario 2: the SSL certificate on your Web hosting plan does not work
+#### Scenario 2: The SSL certificate on your Web Hosting plan does not work
 
 If you have generated a **Let's Encrypt SSL certificate**, enable the SSL option on your hosting by following the instructions in [this guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-If you **ordered a SSL certificate** of our partner [SECTIGO](https://sectigo.com/), check if you have received an e-mail offering to renew it.
-<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more informations.
+If you have **imported a SSL certificate** from another provider and it does not work, contact the appropriate support team.
 
-If you **imported a SSL certificate** from another provider, contact its support team.
+If you have **ordered a SSL certificate** from our partner [SECTIGO](https://sectigo.com/), check if you have received an email offering to renew it.
+<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more information.
 
 > [!primary]
 >
-> To check all the emails sent by OVHcloud teams, click on the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then on `My messages`{.action}.
+> To check all the emails sent by OVHcloud, go to the [My communications](/links/control-panel/account-messages) page.
 
 ## Go further <a name="go-further"></a>
 
@@ -119,14 +201,14 @@ If you **imported a SSL certificate** from another provider, contact its support
 
 [Activating HTTPS on your website with an SSL certificate](/pages/web_cloud/web_hosting/ssl-activate-https-website)
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
-For specialized service providers (SEO, IT development, etc.), contact the [OVHcloud partners](/links/partner).
 
-If you need assistance using and configuring your OVHcloud solutions, please refer to our [support offers page](/links/support).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-gb.md
@@ -1,12 +1,26 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2025-10-28
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective <a name="objective"></a>
 
-Several error messages may appear if your website is inaccessible. The examples below indicate that your Web Hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section): 
+Several error messages may appear if your website is inaccessible. The examples below indicate that your Web Hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
 
 |Browser|Error message concerned|
 |-|---|
@@ -25,7 +39,7 @@ Several error messages may appear if your website is inaccessible. The examples 
 
 ## Requirements
 
-- Administrative rights to manage your domain name’s [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
+- Administrative rights to manage your domain name's [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -45,7 +59,7 @@ To solve this issue, you will need to:
 1. Determine the hosting plan to which your domain name is linked, in order to intervene on the correct server.
 2. Create, activate or renew a [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) for your domain name on the concerned hosting plan.
 
-### 1: Check the hosting plan attached to your domain name
+### 1 - Check the hosting plan attached to your domain name
 
 #### Check the hosting IP address
 
@@ -58,13 +72,13 @@ To find the IP address of your [OVHcloud hosting plan](/links/web/hosting), clic
 >>
 >> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Step 2**
 >>
 >> In the **General information** box, you will see the addresses under **IPv4** and **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![IPv4 and IPv6 addresses](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Note the IPv4 and/or IPv6 address, then continue reading the guide.
 
@@ -72,28 +86,97 @@ To find the IP address of your [OVHcloud hosting plan](/links/web/hosting), clic
 
 You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [OVHcloud Web Hosting plan](/links/web/hosting).
 
-Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section. Click the `DNS zones`{.action} menu, then choose the domain name concerned.
+Click on the tabs below to view each of the **2** steps.
 
-Note the target of the `A` record for your domain name:
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones page](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Note the target of the `A` record for your domain name:
+>>
+>> ![A record target in DNS zone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Perform the necessary actions
 
-|Scenario|What to do|
-|---|---|
-|The IP address listed in the [DNS Zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan’s IP address.|Proceed to [Step 2](#step2).|
-|The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|The IP address entered in the zone is not your hosting plan’s one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|In the `DNS Zone`{.action} tab, a warning indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).|
-|In the `DNS Zone`{.action} tab, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?**.ovh.net" :<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|Your domain name does not appear in the `Domain names`{.action} section of your [OVHcloud Control Panel](/links/manager).<br><br>Or your domain's `DNS Zone`{.action} tab appears as follows:<br><br>![dns](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|It means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).<br><br>Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.<br><br>You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).<br><br>If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.|
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check your Web Hosting plan’s SSL certificate <a name="step2"></a>
+/// details | The IP address corresponds to that of your shared hosting plan
 
-In the `General information`{.action} tab of the concerned hosting plan within your [OVHcloud Control Panel](/links/manager), check the `SSL certificate` section:
+The IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan's IP address. Proceed to [part 2](#step2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
+
+/// details | The IP address does not concern any of the hosting plans within your account but appears in the Web Cloud server list
+
+The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | The IP address is not your hosting plan's one, nor does it appear in the Web Cloud server list
+
+The IP address entered in the zone is not your hosting plan's one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain uses other OVHcloud DNS servers (ns?.ovh.net / dns?.ovh.net)
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Your domain uses external (non-OVHcloud) DNS servers
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain name does not appear in your OVHcloud Control Panel
+
+Your domain name does not appear on the [Domain names](/links/control-panel/web-domains) page of your OVHcloud Control Panel.
+
+This means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).
+
+Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.
+
+You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).
+
+If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.
+
+///
+
+### 2 - Check your Web Hosting plan's SSL certificate <a name="step2"></a>
+
+Click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, check the `SSL certificate` section:
+>>
+>> ![SSL certificate in general tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
 
 #### Scenario 1: Your Web Hosting plan does not contain any SSL certificate
 
@@ -103,14 +186,14 @@ Activate an [SSL certificate](/links/web/hosting-options-ssl) on your Web Hostin
 
 If you have generated a **Let's Encrypt SSL certificate**, enable the SSL option on your hosting by following the instructions in [this guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-If you **ordered a SSL certificate** of our partner [SECTIGO](https://sectigo.com/), check if you have received an email offering to renew it.
-<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more information.
+If you have **imported a SSL certificate** from another provider and it does not work, contact the appropriate support team.
 
-If you have **imported a SSL certificate** from another provider, contact the appropriate support team.
+If you have **ordered a SSL certificate** from our partner [SECTIGO](https://sectigo.com/), check if you have received an email offering to renew it.
+<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more information.
 
 > [!primary]
 >
-> To check all the emails sent by OVHcloud teams, click on the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then on `My messages`{.action}.
+> To check all the emails sent by OVHcloud, go to the [My communications](/links/control-panel/account-messages) page.
 
 ## Go further <a name="go-further"></a>
 
@@ -118,12 +201,12 @@ If you have **imported a SSL certificate** from another provider, contact the ap
 
 [Activating HTTPS on your website with an SSL certificate](/pages/web_cloud/web_hosting/ssl-activate-https-website)
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
+
 For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-ie.md
@@ -1,12 +1,26 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2025-10-28
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective <a name="objective"></a>
 
-Several error messages may appear if your website is inaccessible. The examples below indicate that your web hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
+Several error messages may appear if your website is inaccessible. The examples below indicate that your Web Hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
 
 |Browser|Error message concerned|
 |-|---|
@@ -18,15 +32,14 @@ Several error messages may appear if your website is inaccessible. The examples 
 **Find out how to solve SSL-related error messages on your website.**
 
 > [!warning]
+> OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
->
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the "[Go further](#go-further)" section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- Administrative rights to manage your domain name’s [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
+- Administrative rights to manage your domain name's [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -46,7 +59,7 @@ To solve this issue, you will need to:
 1. Determine the hosting plan to which your domain name is linked, in order to intervene on the correct server.
 2. Create, activate or renew a [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) for your domain name on the concerned hosting plan.
 
-### 1: check the hosting plan attached to your domain name
+### 1 - Check the hosting plan attached to your domain name
 
 #### Check the hosting IP address
 
@@ -59,59 +72,128 @@ To find the IP address of your [OVHcloud hosting plan](/links/web/hosting), clic
 >>
 >> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Step 2**
 >>
 >> In the **General information** box, you will see the addresses under **IPv4** and **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![IPv4 and IPv6 addresses](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Note the IPv4 and/or IPv6 address, then continue reading the guide.
 
 #### Check the IP address in the DNS zone
 
-You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [Web Cloud hosting plan](/links/web/hosting).
+You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [OVHcloud Web Hosting plan](/links/web/hosting).
 
-Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section. Click the `DNS zones`{.action} menu, then choose the domain name concerned.
+Click on the tabs below to view each of the **2** steps.
 
-Note the target of the `A` record for your domain name:
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones page](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Note the target of the `A` record for your domain name:
+>>
+>> ![A record target in DNS zone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Perform the necessary actions
 
-|Scenario|What to do|
-|---|---|
-|The IP address listed in the [DNS Zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan’s IP address.|Proceed to [Step 2](#step2).|
-|The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|The IP address entered in the zone is not your hosting plan’s one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|In the `DNS Zone`{.action} tab, a warning indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).|
-|In the `DNS Zone`{.action} tab, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?**.ovh.net" :<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|Your domain name does not appear in the `Domain names`{.action} section of your [OVHcloud Control Panel](/links/manager).<br><br>Or your domain's `DNS Zone`{.action} tab appears as follows:<br><br>![dns](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|It means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).<br><br>Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.<br><br>You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).<br><br>If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.|
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check your hosting plan’s SSL certificate <a name="step2"></a>
+/// details | The IP address corresponds to that of your shared hosting plan
 
-In the `General information`{.action} tab of the concerned hosting plan within your [OVHcloud Control Panel](/links/manager), check the `SSL certificate` section:
+The IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan's IP address. Proceed to [part 2](#step2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
 
-#### Scenario 1: your web hosting plan does not contain any SSL certificate
+/// details | The IP address does not concern any of the hosting plans within your account but appears in the Web Cloud server list
+
+The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | The IP address is not your hosting plan's one, nor does it appear in the Web Cloud server list
+
+The IP address entered in the zone is not your hosting plan's one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain uses other OVHcloud DNS servers (ns?.ovh.net / dns?.ovh.net)
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Your domain uses external (non-OVHcloud) DNS servers
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain name does not appear in your OVHcloud Control Panel
+
+Your domain name does not appear on the [Domain names](/links/control-panel/web-domains) page of your OVHcloud Control Panel.
+
+This means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).
+
+Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.
+
+You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).
+
+If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.
+
+///
+
+### 2 - Check your Web Hosting plan's SSL certificate <a name="step2"></a>
+
+Click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, check the `SSL certificate` section:
+>>
+>> ![SSL certificate in general tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+
+#### Scenario 1: Your Web Hosting plan does not contain any SSL certificate
 
 Activate an [SSL certificate](/links/web/hosting-options-ssl) on your Web Hosting plan by following the instructions in this [guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-#### Scenario 2: the SSL certificate on your Web hosting plan does not work
+#### Scenario 2: The SSL certificate on your Web Hosting plan does not work
 
 If you have generated a **Let's Encrypt SSL certificate**, enable the SSL option on your hosting by following the instructions in [this guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-If you **ordered a SSL certificate** of our partner [SECTIGO](https://sectigo.com/), check if you have received an e-mail offering to renew it.
-<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more informations.
+If you have **imported a SSL certificate** from another provider and it does not work, contact the appropriate support team.
 
-If you **imported a SSL certificate** from another provider, contact its support team.
+If you have **ordered a SSL certificate** from our partner [SECTIGO](https://sectigo.com/), check if you have received an email offering to renew it.
+<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more information.
 
 > [!primary]
 >
-> To check all the emails sent by OVHcloud teams, click on the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then on `My messages`{.action}.
+> To check all the emails sent by OVHcloud, go to the [My communications](/links/control-panel/account-messages) page.
 
 ## Go further <a name="go-further"></a>
 
@@ -119,14 +201,14 @@ If you **imported a SSL certificate** from another provider, contact its support
 
 [Activating HTTPS on your website with an SSL certificate](/pages/web_cloud/web_hosting/ssl-activate-https-website)
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
-For specialized service providers (SEO, IT development, etc.), contact [OVHcloud partners](/links/partner).
 
-If you need assistance using and configuring your OVHcloud solutions, please refer to our [support offers page](/links/support).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-sg.md
@@ -1,12 +1,26 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2025-10-28
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective <a name="objective"></a>
 
-Several error messages may appear if your website is inaccessible. The examples below indicate that your web hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
+Several error messages may appear if your website is inaccessible. The examples below indicate that your Web Hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
 
 |Browser|Error message concerned|
 |-|---|
@@ -18,15 +32,14 @@ Several error messages may appear if your website is inaccessible. The examples 
 **Find out how to solve SSL-related error messages on your website.**
 
 > [!warning]
+> OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
->
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the "[Go further](#go-further)" section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- Administrative rights to manage your domain name’s [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
+- Administrative rights to manage your domain name's [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -46,7 +59,7 @@ To solve this issue, you will need to:
 1. Determine the hosting plan to which your domain name is linked, in order to intervene on the correct server.
 2. Create, activate or renew a [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) for your domain name on the concerned hosting plan.
 
-### 1: check the hosting plan attached to your domain name
+### 1 - Check the hosting plan attached to your domain name
 
 #### Check the hosting IP address
 
@@ -59,59 +72,128 @@ To find the IP address of your [OVHcloud hosting plan](/links/web/hosting), clic
 >>
 >> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Step 2**
 >>
 >> In the **General information** box, you will see the addresses under **IPv4** and **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![IPv4 and IPv6 addresses](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Note the IPv4 and/or IPv6 address, then continue reading the guide.
 
 #### Check the IP address in the DNS zone
 
-You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [Web Cloud hosting plan](/links/web/hosting).
+You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [OVHcloud Web Hosting plan](/links/web/hosting).
 
-Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section. Click the `DNS zones`{.action} menu, then choose the domain name concerned.
+Click on the tabs below to view each of the **2** steps.
 
-Note the target of the `A` record for your domain name:
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones page](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Note the target of the `A` record for your domain name:
+>>
+>> ![A record target in DNS zone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Perform the necessary actions
 
-|Scenario|What to do|
-|---|---|
-|The IP address listed in the [DNS Zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan’s IP address.|Proceed to [Step 2](#step2).|
-|The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|The IP address entered in the zone is not your hosting plan’s one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|In the `DNS Zone`{.action} tab, a warning indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).|
-|In the `DNS Zone`{.action} tab, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?**.ovh.net" :<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|Your domain name does not appear in the `Domain names`{.action} section of your [OVHcloud Control Panel](/links/manager).<br><br>Or your domain's `DNS Zone`{.action} tab appears as follows:<br><br>![dns](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|It means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).<br><br>Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.<br><br>You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).<br><br>If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.|
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check your hosting plan’s SSL certificate <a name="step2"></a>
+/// details | The IP address corresponds to that of your shared hosting plan
 
-In the `General information`{.action} tab of the concerned hosting plan within your [OVHcloud Control Panel](/links/manager), check the `SSL certificate` section:
+The IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan's IP address. Proceed to [part 2](#step2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
 
-#### Scenario 1: your web hosting plan does not contain any SSL certificate
+/// details | The IP address does not concern any of the hosting plans within your account but appears in the Web Cloud server list
+
+The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | The IP address is not your hosting plan's one, nor does it appear in the Web Cloud server list
+
+The IP address entered in the zone is not your hosting plan's one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain uses other OVHcloud DNS servers (ns?.ovh.net / dns?.ovh.net)
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Your domain uses external (non-OVHcloud) DNS servers
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain name does not appear in your OVHcloud Control Panel
+
+Your domain name does not appear on the [Domain names](/links/control-panel/web-domains) page of your OVHcloud Control Panel.
+
+This means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).
+
+Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.
+
+You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).
+
+If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.
+
+///
+
+### 2 - Check your Web Hosting plan's SSL certificate <a name="step2"></a>
+
+Click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, check the `SSL certificate` section:
+>>
+>> ![SSL certificate in general tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+
+#### Scenario 1: Your Web Hosting plan does not contain any SSL certificate
 
 Activate an [SSL certificate](/links/web/hosting-options-ssl) on your Web Hosting plan by following the instructions in this [guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-#### Scenario 2: the SSL certificate on your Web hosting plan does not work
+#### Scenario 2: The SSL certificate on your Web Hosting plan does not work
 
 If you have generated a **Let's Encrypt SSL certificate**, enable the SSL option on your hosting by following the instructions in [this guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-If you **ordered a SSL certificate** of our partner [SECTIGO](https://sectigo.com/), check if you have received an e-mail offering to renew it.
-<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more informations.
+If you have **imported a SSL certificate** from another provider and it does not work, contact the appropriate support team.
 
-If you **imported a SSL certificate** from another provider, contact its support team.
+If you have **ordered a SSL certificate** from our partner [SECTIGO](https://sectigo.com/), check if you have received an email offering to renew it.
+<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more information.
 
 > [!primary]
 >
-> To check all the emails sent by OVHcloud teams, click on the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then on `My messages`{.action}.
+> To check all the emails sent by OVHcloud, go to the [My communications](/links/control-panel/account-messages) page.
 
 ## Go further <a name="go-further"></a>
 
@@ -119,14 +201,14 @@ If you **imported a SSL certificate** from another provider, contact its support
 
 [Activating HTTPS on your website with an SSL certificate](/pages/web_cloud/web_hosting/ssl-activate-https-website)
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
-For specialized service providers (SEO, IT development, etc.), contact the [OVHcloud partners](/links/partner).
 
-If you need assistance using and configuring your OVHcloud solutions, please refer to our [support offers page](/links/support).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-us.md
@@ -1,12 +1,26 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2025-10-28
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective <a name="objective"></a>
 
-Several error messages may appear if your website is inaccessible. The examples below indicate that your web hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
+Several error messages may appear if your website is inaccessible. The examples below indicate that your Web Hosting plan does not contain any [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) (if your website does not display one of the anomalies described in this guide, please refer to the "[Go further](#go-further)" section):
 
 |Browser|Error message concerned|
 |-|---|
@@ -18,15 +32,14 @@ Several error messages may appear if your website is inaccessible. The examples 
 **Find out how to solve SSL-related error messages on your website.**
 
 > [!warning]
+> OVHcloud is providing you with services for which you are responsible, with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
->
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the "[Go further](#go-further)" section of this guide.
+> This guide is designed to assist you in common tasks as much as possible. Nevertheless, we recommend that you contact a [specialist service provider](/links/partner) and/or discuss the issue with our community on if you have difficulties or doubts. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
 
-- Administrative rights to manage your domain name’s [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
+- Administrative rights to manage your domain name's [DNS servers](/pages/web_cloud/domains/dns_server_general_information) and [DNS zone](/pages/web_cloud/domains/dns_zone_general_information)
 
 <!-- CP-NAV-START:web-hosting -->
 ---
@@ -46,7 +59,7 @@ To solve this issue, you will need to:
 1. Determine the hosting plan to which your domain name is linked, in order to intervene on the correct server.
 2. Create, activate or renew a [SSL certificate](/pages/web_cloud/web_hosting/ssl_on_webhosting) for your domain name on the concerned hosting plan.
 
-### 1: check the hosting plan attached to your domain name
+### 1 - Check the hosting plan attached to your domain name
 
 #### Check the hosting IP address
 
@@ -59,59 +72,128 @@ To find the IP address of your [OVHcloud hosting plan](/links/web/hosting), clic
 >>
 >> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Step 2**
 >>
 >> In the **General information** box, you will see the addresses under **IPv4** and **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![IPv4 and IPv6 addresses](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Note the IPv4 and/or IPv6 address, then continue reading the guide.
 
 #### Check the IP address in the DNS zone
 
-You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [Web Cloud hosting plan](/links/web/hosting).
+You now need to check that the IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to the one of your [OVHcloud Web Hosting plan](/links/web/hosting).
 
-Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section. Click the `DNS zones`{.action} menu, then choose the domain name concerned.
+Click on the tabs below to view each of the **2** steps.
 
-Note the target of the `A` record for your domain name:
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones page](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Note the target of the `A` record for your domain name:
+>>
+>> ![A record target in DNS zone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Perform the necessary actions
 
-|Scenario|What to do|
-|---|---|
-|The IP address listed in the [DNS Zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan’s IP address.|Proceed to [Step 2](#step2).|
-|The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|The IP address entered in the zone is not your hosting plan’s one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|In the `DNS Zone`{.action} tab, a warning indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).|
-|In the `DNS Zone`{.action} tab, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?**.ovh.net" :<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.|
-|Your domain name does not appear in the `Domain names`{.action} section of your [OVHcloud Control Panel](/links/manager).<br><br>Or your domain's `DNS Zone`{.action} tab appears as follows:<br><br>![dns](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|It means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).<br><br>Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.<br><br>You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).<br><br>If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.|
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check your hosting plan’s SSL certificate <a name="step2"></a>
+/// details | The IP address corresponds to that of your shared hosting plan
 
-In the `General information`{.action} tab of the concerned hosting plan within your [OVHcloud Control Panel](/links/manager), check the `SSL certificate` section:
+The IP address listed in the [DNS zone](/pages/web_cloud/domains/dns_zone_edit) corresponds to your Web Hosting plan's IP address. Proceed to [part 2](#step2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
 
-#### Scenario 1: your web hosting plan does not contain any SSL certificate
+/// details | The IP address does not concern any of the hosting plans within your account but appears in the Web Cloud server list
+
+The IP address listed in the zone does not concern any of the Web Hosting plans within your [OVHcloud account](/links/manager), but appears in the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Check that you do not have a hosting plan with this IP address within one of your other [OVHcloud customer accounts](/links/manager), if you have several of them. If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | The IP address is not your hosting plan's one, nor does it appear in the Web Cloud server list
+
+The IP address entered in the zone is not your hosting plan's one, nor does it appear on the [list of our Web Cloud servers](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain uses other OVHcloud DNS servers (ns?.ovh.net / dns?.ovh.net)
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain name uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers. These appear as "ns **?** .ovh.net" or "dns **?** .ovh.net" (replace "**?**" with the relevant DNS server number):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+You must modify your domain's DNS servers to match the `NS` records of the DNS zone. To perform this operation, follow the instructions of [this guide](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Your domain uses external (non-OVHcloud) DNS servers
+
+Above the DNS zone displayed in your OVHcloud Control Panel, a message indicates that your domain uses other [DNS](/pages/web_cloud/domains/dns_zone_edit) servers and these do not appear as "ns **?** .ovh.net" or "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contact your webmaster or the [OVHcloud partners](/links/partner) for further information.
+
+///
+
+/// details | Your domain name does not appear in your OVHcloud Control Panel
+
+Your domain name does not appear on the [Domain names](/links/control-panel/web-domains) page of your OVHcloud Control Panel.
+
+This means that your domain name is not managed from your [OVHcloud Control Panel](/links/manager).
+
+Check if it is managed from one of your other [OVHcloud customer accounts](/links/manager), if you have created more than one of them.
+
+You can also check the registrar of your domain name and its actual DNS servers with our [WHOIS tool](/links/web/domains-whois).
+
+If necessary, contact your webmaster or the [OVHcloud partners](/links/partner) about this.
+
+///
+
+### 2 - Check your Web Hosting plan's SSL certificate <a name="step2"></a>
+
+Click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans page](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `General information`{.action} tab, check the `SSL certificate` section:
+>>
+>> ![SSL certificate in general tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+
+#### Scenario 1: Your Web Hosting plan does not contain any SSL certificate
 
 Activate an [SSL certificate](/links/web/hosting-options-ssl) on your Web Hosting plan by following the instructions in this [guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-#### Scenario 2: the SSL certificate on your Web hosting plan does not work
+#### Scenario 2: The SSL certificate on your Web Hosting plan does not work
 
 If you have generated a **Let's Encrypt SSL certificate**, enable the SSL option on your hosting by following the instructions in [this guide](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
-If you **ordered a SSL certificate** of our partner [SECTIGO](https://sectigo.com/), check if you have received an e-mail offering to renew it.
-<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more informations.
+If you have **imported a SSL certificate** from another provider and it does not work, contact the appropriate support team.
 
-If you **imported a SSL certificate** from another provider, contact its support team.
+If you have **ordered a SSL certificate** from our partner [SECTIGO](https://sectigo.com/), check if you have received an email offering to renew it.
+<br>If necessary, contact the [SECTIGO support team](https://sectigo.com/support) for more information.
 
 > [!primary]
 >
-> To check all the emails sent by OVHcloud teams, click on the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then on `My messages`{.action}.
+> To check all the emails sent by OVHcloud, go to the [My communications](/links/control-panel/account-messages) page.
 
 ## Go further <a name="go-further"></a>
 
@@ -119,14 +201,14 @@ If you **imported a SSL certificate** from another provider, contact its support
 
 [Activating HTTPS on your website with an SSL certificate](/pages/web_cloud/web_hosting/ssl-activate-https-website)
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Resolving the most common 1-click module errors](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
-For specialized service providers (SEO, IT development, etc.), contact [OVHcloud partners](/links/partner).
 
-If you need assistance using and configuring your OVHcloud solutions, please refer to our [support offers page](/links/support).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+
+If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: What to do if you get a "Your connection is not private" error?
 excerpt: How to react to a security error message on your website
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "¿Qué hacer en caso de error 'La conexión no es privada'?"
 excerpt: "Responder en caso de que aparezca un mensaje de error relacionado con la seguridad de su sitio web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-es.md
@@ -1,19 +1,33 @@
 ---
 title: "¿Qué hacer en caso de error 'La conexión no es privada'?"
 excerpt: "Responder en caso de que aparezca un mensaje de error relacionado con la seguridad de su sitio web"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
- 
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
+
 ## Objetivo <a name="objective"></a>
 
-En caso de que su sitio web no sea accesible, puede aparecer varios mensajes de error. Los siguientes ejemplos indican que su alojamiento web no contiene [certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) (si su sitio web no muestra una de las anomalías descritas en esta guía, consulte la sección ["Más información"](#go-further)): 
+En caso de que su sitio web no sea accesible, pueden aparecer varios mensajes de error. Los siguientes ejemplos indican que su alojamiento web no contiene [certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) (si su sitio web no muestra una de las anomalías descritas en esta guía, consulte la sección ["Más información"](#go-further)):
 
 |Navegador|Mensaje de error correspondiente|
 |-|---|
-|Chrome :<br>"La conexión no es privada"|![notsecured_chrome](/pages/assets/screens/other/browsers/errors/notsecured-chrome.png){.thumbnail}|
-|Firefox :<br>"Advertencia: riesgo potencial de seguridad a continuación"|![notsecured_firefox](/pages/assets/screens/other/browsers/errors/notsecured-firefox.png){.thumbnail}|
-|Edge :<br>"Su conexión no es privada"|![notsecured_edge](/pages/assets/screens/other/browsers/errors/notsecured-edge.png){.thumbnail}|
-|Safari :<br>"Esta conexión no es privada"|![notsecured_safari](/pages/assets/screens/other/browsers/errors/notsecured-safari.png){.thumbnail}|
+|Chrome:<br>"La conexión no es privada"|![notsecured_chrome](/pages/assets/screens/other/browsers/errors/notsecured-chrome.png){.thumbnail}|
+|Firefox:<br>"Advertencia: riesgo potencial de seguridad a continuación"|![notsecured_firefox](/pages/assets/screens/other/browsers/errors/notsecured-firefox.png){.thumbnail}|
+|Edge:<br>"Su conexión no es privada"|![notsecured_edge](/pages/assets/screens/other/browsers/errors/notsecured-edge.png){.thumbnail}|
+|Safari:<br>"Esta conexión no es privada"|![notsecured_safari](/pages/assets/screens/other/browsers/errors/notsecured-safari.png){.thumbnail}|
 
 **Descubra cómo resolver los errores del tipo "La conexión no es privada".**
 
@@ -27,12 +41,13 @@ En caso de que su sitio web no sea accesible, puede aparecer varios mensajes de 
 ## Requisitos
 
 - Tener la gestión de los [servidores DNS](/pages/web_cloud/domains/dns_server_general_information) y de la [zona DNS](/pages/web_cloud/domains/dns_zone_general_information) del dominio
+
 <!-- CP-NAV-START:web-hosting -->
 ---
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -45,7 +60,7 @@ Para resolver esta anomalía, deberá:
 1. determinar el alojamiento al que está asociado el dominio para intervenir en el servidor correcto;
 2. crear, activar o renovar un [certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) para su nombre de dominio en el alojamiento correspondiente.
 
-### 1: Comprobar el alojamiento asociado a su dominio
+### 1 - Comprobar el alojamiento asociado a su dominio
 
 #### Comprobar la dirección IP del alojamiento
 
@@ -56,52 +71,121 @@ Para encontrar la dirección IP de su [alojamiento OVHcloud](/links/web/hosting)
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Página de alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Etapa 2**
 >>
 >> En el cuadro **Información general**, encontrará las menciones **IPv4** y **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![Direcciones IPv4 e IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Anote la dirección IPv4 y/o IPv6, y continúe leyendo la guía.
 
 #### Verificar la dirección IP en la zona DNS
 
-Compruebe que la dirección IP indicada en [Zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde a la de su [Web Cloud hosting](/links/web/hosting).
+Compruebe que la dirección IP indicada en la [zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde a la de su [alojamiento Web Cloud](/links/web/hosting).
 
-Conéctese a su [área de cliente de OVHcloud](/links/manager) y acceda a la sección `Web Cloud`{.action}. Haga clic en el menú `Zonas DNS`{.action} y seleccione el dominio correspondiente.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
-Anote el destino del registro de tipo `A` para su dominio:
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Zonas DNS](/links/control-panel/web-dns-zone) y seleccione el dominio correspondiente.
+>>
+>> ![Página de zonas DNS](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Anote el destino del registro de tipo `A` para su dominio:
+>>
+>> ![Destino del registro A en la zona DNS](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Realizar las acciones necesarias
 
-|Escenario|Acción a emprender|
-|---|---|
-|La dirección IP indicada en la [Zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde a la de su alojamiento compartido.|Pase a el [etapa 2](#etape2).|
-|La dirección IP indicada en la zona no concierne ningún alojamiento de su [cuenta OVHcloud](/links/manager), pero aparece en la [lista de servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Compruebe que no tiene un alojamiento con esta dirección IP en cualquiera de sus otras [cuentas OVHcloud](/links/manager) si ha creado más de uno. Si lo necesita, contacte con su webmaster o los [partners de OVHcloud](/links/partner) a este respecto.|
-|La dirección IP indicada en la zona no es la de su alojamiento y tampoco aparece en la [lista de servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contacte su webmaster o los [partners de OVHcloud](/links/partner) a este respecto.|
-|En la pestaña `Zona DNS`{.action}, un mensaje indica que su dominio utiliza otros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit) y estos aparecen en forma de "ns **?** .ovh.net" o "dns **?** .ovh.net" (sustituya el "**?**" por el número de servidor DNS correspondiente):<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|Modifique los servidores DNS de su dominio para que se ajusten a los inscritos en los registros de tipo `NS` de la zona. Para ello, siga las indicaciones de [esta guía](/pages/web_cloud/domains/dns_server_edit)|
-|En la pestaña `Zona DNS`{.action}, un mensaje indica que su dominio utiliza otros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit) y estos no aparecen en el formato "ns **?** .ovh.net" o "dns **?** .ovh.net":<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contacte con su webmaster o los [partners de OVHcloud](/links/partner) al respecto.|
-|Su nombre de dominio no aparece en la sección `Dominios`{.action} de su [área de cliente OVHcloud](/links/manager).<br><br>O la pestaña `Zona DNS`{.action} de su dominio se muestra de la siguiente manera:<br><br>![zonedns_ndd_pas_en_lec2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|Significa que su dominio no es gestionado desde su [área de cliente de OVHcloud](/links/manager).<br><br>Compruebe que no esté gestionado desde cualquiera de sus [cuentas OVHcloud](/links/manager), si ha creado varias.<br><br>También puede determinar su agente registrador y los servidores DNS a los que está asociado a través de nuestro herramienta [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).<br><br>Si es necesario, contacte con su webmaster o los [partners de OVHcloud](/links/partner) al respecto.|
+**Haga clic en el escenario correspondiente a su situación para ver el contenido.**
 
-### 2: Verificar el certificado SSL de su alojamiento <a name="etape2"></a>
+/// details | La dirección IP corresponde a la de su alojamiento compartido
 
-En la pestaña `Información general`{.action} de su alojamiento OVHcloud, consulte el apartado `Certificado SSL`.
+La dirección IP indicada en la [zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde a la de su alojamiento compartido. Pase a la [parte 2](#etape2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
+
+/// details | La dirección IP no concierne ningún alojamiento de su cuenta, pero aparece en la lista de servidores Web Cloud
+
+La dirección IP indicada en la zona no concierne ningún alojamiento de su [cuenta OVHcloud](/links/manager), pero aparece en la [lista de servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Compruebe que no tiene un alojamiento con esta dirección IP en cualquiera de sus otras [cuentas OVHcloud](/links/manager), si ha creado más de una. Si lo necesita, contacte con su webmaster o los [partners de OVHcloud](/links/partner) a este respecto.
+
+///
+
+/// details | La dirección IP no es la de su alojamiento y no aparece en la lista de servidores Web Cloud
+
+La dirección IP indicada en la zona no es la de su alojamiento y tampoco aparece en la [lista de servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contacte con su webmaster o los [partners de OVHcloud](/links/partner) a este respecto.
+
+///
+
+/// details | Su dominio utiliza otros servidores DNS de OVHcloud (ns?.ovh.net / dns?.ovh.net)
+
+Encima de la zona DNS mostrada en su área de cliente de OVHcloud, un mensaje indica que su dominio utiliza otros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit) y estos aparecen en forma de "ns **?** .ovh.net" o "dns **?** .ovh.net" (sustituya el "**?**" por el número de servidor DNS correspondiente):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+Modifique los servidores DNS de su dominio para que se ajusten a los inscritos en los registros de tipo `NS` de la zona. Para ello, siga las indicaciones de [esta guía](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Su dominio utiliza servidores DNS externos (no OVHcloud)
+
+Encima de la zona DNS mostrada en su área de cliente de OVHcloud, un mensaje indica que su dominio utiliza otros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit) y estos no aparecen en el formato "ns **?** .ovh.net" o "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contacte con su webmaster o los [partners de OVHcloud](/links/partner) al respecto.
+
+///
+
+/// details | Su nombre de dominio no aparece en su área de cliente de OVHcloud
+
+Su nombre de dominio no aparece en la página [Dominios](/links/control-panel/web-domains) de su área de cliente de OVHcloud.
+
+Significa que su dominio no es gestionado desde su [área de cliente de OVHcloud](/links/manager).
+
+Compruebe que no esté gestionado desde cualquiera de sus [cuentas OVHcloud](/links/manager), si ha creado varias.
+
+También puede determinar su agente registrador y los servidores DNS a los que está asociado a través de nuestra herramienta [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+
+Si es necesario, contacte con su webmaster o los [partners de OVHcloud](/links/partner) al respecto.
+
+///
+
+### 2 - Verificar el certificado SSL de su alojamiento <a name="etape2"></a>
+
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
+
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Página de alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> En la pestaña `Información general`{.action}, consulte el apartado `Certificado SSL`:
+>>
+>> ![Certificado SSL en la pestaña de información general](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
 
 #### Escenario 1: su alojamiento no contiene certificado SSL
 
-Active un [certificado SSL](/links/web/hosting-options-ssl) en su alojamiento siguiendo las instrucciones de este [guía](/pages/web_cloud/web_hosting/ssl_on_webhosting).
+Active un [certificado SSL](/links/web/hosting-options-ssl) en su alojamiento siguiendo las instrucciones de esta [guía](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
 #### Escenario 2: el certificado SSL de su alojamiento no funciona
 
-Si ha generado un **certificado SSL "Let's Encrypt"**, active la opción SSL de su alojamiento siguiendo las instrucciones del siguiente [tutorial](/pages/web_cloud/web_hosting/ssl_on_webhosting).
+Si ha generado un **certificado SSL "Let's Encrypt"**, active la opción SSL de su alojamiento siguiendo las instrucciones de [esta guía](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
 Si tiene un **certificado SSL importado** y este no funciona, póngase en contacto con su proveedor.
 
@@ -110,7 +194,7 @@ Si ha contratado uno de los **certificados SSL de pago** de nuestro partner [SEC
 
 > [!primary]
 >
-> Para consultar todos los mensajes enviados por nuestros servicios, haga clic en el botón superior derecha de su [área de cliente de OVHcloud](/links/manager) y seleccione `Mis mensajes`{.action}.
+> Para consultar todos los mensajes enviados por nuestros servicios, acceda a la página [Mis mensajes](/links/control-panel/account-messages).
 
 ## Más información <a name="go-further"></a>
 
@@ -123,7 +207,7 @@ Si ha contratado uno de los **certificados SSL de pago** de nuestro partner [SEC
 [¿Qué hacer en caso de error 500 Internal Server Error?](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Resolver los errores más frecuentes asociados a los módulos en 1 clic](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
+
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](/links/partner).
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas [soluciones de soporte](/links/support).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-es.md
@@ -134,7 +134,7 @@ Encima de la zona DNS mostrada en su área de cliente de OVHcloud, un mensaje in
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modifique los servidores DNS de su dominio para que se ajusten a los inscritos en los registros de tipo `NS` de la zona. Para ello, siga las indicaciones de [esta guía](/pages/web_cloud/domains/dns_server_edit).
+Modifique los servidores DNS de su dominio para que se ajusten a los inscritos en los registros de tipo `NS` de la zona. Para ello, siga las indicaciones de nuestra guía "[Modificar los servidores DNS de un nombre de dominio de OVHcloud](/pages/web_cloud/domains/dns_server_edit)".
 
 ///
 
@@ -156,7 +156,7 @@ Significa que su dominio no es gestionado desde su [área de cliente de OVHcloud
 
 Compruebe que no esté gestionado desde cualquiera de sus [cuentas OVHcloud](/links/manager), si ha creado varias.
 
-También puede determinar su agente registrador y los servidores DNS a los que está asociado a través de nuestra herramienta [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+También puede determinar su agente registrador y los servidores DNS a los que está asociado a través de nuestra herramienta [WHOIS](/links/web/domains-whois).
 
 Si es necesario, contacte con su webmaster o los [partners de OVHcloud](/links/partner) al respecto.
 
@@ -185,7 +185,7 @@ Active un [certificado SSL](/links/web/hosting-options-ssl) en su alojamiento si
 
 #### Escenario 2: el certificado SSL de su alojamiento no funciona
 
-Si ha generado un **certificado SSL "Let's Encrypt"**, active la opción SSL de su alojamiento siguiendo las instrucciones de [esta guía](/pages/web_cloud/web_hosting/ssl_on_webhosting).
+Si ha generado un **certificado SSL "Let's Encrypt"**, active la opción SSL de su alojamiento siguiendo las instrucciones de nuestra guía "[Web hosting - Gestionar un certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting)".
 
 Si tiene un **certificado SSL importado** y este no funciona, póngase en contacto con su proveedor.
 

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "¿Qué hacer en caso de error 'La conexión no es privada'?"
 excerpt: "Responder en caso de que aparezca un mensaje de error relacionado con la seguridad de su sitio web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-us.md
@@ -1,21 +1,35 @@
 ---
 title: "¿Qué hacer en caso de error 'La conexión no es privada'?"
 excerpt: "Responder en caso de que aparezca un mensaje de error relacionado con la seguridad de su sitio web"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo <a name="objective"></a>
 
-En caso de que su sitio web no sea accesible, puede aparecer varios mensajes de error. Los siguientes ejemplos indican que su alojamiento web no contiene [certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) (si su sitio web no muestra una de las anomalías descritas en esta guía, consulte la sección ["Más información"](#go-further)): 
+En caso de que su sitio web no sea accesible, pueden aparecer varios mensajes de error. Los siguientes ejemplos indican que su alojamiento web no contiene [certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) (si su sitio web no muestra una de las anomalías descritas en esta guía, consulte la sección ["Más información"](#go-further)):
 
 |Navegador|Mensaje de error correspondiente|
 |-|---|
-|Chrome :<br>"La conexión no es privada"|![notsecured_chrome](/pages/assets/screens/other/browsers/errors/notsecured-chrome.png){.thumbnail}|
-|Firefox :<br>"Advertencia: riesgo potencial de seguridad a continuación"|![notsecured_firefox](/pages/assets/screens/other/browsers/errors/notsecured-firefox.png){.thumbnail}|
-|Edge :<br>"Su conexión no es privada"|![notsecured_edge](/pages/assets/screens/other/browsers/errors/notsecured-edge.png){.thumbnail}|
-|Safari :<br>"Esta conexión no es privada"|![notsecured_safari](/pages/assets/screens/other/browsers/errors/notsecured-safari.png){.thumbnail}|
+|Chrome:<br>"La conexión no es privada"|![notsecured_chrome](/pages/assets/screens/other/browsers/errors/notsecured-chrome.png){.thumbnail}|
+|Firefox:<br>"Advertencia: riesgo potencial de seguridad a continuación"|![notsecured_firefox](/pages/assets/screens/other/browsers/errors/notsecured-firefox.png){.thumbnail}|
+|Edge:<br>"Su conexión no es privada"|![notsecured_edge](/pages/assets/screens/other/browsers/errors/notsecured-edge.png){.thumbnail}|
+|Safari:<br>"Esta conexión no es privada"|![notsecured_safari](/pages/assets/screens/other/browsers/errors/notsecured-safari.png){.thumbnail}|
 
-**Descubra cómo resolver los errores del tipo "Su conexión no es privada".**
+**Descubra cómo resolver los errores del tipo "La conexión no es privada".**
 
 > [!warning]
 >
@@ -27,12 +41,13 @@ En caso de que su sitio web no sea accesible, puede aparecer varios mensajes de 
 ## Requisitos
 
 - Tener la gestión de los [servidores DNS](/pages/web_cloud/domains/dns_server_general_information) y de la [zona DNS](/pages/web_cloud/domains/dns_zone_general_information) del dominio
+
 <!-- CP-NAV-START:web-hosting -->
 ---
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -45,7 +60,7 @@ Para resolver esta anomalía, deberá:
 1. determinar el alojamiento al que está asociado el dominio para intervenir en el servidor correcto;
 2. crear, activar o renovar un [certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) para su nombre de dominio en el alojamiento correspondiente.
 
-### 1: Comprobar el alojamiento asociado a su dominio
+### 1 - Comprobar el alojamiento asociado a su dominio
 
 #### Comprobar la dirección IP del alojamiento
 
@@ -56,52 +71,121 @@ Para encontrar la dirección IP de su [alojamiento OVHcloud](/links/web/hosting)
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Página de alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Etapa 2**
 >>
 >> En el cuadro **Información general**, encontrará las menciones **IPv4** y **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![Direcciones IPv4 e IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Anote la dirección IPv4 y/o IPv6, y continúe leyendo la guía.
 
 #### Verificar la dirección IP en la zona DNS
 
-Compruebe que la dirección IP indicada en [zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde a la de su [Web Cloud hosting](/links/web/hosting).
+Compruebe que la dirección IP indicada en la [zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde a la de su [alojamiento Web Cloud](/links/web/hosting).
 
-Conéctese a su [área de cliente de OVHcloud](/links/manager) y acceda a la sección `Web Cloud`{.action}. Haga clic en el menú `Zonas DNS`{.action} y seleccione el dominio correspondiente.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
-Anote el destino del registro de tipo `A` para su dominio:
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Zonas DNS](/links/control-panel/web-dns-zone) y seleccione el dominio correspondiente.
+>>
+>> ![Página de zonas DNS](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Anote el destino del registro de tipo `A` para su dominio:
+>>
+>> ![Destino del registro A en la zona DNS](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Realizar las acciones necesarias
 
-|Escenario|Acción a emprender|
-|---|---|
-|La dirección IP indicada en la [Zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde a la de su alojamiento compartido.|pase a el [etapa 2](#step2).|
-|La dirección IP indicada en la zona no concierne ningún alojamiento de su [cuenta OVHcloud](/links/manager), pero aparece en la [lista de servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Compruebe que no tiene un alojamiento con esta dirección IP en cualquiera de sus otras [cuentas OVHcloud](/links/manager) si ha creado más de uno. Si lo necesita, contacte con su webmaster o los [partners de OVHcloud](/links/partner) a este respecto.|
-|La dirección IP indicada en la zona no es la de su alojamiento y tampoco aparece en la [lista de servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contacte su webmaster o los [partners de OVHcloud](/links/partner) a este respecto.|
-|En la pestaña `Zona DNS`{.action}, un mensaje indica que su dominio utiliza otros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit) y estos aparecen en forma de "ns **?** .ovh.net" o "dns **?** .ovh.net" (sustituya el "**?**" por el número de servidor DNS correspondiente):<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|Modifique los servidores DNS de su dominio para que se ajusten a los inscritos en los registros de tipo `NS` de la zona. Para ello, siga las indicaciones de [esta guía](/pages/web_cloud/domains/dns_server_edit)|
-|En la pestaña `Zona DNS`{.action}, un mensaje indica que su dominio utiliza otros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit) y estos no aparecen en el formato "ns **?** .ovh.net" o "dns **?** .ovh.net":<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contacte con su webmaster o los [partners de OVHcloud](/links/partner) al respecto.|
-|Su nombre de dominio no aparece en la sección `Dominios`{.action} de su [área de cliente OVHcloud](/links/manager).<br><br>O la pestaña `Zona DNS`{.action} de su dominio se muestra de la siguiente manera:<br><br>![zonedns_ndd_pas_en_lec2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|Significa que su dominio no es gestionado desde su [área de cliente de OVHcloud](/links/manager).<br><br>Compruebe que no esté gestionado desde cualquiera de sus [cuentas OVHcloud](/links/manager), si ha creado varias.<br><br>También puede determinar su agente registrador y los servidores DNS a los que está asociado a través de nuestro herramienta [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).<br><br>Si es necesario, contacte con su webmaster o los [partners de OVHcloud](/links/partner) al respecto.|
+**Haga clic en el escenario correspondiente a su situación para ver el contenido.**
 
-### 2: Verificar el certificado SSL de su alojamiento <a name="step2"></a>
+/// details | La dirección IP corresponde a la de su alojamiento compartido
 
-En la pestaña `Información general`{.action} de su alojamiento OVHcloud, consulte el apartado `Certificado SSL`.
+La dirección IP indicada en la [zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde a la de su alojamiento compartido. Pase a la [parte 2](#etape2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
+
+/// details | La dirección IP no concierne ningún alojamiento de su cuenta, pero aparece en la lista de servidores Web Cloud
+
+La dirección IP indicada en la zona no concierne ningún alojamiento de su [cuenta OVHcloud](/links/manager), pero aparece en la [lista de servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Compruebe que no tiene un alojamiento con esta dirección IP en cualquiera de sus otras [cuentas OVHcloud](/links/manager), si ha creado más de una. Si lo necesita, contacte con su webmaster o los [partners de OVHcloud](/links/partner) a este respecto.
+
+///
+
+/// details | La dirección IP no es la de su alojamiento y no aparece en la lista de servidores Web Cloud
+
+La dirección IP indicada en la zona no es la de su alojamiento y tampoco aparece en la [lista de servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contacte con su webmaster o los [partners de OVHcloud](/links/partner) a este respecto.
+
+///
+
+/// details | Su dominio utiliza otros servidores DNS de OVHcloud (ns?.ovh.net / dns?.ovh.net)
+
+Encima de la zona DNS mostrada en su área de cliente de OVHcloud, un mensaje indica que su dominio utiliza otros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit) y estos aparecen en forma de "ns **?** .ovh.net" o "dns **?** .ovh.net" (sustituya el "**?**" por el número de servidor DNS correspondiente):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+Modifique los servidores DNS de su dominio para que se ajusten a los inscritos en los registros de tipo `NS` de la zona. Para ello, siga las indicaciones de [esta guía](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Su dominio utiliza servidores DNS externos (no OVHcloud)
+
+Encima de la zona DNS mostrada en su área de cliente de OVHcloud, un mensaje indica que su dominio utiliza otros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit) y estos no aparecen en el formato "ns **?** .ovh.net" o "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contacte con su webmaster o los [partners de OVHcloud](/links/partner) al respecto.
+
+///
+
+/// details | Su nombre de dominio no aparece en su área de cliente de OVHcloud
+
+Su nombre de dominio no aparece en la página [Dominios](/links/control-panel/web-domains) de su área de cliente de OVHcloud.
+
+Significa que su dominio no es gestionado desde su [área de cliente de OVHcloud](/links/manager).
+
+Compruebe que no esté gestionado desde cualquiera de sus [cuentas OVHcloud](/links/manager), si ha creado varias.
+
+También puede determinar su agente registrador y los servidores DNS a los que está asociado a través de nuestra herramienta [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+
+Si es necesario, contacte con su webmaster o los [partners de OVHcloud](/links/partner) al respecto.
+
+///
+
+### 2 - Verificar el certificado SSL de su alojamiento <a name="etape2"></a>
+
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
+
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Página de alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> En la pestaña `Información general`{.action}, consulte el apartado `Certificado SSL`:
+>>
+>> ![Certificado SSL en la pestaña de información general](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
 
 #### Escenario 1: su alojamiento no contiene certificado SSL
 
-Active un [certificado SSL](/links/web/hosting-options-ssl) en su alojamiento siguiendo las instrucciones de este [guía](/pages/web_cloud/web_hosting/ssl_on_webhosting).
+Active un [certificado SSL](/links/web/hosting-options-ssl) en su alojamiento siguiendo las instrucciones de esta [guía](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
 #### Escenario 2: el certificado SSL de su alojamiento no funciona
 
-Si ha generado un **certificado SSL "Let's Encrypt"**, active la opción SSL de su alojamiento siguiendo las instrucciones del siguiente [tutorial](/pages/web_cloud/web_hosting/ssl_on_webhosting).
+Si ha generado un **certificado SSL "Let's Encrypt"**, active la opción SSL de su alojamiento siguiendo las instrucciones de [esta guía](/pages/web_cloud/web_hosting/ssl_on_webhosting).
 
 Si tiene un **certificado SSL importado** y este no funciona, póngase en contacto con su proveedor.
 
@@ -110,7 +194,7 @@ Si ha contratado uno de los **certificados SSL de pago** de nuestro partner [SEC
 
 > [!primary]
 >
-> Para consultar todos los mensajes enviados por nuestros servicios, haga clic en el botón superior derecha de su [área de cliente de OVHcloud](/links/manager) y seleccione `Mis mensajes`{.action}.
+> Para consultar todos los mensajes enviados por nuestros servicios, acceda a la página [Mis mensajes](/links/control-panel/account-messages).
 
 ## Más información <a name="go-further"></a>
 
@@ -123,7 +207,7 @@ Si ha contratado uno de los **certificados SSL de pago** de nuestro partner [SEC
 [¿Qué hacer en caso de error 500 Internal Server Error?](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Resolver los errores más frecuentes asociados a los módulos en 1 clic](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
+
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](/links/partner).
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas [soluciones de soporte](/links/support).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.es-us.md
@@ -134,7 +134,7 @@ Encima de la zona DNS mostrada en su área de cliente de OVHcloud, un mensaje in
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modifique los servidores DNS de su dominio para que se ajusten a los inscritos en los registros de tipo `NS` de la zona. Para ello, siga las indicaciones de [esta guía](/pages/web_cloud/domains/dns_server_edit).
+Modifique los servidores DNS de su dominio para que se ajusten a los inscritos en los registros de tipo `NS` de la zona. Para ello, siga las indicaciones de nuestra guía "[Modificar los servidores DNS de un nombre de dominio de OVHcloud](/pages/web_cloud/domains/dns_server_edit)".
 
 ///
 
@@ -156,7 +156,7 @@ Significa que su dominio no es gestionado desde su [área de cliente de OVHcloud
 
 Compruebe que no esté gestionado desde cualquiera de sus [cuentas OVHcloud](/links/manager), si ha creado varias.
 
-También puede determinar su agente registrador y los servidores DNS a los que está asociado a través de nuestra herramienta [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+También puede determinar su agente registrador y los servidores DNS a los que está asociado a través de nuestra herramienta [WHOIS](/links/web/domains-whois).
 
 Si es necesario, contacte con su webmaster o los [partners de OVHcloud](/links/partner) al respecto.
 
@@ -185,7 +185,7 @@ Active un [certificado SSL](/links/web/hosting-options-ssl) en su alojamiento si
 
 #### Escenario 2: el certificado SSL de su alojamiento no funciona
 
-Si ha generado un **certificado SSL "Let's Encrypt"**, active la opción SSL de su alojamiento siguiendo las instrucciones de [esta guía](/pages/web_cloud/web_hosting/ssl_on_webhosting).
+Si ha generado un **certificado SSL "Let's Encrypt"**, active la opción SSL de su alojamiento siguiendo las instrucciones de nuestra guía "[Web hosting - Gestionar un certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting)".
 
 Si tiene un **certificado SSL importado** y este no funciona, póngase en contacto con su proveedor.
 

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Que faire en cas d'erreur « Votre connexion n'est pas privée » ?"
 excerpt: "Réagir en cas de message d'erreur lié à la sécurité de votre site"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-ca.md
@@ -1,8 +1,22 @@
 ---
 title: "Que faire en cas d'erreur « Votre connexion n'est pas privée » ?"
 excerpt: "Réagir en cas de message d'erreur lié à la sécurité de votre site"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objectif <a name="objectif"></a>
 
@@ -12,7 +26,7 @@ Plusieurs messages d'erreur peuvent apparaître en cas d'inaccessibilité de vot
 |-|---|
 |Sur Chrome :<br>« Votre connexion n'est pas privée »|![notsecured_chrome](/pages/assets/screens/other/browsers/errors/notsecured-chrome.png){.thumbnail}|
 |Sur Firefox :<br>« Attention : risque probable de sécurité »|![notsecured_firefox](/pages/assets/screens/other/browsers/errors/notsecured-firefox.png){.thumbnail}|
-|Sur Edge :<br>« Votre connexion n’est pas privée »|![notsecured_edge](/pages/assets/screens/other/browsers/errors/notsecured-edge.png){.thumbnail}|
+|Sur Edge :<br>« Votre connexion n'est pas privée »|![notsecured_edge](/pages/assets/screens/other/browsers/errors/notsecured-edge.png){.thumbnail}|
 |Sur Safari :<br>« Cette connexion n'est pas privée »|![notsecured_safari](/pages/assets/screens/other/browsers/errors/notsecured-safari.png){.thumbnail}|
 
 **Découvrez comment résoudre les erreurs du type « Votre connexion n'est pas privée ».**
@@ -46,7 +60,7 @@ Afin de résoudre cette anomalie, vous devrez :
 1. déterminer l'hébergement auquel est relié votre nom de domaine, afin d'intervenir sur le bon serveur ;
 2. créer, activer ou renouveler un [certificat SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) pour votre nom de domaine sur l'hébergement concerné.
 
-### 1 : Vérifier l'hébergement attaché à votre nom de domaine
+### 1 - Vérifier l'hébergement attaché à votre nom de domaine
 
 #### Vérifier l'adresse IP de l'hébergement
 
@@ -59,7 +73,7 @@ Pour retrouver l'adresse IP de votre [hébergement OVHcloud](/links/web/hosting)
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -73,28 +87,97 @@ Pour retrouver l'adresse IP de votre [hébergement OVHcloud](/links/web/hosting)
 
 Il vous faut maintenant vérifier que l'adresse IP indiquée dans la [Zone DNS](/pages/web_cloud/domains/dns_zone_edit) correspond bien à celle de votre [hébergement Web Cloud](/links/web/hosting).
 
-Connectez-vous à votre [espace client OVHcloud](/links/manager), puis rendez-vous dans la partie `Web Cloud`{.action}. Cliquez sur le menu `Zones DNS`{.action}, puis choisissez le nom de domaine concerné. 
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
-Notez la cible de l'entrée de type `A` pour votre domaine :
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Zones DNS](/links/control-panel/web-dns-zone), puis choisissez le nom de domaine concerné.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Notez la cible de l'entrée de type `A` pour votre nom de domaine :
+>>
+>> ![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Effectuer les actions nécessaires
 
-|Scénario|Action à entreprendre|
-|---|---|
-|L'adresse IP indiquée dans la [Zone DNS](/pages/web_cloud/domains/dns_zone_edit) correspond à celle de votre hébergement mutualisé.|Passez à [l'étape 2](#etape2).|
-|L'adresse IP indiquée dans la zone ne concerne aucun hébergement de votre [compte OVHcloud](/links/manager), mais elle apparaît dans la [liste des serveurs Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Vérifiez que vous ne possédez pas un hébergement possédant cette adresse IP dans l'un de vos autres [comptes OVHcloud](/links/manager) si vous en avez créé plusieurs. Si besoin, contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.|
-|L'adresse IP indiquée dans la zone n'est pas celle de votre hébergement et elle n'apparaît pas non plus dans la [liste des serveurs Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.|
-|Dans l'onglet `Zone DNS`{.action}, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci apparaissent sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » (remplacez le « **?** » par le numéro de serveur DNS concerné) :<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|Modifiez les serveurs DNS de votre domaine, afin qu'ils correspondent à ceux inscrits dans les entrées de type `NS` de la zone. Pour effectuer cette opération, suivez les instructions de [ce guide](/pages/web_cloud/domains/dns_server_edit).|
-|Dans l'onglet `Zone DNS`{.action}, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci n'apparaissent pas sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » :<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.|
-|Votre nom de domaine n'apparaît pas dans la partie `Noms de domaine`{.action} de votre [espace client OVHcloud](/links/manager).<br><br>Ou l'onglet `Zone DNS`{.action} de votre domaine s'affiche de la façon suivante :<br><br>![zonedns_ndd_pas_sur_lec2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|Cela signifie que votre domaine n'est pas géré depuis votre [espace client OVHcloud](/links/manager).<br><br>Vérifiez qu'il n'est pas géré depuis l'un de vos autres [comptes OVHcloud](/links/manager), si vous en avez créé plusieurs.<br><br>Vous pouvez également déterminer son bureau d'enregistrement et les serveurs DNS auxquels il est lié via notre outil [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).<br><br>Si besoin, contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.|
+**Cliquez sur le scénario correspondant à votre situation pour afficher le contenu.**
 
-### 2 : Vérifier le certificat SSL de votre hébergement <a name="etape2"></a>
+/// details | L'adresse IP correspond à celle de votre hébergement mutualisé
 
-Dans l'onglet `Informations générales`{.action} de votre hébergement OVHcloud, vérifiez la partie `Certificat SSL` :
+L'adresse IP indiquée dans la [Zone DNS](/pages/web_cloud/domains/dns_zone_edit) correspond à celle de votre hébergement mutualisé. Passez à la [partie 2](#etape2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
+
+/// details | L'adresse IP ne concerne aucun hébergement de votre compte mais apparaît dans la liste des serveurs Web Cloud
+
+L'adresse IP indiquée dans la zone ne concerne aucun hébergement de votre [compte OVHcloud](/links/manager), mais elle apparaît dans la [liste des serveurs Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Vérifiez que vous ne possédez pas un hébergement possédant cette adresse IP dans l'un de vos autres [comptes OVHcloud](/links/manager) si vous en avez créé plusieurs. Si besoin, contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.
+
+///
+
+/// details | L'adresse IP n'est pas celle de votre hébergement et n'apparaît pas dans la liste des serveurs Web Cloud
+
+L'adresse IP indiquée dans la zone n'est pas celle de votre hébergement et elle n'apparaît pas non plus dans la [liste des serveurs Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.
+
+///
+
+/// details | Votre domaine utilise d'autres serveurs DNS OVHcloud (ns?.ovh.net / dns?.ovh.net)
+
+Au-dessus de la zone DNS présente dans votre espace client OVHcloud, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci apparaissent sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » (remplacez le « **?** » par le numéro de serveur DNS concerné) :
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+Modifiez les serveurs DNS de votre domaine, afin qu'ils correspondent à ceux inscrits dans les entrées de type `NS` de la zone. Pour effectuer cette opération, suivez les instructions de [ce guide](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Votre domaine utilise des serveurs DNS externes (non OVHcloud)
+
+Au-dessus de la zone DNS présente dans votre espace client OVHcloud, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci n'apparaissent pas sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » :
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.
+
+///
+
+/// details | Votre nom de domaine n'apparaît pas dans votre espace client OVHcloud
+
+Votre nom de domaine n'apparaît pas sur la page [Noms de domaine](/links/control-panel/web-domains) de votre espace client OVHcloud.
+
+Cela signifie que votre nom de domaine n'est pas géré depuis votre [espace client OVHcloud](/links/manager).
+
+Vérifiez qu'il n'est pas géré depuis l'un de vos autres [comptes OVHcloud](/links/manager), si vous en avez créé plusieurs.
+
+Vous pouvez également déterminer son bureau d'enregistrement et les serveurs DNS auxquels il est lié via notre outil [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+
+Si besoin, contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.
+
+///
+
+### 2 - Vérifier le certificat SSL de votre hébergement <a name="etape2"></a>
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `Informations générales`{.action}, vérifiez la partie `Certificat SSL` :
+>>
+>> ![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
 
 #### Scénario 1 : votre hébergement ne contient pas de certificat SSL
 
@@ -111,7 +194,7 @@ Si vous avez commandé l'un des **certificats SSL payants** de notre partenaire 
 
 > [!primary]
 >
-> Pour retrouver l'ensemble des e-mails envoyés par nos services, cliquez en haut à droite de votre [espace client OVHcloud](/links/manager), puis sur `Mes communications`{.action}.
+> Pour retrouver l'ensemble des e-mails envoyés par nos services, rendez-vous sur la page [Mes communications](/links/control-panel/account-messages).
 
 ## Aller plus loin <a name="go-further"></a>
 
@@ -119,12 +202,12 @@ Si vous avez commandé l'un des **certificats SSL payants** de notre partenaire 
 
 [Passer son site internet en HTTPS grâce au SSL](/pages/web_cloud/web_hosting/ssl-activate-https-website)
 
-[Résoudre l’erreur « Site non installé »](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Résoudre l'erreur « Site non installé »](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
-[Que faire en cas d’erreur 500 Internal Server Error ?](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
+[Que faire en cas d'erreur 500 Internal Server Error ?](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Résoudre les erreurs les plus fréquentes liées aux modules en 1 clic](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
+
 Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-ca.md
@@ -156,7 +156,7 @@ Cela signifie que votre nom de domaine n'est pas géré depuis votre [espace cli
 
 Vérifiez qu'il n'est pas géré depuis l'un de vos autres [comptes OVHcloud](/links/manager), si vous en avez créé plusieurs.
 
-Vous pouvez également déterminer son bureau d'enregistrement et les serveurs DNS auxquels il est lié via notre outil [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+Vous pouvez également déterminer son bureau d'enregistrement et les serveurs DNS auxquels il est lié via notre outil [WHOIS](/links/web/domains-whois).
 
 Si besoin, contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.
 

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Que faire en cas d'erreur « Votre connexion n'est pas privée » ?"
 excerpt: "Réagir en cas de message d'erreur lié à la sécurité de votre site"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-fr.md
@@ -73,7 +73,7 @@ Pour retrouver l'adresse IP de votre [hébergement OVHcloud](/links/web/hosting)
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -130,7 +130,7 @@ Contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce su
 
 /// details | Votre domaine utilise d'autres serveurs DNS OVHcloud (ns?.ovh.net / dns?.ovh.net)
 
-Au dessus de la zone DNS présente dans votre espace client OVHcloud, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci apparaissent sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » (remplacez le « **?** » par le numéro de serveur DNS concerné) :
+Au-dessus de la zone DNS présente dans votre espace client OVHcloud, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci apparaissent sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » (remplacez le « **?** » par le numéro de serveur DNS concerné) :
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
@@ -140,7 +140,7 @@ Modifiez les serveurs DNS de votre domaine, afin qu'ils correspondent à ceux in
 
 /// details | Votre domaine utilise des serveurs DNS externes (non OVHcloud)
 
-Au dessus de la zone DNS présente dans votre espace client OVHcloud, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci n'apparaissent pas sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » :
+Au-dessus de la zone DNS présente dans votre espace client OVHcloud, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci n'apparaissent pas sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » :
 
 ![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
@@ -171,7 +171,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2*
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-fr.md
@@ -1,8 +1,22 @@
 ---
 title: "Que faire en cas d'erreur « Votre connexion n'est pas privée » ?"
 excerpt: "Réagir en cas de message d'erreur lié à la sécurité de votre site"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objectif <a name="objectif"></a>
 
@@ -46,7 +60,7 @@ Afin de résoudre cette anomalie, vous devrez :
 1. déterminer l'hébergement auquel est relié votre nom de domaine, afin d'intervenir sur le bon serveur ;
 2. créer, activer ou renouveler un [certificat SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) pour votre nom de domaine sur l'hébergement concerné.
 
-### 1 : Vérifier l'hébergement attaché à votre nom de domaine
+### 1 - Vérifier l'hébergement attaché à votre nom de domaine
 
 #### Vérifier l'adresse IP de l'hébergement
 
@@ -73,28 +87,97 @@ Pour retrouver l'adresse IP de votre [hébergement OVHcloud](/links/web/hosting)
 
 Il vous faut maintenant vérifier que l'adresse IP indiquée dans la [Zone DNS](/pages/web_cloud/domains/dns_zone_edit) correspond bien à celle de votre [hébergement Web Cloud](/links/web/hosting).
 
-Connectez-vous à votre [espace client OVHcloud](/links/manager), puis rendez-vous dans la partie `Web Cloud`{.action}. Cliquez sur le menu `Zones DNS`{.action}, puis choisissez le nom de domaine concerné. 
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
-Notez la cible de l'entrée de type `A` pour votre domaine :
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Zones DNS](/links/control-panel/web-dns-zone), puis choisissez le nom de domaine concerné.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Notez la cible de l'entrée de type `A` pour votre nom de domaine :
+>>
+>> ![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Effectuer les actions nécessaires
 
-|Scénario|Action à entreprendre|
-|---|---|
-|L'adresse IP indiquée dans la [Zone DNS](/pages/web_cloud/domains/dns_zone_edit) correspond à celle de votre hébergement mutualisé.|Passez à [l'étape 2](#etape2).|
-|L'adresse IP indiquée dans la zone ne concerne aucun hébergement de votre [compte OVHcloud](/links/manager), mais elle apparaît dans la [liste des serveurs Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Vérifiez que vous ne possédez pas un hébergement possédant cette adresse IP dans l'un de vos autres [comptes OVHcloud](/links/manager) si vous en avez créé plusieurs. Si besoin, contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.|
-|L'adresse IP indiquée dans la zone n'est pas celle de votre hébergement et elle n'apparaît pas non plus dans la [liste des serveurs Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.|
-|Dans l'onglet `Zone DNS`{.action}, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci apparaissent sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » (remplacez le « **?** » par le numéro de serveur DNS concerné) :<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|Modifiez les serveurs DNS de votre domaine, afin qu'ils correspondent à ceux inscrits dans les entrées de type `NS` de la zone. Pour effectuer cette opération, suivez les instructions de [ce guide](/pages/web_cloud/domains/dns_server_edit).|
-|Dans l'onglet `Zone DNS`{.action}, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci n'apparaissent pas sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » :<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.|
-|Votre nom de domaine n'apparaît pas dans la partie `Noms de domaine`{.action} de votre [espace client OVHcloud](/links/manager).<br><br>Ou l'onglet `Zone DNS`{.action} de votre domaine s'affiche de la façon suivante :<br><br>![zonedns_ndd_pas_sur_lec2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|Cela signifie que votre domaine n'est pas géré depuis votre [espace client OVHcloud](/links/manager).<br><br>Vérifiez qu'il n'est pas géré depuis l'un de vos autres [comptes OVHcloud](/links/manager), si vous en avez créé plusieurs.<br><br>Vous pouvez également déterminer son bureau d'enregistrement et les serveurs DNS auxquels il est lié via notre outil [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).<br><br>Si besoin, contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.|
+**Cliquez sur le scénario correspondant à votre situation pour afficher le contenu.**
 
-### 2 : Vérifier le certificat SSL de votre hébergement <a name="etape2"></a>
+/// details | L'adresse IP correspond à celle de votre hébergement mutualisé
 
-Dans l'onglet `Informations générales`{.action} de votre hébergement OVHcloud, vérifiez la partie `Certificat SSL` :
+L'adresse IP indiquée dans la [Zone DNS](/pages/web_cloud/domains/dns_zone_edit) correspond à celle de votre hébergement mutualisé. Passez à la [partie 2](#etape2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
+
+/// details | L'adresse IP ne concerne aucun hébergement de votre compte mais apparaît dans la liste des serveurs Web Cloud
+
+L'adresse IP indiquée dans la zone ne concerne aucun hébergement de votre [compte OVHcloud](/links/manager), mais elle apparaît dans la [liste des serveurs Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Vérifiez que vous ne possédez pas un hébergement possédant cette adresse IP dans l'un de vos autres [comptes OVHcloud](/links/manager) si vous en avez créé plusieurs. Si besoin, contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.
+
+///
+
+/// details | L'adresse IP n'est pas celle de votre hébergement et n'apparaît pas dans la liste des serveurs Web Cloud
+
+L'adresse IP indiquée dans la zone n'est pas celle de votre hébergement et elle n'apparaît pas non plus dans la [liste des serveurs Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.
+
+///
+
+/// details | Votre domaine utilise d'autres serveurs DNS OVHcloud (ns?.ovh.net / dns?.ovh.net)
+
+Au dessus de la zone DNS présente dans votre espace client OVHcloud, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci apparaissent sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » (remplacez le « **?** » par le numéro de serveur DNS concerné) :
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+Modifiez les serveurs DNS de votre domaine, afin qu'ils correspondent à ceux inscrits dans les entrées de type `NS` de la zone. Pour effectuer cette opération, suivez les instructions de [ce guide](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Votre domaine utilise des serveurs DNS externes (non OVHcloud)
+
+Au dessus de la zone DNS présente dans votre espace client OVHcloud, un message indique que votre domaine utilise d'autres serveurs [DNS](/pages/web_cloud/domains/dns_zone_edit) et ceux-ci n'apparaissent pas sous la forme « ns **?** .ovh.net » ou « dns **?** .ovh.net » :
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.
+
+///
+
+/// details | Votre nom de domaine n'apparaît pas dans votre espace client OVHcloud
+
+Votre nom de domaine n'apparaît pas sur la page [Noms de domaine](/links/control-panel/web-domains) de votre espace client OVHcloud.
+
+Cela signifie que votre nom de domaine n'est pas géré depuis votre [espace client OVHcloud](/links/manager).
+
+Vérifiez qu'il n'est pas géré depuis l'un de vos autres [comptes OVHcloud](/links/manager), si vous en avez créé plusieurs.
+
+Vous pouvez également déterminer son bureau d'enregistrement et les serveurs DNS auxquels il est lié via notre outil [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+
+Si besoin, contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.
+
+///
+
+### 2 - Vérifier le certificat SSL de votre hébergement <a name="etape2"></a>
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `Informations générales`{.action}, vérifiez la partie `Certificat SSL` :
+>>
+>> ![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
 
 #### Scénario 1 : votre hébergement ne contient pas de certificat SSL
 
@@ -111,7 +194,7 @@ Si vous avez commandé l'un des **certificats SSL payants** de notre partenaire 
 
 > [!primary]
 >
-> Pour retrouver l'ensemble des e-mails envoyés par nos services, cliquez en haut à droite de votre [espace client OVHcloud](/links/manager), puis sur `Mes communications`{.action}.
+> Pour retrouver l'ensemble des e-mails envoyés par nos services, rendez-vous sur la page [Mes communications](/links/control-panel/account-messages).
 
 ## Aller plus loin <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.fr-fr.md
@@ -156,7 +156,7 @@ Cela signifie que votre nom de domaine n'est pas géré depuis votre [espace cli
 
 Vérifiez qu'il n'est pas géré depuis l'un de vos autres [comptes OVHcloud](/links/manager), si vous en avez créé plusieurs.
 
-Vous pouvez également déterminer son bureau d'enregistrement et les serveurs DNS auxquels il est lié via notre outil [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+Vous pouvez également déterminer son bureau d'enregistrement et les serveurs DNS auxquels il est lié via notre outil [WHOIS](/links/web/domains-whois).
 
 Si besoin, contactez votre webmaster ou les [partenaires OVHcloud](/links/partner) à ce sujet.
 

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Cosa fare in caso di errore 'La connessione non è privata'?"
 excerpt: "Reagire in caso di messaggio di errore relativo alla sicurezza del tuo sito"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.it-it.md
@@ -156,7 +156,7 @@ Questo significa che il tuo dominio non è gestito dal tuo [Spazio Cliente OVHcl
 
 Verifica che non sia gestito da uno degli altri [account OVHcloud](/links/manager), se ne hai creati diversi.
 
-Puoi anche determinare il suo Registrar e i server DNS a cui è associato tramite il nostro tool [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+Puoi anche determinare il suo Registrar e i server DNS a cui è associato tramite il nostro tool [WHOIS](/links/web/domains-whois).
 
 Se necessario, contatta il tuo webmaster o i [partner OVHcloud](/links/partner) a questo proposito.
 

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.it-it.md
@@ -1,19 +1,33 @@
 ---
 title: "Cosa fare in caso di errore 'La connessione non è privata'?"
 excerpt: "Reagire in caso di messaggio di errore relativo alla sicurezza del tuo sito"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Obiettivo <a name="objective"></a>
 
-In caso di inaccessibilità del sito, potrebbero comparire diversi messaggi di errore. Gli esempi che seguono indicano che il tuo hosting Web non contiene [certificato SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) (se il tuo sito non mostra una delle anomalie descritte in questa guida, consulta la sezione ["Per saperne di più"](#go-further)): 
+In caso di inaccessibilità del sito, potrebbero comparire diversi messaggi di errore. Gli esempi che seguono indicano che il tuo hosting Web non contiene [certificato SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) (se il tuo sito non mostra una delle anomalie descritte in questa guida, consulta la sezione ["Per saperne di più"](#go-further)):
 
 |Browser|Messaggio di errore interessato|
 |-|---|
-|Chrome :<br>"La connessione non è privata"|![notsecured_chrome](/pages/assets/screens/other/browsers/errors/notsecured-chrome.png){.thumbnail}|
-|Firefox :<br>"Attenzione: potenziale rischio per la sicurezza"|![notsecured_firefox](/pages/assets/screens/other/browsers/errors/notsecured-firefox.png){.thumbnail}|
-|Edge :<br>"La tua connessione non è privata"|![notsecured_edge](/pages/assets/screens/other/browsers/errors/notsecured-edge.png){.thumbnail}|
-|Safari :<br>"Questa connessione non è privata"|![notsecured_safari](/pages/assets/screens/other/browsers/errors/notsecured-safari.png){.thumbnail}|
+|Chrome:<br>"La connessione non è privata"|![notsecured_chrome](/pages/assets/screens/other/browsers/errors/notsecured-chrome.png){.thumbnail}|
+|Firefox:<br>"Attenzione: potenziale rischio per la sicurezza"|![notsecured_firefox](/pages/assets/screens/other/browsers/errors/notsecured-firefox.png){.thumbnail}|
+|Edge:<br>"La tua connessione non è privata"|![notsecured_edge](/pages/assets/screens/other/browsers/errors/notsecured-edge.png){.thumbnail}|
+|Safari:<br>"Questa connessione non è privata"|![notsecured_safari](/pages/assets/screens/other/browsers/errors/notsecured-safari.png){.thumbnail}|
 
 **Scopri come risolvere errori di tipo "La tua connessione non è privata".**
 
@@ -27,12 +41,13 @@ In caso di inaccessibilità del sito, potrebbero comparire diversi messaggi di e
 ## Prerequisiti
 
 - Avere la gestione dei [server DNS](/pages/web_cloud/domains/dns_server_general_information) e della [zona DNS](/pages/web_cloud/domains/dns_zone_general_information) del dominio
+
 <!-- CP-NAV-START:web-hosting -->
 ---
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -45,55 +60,124 @@ Per risolvere questa anomalia, è necessario:
 1. determinare l'hosting al quale è associato il tuo dominio, per intervenire sul server giusto;
 2. creare, attivare o rinnovare un [certificato SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) per il tuo dominio sull'hosting in questione.
 
-### 1: Verifica l'hosting associato al tuo dominio
+### 1 - Verifica l'hosting associato al tuo dominio
 
 #### Verifica l'indirizzo IP dell'hosting
 
 I messaggi di errore menzionati [sopra](#objective) non significano necessariamente che il tuo sito è ospitato su una delle nostre [offerte Web Cloud](/links/web/hosting). Dovrai quindi verificare l'indirizzo IP del server al quale è collegato il tuo [dominio](/links/web/domains).
 
-Per recuperare l'indirizzo IP del tuo [hosting OVHcloud](/links/web/hosting), clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passi.
+Per recuperare l'indirizzo IP del tuo [hosting OVHcloud](/links/web/hosting), clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
 > [!tabs]
 > **Passaggio 1**
 >>
->> Accedi alla pagina [Hosting plans](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Pagina Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Passaggio 2**
 >>
->> Nel riquadro **Informazioni generali**, troverete le informazioni **IPv4** e **IPv6**.
+>> Nel riquadro **Informazioni generali**, troverai le informazioni **IPv4** e **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![Indirizzi IPv4 e IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> Annotate l'indirizzo IPv4 e/o IPv6, poi prosegui nella lettura della guida.
+>> Annota l'indirizzo IPv4 e/o IPv6, poi prosegui nella lettura della guida.
 
 #### Verifica l'indirizzo IP nella zona DNS
 
-A questo punto è necessario verificare che l'indirizzo IP indicato nella [Zona DNS](/pages/web_cloud/domains/dns_zone_edit) corrisponda a quello del tuo [hosting Web Cloud](/links/web/hosting).
+A questo punto è necessario verificare che l'indirizzo IP indicato nella [zona DNS](/pages/web_cloud/domains/dns_zone_edit) corrisponda a quello del tuo [hosting Web Cloud](/links/web/hosting).
 
-Accedi allo [Spazio Cliente OVHcloud](/links/manager) e clicca su `Web Cloud`{.action}. Clicca sul menu `Zone DNS`{.action} e seleziona il dominio interessato.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
-Annota la destinazione d'ingresso di tipo `A` per il tuo dominio:
-
-![zona-DNP](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Zone DNS](/links/control-panel/web-dns-zone), poi seleziona il dominio interessato.
+>>
+>> ![Pagina Zone DNS](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Annota la destinazione del record di tipo `A` per il tuo dominio:
+>>
+>> ![Destinazione del record A nella zona DNS](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Effettua le azioni necessarie
 
-|Scenario|Messaggio di errore interessato|
-|-|---|
-|L'indirizzo IP indicato nella [Zona DNS](/pages/web_cloud/domains/dns_zone_edit) corrisponde a quello del tuo hosting condiviso.|Passate allo [step 2](#step2).|
-|L'indirizzo IP indicato nella zona non riguarda alcun hosting del tuo [account OVHcloud](/links/manager), ma appare nella [lista dei server Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Ti ricordiamo che non possiedi un hosting che dispone di questo indirizzo IP in uno dei tuoi altri [account OVHcloud cloud](/links/manager) se ne hai creati diversi. In caso di necessità, contatta il tuo webmaster o i [partner OVHcloud](/links/partner) a questo proposito|
-|L'indirizzo IP indicato nella zona non corrisponde a quello del tuo hosting e non compare nemmeno nella [lista dei server Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contatta il tuo webmaster o i [partner OVHcloud](/links/partner) a questo proposito.|
-|Nella scheda `Zona DNS`{.action}, un messaggio indica che il tuo dominio utilizza altri server [DNS](/pages/web_cloud/domains/dns_zone_edit) e questi compaiono nella forma "ns **?** .ovh.net" o "dns **?** .ovh.net" (sostituisci il "**?**" con il numero del server DNS interessato):<br><br>![warning_other_ovh_DNS_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|Modifica i server DNS del tuo dominio in modo che corrispondano a quelli registrati nelle record di tipo `NS` della zona. Per effettuare questa operazione, segui le istruzioni di [questa guida](/pages/web_cloud/domains/dns_server_edit).|
-|Nella scheda `Zona DNS`{.action}, un messaggio indica che il tuo dominio utilizza altri server [DNS](/pages/web_cloud/domains/dns_zone_edit) e questi non compaiono nella forma "ns **?** .ovh.net" o "dns **?** .net" :<br><br>![warning_external_DNS_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contatta il tuo webmaster o i [partner OVHcloud](/links/partner) a questo proposito.|
-|Il tuo dominio non compare nella sezione `Domini`{.action} del tuo [Spazio Cliente OVHcloud](/links/manager).<br><br>O la scheda `Zona DNS`{.action} del tuo dominio viene mostrata come segue:<br><br>![zonedns_ndd_pas_pas_sur_lec2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|Questo significa che il tuo dominio non è gestito dal tuo [Spazio Cliente OVHcloud](/links/manager).<br><br>Verifica che non sia gestito da uno degli altri [account OVHcloud](/links/manager), se ne hai creato diversi.<br><br>Potrai anche determinare il suo Registrar e i server DNS a cui è associato tramite il nostro tool [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).<br><br>Se necessario, contatta il tuo webmaster o i [partner OVHcloud](/links/partner) a questo proposito.|
+**Clicca sullo scenario corrispondente alla tua situazione per visualizzare il contenuto.**
 
-### 2: Verifica il certificato SSL del tuo hosting <a name="step2"></a>
+/// details | L'indirizzo IP corrisponde a quello del tuo hosting condiviso
 
-Nella scheda `Informazioni generali`{.action} dell'hosting OVHcloud, verifica la sezione `Certificato SSL`:
+L'indirizzo IP indicato nella [zona DNS](/pages/web_cloud/domains/dns_zone_edit) corrisponde a quello del tuo hosting condiviso. Passa alla [parte 2](#step2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
+
+/// details | L'indirizzo IP non riguarda alcun hosting del tuo account ma appare nella lista dei server Web Cloud
+
+L'indirizzo IP indicato nella zona non riguarda alcun hosting del tuo [account OVHcloud](/links/manager), ma appare nella [lista dei server Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Verifica di non possedere un hosting con questo indirizzo IP in uno dei tuoi altri [account OVHcloud](/links/manager), se ne hai creati diversi. Se necessario, contatta il tuo webmaster o i [partner OVHcloud](/links/partner) a questo proposito.
+
+///
+
+/// details | L'indirizzo IP non corrisponde a quello del tuo hosting e non compare nella lista dei server Web Cloud
+
+L'indirizzo IP indicato nella zona non corrisponde a quello del tuo hosting e non compare nemmeno nella [lista dei server Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contatta il tuo webmaster o i [partner OVHcloud](/links/partner) a questo proposito.
+
+///
+
+/// details | Il tuo dominio utilizza altri server DNS OVHcloud (ns?.ovh.net / dns?.ovh.net)
+
+Sopra la zona DNS mostrata nel tuo Spazio Cliente OVHcloud, un messaggio indica che il tuo dominio utilizza altri server [DNS](/pages/web_cloud/domains/dns_zone_edit) e questi compaiono nella forma "ns **?** .ovh.net" o "dns **?** .ovh.net" (sostituisci il "**?**" con il numero del server DNS interessato):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+Modifica i server DNS del tuo dominio in modo che corrispondano a quelli registrati nei record di tipo `NS` della zona. Per effettuare questa operazione, segui le istruzioni di [questa guida](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Il tuo dominio utilizza server DNS esterni (non OVHcloud)
+
+Sopra la zona DNS mostrata nel tuo Spazio Cliente OVHcloud, un messaggio indica che il tuo dominio utilizza altri server [DNS](/pages/web_cloud/domains/dns_zone_edit) e questi non compaiono nella forma "ns **?** .ovh.net" o "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contatta il tuo webmaster o i [partner OVHcloud](/links/partner) a questo proposito.
+
+///
+
+/// details | Il tuo dominio non compare nel tuo Spazio Cliente OVHcloud
+
+Il tuo dominio non compare nella pagina [Domini](/links/control-panel/web-domains) del tuo Spazio Cliente OVHcloud.
+
+Questo significa che il tuo dominio non è gestito dal tuo [Spazio Cliente OVHcloud](/links/manager).
+
+Verifica che non sia gestito da uno degli altri [account OVHcloud](/links/manager), se ne hai creati diversi.
+
+Puoi anche determinare il suo Registrar e i server DNS a cui è associato tramite il nostro tool [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+
+Se necessario, contatta il tuo webmaster o i [partner OVHcloud](/links/partner) a questo proposito.
+
+///
+
+### 2 - Verifica il certificato SSL del tuo hosting <a name="step2"></a>
+
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
+>>
+>> ![Pagina Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Nella scheda `Informazioni generali`{.action}, verifica la sezione `Certificato SSL`:
+>>
+>> ![Certificato SSL nella scheda informazioni generali](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
 
 #### Scenario 1: il tuo hosting non contiene un certificato SSL
 
@@ -108,9 +192,9 @@ Se disponi di un **certificato SSL importato** e questo non funziona, contatta i
 Se hai ordinato uno dei **certificati SSL a pagamento** del nostro partner [SECTIGO](https://sectigo.com/), verifica se hai ricevuto un'email che ti propone di rinnovarlo.
 <br>Se necessario, contatta il [supporto di SECTIGO](https://sectigo.com/support) a questo proposito.
 
->[!primary]
+> [!primary]
 >
-> Per visualizzare tutte le email inviate dai nostri servizi, clicca in alto a destra del tuo [Spazio Cliente OVHcloud](/links/manager) e poi su `Le mie comunicazioni`{.action}.
+> Per visualizzare tutte le email inviate dai nostri servizi, accedi alla pagina [Le mie comunicazioni](/links/control-panel/account-messages).
 
 ## Per saperne di più <a name="go-further"></a>
 
@@ -118,12 +202,12 @@ Se hai ordinato uno dei **certificati SSL a pagamento** del nostro partner [SECT
 
 [Attivare HTTPS su un sito Internet tramite il certificato SSL](/pages/web_cloud/web_hosting/ssl-activate-https-website)
 
-[Risolvere l’errore «Sito non installato»](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Risolvere l'errore «Sito non installato»](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Cosa fare in caso di errore 500 Internal Server Error?](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Risolvere gli errori più frequenti associati ai moduli in 1 click](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
+
 Per prestazioni specializzate (referenziamento, sviluppo, ecc..), contatta i [partner OVHcloud](/links/partner).
 
 Per usufruire di un supporto per l'utilizzo e la configurazione delle soluzioni OVHcloud, è possibile consultare le nostre [soluzioni offerte di supporto](/links/support).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pl-pl.md
@@ -1,10 +1,24 @@
 ---
 title: "Co zrobić w przypadku błędu 'Połączenie nie jest prywatne'?"
 excerpt: "Reagowanie w przypadku wiadomości z błędem związanej z bezpieczeństwem strony"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
-## Wprowadzenie  <a name="objective"></a>
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
+
+## Wprowadzenie <a name="objective"></a>
 
 W przypadku niedostępności Twojej strony może wystąpić kilka komunikatów o błędzie. Poniższe przykłady wskazują, że Twój hosting WWW nie zawiera [certyfikatu SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) (jeśli Twoja strona nie wyświetla żadnego z anomalii opisanych w tym przewodniku, sprawdź sekcję "[Sprawdź również](#go-further)"):
 
@@ -15,7 +29,7 @@ W przypadku niedostępności Twojej strony może wystąpić kilka komunikatów o
 |Edge:<br>"Twoje połączenie nie jest prywatne"|![notsecured_edge](/pages/assets/screens/other/browsers/errors/notsecured-edge.png){.thumbnail}|
 |Safari:<br>"To połączenie nie jest prywatne"|![notsecured_safari](/pages/assets/screens/other/browsers/errors/notsecured-safari.png){.thumbnail}|
 
-**Dowiedz się, jak usunąć błędy związane z plikiem "Połączenie nie jest prywatne".**
+**Dowiedz się, jak usunąć błędy związane z komunikatem "Połączenie nie jest prywatne".**
 
 > [!warning]
 >
@@ -33,7 +47,7 @@ W przypadku niedostępności Twojej strony może wystąpić kilka komunikatów o
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -43,58 +57,127 @@ W przypadku niedostępności Twojej strony może wystąpić kilka komunikatów o
 
 Aby usunąć tę anomalię, należy:
 
-1. określenie hostingu, do którego jest podłączona Twoja domena, w celu przeprowadzenia interwencji na właściwym serwerze;
-2. tworzenie, aktywacja lub odnawianie [certyfikatu SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) dla Twojej domeny na wybranym hostingu.
+1. określić hosting, do którego jest podłączona Twoja domena, w celu przeprowadzenia interwencji na właściwym serwerze;
+2. utworzyć, aktywować lub odnowić [certyfikat SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) dla Twojej domeny na wybranym hostingu.
 
-### 1: Sprawdź hosting przypisany do Twojej domeny
+### 1 - Sprawdź hosting przypisany do Twojej domeny
 
 #### Sprawdź adres IP hostingu
 
-[Poprzednie](#objective) komunikaty błędów niekoniecznie oznaczają, że Twoja strona WWW jest zainstalowana na jednym z naszych [pakietów Web Cloud](/links/web/hosting). Należy zatem sprawdzić adres IP serwera, do którego jest podłączony Twoja [nazwa domeny](/links/web/domains).
+[Powyższe](#objective) komunikaty błędów niekoniecznie oznaczają, że Twoja strona WWW jest zainstalowana na jednym z naszych [pakietów Web Cloud](/links/web/hosting). Należy zatem sprawdzić adres IP serwera, do którego jest podłączona Twoja [nazwa domeny](/links/web/domains).
 
 Aby odnaleźć adres IP Twojego [hostingu OVHcloud](/links/web/hosting), kliknij poniższe zakładki, aby wyświetlić kolejne **2** kroki.
 
 > [!tabs]
 > **Krok 1**
 >>
->> Przejdź na stronę [Hosting plans](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Strona Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Krok 2**
 >>
 >> W ramce **Informacje ogólne** znajdziesz oznaczenia **IPv4** i **IPv6**.
 >>
->> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![Adresy IPv4 i IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Zapisz adres IPv4 i/lub IPv6, a następnie kontynuuj czytanie przewodnika.
 
 #### Sprawdź adres IP w strefie DNS
 
-Teraz sprawdź, czy adres IP podany w [Strefa DNS](/pages/web_cloud/domains/dns_zone_edit) odpowiada adresowi Twojej [hostingu Web Cloud](/links/web/hosting).
+Teraz sprawdź, czy adres IP podany w [strefie DNS](/pages/web_cloud/domains/dns_zone_edit) odpowiada adresowi Twojego [hostingu Web Cloud](/links/web/hosting).
 
-Zaloguj się do [Panelu klienta OVHcloud](/links/manager) i przejdź do sekcji `Web Cloud`{.action}. Kliknij menu `Strefy DNS`{.action}, następnie wybierz odpowiednią domenę.
+Kliknij poniższe zakładki, aby wyświetlić kolejne **2** kroki.
 
-Zapisz docelowy wpis `A` dla Twojej domeny:
-
-![zone-dns-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Strefy DNS](/links/control-panel/web-dns-zone), następnie wybierz odpowiednią domenę.
+>>
+>> ![Strona Strefy DNS](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Zapisz docelowy wpis typu `A` dla Twojej domeny:
+>>
+>> ![Wpis A w strefie DNS](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Wykonaj niezbędne operacje
 
-|Scenariusz|Działania do podjęcia|
-|---|---|
-|Adres IP podany w [Strefa DNS](/pages/web_cloud/domains/dns_zone_edit) odpowiada adresowi IP Twojego hostingu.|Skorzystaj z [etapu 2](#step2).|
-|Adres IP wskazany w strefie nie dotyczy hostingu [konta OVHcloud](/links/manager), ale pojawia się w [liście serwerów Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Sprawdź, czy nie posiadasz hostingu posiadającego ten adres IP w jednym z pozostałych [kont OVHcloud cloud](/links/manager), jeśli utworzyłeś kilka z nich. W razie potrzeby skontaktuj się z webmasterem lub [partnerami OVHcloud](/links/partner) w tej sprawie.|
-|Adres IP wskazany w strefie nie jest adresem Twojego hostingu i nie pojawia się również w [liście serwerów Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Skontaktuj się ze swoim webmasterem lub [partnerami OVHcloud](/links/partner) w tym zakresie.|
-|W zakładce `Strefa DNS`{.action} komunikat wskazuje, że Twoja domena używa innych serwerów [DNS](/pages/web_cloud/domains/dns_zone_edit) i wyświetla się je w formie "ns **?** .ovh.net" lub "dns **?** net" (zastąp "**?**" odpowiednim numerem serwera DNS):<br><br>![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|Zmień serwery DNS domeny, aby odpowiadały one tym, które są zapisane w rekordach typu `NS` strefy. Aby wykonać tę operację, postępuj zgodnie z instrukcjami z [tego przewodnika](/pages/web_cloud/domains/dns_server_edit).|
-|W zakładce `Strefa DNS{.action} komunikat wskazuje, że Twoja domena używa innych serwerów [DNS](/pages/web_cloud/domains/dns_zone_edit), a te nie wyświetlają się w formie "ns **?** .ovh.net" lub "dns **?** ovh.net":<br><br>![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Skontaktuj się z webmasterem lub [partnerami OVHcloud](/links/partner) w tym zakresie.|
-|Twoja domena nie wyświetla się w części `Domeny`{.action} [Panel klienta OVHcloud](/links/manager).<br><br>Lub zakładka `Strefa DNS`{.action} Twojej domeny wyświetla się w następujący sposób:<br><br<>![zonedns_ndd_pas_sur_lec_lec_lec_lec2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|Oznacza to, że Twoja domena nie jest zarządzana z poziomu [panelu klienta OVHcloud](/links/manager).<br><br>Sprawdź, czy domena nie jest zarządzana z poziomu jednego z Twoich pozostałych [kont OVHcloud](/links/manager), jeśli utworzyłeś kilka domen.<br><br>Możesz również wskazać jej operatora oraz serwery DNS, z którymi jest powiązana. za pomocą naszego narzędzia [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).<br><br>W razie potrzeby skontaktuj się z webmasterem lub [partnerami OVHcloud](/links/partner) w tym zakresie.|
+**Kliknij scenariusz odpowiadający Twojej sytuacji, aby wyświetlić treść.**
 
-### 2: Sprawdź certyfikat SSL na Twoim hostingu <a name="step2"></a>
+/// details | Adres IP odpowiada adresowi IP Twojego hostingu
 
-W zakładce `Informacje ogólne`{.action} Twojego hostingu OVHcloud sprawdź sekcję `Certyfikat SSL`:
+Adres IP podany w [strefie DNS](/pages/web_cloud/domains/dns_zone_edit) odpowiada adresowi IP Twojego hostingu. Przejdź do [części 2](#step2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
+
+/// details | Adres IP nie dotyczy żadnego hostingu z Twojego konta, ale pojawia się w liście serwerów Web Cloud
+
+Adres IP wskazany w strefie nie dotyczy hostingu na Twoim [koncie OVHcloud](/links/manager), ale pojawia się w [liście serwerów Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Sprawdź, czy nie posiadasz hostingu z tym adresem IP na jednym z pozostałych [kont OVHcloud](/links/manager), jeśli utworzyłeś kilka z nich. W razie potrzeby skontaktuj się z webmasterem lub [partnerami OVHcloud](/links/partner) w tej sprawie.
+
+///
+
+/// details | Adres IP nie jest adresem Twojego hostingu i nie pojawia się w liście serwerów Web Cloud
+
+Adres IP wskazany w strefie nie jest adresem Twojego hostingu i nie pojawia się również w [liście serwerów Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Skontaktuj się ze swoim webmasterem lub [partnerami OVHcloud](/links/partner) w tym zakresie.
+
+///
+
+/// details | Twoja domena używa innych serwerów DNS OVHcloud (ns?.ovh.net / dns?.ovh.net)
+
+Powyżej strefy DNS w Panelu klienta OVHcloud komunikat wskazuje, że Twoja domena używa innych serwerów [DNS](/pages/web_cloud/domains/dns_zone_edit) i wyświetlają się one w formie "ns **?** .ovh.net" lub "dns **?** .ovh.net" (zastąp "**?**" odpowiednim numerem serwera DNS):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+Zmień serwery DNS domeny, aby odpowiadały one tym, które są zapisane w rekordach typu `NS` strefy. Aby wykonać tę operację, postępuj zgodnie z instrukcjami z [tego przewodnika](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | Twoja domena używa zewnętrznych serwerów DNS (nie OVHcloud)
+
+Powyżej strefy DNS w Panelu klienta OVHcloud komunikat wskazuje, że Twoja domena używa innych serwerów [DNS](/pages/web_cloud/domains/dns_zone_edit), a te nie wyświetlają się w formie "ns **?** .ovh.net" lub "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Skontaktuj się z webmasterem lub [partnerami OVHcloud](/links/partner) w tym zakresie.
+
+///
+
+/// details | Twoja domena nie wyświetla się w Panelu klienta OVHcloud
+
+Twoja domena nie pojawia się na stronie [Domeny](/links/control-panel/web-domains) w Panelu klienta OVHcloud.
+
+Oznacza to, że Twoja domena nie jest zarządzana z poziomu [Panelu klienta OVHcloud](/links/manager).
+
+Sprawdź, czy domena nie jest zarządzana z poziomu jednego z Twoich pozostałych [kont OVHcloud](/links/manager), jeśli utworzyłeś kilka z nich.
+
+Możesz również wskazać jej operatora oraz serwery DNS, z którymi jest powiązana, za pomocą naszego narzędzia [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+
+W razie potrzeby skontaktuj się z webmasterem lub [partnerami OVHcloud](/links/partner) w tym zakresie.
+
+///
+
+### 2 - Sprawdź certyfikat SSL na Twoim hostingu <a name="step2"></a>
+
+Kliknij poniższe zakładki, aby wyświetlić kolejne **2** kroki.
+
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
+>>
+>> ![Strona Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> W zakładce `Informacje ogólne`{.action} sprawdź sekcję `Certyfikat SSL`:
+>>
+>> ![Certyfikat SSL w zakładce informacji ogólnych](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
 
 #### Scenariusz 1: Twój hosting nie zawiera certyfikatu SSL
 
@@ -111,7 +194,7 @@ Jeśli zamówiłeś jeden z płatnych **certyfikatów SSL** od naszego partnera 
 
 > [!primary]
 >
-> Aby odnaleźć wszystkie e-maile wysłane przez nasze usługi, kliknij w prawym górnym rogu [Panelu klienta OVHcloud](/links/manager), następnie kliknij `Połączenia`{.action}.
+> Aby odnaleźć wszystkie e-maile wysłane przez nasze usługi, przejdź na stronę [Moje wiadomości](/links/control-panel/account-messages).
 
 ## Sprawdź również <a name="go-further"></a>
 
@@ -119,12 +202,12 @@ Jeśli zamówiłeś jeden z płatnych **certyfikatów SSL** od naszego partnera 
 
 [Aktywacja protokołu HTTPS na stronie WWW za pomocą certyfikatu SSL](/pages/web_cloud/web_hosting/ssl-activate-https-website)
 
-[Usunięcie błędu “Strona nie została zainstalowana”](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Usunięcie błędu "Strona nie została zainstalowana"](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Co zrobić w przypadku błędu 500 Internal Server Error?](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Rozwiąż najczęstsze błędy związane z modułami za pomocą 1 kliknięcia](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
+
 W przypadku wyspecjalizowanych usług (pozycjonowanie, rozwój, etc.) skontaktuj się z [partnerami OVHcloud](/links/partner).
 
 Jeśli chcesz otrzymywać wsparcie w zakresie konfiguracji i użytkowania Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami pomocy](/links/support).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pl-pl.md
@@ -156,7 +156,7 @@ Oznacza to, że Twoja domena nie jest zarządzana z poziomu [Panelu klienta OVHc
 
 Sprawdź, czy domena nie jest zarządzana z poziomu jednego z Twoich pozostałych [kont OVHcloud](/links/manager), jeśli utworzyłeś kilka z nich.
 
-Możesz również wskazać jej operatora oraz serwery DNS, z którymi jest powiązana, za pomocą naszego narzędzia [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+Możesz również wskazać jej operatora oraz serwery DNS, z którymi jest powiązana, za pomocą naszego narzędzia [WHOIS](/links/web/domains-whois).
 
 W razie potrzeby skontaktuj się z webmasterem lub [partnerami OVHcloud](/links/partner) w tym zakresie.
 

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Co zrobić w przypadku błędu 'Połączenie nie jest prywatne'?"
 excerpt: "Reagowanie w przypadku wiadomości z błędem związanej z bezpieczeństwem strony"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pt-pt.md
@@ -20,7 +20,7 @@ details[open]>summary::before {
 
 ## Objetivo <a name="objective"></a>
 
-Em caso de inacessibilidade do seu site, podem surgir várias mensagens de erro. Os exemplos abaixo indicam que o seu alojamento Web não contém [certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) (se o seu site não apresentar uma das anomalias descritas neste guia, consulte a secção "[Quer saber mais?](#go-further)"):
+Em caso de inacessibilidade do seu site, podem surgir várias mensagens de erro. Os exemplos abaixo indicam que o seu alojamento web não contém [certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) (se o seu site não apresentar uma das anomalias descritas neste guia, consulte a secção "[Quer saber mais?](#go-further)"):
 
 |Browser|Mensagem de erro em questão|
 |-|---|
@@ -116,7 +116,7 @@ O endereço IP indicado na [zona DNS](/pages/web_cloud/domains/dns_zone_edit) co
 
 O endereço IP indicado na zona não diz respeito a nenhum alojamento da sua [conta OVHcloud](/links/manager), mas aparece na [lista dos servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
 
-Verifique que não possui um alojamento com este endereço IP num dos seus outros [contas OVHcloud](/links/manager), caso tenha criado vários. Se necessário, contacte o seu webmaster ou os [parceiros OVHcloud](/links/partner) a este respeito.
+Verifique que não possui um alojamento com este endereço IP numa das suas outras [contas OVHcloud](/links/manager), caso tenha criado vários. Se necessário, contacte o seu webmaster ou os [parceiros OVHcloud](/links/partner) a este respeito.
 
 ///
 
@@ -154,9 +154,9 @@ O seu nome de domínio não aparece na página [Nomes de domínio](/links/contro
 
 Isto significa que o seu domínio não é gerido a partir da sua [Área de Cliente OVHcloud](/links/manager).
 
-Verifique que o domínio não é gerido a partir de uma das suas outras [contas OVHcloud](/links/manager), se tiver criado vários.
+Verifique que o domínio não é gerido a partir de uma das suas outras [contas OVHcloud](/links/manager), se tiver criado várias.
 
-Pode igualmente determinar o seu bureau de registo e os servidores DNS aos quais está ligado através da nossa ferramenta [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+Pode igualmente determinar o seu bureau de registo e os servidores DNS aos quais está ligado através da nossa ferramenta [WHOIS](/links/web/domains-whois).
 
 Se necessário, contacte o seu webmaster ou os [parceiros OVHcloud](/links/partner).
 
@@ -212,4 +212,4 @@ Para serviços especializados (referenciamento, desenvolvimento, etc), contacte 
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 
-Fale com nossa [comunidade de utilizadores](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "O que fazer em caso de erro 'Sua conexão não é particular'?"
 excerpt: "Reagir em caso de mensagem de erro relacionado com a segurança do seu site"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic-not-secured/guide.pt-pt.md
@@ -1,12 +1,26 @@
 ---
 title: "O que fazer em caso de erro 'Sua conexão não é particular'?"
 excerpt: "Reagir em caso de mensagem de erro relacionado com a segurança do seu site"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo <a name="objective"></a>
 
-Em caso de inacessibilidade do seu site, podem surgir várias mensagens de erro. Os exemplos abaixo indicam que o seu alojamento Web não contém [certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) (se o seu site não apresentar uma das anomalias descritas neste guia, consulte a secção "[Quer saber mais?](#go-further)"): 
+Em caso de inacessibilidade do seu site, podem surgir várias mensagens de erro. Os exemplos abaixo indicam que o seu alojamento Web não contém [certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) (se o seu site não apresentar uma das anomalias descritas neste guia, consulte a secção "[Quer saber mais?](#go-further)"):
 
 |Browser|Mensagem de erro em questão|
 |-|---|
@@ -27,12 +41,13 @@ Em caso de inacessibilidade do seu site, podem surgir várias mensagens de erro.
 ## Requisitos
 
 - Ter a gestão dos [servidores DNS](/pages/web_cloud/domains/dns_server_general_information) e da [zona DNS](/pages/web_cloud/domains/dns_zone_general_information) do seu domínio
+
 <!-- CP-NAV-START:web-hosting -->
 ---
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -45,7 +60,7 @@ Para resolver esta anomalia, deverá:
 1. determinar o alojamento ao qual está ligado o seu nome de domínio, para que possa intervir no bom servidor;
 2. criar, ativar ou renovar um [certificado SSL](/pages/web_cloud/web_hosting/ssl_on_webhosting) para o seu nome de domínio no alojamento em causa.
 
-### 1: Verificar o alojamento associado ao seu domínio
+### 1 - Verificar o alojamento associado ao seu domínio
 
 #### Verificar o endereço IP do alojamento
 
@@ -56,44 +71,113 @@ Para encontrar o endereço IP do seu [alojamento OVHcloud](/links/web/hosting), 
 > [!tabs]
 > **Etapa 1**
 >>
->> Aceda à página [Hosting plans](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Página de alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Etapa 2**
 >>
->> No marco **Informações gerais**, encontrará as referências **IPv4** e **IPv6**.
+>> No quadro **Informações gerais**, encontrará as referências **IPv4** e **IPv6**.
 >>
->>  ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![Endereços IPv4 e IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
 >> Anote o endereço IPv4 e/ou IPv6 e continue lendo o guia.
 
 #### Verificar o endereço IP na zona DNS
 
-Agora tem de verificar que o endereço IP indicado na [Zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde ao do seu [alojamento Web Cloud](/links/web/hosting).
+Agora tem de verificar que o endereço IP indicado na [zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde ao do seu [alojamento Web Cloud](/links/web/hosting).
 
-Aceda à [Área de Cliente OVHcloud](/links/manager) e aceda à secção `Web Cloud`{.action}. Clique no menu `Zonas DNS`{.action} e escolha o domínio em causa.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
-Nota do destino do tipo `A` para o seu domínio:
-
-![zone-ip](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Zonas DNS](/links/control-panel/web-dns-zone) e escolha o domínio em causa.
+>>
+>> ![Página de zonas DNS](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Anote o destino do registo de tipo `A` para o seu domínio:
+>>
+>> ![Destino do registo A na zona DNS](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
 #### Efetuar as ações necessárias
 
-|Cenário|Ação|
-|---|---|
-|O endereço IP indicado na [Zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde ao do seu alojamento partilhado.|Passe para [Etapa 2](#step2).|
-|O endereço IP indicado na zona não diz respeito a nenhum alojamento do seu [conta OVHcloud](/links/manager), mas aparece na [lista dos servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Verifique que não possui um alojamento que possua este endereço IP num dos seus outros [contas OVHcloud](/links/manager), caso tenha criado vários. Se necessário, contacte o seu webmaster ou os [parceiros da OVHcloud](/links/partner) a este respeito.|
-|O endereço IP indicado na zona não é o do seu alojamento nem aparece na [lista dos servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|Contacte o seu webmaster ou os [parceiros OVHcloud](/links/partner) a este respeito.|
-|No separador `Zona DNS`{.action}, uma mensagem indica que o seu domínio utiliza outros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit), que aparecem na forma "ns **?** .ovh.net" ou "dns **?** .ovh.net" (substitua "**?**" pelo número do servidor DNS em causa):<br><br>![warning_other_ovh_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}|Modifique os servidores DNS do seu domínio, de modo a que correspondam aos inscritos nas entradas de tipo `NS` da zona. Para efetuar esta operação, siga as instruções do [presente guia](/pages/web_cloud/domains/dns_server_edit).|
-|No separador `Zona DNS`{.action}, uma mensagem indica que o seu domínio utiliza outros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit) e estes não aparecem na forma "ns **?** .ovh.net" ou "dns **?** .ovh.net":<br><br>![warning_external_dn_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}|Contacte o seu webmaster ou os [parceiros OVHcloud](/links/partner) a este respeito.|
-|`Noms de domínio`{.action} do seu [Área de Cliente OVHcloud](/links/manager).<br><br>Ou o separador `Zona DNS`{.action} do seu domínio aparece da seguinte forma:<br><br>![zonedns_ndd_non_sur_lec2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/zone-without-domain-top-of-the-page.png){.thumbnail}|Isto significa que o seu domínio não é gerido a partir do seu [Área de Cliente OVHcloud](/links/manager).<br><br>Verifique que o domínio não é gerido a partir de uma das suas outras [contas OVHcloud](/links/manager), se tiver criado vários.<br><br>Pode igualmente determinar o seu escritório de's registo e os servidores DNS aos quais está ligado através da nossa ferramenta [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).<br><br>Se necessário, contacte o seu webmaster ou os [parceiros OVHcloud](/links/partner).|
+**Clique no cenário correspondente à sua situação para ver o conteúdo.**
 
-### 2: Verificar o certificado SSL do alojamento <a name="step2"></a>
+/// details | O endereço IP corresponde ao do seu alojamento partilhado
 
-No separador `Informações gerais`{.action} do seu alojamento OVHcloud, verifique a parte `Certificado SSL`:
+O endereço IP indicado na [zona DNS](/pages/web_cloud/domains/dns_zone_edit) corresponde ao do seu alojamento partilhado. Passe para a [parte 2](#step2).
 
-![ssl-certificate-in-general-tab](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
+///
+
+/// details | O endereço IP não diz respeito a nenhum alojamento da sua conta, mas aparece na lista dos servidores Web Cloud
+
+O endereço IP indicado na zona não diz respeito a nenhum alojamento da sua [conta OVHcloud](/links/manager), mas aparece na [lista dos servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Verifique que não possui um alojamento com este endereço IP num dos seus outros [contas OVHcloud](/links/manager), caso tenha criado vários. Se necessário, contacte o seu webmaster ou os [parceiros OVHcloud](/links/partner) a este respeito.
+
+///
+
+/// details | O endereço IP não é o do seu alojamento nem aparece na lista dos servidores Web Cloud
+
+O endereço IP indicado na zona não é o do seu alojamento nem aparece na [lista dos servidores Web Cloud](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).
+
+Contacte o seu webmaster ou os [parceiros OVHcloud](/links/partner) a este respeito.
+
+///
+
+/// details | O seu domínio utiliza outros servidores DNS OVHcloud (ns?.ovh.net / dns?.ovh.net)
+
+Acima da zona DNS apresentada na Área de Cliente OVHcloud, uma mensagem indica que o seu domínio utiliza outros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit), que aparecem na forma "ns **?** .ovh.net" ou "dns **?** .ovh.net" (substitua "**?**" pelo número do servidor DNS em causa):
+
+![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+
+Modifique os servidores DNS do seu domínio, de modo a que correspondam aos inscritos nas entradas de tipo `NS` da zona. Para efetuar esta operação, siga as instruções do [presente guia](/pages/web_cloud/domains/dns_server_edit).
+
+///
+
+/// details | O seu domínio utiliza servidores DNS externos (não OVHcloud)
+
+Acima da zona DNS apresentada na Área de Cliente OVHcloud, uma mensagem indica que o seu domínio utiliza outros servidores [DNS](/pages/web_cloud/domains/dns_zone_edit) e estes não aparecem na forma "ns **?** .ovh.net" ou "dns **?** .ovh.net":
+
+![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+
+Contacte o seu webmaster ou os [parceiros OVHcloud](/links/partner) a este respeito.
+
+///
+
+/// details | O seu nome de domínio não aparece na Área de Cliente OVHcloud
+
+O seu nome de domínio não aparece na página [Nomes de domínio](/links/control-panel/web-domains) da Área de Cliente OVHcloud.
+
+Isto significa que o seu domínio não é gerido a partir da sua [Área de Cliente OVHcloud](/links/manager).
+
+Verifique que o domínio não é gerido a partir de uma das suas outras [contas OVHcloud](/links/manager), se tiver criado vários.
+
+Pode igualmente determinar o seu bureau de registo e os servidores DNS aos quais está ligado através da nossa ferramenta [WHOIS](https://www.ovh.com/fr/support/outils/check_whois.pl).
+
+Se necessário, contacte o seu webmaster ou os [parceiros OVHcloud](/links/partner).
+
+///
+
+### 2 - Verificar o certificado SSL do alojamento <a name="step2"></a>
+
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
+
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
+>>
+>> ![Página de alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> No separador `Informações gerais`{.action}, verifique a parte `Certificado SSL`:
+>>
+>> ![Certificado SSL no separador de informações gerais](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/no-ssl-certificate.png){.thumbnail}
 
 #### Cenário 1: o seu alojamento não contém um certificado SSL
 
@@ -110,7 +194,7 @@ Se encomendou um dos **certificados SSL pagos** do nosso parceiro [SECTIGO](http
 
 > [!primary]
 >
-> Para encontrar o conjunto dos e-mails enviados pelos nossos serviços, clique no canto superior direito do seu [Área de Cliente OVHcloud](/links/manager), depois em `As minhas comunicações`{.action}.
+> Para encontrar o conjunto dos e-mails enviados pelos nossos serviços, aceda à página [As minhas comunicações](/links/control-panel/account-messages).
 
 ## Quer saber mais? <a name="go-further"></a>
 
@@ -118,14 +202,14 @@ Se encomendou um dos **certificados SSL pagos** do nosso parceiro [SECTIGO](http
 
 [Ativar o HTTPS num website com certificado SSL](/pages/web_cloud/web_hosting/ssl-activate-https-website)
 
-[Resolver o erro “Site não instalado”](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolver o erro "Site não instalado"](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [O que fazer em caso de erro 500 Internal Server Error?](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Resolver os erros mais frequentes associados aos módulos 1 clique](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
- 
+
 Para serviços especializados (referenciamento, desenvolvimento, etc), contacte os [parceiros OVHcloud](/links/partner).
 
-Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes ofertas de suporte (/links/support).
+Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 
 Fale com nossa [comunidade de utilizadores](/links/community).

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.de-de.md
@@ -1,10 +1,24 @@
 ---
 title: "Was tun, wenn Ihre Website nicht erreichbar ist?"
 excerpt: Diagnose der Ursachen für die Unverfügbarkeit Ihrer Website
-updated: 2025-10-09
+updated: 2026-03-26
 ---
 
-## Ziel 
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
+
+## Ziel
 
 Wenn Ihre Website nicht erreichbar ist, können in Ihrem Browser mehrere Fehlermeldungen angezeigt werden. Die folgenden Beispiele zeigen eine fehlerhafte Konfiguration Ihrer [DNS-Server](/pages/web_cloud/domains/dns_server_edit), Ihrer [DNS-Zone](/pages/web_cloud/domains/dns_zone_edit) oder einer gesperrten Domäne (wenn auf Ihrer Website eine der hier beschriebenen Fehlermeldungen nicht angezeigt wird, finden Sie weitere Informationen im Abschnitt [Weiterführende Informationen](#go-further):
 
@@ -19,7 +33,7 @@ Wenn Ihre Website nicht erreichbar ist, können in Ihrem Browser mehrere Fehlerm
 
 > [!warning]
 > OVHcloud stellt Ihnen Dienstleistungen zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit bei Ihnen, sicherzustellen, dass diese ordnungsgemäß funktionieren.
-> 
+>
 > Diese Anleitung soll Sie bei allgemeinen Aufgaben bestmöglich unterstützen. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) zu kontaktieren und/oder Ihre Fragen in der OVHcloud Community zu stellen. Leider können wir Ihnen für administrative Aufgaben keine weitergehende technische Unterstützung anbieten. Weitere Informationen finden Sie am [Ende dieser Anleitung](#go-further).
 >
 
@@ -40,7 +54,7 @@ Wenn Ihre Website nicht erreichbar ist, können in Ihrem Browser mehrere Fehlerm
 
 ## In der praktischen Anwendung
 
-### 1: Die Gültigkeit Ihrer Domain überprüfen
+### 1 - Die Gültigkeit Ihrer Domain überprüfen
 
 > [!warning]
 >
@@ -50,39 +64,63 @@ Wenn Ihre Website nicht erreichbar ist, können in Ihrem Browser mehrere Fehlerm
 > Daher empfehlen wir Ihnen dringend, die [automatische Verlängerung](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#in-der-praktischen-anwendung) für alle Ihre OVHcloud Abonnements zu aktivieren.
 >
 
-Um die Gültigkeit des Abonnements für Ihre Domain zu überprüfen, klicken Sie oben rechts in Ihrem [OVHcloud Kundencenter](/links/manager) auf Ihren Namen, um das Kontextmenü anzuzeigen, und dann auf `Meine Angebote und Dienste`{.action}.
+Um die Gültigkeit des Abonnements für Ihre Domain zu überprüfen, klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Meine Angebote und Dienste](/links/control-panel/billing-services).
+>>
+> **Schritt 2**
+>>
+>> Wenn nötig verlängern Sie Ihre Domain mit Klick auf den Button `...`{.action}, dann auf `Dienst verlängern`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Schritt 3**
+>>
+>> Nach dieser Verlängerung ist Ihre Website innerhalb von maximal 48 Stunden verfügbar.
 
-Wenn nötig verlängern Sie Ihre Domain mit Klick auf den Button `...`{.action} rechts und dann auf `Dienst verlängern`{.action}.
+### 2 - DNS Server überprüfen
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+Um die Gültigkeit Ihrer [DNS Server](/pages/web_cloud/domains/dns_server_edit) zu überprüfen, gehen Sie auf die Seite [Domainnamen](/links/control-panel/web-domains), und wählen Sie den betreffenden Domainnamen aus.
 
-Nach dieser Verlängerung ist Ihre Website innerhalb von maximal 48 Stunden verfügbar.
+**Klicken Sie auf das Szenario, das Ihrer Situation entspricht, um den Inhalt anzuzeigen.**
 
-### 2: DNS Server überprüfen
+/// details | Szenario 1 - Keine Anomalien bei den DNS Servern
 
-Um die Gültigkeit Ihrer [DNS Server](/pages/web_cloud/domains/dns_server_edit) zu überprüfen, klicken Sie in Ihrem [OVHcloud Kundencenter](/links/manager) auf `Domainnamen`{.action} und dann auf die Domain Ihrer Website.
+Um die deklarierten DNS Server zu überprüfen, klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
 
-#### Szenario 1: keine Anomalien bei den DNS Servern
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Domainnamen](/links/control-panel/web-domains), und wählen Sie den betreffenden Domainnamen aus.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Überprüfen Sie die im Tab `DNS-Server`{.action} angezeigten Informationen:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Schritt 3**
+>>
+>> Wenn die Servernamen mit den Zielen der `NS`-Einträge in der **DNS-Zone** identisch sind, gehen Sie zu [Teil 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Überprüfen Sie die im Tab `DNS-Server`{.action} angezeigten Informationen:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Szenario 2 - Eine Warnung erscheint über der DNS Zone
 
-Wenn die Servernamen mit den Zielen der `NS`-Einträge in der `DNS-Zone`{.action} identisch sind, gehen Sie zu [Schritt 3](#step3).
-
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Szenario 2: eine Warnung erscheint über der DNS Zone
-
-Eine Warnung im Tab `DNS-Zone`{.action} zeigt an, dass die von Ihrer Domain verwendeten DNS Server nicht in Ihrer Zone hinterlegt sind. Hier sind zwei Szenarien möglich.
+Eine Warnung im Tab **DNS-Zone** zeigt an, dass die von Ihrer Domain verwendeten DNS Server nicht in Ihrer Zone hinterlegt sind. Hier sind zwei Szenarien möglich.
 
 - Unter "Sie verwenden derzeit folgende DNS-Server:" sind die angegebenen Server vom Typ "ns **?** .ovh.net" und "dns **?** .ovh.net" (wobei "**?**" für eine zweistellige Zahl steht):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Ändern Sie die DNS Server entsprechend den Anweisungen in dieser [Anleitung](/pages/web_cloud/domains/dns_server_edit), damit diese mit den Zielen der Einträge vom Typ `NS` in der `DNS-Zone`{.action} identisch sind.
+Ändern Sie die DNS Server entsprechend den Anweisungen in dieser [Anleitung](/pages/web_cloud/domains/dns_server_edit), damit diese mit den Zielen der Einträge vom Typ `NS` in der **DNS-Zone** identisch sind.
 
 Ihre Website wird dann innerhalb von maximal 48 Stunden verfügbar sein.
 
@@ -95,29 +133,49 @@ Ihre Website wird dann innerhalb von maximal 48 Stunden verfügbar sein.
 > Kontaktieren Sie in diesem Fall den Hoster Ihrer DNS Zone, Ihren Webmaster oder die [OVHcloud Partner](/links/partner), bevor Sie die Änderung vornehmen.
 >
 > Es ist möglich, dass die von Ihrer Domain verwendeten DNS Server funktionieren und dass das Problem beim Zugriff auf Ihre Website auf einen fehlenden oder fehlerhaften Eintrag in der [DNS Zone](/pages/web_cloud/domains/dns_zone_general_information) zurückzuführen ist. Jede Änderung der DNS Server kann dazu führen, dass Ihre E-Mail Adressen oder andere Online-Anwendungen nicht mehr verfügbar sind.
->
 
-#### Szenario 3: In der DNS Zone wird kein Eintrag des Typs "NS" angezeigt
+///
 
-Die `DNS-Zone`{.action} Ihrer Domain enthält keinen Eintrag vom Typ `NS`:
+/// details | Szenario 3 - In der DNS Zone wird kein Eintrag des Typs "NS" angezeigt
+
+Die **DNS-Zone** Ihrer Domain enthält keinen Eintrag vom Typ `NS`:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Erstellen Sie ein Backup der aktuellen DNS Zone, indem Sie rechts im Menü auf den Button `Im Textmodus bearbeiten`{.action} klicken:
+Klicken Sie auf die Tabs, um die **4** Schritte anzuzeigen.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [DNS-Zone](/links/control-panel/web-dns-zone), und wählen Sie den betreffenden Domainnamen aus.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Erstellen Sie ein Backup der aktuellen DNS Zone, indem Sie auf den Button `Im Textmodus bearbeiten`{.action} klicken:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Kopieren Sie den Inhalt Ihrer **DNS-Zone** in ein Textdokument. Speichern Sie diese Datei lokal ab.
+>>
+> **Schritt 3**
+>>
+>> Klicken Sie auf `Meine DNS-Zone zurücksetzen`{.action} und wählen Sie `Nein, aber ich möchte meine DNS-Zone zurücksetzen.`{.action}.
+>>
+>> Wählen Sie Ihre E-Mail- und Hosting-Server aus und klicken Sie auf `Bestätigen`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Schritt 4**
+>>
+>> Ihre Website wird dann innerhalb von maximal 24 Stunden verfügbar sein.
 
-Kopieren Sie anschließend den Inhalt Ihrer `DNS-Zone`{.action} in ein Textdokument. Speichern Sie diese Datei lokal ab.
+///
 
-Klicken Sie anschließend auf `Meine DNS-Zone zurücksetzen`{.action} und wählen Sie `Nein, aber ich möchte meine DNS-Zone zurücksetzen.`{.action}, wählen Sie Ihre E-Mail- und Hosting-Server aus und klicken Sie auf `Bestätigen`{.action}.
+### 3 - Die DNS Zone überprüfen <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
-
-Ihre Website wird dann innerhalb von maximal 24 Stunden verfügbar sein.
-
-### 3: Die DNS Zone überprüfen <a name="step3"></a>
-
-In diesem Schritt ermitteln Sie die IP-Adresse Ihres Hostings und fügen sie zu Ihrer `DNS-Zone`{.action} hinzu.
+In diesem Schritt ermitteln Sie die IP-Adresse Ihres Hostings und fügen sie zu Ihrer **DNS-Zone** hinzu.
 
 Wenn Ihre Website nicht auf der OVHcloud Infrastruktur gehostet ist oder von einem anderen Anbieter verwaltet wird, kontaktieren Sie bitte den zuständigen Support.
 
@@ -136,7 +194,7 @@ Wenn Ihre Website auf einem unserer [Hosting-Angebote](/links/web/hosting) gehos
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> Kopieren Sie im Tab `Allgemeine Informationen`{.action} die IPv4- und/oder IPv6-Adresse Ihrer Domain.
+>> Kopieren Sie die IPv4- und/oder IPv6-Adresse Ihrer Domain.
 
 Tragen Sie diese dann in die [DNS-Zone](/pages/web_cloud/domains/dns_zone_edit) Ihrer Domain ein, indem Sie einen oder mehrere Einträge vom Typ `A` bearbeiten oder erstellen.
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Was tun, wenn Ihre Website nicht erreichbar ist?"
 excerpt: Diagnose der Ursachen für die Unverfügbarkeit Ihrer Website
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-asia.md
@@ -1,8 +1,22 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -21,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -42,7 +56,7 @@ Several error returns may appear on your browser if your website becomes inacces
 
 ## Instructions
 
-### 1: check the validity of your domain name subscription
+### 1 - Check the validity of your domain name subscription
 
 > [!warning]
 >
@@ -52,43 +66,67 @@ Several error returns may appear on your browser if your website becomes inacces
 > As a result, we strongly recommend that you enable [automatic renewal](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#instructions) for all of your OVHcloud subscriptions.
 >
 
-To check that your domain name subscription is valid, click on your name at the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then click on `My offers and services`{.action} within the right-hand menu.
+To check that your domain name subscription is valid, click on the tabs below to view each of the **3** steps.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [My offers and services](/links/control-panel/billing-services) page.
+>>
+> **Step 2**
+>>
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> After this renewal, your website will be accessible again within 48 hours maximum.
 
-Renew your domain if necessary with the `...`{.action} button, then click on `Renew service`{.action}.
+### 2 - Check the DNS servers
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+To check the validity of your [DNS servers](/pages/web_cloud/domains/dns_server_edit), go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
 
-After the renewal of your offer is completed, your website will be available within a maximum of 48 hours.
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check the DNS servers
+/// details | Scenario 1 - No anomalies appear on the DNS servers
 
-To check that your [DNS servers](/pages/web_cloud/domains/dns_server_edit) are valid, click on `Domain names`{.action} in your [OVHcloud Control Panel](/links/manager), then on your domain name.
+To check the DNS servers declared, click on the tabs below to view each of the **3** steps.
 
-#### Scenario 1: no anomalies appear on the DNS servers
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Check the servers listed in the `DNS servers`{.action} tab:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Check the servers listed in the `DNS servers`{.action} tab:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Scenario 2 - A warning appears above the DNS zone
 
-If they are identical to the targets of the `NS` type entries in the `DNS zone`{.action}, go to [step 3](#step3):
+A warning in the **DNS zone** tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
 
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Scenario 2: a warning appears above the DNS zone
-
-A warning in the `DNS zone`{.action} tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
-
-- Under the sentence "You are currently using the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
+- Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your `DNS zone`{.action}.
+Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
-- Under the sentence "You are currently using the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
+- Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
 ![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
@@ -97,33 +135,53 @@ Your website will then be available within a maximum of 48 hours.
 > In this situation, please contact your DNS Zone provider, your webmaster or a [OVHcloud partner](/links/partner) before making any changes.
 >
 > The DNS servers used by your domain name may be functional and the problem accessing your website be linked to a missing or incorrect entry in the active [DNS zone](/pages/web_cloud/domains/dns_zone_general_information). Changing the DNS servers in this situation might make your e-mail addresses or other online applications related to your domain name unavailable.
->
 
-#### Scenario 3: no NS-type entries appear in the DNS zone
+///
 
-Your domain’s `DNS zone`{.action} does not contain any `NS` record:
+/// details | Scenario 3 - No NS-type entries appear in the DNS zone
+
+Your domain's **DNS zone** does not contain any `NS` record:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Back up the current zone by clicking on the `Change in text format`{.action} button:
+Click on the tabs below to view each of the **4** steps.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Back up the current zone by clicking on the `Change in text format`{.action} button:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copy and paste the content of your **DNS zone** into a text document on your computer.
+>>
+> **Step 3**
+>>
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>>
+>> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> Your website will be accessible again within 24 hours maximum.
 
-Then copy and paste the content of your `DNS zone`{.action} into a text document on your computer.
+///
 
-Then click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}. Select your e-mail and hosting servers and click on `Confirm`{.action}.
+### 3 - Check the DNS zone <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+In this step, you will find your hosting plan's IP address, then add it to your **DNS zone**.
 
-Your website will then be available again within a maximum of 24 hours.
+If your website is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
 
-### 3: check the DNS zone <a name="step3"></a>
-
-In this step, you will find your hosting plan’s IP address, then add it to your `DNS zone`{.action}.
-
-If your site is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
-
-If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
+If your website is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
 
 > [!tabs]
 > **Step 1**
@@ -138,9 +196,9 @@ If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), c
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> In the `General information`{.action} tab, copy the IPv4 and/or IPv6 address of your domain name.
+>> Copy the IPv4 and/or IPv6 address of your domain name.
 
-Then refer to it in your domain’s [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
+Then refer to it in your domain's [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
 
 ![ipv4-DNSzone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
@@ -148,7 +206,7 @@ Your website will then be available within a maximum of 24 hours.
 
 ## Go further <a name="go-further"></a>
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-asia.md
@@ -35,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -75,7 +75,7 @@ To check that your domain name subscription is valid, click on the tabs below to
 >>
 > **Step 2**
 >>
->> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew`{.action}.
 >>
 >> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
 >>
@@ -104,13 +104,13 @@ To check the DNS servers declared, click on the tabs below to view each of the *
 >>
 >> Check the servers listed in the `DNS servers`{.action} tab:
 >>
->> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>> ![DNS server confirmed](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
 >>
->> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
+>> ![DNS server verified](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
 ///
 
@@ -120,15 +120,15 @@ A warning in the **DNS zone** tab indicates that the DNS servers used by your do
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
-![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+![OVHcloud DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
+Modify the DNS servers as described in our guide "[How to modify the DNS servers of an OVHcloud domain name](/pages/web_cloud/domains/dns_server_edit)", so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
-![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+![External DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
 > [!warning]
 >
@@ -142,7 +142,7 @@ Your website will then be available within a maximum of 48 hours.
 
 Your domain's **DNS zone** does not contain any `NS` record:
 
-![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
+![Missing NS record warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
 Click on the tabs below to view each of the **4** steps.
 
@@ -157,17 +157,17 @@ Click on the tabs below to view each of the **4** steps.
 >>
 >> Back up the current zone by clicking on the `Change in text format`{.action} button:
 >>
->> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>> ![DNS zone text format button](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
 >>
 >> Copy and paste the content of your **DNS zone** into a text document on your computer.
 >>
 > **Step 3**
 >>
->> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone.`{.action}.
 >>
->> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>> Select your email and hosting servers, then click on `Confirm`{.action}.
 >>
->> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>> ![DNS zone reset dialog](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
 >>
 > **Step 4**
 >>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-au.md
@@ -1,8 +1,22 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -21,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -42,7 +56,7 @@ Several error returns may appear on your browser if your website becomes inacces
 
 ## Instructions
 
-### 1: check the validity of your domain name subscription
+### 1 - Check the validity of your domain name subscription
 
 > [!warning]
 >
@@ -52,43 +66,67 @@ Several error returns may appear on your browser if your website becomes inacces
 > As a result, we strongly recommend that you enable [automatic renewal](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#instructions) for all of your OVHcloud subscriptions.
 >
 
-To check that your domain name subscription is valid, click on your name at the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then click on `My offers and services`{.action} within the right-hand menu.
+To check that your domain name subscription is valid, click on the tabs below to view each of the **3** steps.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [My offers and services](/links/control-panel/billing-services) page.
+>>
+> **Step 2**
+>>
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> After this renewal, your website will be accessible again within 48 hours maximum.
 
-Renew your domain if necessary with the `...`{.action} button, then click on `Renew service`{.action}.
+### 2 - Check the DNS servers
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+To check the validity of your [DNS servers](/pages/web_cloud/domains/dns_server_edit), go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
 
-After the renewal of your offer is completed, your website will be available within a maximum of 48 hours.
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check the DNS servers
+/// details | Scenario 1 - No anomalies appear on the DNS servers
 
-To check that your [DNS servers](/pages/web_cloud/domains/dns_server_edit) are valid, click on `Domain names`{.action} in your [OVHcloud Control Panel](/links/manager), then on your domain name.
+To check the DNS servers declared, click on the tabs below to view each of the **3** steps.
 
-#### Scenario 1: no anomalies appear on the DNS servers
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Check the servers listed in the `DNS servers`{.action} tab:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Check the servers listed in the `DNS servers`{.action} tab:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Scenario 2 - A warning appears above the DNS zone
 
-If they are identical to the targets of the `NS` type entries in the `DNS zone`{.action}, go to [step 3](#step3):
+A warning in the **DNS zone** tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
 
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Scenario 2: a warning appears above the DNS zone
-
-A warning in the `DNS zone`{.action} tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
-
-- Under the sentence "You are currently using the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
+- Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your `DNS zone`{.action}.
+Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
-- Under the sentence "You are currently using the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
+- Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
 ![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
@@ -97,33 +135,53 @@ Your website will then be available within a maximum of 48 hours.
 > In this situation, please contact your DNS Zone provider, your webmaster or a [OVHcloud partner](/links/partner) before making any changes.
 >
 > The DNS servers used by your domain name may be functional and the problem accessing your website be linked to a missing or incorrect entry in the active [DNS zone](/pages/web_cloud/domains/dns_zone_general_information). Changing the DNS servers in this situation might make your e-mail addresses or other online applications related to your domain name unavailable.
->
 
-#### Scenario 3: no NS-type entries appear in the DNS zone
+///
 
-Your domain’s `DNS zone`{.action} does not contain any `NS` record:
+/// details | Scenario 3 - No NS-type entries appear in the DNS zone
+
+Your domain's **DNS zone** does not contain any `NS` record:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Back up the current zone by clicking on the `Change in text format`{.action} button:
+Click on the tabs below to view each of the **4** steps.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Back up the current zone by clicking on the `Change in text format`{.action} button:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copy and paste the content of your **DNS zone** into a text document on your computer.
+>>
+> **Step 3**
+>>
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>>
+>> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> Your website will be accessible again within 24 hours maximum.
 
-Then copy and paste the content of your `DNS zone`{.action} into a text document on your computer.
+///
 
-Then click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}. Select your e-mail and hosting servers and click on `Confirm`{.action}.
+### 3 - Check the DNS zone <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+In this step, you will find your hosting plan's IP address, then add it to your **DNS zone**.
 
-Your website will then be available again within a maximum of 24 hours.
+If your website is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
 
-### 3: check the DNS zone <a name="step3"></a>
-
-In this step, you will find your hosting plan’s IP address, then add it to your `DNS zone`{.action}.
-
-If your site is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
-
-If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
+If your website is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
 
 > [!tabs]
 > **Step 1**
@@ -138,9 +196,9 @@ If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), c
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> In the `General information`{.action} tab, copy the IPv4 and/or IPv6 address of your domain name.
+>> Copy the IPv4 and/or IPv6 address of your domain name.
 
-Then refer to it in your domain’s [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
+Then refer to it in your domain's [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
 
 ![ipv4-DNSzone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
@@ -148,7 +206,7 @@ Your website will then be available within a maximum of 24 hours.
 
 ## Go further <a name="go-further"></a>
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-au.md
@@ -35,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -75,7 +75,7 @@ To check that your domain name subscription is valid, click on the tabs below to
 >>
 > **Step 2**
 >>
->> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew`{.action}.
 >>
 >> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
 >>
@@ -104,13 +104,13 @@ To check the DNS servers declared, click on the tabs below to view each of the *
 >>
 >> Check the servers listed in the `DNS servers`{.action} tab:
 >>
->> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>> ![DNS server confirmed](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
 >>
->> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
+>> ![DNS server verified](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
 ///
 
@@ -120,15 +120,15 @@ A warning in the **DNS zone** tab indicates that the DNS servers used by your do
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
-![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+![OVHcloud DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
+Modify the DNS servers as described in our guide "[How to modify the DNS servers of an OVHcloud domain name](/pages/web_cloud/domains/dns_server_edit)", so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
-![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+![External DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
 > [!warning]
 >
@@ -142,7 +142,7 @@ Your website will then be available within a maximum of 48 hours.
 
 Your domain's **DNS zone** does not contain any `NS` record:
 
-![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
+![Missing NS record warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
 Click on the tabs below to view each of the **4** steps.
 
@@ -157,17 +157,17 @@ Click on the tabs below to view each of the **4** steps.
 >>
 >> Back up the current zone by clicking on the `Change in text format`{.action} button:
 >>
->> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>> ![DNS zone text format button](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
 >>
 >> Copy and paste the content of your **DNS zone** into a text document on your computer.
 >>
 > **Step 3**
 >>
->> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone.`{.action}.
 >>
->> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>> Select your email and hosting servers, then click on `Confirm`{.action}.
 >>
->> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>> ![DNS zone reset dialog](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
 >>
 > **Step 4**
 >>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ca.md
@@ -1,8 +1,22 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -21,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -42,7 +56,7 @@ Several error returns may appear on your browser if your website becomes inacces
 
 ## Instructions
 
-### 1: check the validity of your domain name subscription
+### 1 - Check the validity of your domain name subscription
 
 > [!warning]
 >
@@ -52,43 +66,67 @@ Several error returns may appear on your browser if your website becomes inacces
 > As a result, we strongly recommend that you enable [automatic renewal](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#instructions) for all of your OVHcloud subscriptions.
 >
 
-To check that your domain name subscription is valid, click on your name at the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then click on `My offers and services`{.action} within the right-hand menu.
+To check that your domain name subscription is valid, click on the tabs below to view each of the **3** steps.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [My offers and services](/links/control-panel/billing-services) page.
+>>
+> **Step 2**
+>>
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> After this renewal, your website will be accessible again within 48 hours maximum.
 
-Renew your domain if necessary with the `...`{.action} button, then click on `Renew service`{.action}.
+### 2 - Check the DNS servers
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+To check the validity of your [DNS servers](/pages/web_cloud/domains/dns_server_edit), go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
 
-After the renewal of your offer is completed, your website will be available within a maximum of 48 hours.
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check the DNS servers
+/// details | Scenario 1 - No anomalies appear on the DNS servers
 
-To check that your [DNS servers](/pages/web_cloud/domains/dns_server_edit) are valid, click on `Domain names`{.action} in your [OVHcloud Control Panel](/links/manager), then on your domain name.
+To check the DNS servers declared, click on the tabs below to view each of the **3** steps.
 
-#### Scenario 1: no anomalies appear on the DNS servers
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Check the servers listed in the `DNS servers`{.action} tab:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Check the servers listed in the `DNS servers`{.action} tab:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Scenario 2 - A warning appears above the DNS zone
 
-If they are identical to the targets of the `NS` type entries in the `DNS zone`{.action}, go to [step 3](#step3):
+A warning in the **DNS zone** tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
 
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Scenario 2: a warning appears above the DNS zone
-
-A warning in the `DNS zone`{.action} tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
-
-- Under the sentence "You are currently using the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
+- Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your `DNS zone`{.action}.
+Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
-- Under the sentence "You are currently using the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
+- Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
 ![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
@@ -97,33 +135,53 @@ Your website will then be available within a maximum of 48 hours.
 > In this situation, please contact your DNS Zone provider, your webmaster or a [OVHcloud partner](/links/partner) before making any changes.
 >
 > The DNS servers used by your domain name may be functional and the problem accessing your website be linked to a missing or incorrect entry in the active [DNS zone](/pages/web_cloud/domains/dns_zone_general_information). Changing the DNS servers in this situation might make your e-mail addresses or other online applications related to your domain name unavailable.
->
 
-#### Scenario 3: no NS-type entries appear in the DNS zone
+///
 
-Your domain’s `DNS zone`{.action} does not contain any `NS` record:
+/// details | Scenario 3 - No NS-type entries appear in the DNS zone
+
+Your domain's **DNS zone** does not contain any `NS` record:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Back up the current zone by clicking on the `Change in text format`{.action} button:
+Click on the tabs below to view each of the **4** steps.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Back up the current zone by clicking on the `Change in text format`{.action} button:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copy and paste the content of your **DNS zone** into a text document on your computer.
+>>
+> **Step 3**
+>>
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>>
+>> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> Your website will be accessible again within 24 hours maximum.
 
-Then copy and paste the content of your `DNS zone`{.action} into a text document on your computer.
+///
 
-Then click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}. Select your e-mail and hosting servers and click on `Confirm`{.action}.
+### 3 - Check the DNS zone <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+In this step, you will find your hosting plan's IP address, then add it to your **DNS zone**.
 
-Your website will then be available again within a maximum of 24 hours.
+If your website is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
 
-### 3: check the DNS zone <a name="step3"></a>
-
-In this step, you will find your hosting plan’s IP address, then add it to your `DNS zone`{.action}.
-
-If your site is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
-
-If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
+If your website is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
 
 > [!tabs]
 > **Step 1**
@@ -138,9 +196,9 @@ If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), c
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> In the `General information`{.action} tab, copy the IPv4 and/or IPv6 address of your domain name.
+>> Copy the IPv4 and/or IPv6 address of your domain name.
 
-Then refer to it in your domain’s [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
+Then refer to it in your domain's [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
 
 ![ipv4-DNSzone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
@@ -148,7 +206,7 @@ Your website will then be available within a maximum of 24 hours.
 
 ## Go further <a name="go-further"></a>
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ca.md
@@ -35,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -75,7 +75,7 @@ To check that your domain name subscription is valid, click on the tabs below to
 >>
 > **Step 2**
 >>
->> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew`{.action}.
 >>
 >> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
 >>
@@ -104,13 +104,13 @@ To check the DNS servers declared, click on the tabs below to view each of the *
 >>
 >> Check the servers listed in the `DNS servers`{.action} tab:
 >>
->> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>> ![DNS server confirmed](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
 >>
->> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
+>> ![DNS server verified](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
 ///
 
@@ -120,15 +120,15 @@ A warning in the **DNS zone** tab indicates that the DNS servers used by your do
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
-![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+![OVHcloud DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
+Modify the DNS servers as described in our guide "[How to modify the DNS servers of an OVHcloud domain name](/pages/web_cloud/domains/dns_server_edit)", so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
-![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+![External DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
 > [!warning]
 >
@@ -142,7 +142,7 @@ Your website will then be available within a maximum of 48 hours.
 
 Your domain's **DNS zone** does not contain any `NS` record:
 
-![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
+![Missing NS record warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
 Click on the tabs below to view each of the **4** steps.
 
@@ -157,17 +157,17 @@ Click on the tabs below to view each of the **4** steps.
 >>
 >> Back up the current zone by clicking on the `Change in text format`{.action} button:
 >>
->> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>> ![DNS zone text format button](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
 >>
 >> Copy and paste the content of your **DNS zone** into a text document on your computer.
 >>
 > **Step 3**
 >>
->> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone.`{.action}.
 >>
->> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>> Select your email and hosting servers, then click on `Confirm`{.action}.
 >>
->> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>> ![DNS zone reset dialog](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
 >>
 > **Step 4**
 >>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: What do I do if my website is down?
 excerpt: How to diagnose the causes of inaccessibility of your web site
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-gb.md
@@ -1,8 +1,22 @@
 ---
 title: What do I do if my website is down?
 excerpt: How to diagnose the causes of inaccessibility of your web site
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -41,7 +55,7 @@ Several error returns may appear on your browser if your website becomes inacces
 
 ## Instructions
 
-### 1: Check the validity of your domain name subscription
+### 1 - Check the validity of your domain name subscription
 
 > [!warning]
 >
@@ -51,39 +65,63 @@ Several error returns may appear on your browser if your website becomes inacces
 > As a result, we strongly recommend that you enable [automatic renewal](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#instructions) for all of your OVHcloud subscriptions.
 >
 
-To ensure that your domain name subscription is valid, click on your name at the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then click on `My offers and services`{.action} within the right-hand menu.
+To check that your domain name subscription is valid, click on the tabs below to view each of the **3** steps.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [My offers and services](/links/control-panel/billing-services) page.
+>>
+> **Step 2**
+>>
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> After this renewal, your website will be accessible again within 48 hours maximum.
 
-Renew your domain if necessary by clicking on the `...`{.action} button, then select `Renew service`{.action}.
+### 2 - Check the DNS servers
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+To check the validity of your [DNS servers](/pages/web_cloud/domains/dns_server_edit), go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
 
-After the renewal of your offer is completed, your website will be available within a maximum of 48 hours.
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: Check the DNS servers
+/// details | Scenario 1 - No anomalies appear on the DNS servers
 
-To check that your [DNS servers](/pages/web_cloud/domains/dns_server_edit) are valid, click on `Domain names`{.action} in your [OVHcloud Control Panel](/links/manager), then on your domain name.
+To check the DNS servers declared, click on the tabs below to view each of the **3** steps.
 
-#### Scenario 1: No anomalies appear on the DNS servers
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Check the servers listed in the `DNS servers`{.action} tab:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Check the servers listed in the `DNS servers`{.action} tab:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Scenario 2 - A warning appears above the DNS zone
 
-If they are identical to the targets of the `NS` type entries in the `DNS zone`{.action}, go to [step 3](#step3):
-
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Scenario 2: A warning appears above the DNS zone
-
-A warning in the `DNS zone`{.action} tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
+A warning in the **DNS zone** tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (in which "**?**" stands for a double-digit number):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your `DNS zone`{.action}.
+Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
@@ -96,33 +134,53 @@ Your website will then be available within a maximum of 48 hours.
 > In this situation, please contact your DNS Zone provider, your webmaster or a [OVHcloud partner](/links/partner) before making any changes.
 >
 > The DNS servers used by your domain name may be functional and the problem accessing your website be linked to a missing or incorrect entry in the active [DNS zone](/pages/web_cloud/domains/dns_zone_general_information). Changing the DNS servers in this situation might make your email addresses or other online applications related to your domain name unavailable.
->
 
-#### Scenario 3: No NS-type entries appear in the DNS zone
+///
 
-Your domain’s `DNS zone`{.action} does not contain any `NS` record:
+/// details | Scenario 3 - No NS-type entries appear in the DNS zone
+
+Your domain's **DNS zone** does not contain any `NS` record:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Back up the current zone by clicking on the `Change in text format`{.action} button:
+Click on the tabs below to view each of the **4** steps.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Back up the current zone by clicking on the `Change in text format`{.action} button:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copy and paste the content of your **DNS zone** into a text document on your computer.
+>>
+> **Step 3**
+>>
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>>
+>> Select your email and hosting servers, then click on `Confirm`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> Your website will be accessible again within 24 hours maximum.
 
-Then copy and paste the content of your `DNS zone`{.action} into a text document on your computer.
+///
 
-Then click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}. Select your email and hosting servers and click on `Confirm`{.action}.
+### 3 - Check the DNS zone <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+In this step, you will find your hosting plan's IP address, then add it to your **DNS zone**.
 
-Your website will then be available again within a maximum of 24 hours.
+If your website is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
 
-### 3: Check the DNS zone <a name="step3"></a>
-
-In this step, you will find your hosting plan’s IP address, then add it to your `DNS zone`{.action}.
-
-If your site is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
-
-If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
+If your website is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
 
 > [!tabs]
 > **Step 1**
@@ -137,9 +195,9 @@ If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), c
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> In the `General information`{.action} tab, copy the IPv4 and/or IPv6 address of your domain name.
+>> Copy the IPv4 and/or IPv6 address of your domain name.
 
-Then refer to it in your domain’s [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
+Then refer to it in your domain's [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
 
 ![ipv4-DNSzone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
@@ -147,7 +205,7 @@ Your website will then be available within a maximum of 24 hours.
 
 ## Go further <a name="go-further"></a>
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-gb.md
@@ -74,7 +74,7 @@ To check that your domain name subscription is valid, click on the tabs below to
 >>
 > **Step 2**
 >>
->> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew`{.action}.
 >>
 >> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
 >>
@@ -103,13 +103,13 @@ To check the DNS servers declared, click on the tabs below to view each of the *
 >>
 >> Check the servers listed in the `DNS servers`{.action} tab:
 >>
->> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>> ![DNS server confirmed](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
 >>
->> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
+>> ![DNS server verified](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
 ///
 
@@ -119,15 +119,15 @@ A warning in the **DNS zone** tab indicates that the DNS servers used by your do
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (in which "**?**" stands for a double-digit number):
 
-![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+![OVHcloud DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
+Modify the DNS servers as described in our guide "[How to modify the DNS servers of an OVHcloud domain name](/pages/web_cloud/domains/dns_server_edit)", so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
-![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+![External DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
 > [!warning]
 >
@@ -141,7 +141,7 @@ Your website will then be available within a maximum of 48 hours.
 
 Your domain's **DNS zone** does not contain any `NS` record:
 
-![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
+![Missing NS record warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
 Click on the tabs below to view each of the **4** steps.
 
@@ -156,17 +156,17 @@ Click on the tabs below to view each of the **4** steps.
 >>
 >> Back up the current zone by clicking on the `Change in text format`{.action} button:
 >>
->> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>> ![DNS zone text format button](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
 >>
 >> Copy and paste the content of your **DNS zone** into a text document on your computer.
 >>
 > **Step 3**
 >>
->> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone.`{.action}.
 >>
 >> Select your email and hosting servers, then click on `Confirm`{.action}.
 >>
->> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>> ![DNS zone reset dialog](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
 >>
 > **Step 4**
 >>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ie.md
@@ -1,8 +1,22 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -21,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -42,7 +56,7 @@ Several error returns may appear on your browser if your website becomes inacces
 
 ## Instructions
 
-### 1: check the validity of your domain name subscription
+### 1 - Check the validity of your domain name subscription
 
 > [!warning]
 >
@@ -52,43 +66,67 @@ Several error returns may appear on your browser if your website becomes inacces
 > As a result, we strongly recommend that you enable [automatic renewal](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#instructions) for all of your OVHcloud subscriptions.
 >
 
-To check that your domain name subscription is valid, click on your name at the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then click on `My offers and services`{.action} within the right-hand menu.
+To check that your domain name subscription is valid, click on the tabs below to view each of the **3** steps.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [My offers and services](/links/control-panel/billing-services) page.
+>>
+> **Step 2**
+>>
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> After this renewal, your website will be accessible again within 48 hours maximum.
 
-Renew your domain if necessary with the `...`{.action} button, then click on `Renew service`{.action}.
+### 2 - Check the DNS servers
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+To check the validity of your [DNS servers](/pages/web_cloud/domains/dns_server_edit), go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
 
-After the renewal of your offer is completed, your website will be available within a maximum of 48 hours.
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check the DNS servers
+/// details | Scenario 1 - No anomalies appear on the DNS servers
 
-To check that your [DNS servers](/pages/web_cloud/domains/dns_server_edit) are valid, click on `Domain names`{.action} in your [OVHcloud Control Panel](/links/manager), then on your domain name.
+To check the DNS servers declared, click on the tabs below to view each of the **3** steps.
 
-#### Scenario 1: no anomalies appear on the DNS servers
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Check the servers listed in the `DNS servers`{.action} tab:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Check the servers listed in the `DNS servers`{.action} tab:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Scenario 2 - A warning appears above the DNS zone
 
-If they are identical to the targets of the `NS` type entries in the `DNS zone`{.action}, go to [step 3](#step3):
+A warning in the **DNS zone** tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
 
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Scenario 2: a warning appears above the DNS zone
-
-A warning in the `DNS zone`{.action} tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
-
-- Under the sentence "You are currently using the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
+- Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your `DNS zone`{.action}.
+Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
-- Under the sentence "You are currently using the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
+- Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
 ![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
@@ -97,33 +135,53 @@ Your website will then be available within a maximum of 48 hours.
 > In this situation, please contact your DNS Zone provider, your webmaster or a [OVHcloud partner](/links/partner) before making any changes.
 >
 > The DNS servers used by your domain name may be functional and the problem accessing your website be linked to a missing or incorrect entry in the active [DNS zone](/pages/web_cloud/domains/dns_zone_general_information). Changing the DNS servers in this situation might make your e-mail addresses or other online applications related to your domain name unavailable.
->
 
-#### Scenario 3: no NS-type entries appear in the DNS zone
+///
 
-Your domain’s `DNS zone`{.action} does not contain any `NS` record:
+/// details | Scenario 3 - No NS-type entries appear in the DNS zone
+
+Your domain's **DNS zone** does not contain any `NS` record:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Back up the current zone by clicking on the `Change in text format`{.action} button:
+Click on the tabs below to view each of the **4** steps.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Back up the current zone by clicking on the `Change in text format`{.action} button:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copy and paste the content of your **DNS zone** into a text document on your computer.
+>>
+> **Step 3**
+>>
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>>
+>> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> Your website will be accessible again within 24 hours maximum.
 
-Then copy and paste the content of your `DNS zone`{.action} into a text document on your computer.
+///
 
-Then click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}. Select your e-mail and hosting servers and click on `Confirm`{.action}.
+### 3 - Check the DNS zone <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+In this step, you will find your hosting plan's IP address, then add it to your **DNS zone**.
 
-Your website will then be available again within a maximum of 24 hours.
+If your website is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
 
-### 3: check the DNS zone <a name="step3"></a>
-
-In this step, you will find your hosting plan’s IP address, then add it to your `DNS zone`{.action}.
-
-If your site is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
-
-If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
+If your website is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
 
 > [!tabs]
 > **Step 1**
@@ -138,9 +196,9 @@ If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), c
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> In the `General information`{.action} tab, copy the IPv4 and/or IPv6 address of your domain name.
+>> Copy the IPv4 and/or IPv6 address of your domain name.
 
-Then refer to it in your domain’s [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
+Then refer to it in your domain's [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
 
 ![ipv4-DNSzone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
@@ -148,7 +206,7 @@ Your website will then be available within a maximum of 24 hours.
 
 ## Go further <a name="go-further"></a>
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-ie.md
@@ -35,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -75,7 +75,7 @@ To check that your domain name subscription is valid, click on the tabs below to
 >>
 > **Step 2**
 >>
->> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew`{.action}.
 >>
 >> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
 >>
@@ -104,13 +104,13 @@ To check the DNS servers declared, click on the tabs below to view each of the *
 >>
 >> Check the servers listed in the `DNS servers`{.action} tab:
 >>
->> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>> ![DNS server confirmed](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
 >>
->> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
+>> ![DNS server verified](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
 ///
 
@@ -120,15 +120,15 @@ A warning in the **DNS zone** tab indicates that the DNS servers used by your do
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
-![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+![OVHcloud DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
+Modify the DNS servers as described in our guide "[How to modify the DNS servers of an OVHcloud domain name](/pages/web_cloud/domains/dns_server_edit)", so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
-![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+![External DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
 > [!warning]
 >
@@ -142,7 +142,7 @@ Your website will then be available within a maximum of 48 hours.
 
 Your domain's **DNS zone** does not contain any `NS` record:
 
-![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
+![Missing NS record warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
 Click on the tabs below to view each of the **4** steps.
 
@@ -157,17 +157,17 @@ Click on the tabs below to view each of the **4** steps.
 >>
 >> Back up the current zone by clicking on the `Change in text format`{.action} button:
 >>
->> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>> ![DNS zone text format button](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
 >>
 >> Copy and paste the content of your **DNS zone** into a text document on your computer.
 >>
 > **Step 3**
 >>
->> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone.`{.action}.
 >>
->> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>> Select your email and hosting servers, then click on `Confirm`{.action}.
 >>
->> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>> ![DNS zone reset dialog](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
 >>
 > **Step 4**
 >>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-sg.md
@@ -1,8 +1,22 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -21,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -42,7 +56,7 @@ Several error returns may appear on your browser if your website becomes inacces
 
 ## Instructions
 
-### 1: check the validity of your domain name subscription
+### 1 - Check the validity of your domain name subscription
 
 > [!warning]
 >
@@ -52,43 +66,67 @@ Several error returns may appear on your browser if your website becomes inacces
 > As a result, we strongly recommend that you enable [automatic renewal](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#instructions) for all of your OVHcloud subscriptions.
 >
 
-To check that your domain name subscription is valid, click on your name at the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then click on `My offers and services`{.action} within the right-hand menu.
+To check that your domain name subscription is valid, click on the tabs below to view each of the **3** steps.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [My offers and services](/links/control-panel/billing-services) page.
+>>
+> **Step 2**
+>>
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> After this renewal, your website will be accessible again within 48 hours maximum.
 
-Renew your domain if necessary with the `...`{.action} button, then click on `Renew service`{.action}.
+### 2 - Check the DNS servers
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+To check the validity of your [DNS servers](/pages/web_cloud/domains/dns_server_edit), go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
 
-After the renewal of your offer is completed, your website will be available within a maximum of 48 hours.
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check the DNS servers
+/// details | Scenario 1 - No anomalies appear on the DNS servers
 
-To check that your [DNS servers](/pages/web_cloud/domains/dns_server_edit) are valid, click on `Domain names`{.action} in your [OVHcloud Control Panel](/links/manager), then on your domain name.
+To check the DNS servers declared, click on the tabs below to view each of the **3** steps.
 
-#### Scenario 1: no anomalies appear on the DNS servers
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Check the servers listed in the `DNS servers`{.action} tab:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Check the servers listed in the `DNS servers`{.action} tab:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Scenario 2 - A warning appears above the DNS zone
 
-If they are identical to the targets of the `NS` type entries in the `DNS zone`{.action}, go to [step 3](#step3):
+A warning in the **DNS zone** tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
 
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Scenario 2: a warning appears above the DNS zone
-
-A warning in the `DNS zone`{.action} tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
-
-- Under the sentence "You are currently using the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
+- Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your `DNS zone`{.action}.
+Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
-- Under the sentence "You are currently using the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
+- Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
 ![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
@@ -97,33 +135,53 @@ Your website will then be available within a maximum of 48 hours.
 > In this situation, please contact your DNS Zone provider, your webmaster or a [OVHcloud partner](/links/partner) before making any changes.
 >
 > The DNS servers used by your domain name may be functional and the problem accessing your website be linked to a missing or incorrect entry in the active [DNS zone](/pages/web_cloud/domains/dns_zone_general_information). Changing the DNS servers in this situation might make your e-mail addresses or other online applications related to your domain name unavailable.
->
 
-#### Scenario 3: no NS-type entries appear in the DNS zone
+///
 
-Your domain’s `DNS zone`{.action} does not contain any `NS` record:
+/// details | Scenario 3 - No NS-type entries appear in the DNS zone
+
+Your domain's **DNS zone** does not contain any `NS` record:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Back up the current zone by clicking on the `Change in text format`{.action} button:
+Click on the tabs below to view each of the **4** steps.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Back up the current zone by clicking on the `Change in text format`{.action} button:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copy and paste the content of your **DNS zone** into a text document on your computer.
+>>
+> **Step 3**
+>>
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>>
+>> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> Your website will be accessible again within 24 hours maximum.
 
-Then copy and paste the content of your `DNS zone`{.action} into a text document on your computer.
+///
 
-Then click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}. Select your e-mail and hosting servers and click on `Confirm`{.action}.
+### 3 - Check the DNS zone <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+In this step, you will find your hosting plan's IP address, then add it to your **DNS zone**.
 
-Your website will then be available again within a maximum of 24 hours.
+If your website is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
 
-### 3: check the DNS zone <a name="step3"></a>
-
-In this step, you will find your hosting plan’s IP address, then add it to your `DNS zone`{.action}.
-
-If your site is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
-
-If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
+If your website is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
 
 > [!tabs]
 > **Step 1**
@@ -138,9 +196,9 @@ If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), c
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> In the `General information`{.action} tab, copy the IPv4 and/or IPv6 address of your domain name.
+>> Copy the IPv4 and/or IPv6 address of your domain name.
 
-Then refer to it in your domain’s [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
+Then refer to it in your domain's [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
 
 ![ipv4-DNSzone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
@@ -148,7 +206,7 @@ Your website will then be available within a maximum of 24 hours.
 
 ## Go further <a name="go-further"></a>
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-sg.md
@@ -35,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -75,7 +75,7 @@ To check that your domain name subscription is valid, click on the tabs below to
 >>
 > **Step 2**
 >>
->> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew`{.action}.
 >>
 >> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
 >>
@@ -104,13 +104,13 @@ To check the DNS servers declared, click on the tabs below to view each of the *
 >>
 >> Check the servers listed in the `DNS servers`{.action} tab:
 >>
->> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>> ![DNS server confirmed](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
 >>
->> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
+>> ![DNS server verified](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
 ///
 
@@ -120,15 +120,15 @@ A warning in the **DNS zone** tab indicates that the DNS servers used by your do
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
-![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+![OVHcloud DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
+Modify the DNS servers as described in our guide "[How to modify the DNS servers of an OVHcloud domain name](/pages/web_cloud/domains/dns_server_edit)", so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
-![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+![External DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
 > [!warning]
 >
@@ -142,7 +142,7 @@ Your website will then be available within a maximum of 48 hours.
 
 Your domain's **DNS zone** does not contain any `NS` record:
 
-![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
+![Missing NS record warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
 Click on the tabs below to view each of the **4** steps.
 
@@ -157,17 +157,17 @@ Click on the tabs below to view each of the **4** steps.
 >>
 >> Back up the current zone by clicking on the `Change in text format`{.action} button:
 >>
->> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>> ![DNS zone text format button](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
 >>
 >> Copy and paste the content of your **DNS zone** into a text document on your computer.
 >>
 > **Step 3**
 >>
->> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone.`{.action}.
 >>
->> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>> Select your email and hosting servers, then click on `Confirm`{.action}.
 >>
->> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>> ![DNS zone reset dialog](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
 >>
 > **Step 4**
 >>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-us.md
@@ -1,8 +1,22 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -21,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -42,7 +56,7 @@ Several error returns may appear on your browser if your website becomes inacces
 
 ## Instructions
 
-### 1: check the validity of your domain name subscription
+### 1 - Check the validity of your domain name subscription
 
 > [!warning]
 >
@@ -52,43 +66,67 @@ Several error returns may appear on your browser if your website becomes inacces
 > As a result, we strongly recommend that you enable [automatic renewal](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#instructions) for all of your OVHcloud subscriptions.
 >
 
-To check that your domain name subscription is valid, click on your name at the top right-hand corner of your [OVHcloud Control Panel](/links/manager), then click on `My offers and services`{.action} within the right-hand menu.
+To check that your domain name subscription is valid, click on the tabs below to view each of the **3** steps.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [My offers and services](/links/control-panel/billing-services) page.
+>>
+> **Step 2**
+>>
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> After this renewal, your website will be accessible again within 48 hours maximum.
 
-Renew your domain if necessary with the `...`{.action} button, then click on `Renew service`{.action}.
+### 2 - Check the DNS servers
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+To check the validity of your [DNS servers](/pages/web_cloud/domains/dns_server_edit), go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
 
-After the renewal of your offer is completed, your website will be available within a maximum of 48 hours.
+**Click on the scenario that matches your situation to view the content.**
 
-### 2: check the DNS servers
+/// details | Scenario 1 - No anomalies appear on the DNS servers
 
-To check that your [DNS servers](/pages/web_cloud/domains/dns_server_edit) are valid, click on `Domain names`{.action} in your [OVHcloud Control Panel](/links/manager), then on your domain name.
+To check the DNS servers declared, click on the tabs below to view each of the **3** steps.
 
-#### Scenario 1: no anomalies appear on the DNS servers
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Domain names](/links/control-panel/web-domains) page, then select the domain name concerned.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Check the servers listed in the `DNS servers`{.action} tab:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Check the servers listed in the `DNS servers`{.action} tab:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Scenario 2 - A warning appears above the DNS zone
 
-If they are identical to the targets of the `NS` type entries in the `DNS zone`{.action}, go to [step 3](#step3):
+A warning in the **DNS zone** tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
 
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Scenario 2: a warning appears above the DNS zone
-
-A warning in the `DNS zone`{.action} tab indicates that the DNS servers used by your domain name are not the ones indicated in your [DNS zone](/pages/web_cloud/domains/dns_zone_edit). Two scenarios are possible:
-
-- Under the sentence "You are currently using the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
+- Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your `DNS zone`{.action}.
+Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
-- Under the sentence "You are currently using the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
+- Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
 ![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
@@ -97,33 +135,53 @@ Your website will then be available within a maximum of 48 hours.
 > In this situation, please contact your DNS Zone provider, your webmaster or a [OVHcloud partner](/links/partner) before making any changes.
 >
 > The DNS servers used by your domain name may be functional and the problem accessing your website be linked to a missing or incorrect entry in the active [DNS zone](/pages/web_cloud/domains/dns_zone_general_information). Changing the DNS servers in this situation might make your e-mail addresses or other online applications related to your domain name unavailable.
->
 
-#### Scenario 3: no NS-type entries appear in the DNS zone
+///
 
-Your domain’s `DNS zone`{.action} does not contain any `NS` record:
+/// details | Scenario 3 - No NS-type entries appear in the DNS zone
+
+Your domain's **DNS zone** does not contain any `NS` record:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Back up the current zone by clicking on the `Change in text format`{.action} button:
+Click on the tabs below to view each of the **4** steps.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Back up the current zone by clicking on the `Change in text format`{.action} button:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copy and paste the content of your **DNS zone** into a text document on your computer.
+>>
+> **Step 3**
+>>
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>>
+>> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Step 4**
+>>
+>> Your website will be accessible again within 24 hours maximum.
 
-Then copy and paste the content of your `DNS zone`{.action} into a text document on your computer.
+///
 
-Then click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}. Select your e-mail and hosting servers and click on `Confirm`{.action}.
+### 3 - Check the DNS zone <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+In this step, you will find your hosting plan's IP address, then add it to your **DNS zone**.
 
-Your website will then be available again within a maximum of 24 hours.
+If your website is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
 
-### 3: check the DNS zone <a name="step3"></a>
-
-In this step, you will find your hosting plan’s IP address, then add it to your `DNS zone`{.action}.
-
-If your site is not hosted on the OVHcloud infrastructure or is managed by another provider, please contact the concerned support service.
-
-If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
+If your website is hosted on one of our [Web Hosting offers](/links/web/hosting), click on the tabs below to view each of the **2** steps.
 
 > [!tabs]
 > **Step 1**
@@ -138,9 +196,9 @@ If your site is hosted on one of our [Web Hosting offers](/links/web/hosting), c
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> In the `General information`{.action} tab, copy the IPv4 and/or IPv6 address of your domain name.
+>> Copy the IPv4 and/or IPv6 address of your domain name.
 
-Then refer to it in your domain’s [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
+Then refer to it in your domain's [DNS zone](/pages/web_cloud/domains/dns_zone_edit), by modifying or creating one or more `A` entries.
 
 ![ipv4-DNSzone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
@@ -148,7 +206,7 @@ Your website will then be available within a maximum of 24 hours.
 
 ## Go further <a name="go-further"></a>
 
-[Resolving a “Site not installed” error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolving a "Site not installed" error](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Fixing the 500 Internal Server Error](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: What do I do if my website is down?
 excerpt: Diagnose the causes of the inaccessibility of your web site
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.en-us.md
@@ -35,7 +35,7 @@ Several error returns may appear on your browser if your website becomes inacces
 >
 > OVHcloud provides services which you are responsible for with regard to their configuration and management. You are therefore responsible for ensuring they function correctly.
 >
-> We have provided you with this guide in order to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
+> We have provided you with this guide to help you with common tasks. Nevertheless, we recommend contacting a specialist provider and/or the service's software publisher if you encounter any difficulties. We will not be able to assist you ourselves. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -75,7 +75,7 @@ To check that your domain name subscription is valid, click on the tabs below to
 >>
 > **Step 2**
 >>
->> Renew your domain if necessary via the `...`{.action} button, then `Renew service`{.action}.
+>> Renew your domain if necessary via the `...`{.action} button, then `Renew`{.action}.
 >>
 >> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
 >>
@@ -104,13 +104,13 @@ To check the DNS servers declared, click on the tabs below to view each of the *
 >>
 >> Check the servers listed in the `DNS servers`{.action} tab:
 >>
->> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>> ![DNS server confirmed](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
 >>
 > **Step 3**
 >>
 >> If they are identical to the targets of the `NS` type entries in the **DNS zone**, go to [part 3](#step3):
 >>
->> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
+>> ![DNS server verified](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
 ///
 
@@ -120,15 +120,15 @@ A warning in the **DNS zone** tab indicates that the DNS servers used by your do
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are "ns **?** .ovh.net" and "dns **?** .ovh.net" (replace the "**?**" by any number):
 
-![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
+![OVHcloud DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modify the DNS servers as described in [this guide](/pages/web_cloud/domains/dns_server_edit), so that they are identical to the targets of the `NS` type records in your **DNS zone**.
+Modify the DNS servers as described in our guide "[How to modify the DNS servers of an OVHcloud domain name](/pages/web_cloud/domains/dns_server_edit)", so that they are identical to the targets of the `NS` type records in your **DNS zone**.
 
 Your website will then be available within a maximum of 48 hours.
 
 - Under the sentence "You currently use the following DNS servers", the servers listed are not "ns **?** .ovh.net" and "dns **?** .ovh.net".
 
-![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
+![External DNS server warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
 > [!warning]
 >
@@ -142,7 +142,7 @@ Your website will then be available within a maximum of 48 hours.
 
 Your domain's **DNS zone** does not contain any `NS` record:
 
-![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
+![Missing NS record warning](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
 Click on the tabs below to view each of the **4** steps.
 
@@ -157,17 +157,17 @@ Click on the tabs below to view each of the **4** steps.
 >>
 >> Back up the current zone by clicking on the `Change in text format`{.action} button:
 >>
->> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>> ![DNS zone text format button](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
 >>
 >> Copy and paste the content of your **DNS zone** into a text document on your computer.
 >>
 > **Step 3**
 >>
->> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone`{.action}.
+>> Click on `Reset my DNS zone`{.action} and select `No, but I want to reset my DNS zone.`{.action}.
 >>
->> Select your e-mail and hosting servers, then click on `Confirm`{.action}.
+>> Select your email and hosting servers, then click on `Confirm`{.action}.
 >>
->> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>> ![DNS zone reset dialog](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
 >>
 > **Step 4**
 >>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "¿Qué hacer si mi sitio web no está accesible?"
 excerpt: "Diagnóstico de las causas de la inaccesibilidad de su sitio web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.es-es.md
@@ -1,8 +1,22 @@
 ---
 title: "¿Qué hacer si mi sitio web no está accesible?"
 excerpt: "Diagnóstico de las causas de la inaccesibilidad de su sitio web"
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo
 
@@ -34,7 +48,7 @@ En caso de que su sitio web no sea accesible, pueden aparecer varios errores en 
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -42,7 +56,7 @@ En caso de que su sitio web no sea accesible, pueden aparecer varios errores en 
 
 ## Procedimiento
 
-### 1: Comprobar la validez de su dominio
+### 1 - Comprobar la validez de su dominio
 
 > [!warning]
 >
@@ -52,39 +66,63 @@ En caso de que su sitio web no sea accesible, pueden aparecer varios errores en 
 > Por lo tanto, le recomendamos que active la [renovación automática](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#procedimiento) en todas sus suscripciones de OVHcloud.
 >
 
-Para comprobar la validez de la suscripción relativa a su nombre de dominio, haga clic en su nombre en la esquina superior derecha del [área de cliente de OVHcloud](/links/manager) y seleccione `Mis soluciones y servicios`{.action}.
+Para comprobar la validez de la suscripción relativa a su nombre de dominio, haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Mis soluciones y servicios](/links/control-panel/billing-services).
+>>
+> **Etapa 2**
+>>
+>> Renueve su dominio si es necesario a través del botón `...`{.action} y luego `Renovar el servicio`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Una vez completada la renovación, su sitio web estará disponible en un plazo máximo de 48 horas.
 
-Renueve su dominio si es necesario a través del botón `...`{.action} a la derecha de la pantalla y luego `Renovar el servicio`{.action}.
+### 2 - Comprobar los servidores DNS
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+Para comprobar la validez de sus [servidores DNS](/pages/web_cloud/domains/dns_server_edit), acceda a la página [Dominios](/links/control-panel/web-domains) y seleccione el dominio correspondiente.
 
-Una vez completada la renovación del plan, su sitio web estará disponible en un plazo máximo de 48 horas.
+**Haga clic en la situación correspondiente a su caso para ver el contenido.**
 
-### 2: Comprobar los servidores DNS
+/// details | Situación 1 - No hay anomalías en los servidores DNS
 
-Para comprobar la validez de sus [servidores DNS](/pages/web_cloud/domains/dns_server_edit), haga clic en [área de cliente de OVHcloud](/links/manager) y seleccione el dominio del `Dominios`{.action}.
+Para comprobar los servidores DNS declarados, haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
-#### Situación 1: No hay anomalías en los servidores DNS
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Dominios](/links/control-panel/web-domains) y seleccione el dominio correspondiente.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Compruebe los servidores indicados en la pestaña `Servidores DNS`{.action}:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Si son idénticos a los objetivos de las entradas de tipo `NS` en la **Zona DNS**, vaya a la [parte 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Compruebe los servidores indicados en la pestaña `Servidores DNS`{.action}:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Situación 2 - Aparecerá un aviso por encima de la zona DNS
 
-Si son idénticos a los objetivos de las entradas de tipo `NS` en la `Zona DNS`{.action}, vaya al [Etapa 3](#step3):
-
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Situación 2: Aparecerá un aviso por encima de la zona DNS
-
-Una advertencia en la pestaña `Zona DNS`{.action} indica que los servidores DNS utilizados por su dominio no son los indicados en su zona. Existen dos posibles situaciones:
+Una advertencia en la pestaña **Zona DNS** indica que los servidores DNS utilizados por su dominio no son los indicados en su zona. Existen dos posibles situaciones:
 
 - Bajo la frase "Actualmente utiliza los siguientes servidores DNS:", los servidores indicados son del tipo "ns **?** .ovh.net" y "dns **?** .ovh.net" (sustituya "**?**" por cualquier número):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modifique los servidores DNS siguiendo las instrucciones de [esta guía](/pages/web_cloud/domains/dns_server_edit) para que sean idénticos a los objetivos de los registros de tipo `NS` en la `Zona DNS`{.action}.
+Modifique los servidores DNS siguiendo las instrucciones de [esta guía](/pages/web_cloud/domains/dns_server_edit) para que sean idénticos a los objetivos de los registros de tipo `NS` en la **Zona DNS**.
 
 Su sitio web estará disponible en un plazo máximo de 48 horas.
 
@@ -97,29 +135,49 @@ Su sitio web estará disponible en un plazo máximo de 48 horas.
 > En ese caso, contacte con el proveedor de hosting de su zona DNS, su webmaster o los [partners de OVHcloud](/links/partner) antes de realizar cualquier operación.
 >
 > Es posible que los servidores DNS utilizados por el dominio sean funcionales y que el problema de acceso al sitio web esté relacionado con un registro que no se encuentra o que no está en la [zona DNS](/pages/web_cloud/domains/dns_zone_general_information). Cualquier modificación de los servidores DNS en esta situación puede hacer que sus direcciones de correo u otras aplicaciones en línea no estén disponibles.
->
 
-#### Situación 3: No aparece ningún registro de tipo NS en la zona DNS
+///
 
-La `Zona DNS`{.action} de su dominio no contiene ningún registro de tipo `NS`:
+/// details | Situación 3 - No aparece ningún registro de tipo NS en la zona DNS
+
+La **Zona DNS** de su dominio no contiene ningún registro de tipo `NS`:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Haga una copia de seguridad del área actual haciendo clic en el botón `Editar en modo de texto`{.action} situado a la derecha de su pantalla:
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Zonas DNS](/links/control-panel/web-dns-zone) y seleccione el dominio correspondiente.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga una copia de seguridad de la zona actual haciendo clic en el botón `Editar en modo de texto`{.action}:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copie y pegue el contenido de su **Zona DNS** en un documento de texto. Guarde el documento de forma local.
+>>
+> **Etapa 3**
+>>
+>> Haga clic en `Restaurar mi zona DNS`{.action} y seleccione `No, pero quiero restaurar la zona DNS.`{.action}.
+>>
+>> Indique los servidores de correo y de alojamiento y haga clic en `Aceptar`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Etapa 4**
+>>
+>> Su sitio web estará disponible en un plazo máximo de 24 horas.
 
-Copie y pegue el contenido de su `Zona DNS`{.action} en un documento de texto. Guarde el documento de forma local.
+///
 
-A continuación, haga clic en `Restaurar mi zona DNS`{.action} y seleccione `No, pero quiero restaurar la zona DNS.`{.action}. Indique los servidores de correo y de alojamiento y haga clic en `Aceptar`{.action}.
+### 3 - Comprobar la zona DNS <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
-
-Su sitio web estará disponible en un plazo máximo de 24 horas.
-
-### 3: Comprobar la zona DNS <a name="step3"></a>
-
-En esta etapa, accederá a la dirección IP de su alojamiento y la añadirá a su `Zona DNS`{.action}.
+En esta etapa, accederá a la dirección IP de su alojamiento y la añadirá a su **Zona DNS**.
 
 Si su sitio web no está alojado en la infraestructura de OVHcloud o si está gestionado por otro proveedor, contacte con el servicio de soporte correspondiente.
 
@@ -128,7 +186,7 @@ Si su sitio web está alojado en uno de nuestros [planes de hosting](/links/web/
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -138,7 +196,7 @@ Si su sitio web está alojado en uno de nuestros [planes de hosting](/links/web/
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> Copie la dirección IPV4 y/o IPV6 de su dominio.
+>> Copie la dirección IPv4 y/o IPv6 de su dominio.
 
 A continuación, cópiela en la [zona DNS](/pages/web_cloud/domains/dns_zone_edit) de su dominio modificando o creando uno o más registros de tipo `A`.
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "¿Qué hacer si mi sitio web no está accesible?"
 excerpt: "Diagnóstico de las causas de la inaccesibilidad de su sitio web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.es-us.md
@@ -1,8 +1,22 @@
 ---
 title: "¿Qué hacer si mi sitio web no está accesible?"
 excerpt: "Diagnóstico de las causas de la inaccesibilidad de su sitio web"
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo
 
@@ -34,7 +48,7 @@ En caso de que su sitio web no sea accesible, pueden aparecer varios errores en 
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -42,7 +56,7 @@ En caso de que su sitio web no sea accesible, pueden aparecer varios errores en 
 
 ## Procedimiento
 
-### 1: Comprobar la validez de su dominio
+### 1 - Comprobar la validez de su dominio
 
 > [!warning]
 >
@@ -52,39 +66,63 @@ En caso de que su sitio web no sea accesible, pueden aparecer varios errores en 
 > Por lo tanto, le recomendamos que active la [renovación automática](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#procedimiento) en todas sus suscripciones de OVHcloud.
 >
 
-Para comprobar la validez de la suscripción relativa a su nombre de dominio, haga clic en su nombre en la esquina superior derecha del [área de cliente de OVHcloud](/links/manager) y seleccione `Mis soluciones y servicios`{.action}.
+Para comprobar la validez de la suscripción relativa a su nombre de dominio, haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Mis soluciones y servicios](/links/control-panel/billing-services).
+>>
+> **Etapa 2**
+>>
+>> Renueve su dominio si es necesario a través del botón `...`{.action} y luego `Renovar el servicio`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Una vez completada la renovación, su sitio web estará disponible en un plazo máximo de 48 horas.
 
-Renueve su dominio si es necesario a través del botón `...`{.action} a la derecha de la pantalla y luego `Renovar el servicio`{.action}.
+### 2 - Comprobar los servidores DNS
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+Para comprobar la validez de sus [servidores DNS](/pages/web_cloud/domains/dns_server_edit), acceda a la página [Dominios](/links/control-panel/web-domains) y seleccione el dominio correspondiente.
 
-Una vez completada la renovación del plan, su sitio web estará disponible en un plazo máximo de 48 horas.
+**Haga clic en la situación correspondiente a su caso para ver el contenido.**
 
-### 2: Comprobar los servidores DNS
+/// details | Situación 1 - No hay anomalías en los servidores DNS
 
-Para comprobar la validez de sus [servidores DNS](/pages/web_cloud/domains/dns_server_edit), haga clic en [área de cliente de OVHcloud](/links/manager) y seleccione el dominio en la parte del `Dominios`{.action}.
+Para comprobar los servidores DNS declarados, haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
-#### Situación 1: No hay anomalías en los servidores DNS
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Dominios](/links/control-panel/web-domains) y seleccione el dominio correspondiente.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Compruebe los servidores indicados en la pestaña `Servidores DNS`{.action}:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Si son idénticos a los objetivos de las entradas de tipo `NS` en la **Zona DNS**, vaya a la [parte 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Compruebe los servidores indicados en la pestaña `Servidores DNS`{.action}:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Situación 2 - Aparecerá un aviso por encima de la zona DNS
 
-Si son idénticos a los objetivos de las entradas de tipo `NS` en la `Zona DNS`{.action}, vaya al [Etapa 3](#step3):
-
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Situación 2: Aparecerá un aviso por encima de la zona DNS
-
-Una advertencia en la pestaña `Zona DNS`{.action} indica que los servidores DNS utilizados por su dominio no son los indicados en su zona. Existen dos posibles situaciones:
+Una advertencia en la pestaña **Zona DNS** indica que los servidores DNS utilizados por su dominio no son los indicados en su zona. Existen dos posibles situaciones:
 
 - Bajo la frase "Actualmente utiliza los siguientes servidores DNS:", los servidores indicados son del tipo "ns **?** .ovh.net" y "dns **?** .ovh.net" (sustituya "**?**" por cualquier número):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modifique los servidores DNS siguiendo las instrucciones de [esta guía](/pages/web_cloud/domains/dns_server_edit) para que sean idénticos a los objetivos de los registros de tipo `NS` en la `Zona DNS`{.action}.
+Modifique los servidores DNS siguiendo las instrucciones de [esta guía](/pages/web_cloud/domains/dns_server_edit) para que sean idénticos a los objetivos de los registros de tipo `NS` en la **Zona DNS**.
 
 Su sitio web estará disponible en un plazo máximo de 48 horas.
 
@@ -97,29 +135,49 @@ Su sitio web estará disponible en un plazo máximo de 48 horas.
 > En ese caso, contacte con el proveedor de hosting de su zona DNS, su webmaster o los [partners de OVHcloud](/links/partner) antes de realizar cualquier operación.
 >
 > Es posible que los servidores DNS utilizados por el dominio sean funcionales y que el problema de acceso al sitio web esté relacionado con un registro que no se encuentra o que no está en la [zona DNS](/pages/web_cloud/domains/dns_zone_general_information). Cualquier modificación de los servidores DNS en esta situación puede hacer que sus direcciones de correo u otras aplicaciones en línea no estén disponibles.
->
 
-#### Situación 3: No aparece ningún registro de tipo NS en la zona DNS
+///
 
-La `Zona DNS`{.action} de su dominio no contiene ningún registro de tipo `NS`:
+/// details | Situación 3 - No aparece ningún registro de tipo NS en la zona DNS
+
+La **Zona DNS** de su dominio no contiene ningún registro de tipo `NS`:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Haga una copia de seguridad del área actual haciendo clic en el botón `Editar en modo de texto`{.action} situado a la derecha de su pantalla:
+Haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Zonas DNS](/links/control-panel/web-dns-zone) y seleccione el dominio correspondiente.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga una copia de seguridad de la zona actual haciendo clic en el botón `Editar en modo de texto`{.action}:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copie y pegue el contenido de su **Zona DNS** en un documento de texto. Guarde el documento de forma local.
+>>
+> **Etapa 3**
+>>
+>> Haga clic en `Restaurar mi zona DNS`{.action} y seleccione `No, pero quiero restaurar la zona DNS.`{.action}.
+>>
+>> Indique los servidores de correo y de alojamiento y haga clic en `Aceptar`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Etapa 4**
+>>
+>> Su sitio web estará disponible en un plazo máximo de 24 horas.
 
-Copie y pegue el contenido de su `Zona DNS`{.action} en un documento de texto. Guarde el documento de forma local.
+///
 
-A continuación, haga clic en `Restaurar mi zona DNS`{.action} y seleccione `No, pero quiero restaurar la zona DNS.`{.action}. Indique los servidores de correo y de alojamiento y haga clic en `Aceptar`{.action}.
+### 3 - Comprobar la zona DNS <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
-
-Su sitio web estará disponible en un plazo máximo de 24 horas.
-
-### 3: Comprobar la zona DNS <a name="step3"></a>
-
-En esta etapa, accederá a la dirección IP de su alojamiento y la añadirá a su `Zona DNS`{.action}.
+En esta etapa, accederá a la dirección IP de su alojamiento y la añadirá a su **Zona DNS**.
 
 Si su sitio web no está alojado en la infraestructura de OVHcloud o si está gestionado por otro proveedor, contacte con el servicio de soporte correspondiente.
 
@@ -128,7 +186,7 @@ Si su sitio web está alojado en uno de nuestros [planes de hosting](/links/web/
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -138,7 +196,7 @@ Si su sitio web está alojado en uno de nuestros [planes de hosting](/links/web/
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> Copie la dirección IPV4 y/o IPV6 de su dominio.
+>> Copie la dirección IPv4 y/o IPv6 de su dominio.
 
 A continuación, cópiela en la [zona DNS](/pages/web_cloud/domains/dns_zone_edit) de su dominio modificando o creando uno o más registros de tipo `A`.
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-ca.md
@@ -1,8 +1,22 @@
 ---
 title: "Que faire si mon site est inaccessible ?"
 excerpt: "Diagnostiquez les causes de l'inaccessibilité de votre site"
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objectif
 
@@ -12,7 +26,7 @@ Plusieurs retours d'erreur peuvent apparaître sur votre navigateur en cas d'ina
 |-|---|
 |Chrome :<br>« Ce site est inaccessible »|![cantbereached_chrome](/pages/assets/screens/other/browsers/errors/cant-be-reached-chrome.png){.thumbnail}|
 |Firefox :<br>« Hum, nous ne parvenons pas à trouver ce site. »|![cantbereached_firefox](/pages/assets/screens/other/browsers/errors/cant-be-reached-firefox.png){.thumbnail}|
-|Edge :<br>« Désolé, impossible d’accéder à cette page »|![cantbereached_edge](/pages/assets/screens/other/browsers/errors/cant-be-reached-edge.png){.thumbnail}|
+|Edge :<br>« Désolé, impossible d'accéder à cette page »|![cantbereached_edge](/pages/assets/screens/other/browsers/errors/cant-be-reached-edge.png){.thumbnail}|
 |Safari :<br>« Safari ne parvient pas à trouver le serveur »|![cantbereached_safari](/pages/assets/screens/other/browsers/errors/cant-be-reached-safari.png){.thumbnail}|
 
 **Découvrez comment résoudre les erreurs du type "Ce site est inaccessible"**
@@ -42,7 +56,7 @@ Plusieurs retours d'erreur peuvent apparaître sur votre navigateur en cas d'ina
 
 ## En pratique
 
-### 1 : Vérifier la validité de votre nom de domaine
+### 1 - Vérifier la validité de votre nom de domaine
 
 > [!warning]
 >
@@ -52,39 +66,63 @@ Plusieurs retours d'erreur peuvent apparaître sur votre navigateur en cas d'ina
 > De ce fait, nous vous recommandons fortement d'activer le [renouvellement automatique](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#en-pratique) sur l'ensemble de vos abonnements OVHcloud.
 >
 
-Pour vérifier la validité de l'abonnement relatif à votre nom de domaine, cliquez sur votre nom en haut à droite de votre [espace client](/links/manager), afin de faire apparaître le menu contextuel, puis sur `Mes offres & services`{.action}.
+Pour vérifier la validité de l'abonnement relatif à votre nom de domaine, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Mes offres et services](/links/control-panel/billing-services).
+>>
+> **Étape 2**
+>>
+>> Renouvelez votre domaine si nécessaire via le bouton `...`{.action} à droite de l'écran, puis `Renouveler le service`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Étape 3**
+>>
+>> Suite à ce renouvellement, votre site sera accessible sous 48 heures maximum.
 
-Renouvelez votre domaine si nécessaire via le bouton `...`{.action} à droite de l'écran, puis `Renouveler le service`{.action}.
+### 2 - Vérifier les serveurs DNS
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+Pour vérifier la validité de vos [serveurs DNS](/pages/web_cloud/domains/dns_server_edit), accédez à la page [Noms de domaine](/links/control-panel/web-domains), puis choisissez le nom de domaine concerné.
 
-Suite à ce renouvellement, votre site sera accessible sous 48 heures maximum.
+**Cliquez sur le scénario correspondant à votre situation pour afficher le contenu.**
 
-### 2 : Vérifier les serveurs DNS
+/// details | Scénario 1 - Aucune anomalie sur les serveurs DNS
 
-Pour vérifier la validité de vos [serveurs DNS](/pages/web_cloud/domains/dns_server_edit), dans votre [espace client OVHcloud](/links/manager) cliquez sur `Noms de domaine`{.action}, puis sur le domaine de votre site.
+Pour vérifier les serveurs DNS déclarés, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-#### Scénario 1 : Aucune anomalie sur les serveurs DNS
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Noms de domaine](/links/control-panel/web-domains), puis choisissez le nom de domaine concerné.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Vérifiez les serveurs indiqués dans l'onglet `Serveurs DNS`{.action} :
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Étape 3**
+>>
+>> S'ils sont identiques aux cibles des entrées de type `NS` dans la **Zone DNS**, passez à la [partie 3](#etape3) :
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Vérifiez les serveurs indiqués dans l'onglet `Serveurs DNS`{.action} :
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Scénario 2 - Un avertissement apparaît au-dessus de la zone DNS
 
-S'ils sont identiques aux cibles des entrées de type `NS` dans la `Zone DNS`{.action}, passez à [l'étape 3](#etape3) :
-
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Scénario 2 : Un avertissement apparaît au-dessus de la zone DNS
-
-Un avertissement dans l'onglet `Zone DNS`{.action} indique que les serveurs DNS utilisés par votre domaine ne sont pas ceux indiqués dans votre zone. Deux scénarios sont ici possibles :
+Un avertissement dans l'onglet **Zone DNS** indique que les serveurs DNS utilisés par votre domaine ne sont pas ceux indiqués dans votre zone. Deux scénarios sont ici possibles :
 
 - Sous la phrase « Vous utilisez actuellement les serveurs DNS suivants : », les serveurs indiqués sont du type « ns **?** .ovh.net » et « dns **?** .ovh.net » (remplacez le « **?** » par n'importe quel numéro) :
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modifiez les serveurs DNS en suivant les instructions de [ce guide](/pages/web_cloud/domains/dns_server_edit), afin qu'ils soient identiques aux cibles des entrées de type `NS` dans la `Zone DNS`{.action}.
+Modifiez les serveurs DNS en suivant les instructions de [ce guide](/pages/web_cloud/domains/dns_server_edit), afin qu'ils soient identiques aux cibles des entrées de type `NS` dans la **Zone DNS**.
 
 Votre site sera de nouveau accessible sous 48 heures maximum.
 
@@ -97,33 +135,53 @@ Votre site sera de nouveau accessible sous 48 heures maximum.
 > Dans cette situation, contactez l'hébergeur de votre Zone DNS, votre webmaster ou les [partenaires OVHcloud](/links/partner) avant toute manipulation.
 >
 > Il est en effet possible que les serveurs DNS utilisés par votre nom de domaine soient fonctionnels et que le problème d'accès à votre site soit lié à une entrée manquante ou erronée dans la [zone DNS](/pages/web_cloud/domains/dns_zone_general_information). Toute modification des serveurs DNS dans cette situation peut rendre vos adresses e-mails ou d'autres applications en ligne indisponibles.
->
 
-#### Scénario 3 : Aucune entrée de type NS n'apparaît dans la zone DNS
+///
 
-La `Zone DNS`{.action} de votre domaine ne contient pas d'entrée de type `NS` :
+/// details | Scénario 3 - Aucune entrée de type NS n'apparaît dans la zone DNS
+
+La **Zone DNS** de votre domaine ne contient pas d'entrée de type `NS` :
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Effectuez une sauvegarde de la zone actuelle en cliquant sur le bouton `Modifier en mode textuel`{.action} à droite de votre écran :
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4** étapes.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Zones DNS](/links/control-panel/web-dns-zone), puis choisissez le nom de domaine concerné.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Effectuez une sauvegarde de la zone actuelle en cliquant sur le bouton `Modifier en mode textuel`{.action} à droite de votre écran :
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copiez/collez le contenu de votre **Zone DNS** dans un document texte. Enregistrez localement ce document.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur `Réinitialiser ma zone DNS`{.action}, puis sélectionnez `Non, mais je veux réinitialiser ma zone DNS`{.action}.
+>>
+>> Indiquez vos serveurs e-mail et d'hébergement, puis cliquez sur `Valider`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Étape 4**
+>>
+>> Votre site sera de nouveau accessible sous 24 heures maximum.
 
-Puis copiez/collez le contenu de votre `Zone DNS`{.action} dans un document texte. Enregistrez localement ce document.
+///
 
-Cliquez ensuite sur `Réinitialiser ma zone DNS`{.action}, puis sélectionnez `Non, mais je veux réinitialiser ma zone DNS`{.action}, indiquez vos serveurs e-mail et d'hébergement et cliquez sur `Valider`{.action}.
+### 3 - Vérifier la zone DNS <a name="etape3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+Dans cette étape, vous allez retrouver l'adresse IP de votre hébergement, puis l'ajouter à votre **Zone DNS**.
 
-Votre site sera de nouveau accessible sous 24 heures maximum.
+Si votre site web est hébergé en dehors de l'infrastructure OVHcloud ou géré par une tierce personne, contactez l'hébergeur ou le prestataire concerné.
 
-### 3 : Vérifier la zone DNS <a name="etape3"></a>
-
-Dans cette étape, vous allez retrouver l'adresse IP de votre hébergement, puis l'ajouter à votre `Zone DNS`{.action}.
-
-Si votre site est hébergé en dehors de l'infrastructure OVHcloud ou géré par une tierce personne, contactez l'hébergeur ou le prestataire concerné.
-
-Si votre site est hébergé sur l'une de nos [offres d'hébergement web](/links/web/hosting), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+Si votre site web est hébergé sur l'une de nos [offres d'hébergement web](/links/web/hosting), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
 > [!tabs]
 > **Étape 1**
@@ -138,9 +196,9 @@ Si votre site est hébergé sur l'une de nos [offres d'hébergement web](/links/
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> Copiez l'adresse IPV4 et/ou IPV6 de votre domaine.
+>> Copiez l'adresse IPv4 et/ou IPv6 de votre nom de domaine.
 
-Puis reportez-la dans la [zone DNS](/pages/web_cloud/domains/dns_zone_edit) de votre domaine, en modifiant ou créant une ou plusieurs entrées de type `A`.
+Puis reportez-la dans la [zone DNS](/pages/web_cloud/domains/dns_zone_edit) de votre nom de domaine, en modifiant ou créant une ou plusieurs entrées de type `A`.
 
 ![ipv4-DNSzone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
@@ -148,9 +206,9 @@ Votre site sera de nouveau accessible sous 24 heures maximum.
 
 ## Aller plus loin <a name="go-further"></a>
 
-[Résoudre l’erreur « Site non installé »](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Résoudre l'erreur « Site non installé »](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
-[Que faire en cas d’erreur 500 Internal Server Error ?](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
+[Que faire en cas d'erreur 500 Internal Server Error ?](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 
 [Résoudre les erreurs les plus fréquentes liées aux modules en 1 clic](/pages/web_cloud/web_hosting/diagnostic_errors_module1clic)
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-ca.md
@@ -163,7 +163,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4*
 >>
 > **Étape 3**
 >>
->> Cliquez sur `Réinitialiser ma zone DNS`{.action}, puis sélectionnez `Non, mais je veux réinitialiser ma zone DNS`{.action}.
+>> Cliquez sur `Réinitialiser ma zone DNS`{.action}, puis sélectionnez `Non, mais je veux réinitialiser ma zone DNS.`{.action}.
 >>
 >> Indiquez vos serveurs e-mail et d'hébergement, puis cliquez sur `Valider`{.action}.
 >>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Que faire si mon site est inaccessible ?"
 excerpt: "Diagnostiquez les causes de l'inaccessibilité de votre site"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-fr.md
@@ -116,7 +116,7 @@ Pour vérifier les serveurs DNS déclarés, cliquez sur les onglets ci-dessous p
 
 /// details | Scénario 2 - Un avertissement apparaît au-dessus de la zone DNS
 
-Au dessus de la zone DNS présente dans votre espace client OVHcloud, un avertissement indique que les serveurs DNS utilisés par votre domaine ne sont pas ceux indiqués dans votre zone. Deux cas sont possibles :
+Au-dessus de la zone DNS présente dans votre espace client OVHcloud, un avertissement indique que les serveurs DNS utilisés par votre domaine ne sont pas ceux indiqués dans votre zone. Deux cas sont possibles :
 
 - Les serveurs indiqués sont du type « ns **?** .ovh.net » et « dns **?** .ovh.net » (remplacez le « **?** » par n'importe quel numéro) :
 
@@ -196,7 +196,7 @@ Si votre site web est hébergé sur l'une de nos [offres d'hébergement web](/li
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> Copiez l'adresse IPV4 et/ou IPV6 de votre nom de domaine.
+>> Copiez l'adresse IPv4 et/ou IPv6 de votre nom de domaine.
 
 Puis reportez-la dans la [zone DNS](/pages/web_cloud/domains/dns_zone_edit) de votre nom de domaine, en modifiant ou créant une ou plusieurs entrées de type `A`.
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-fr.md
@@ -1,8 +1,22 @@
 ---
 title: "Que faire si mon site est inaccessible ?"
 excerpt: "Diagnostiquez les causes de l'inaccessibilité de votre site"
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objectif
 
@@ -42,7 +56,7 @@ Plusieurs retours d'erreur peuvent apparaître sur votre navigateur en cas d'ina
 
 ## En pratique
 
-### 1 : Vérifier la validité de votre nom de domaine
+### 1 - Vérifier la validité de votre nom de domaine
 
 > [!warning]
 >
@@ -52,43 +66,67 @@ Plusieurs retours d'erreur peuvent apparaître sur votre navigateur en cas d'ina
 > De ce fait, nous vous recommandons fortement d'activer le [renouvellement automatique](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#en-pratique) sur l'ensemble de vos abonnements OVHcloud.
 >
 
-Pour vérifier la validité de l'abonnement relatif à votre nom de domaine, cliquez sur votre nom en haut à droite de votre [espace client](/links/manager), afin de faire apparaître le menu contextuel, puis sur `Mes offres & services`{.action}.
+Pour vérifier la validité de l'abonnement relatif à votre nom de domaine, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Mes offres et services](/links/control-panel/billing-services).
+>>
+> **Étape 2**
+>>
+>> Renouvelez votre domaine si nécessaire via le bouton `...`{.action} à droite de l'écran, puis `Renouveler le service`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Étape 3**
+>>
+>> Suite à ce renouvellement, votre site sera accessible sous 48 heures maximum.
 
-Renouvelez votre domaine si nécessaire via le bouton `...`{.action} à droite de l'écran, puis `Renouveler le service`{.action}.
+### 2 - Vérifier les serveurs DNS
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+Pour vérifier la validité de vos [serveurs DNS](/pages/web_cloud/domains/dns_server_edit), accédez à la page [Noms de domaine](/links/control-panel/web-domains), puis choisissez le nom de domaine concerné.
 
-Suite à ce renouvellement, votre site sera accessible sous 48 heures maximum.
+**Cliquez sur le scénario correspondant à votre situation pour afficher le contenu.**
 
-### 2 : Vérifier les serveurs DNS
+/// details | Scénario 1 - Aucune anomalie sur les serveurs DNS
 
-Pour vérifier la validité de vos [serveurs DNS](/pages/web_cloud/domains/dns_server_edit), dans votre [espace client OVHcloud](/links/manager) cliquez sur `Noms de domaine`{.action}, puis sur le domaine de votre site.
+Pour vérifier les serveurs DNS déclarés, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-#### Scénario 1 : Aucune anomalie sur les serveurs DNS
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Noms de domaine](/links/control-panel/web-domains), puis choisissez le nom de domaine concerné.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Vérifiez les serveurs indiqués dans l'onglet `Serveurs DNS`{.action} :
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Étape 3**
+>>
+>> S'ils sont identiques aux cibles des entrées de type `NS` dans la **Zone DNS**, passez à la [partie 3](#etape3) :
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Vérifiez les serveurs indiqués dans l'onglet `Serveurs DNS`{.action} :
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Scénario 2 - Un avertissement apparaît au-dessus de la zone DNS
 
-S'ils sont identiques aux cibles des entrées de type `NS` dans la `Zone DNS`{.action}, passez à [l'étape 3](#etape3) :
+Au dessus de la zone DNS présente dans votre espace client OVHcloud, un avertissement indique que les serveurs DNS utilisés par votre domaine ne sont pas ceux indiqués dans votre zone. Deux cas sont possibles :
 
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Scénario 2 : Un avertissement apparaît au-dessus de la zone DNS
-
-Un avertissement dans l'onglet `Zone DNS`{.action} indique que les serveurs DNS utilisés par votre domaine ne sont pas ceux indiqués dans votre zone. Deux scénarios sont ici possibles :
-
-- Sous la phrase « Vous utilisez actuellement les serveurs DNS suivants : », les serveurs indiqués sont du type « ns **?** .ovh.net » et « dns **?** .ovh.net » (remplacez le « **?** » par n'importe quel numéro) :
+- Les serveurs indiqués sont du type « ns **?** .ovh.net » et « dns **?** .ovh.net » (remplacez le « **?** » par n'importe quel numéro) :
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modifiez les serveurs DNS en suivant les instructions de [ce guide](/pages/web_cloud/domains/dns_server_edit), afin qu'ils soient identiques aux cibles des entrées de type `NS` dans la `Zone DNS`{.action}.
+Modifiez les serveurs DNS en suivant les instructions de [ce guide](/pages/web_cloud/domains/dns_server_edit), afin qu'ils soient identiques aux cibles des entrées de type `NS` dans la **Zone DNS**.
 
 Votre site sera de nouveau accessible sous 48 heures maximum.
 
-- Sous la phrase « Vous utilisez actuellement les serveurs DNS suivants : », les serveurs indiqués ne sont pas du type « ns **?** .ovh.net » et « dns **?** .ovh.net ».
+- Les serveurs indiqués ne sont pas du type « ns **?** .ovh.net » et « dns **?** .ovh.net » :
 
 ![warning_external_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-external-dns-servers.png){.thumbnail}
 
@@ -97,33 +135,53 @@ Votre site sera de nouveau accessible sous 48 heures maximum.
 > Dans cette situation, contactez l'hébergeur de votre Zone DNS, votre webmaster ou les [partenaires OVHcloud](/links/partner) avant toute manipulation.
 >
 > Il est en effet possible que les serveurs DNS utilisés par votre nom de domaine soient fonctionnels et que le problème d'accès à votre site soit lié à une entrée manquante ou erronée dans la [zone DNS](/pages/web_cloud/domains/dns_zone_general_information). Toute modification des serveurs DNS dans cette situation peut rendre vos adresses e-mails ou d'autres applications en ligne indisponibles.
->
 
-#### Scénario 3 : Aucune entrée de type NS n'apparaît dans la zone DNS
+///
 
-La `Zone DNS`{.action} de votre domaine ne contient pas d'entrée de type `NS` :
+/// details | Scénario 3 - Aucune entrée de type NS n'apparaît dans la zone DNS
+
+La **Zone DNS** de votre domaine ne contient pas d'entrée de type `NS` :
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Effectuez une sauvegarde de la zone actuelle en cliquant sur le bouton `Modifier en mode textuel`{.action} à droite de votre écran :
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4** étapes.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Zones DNS](/links/control-panel/web-dns-zone), puis choisissez le nom de domaine concerné.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Effectuez une sauvegarde de la zone actuelle en cliquant sur le bouton `Modifier en mode textuel`{.action} à droite de votre écran :
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copiez/collez le contenu de votre **Zone DNS** dans un document texte. Enregistrez localement ce document.
+>>
+> **Étape 3**
+>>
+>> Cliquez sur `Réinitialiser ma zone DNS`{.action}, puis sélectionnez `Non, mais je veux réinitialiser ma zone DNS`{.action}.
+>>
+>> Indiquez vos serveurs e-mail et d'hébergement, puis cliquez sur `Valider`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Étape 4**
+>>
+>> Votre site sera de nouveau accessible sous 24 heures maximum.
 
-Puis copiez/collez le contenu de votre `Zone DNS`{.action} dans un document texte. Enregistrez localement ce document.
+///
 
-Cliquez ensuite sur `Réinitialiser ma zone DNS`{.action}, puis sélectionnez `Non, mais je veux réinitialiser ma zone DNS`{.action}, indiquez vos serveurs e-mail et d'hébergement et cliquez sur `Valider`{.action}.
+### 3 - Vérifier la zone DNS <a name="etape3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+Dans cette partie, vous allez retrouver l'adresse IP de votre hébergement, puis l'ajouter à votre **Zone DNS**.
 
-Votre site sera de nouveau accessible sous 24 heures maximum.
+Si votre site web est hébergé en dehors de l'infrastructure OVHcloud ou géré par une tierce personne, contactez l'hébergeur ou le prestataire concerné.
 
-### 3 : Vérifier la zone DNS <a name="etape3"></a>
-
-Dans cette étape, vous allez retrouver l'adresse IP de votre hébergement, puis l'ajouter à votre `Zone DNS`{.action}.
-
-Si votre site est hébergé en dehors de l'infrastructure OVHcloud ou géré par une tierce personne, contactez l'hébergeur ou le prestataire concerné.
-
-Si votre site est hébergé sur l'une de nos [offres d'hébergement web](/links/web/hosting), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+Si votre site web est hébergé sur l'une de nos [offres d'hébergement web](/links/web/hosting), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
 > [!tabs]
 > **Étape 1**
@@ -138,9 +196,9 @@ Si votre site est hébergé sur l'une de nos [offres d'hébergement web](/links/
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> Copiez l'adresse IPV4 et/ou IPV6 de votre domaine.
+>> Copiez l'adresse IPV4 et/ou IPV6 de votre nom de domaine.
 
-Puis reportez-la dans la [zone DNS](/pages/web_cloud/domains/dns_zone_edit) de votre domaine, en modifiant ou créant une ou plusieurs entrées de type `A`.
+Puis reportez-la dans la [zone DNS](/pages/web_cloud/domains/dns_zone_edit) de votre nom de domaine, en modifiant ou créant une ou plusieurs entrées de type `A`.
 
 ![ipv4-DNSzone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-fr.md
@@ -163,7 +163,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4*
 >>
 > **Étape 3**
 >>
->> Cliquez sur `Réinitialiser ma zone DNS`{.action}, puis sélectionnez `Non, mais je veux réinitialiser ma zone DNS`{.action}.
+>> Cliquez sur `Réinitialiser ma zone DNS`{.action}, puis sélectionnez `Non, mais je veux réinitialiser ma zone DNS.`{.action}.
 >>
 >> Indiquez vos serveurs e-mail et d'hébergement, puis cliquez sur `Valider`{.action}.
 >>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Que faire si mon site est inaccessible ?"
 excerpt: "Diagnostiquez les causes de l'inaccessibilité de votre site"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Cosa fare se il tuo sito è inaccessibile?"
 excerpt: "Diagnostica le cause dell'inaccessibilità del tuo sito"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.it-it.md
@@ -1,8 +1,22 @@
 ---
 title: "Cosa fare se il tuo sito è inaccessibile?"
 excerpt: "Diagnostica le cause dell'inaccessibilità del tuo sito"
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Obiettivo
 
@@ -19,9 +33,9 @@ Se il tuo sito non è raggiungibile, sul tuo browser potrebbero comparire divers
 
 > [!warning]
 >
-> OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell’utente.
+> OVHcloud mette a tua disposizione servizi di cui tu sei responsabile per la configurazione e la gestione. Garantirne quotidianamente il corretto funzionamento è quindi responsabilità dell'utente.
 >
-> Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l’amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) su questa guida.
+> Questa guida ti aiuta a eseguire le operazioni necessarie alla configurazione del tuo account. Tuttavia, in caso di difficoltà o dubbi, ti consigliamo di contattare un fornitore specializzato o l'amministratore del servizio. OVHcloud non potrà fornirti alcuna assistenza. Per maggiori informazioni consulta la sezione [Per saperne di più](#go-further) su questa guida.
 >
 
 ## Prerequisiti
@@ -34,7 +48,7 @@ Se il tuo sito non è raggiungibile, sul tuo browser potrebbero comparire divers
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -42,7 +56,7 @@ Se il tuo sito non è raggiungibile, sul tuo browser potrebbero comparire divers
 
 ## Procedura
 
-### 1: Verifica la validità del tuo dominio
+### 1 - Verifica la validità del tuo dominio
 
 > [!warning]
 >
@@ -52,41 +66,65 @@ Se il tuo sito non è raggiungibile, sul tuo browser potrebbero comparire divers
 > Per questo motivo, ti consigliamo di attivare il [rinnovo automatico](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#procedura) su tutti gli abbonamenti OVHcloud.
 >
 
-Per verificare la validità dell'abbonamento relativo al tuo dominio, clicca sul tuo nome in alto a destra del tuo [Spazio Cliente OVHcloud](/links/manager) e poi su `Le mie offerte e servizi`{.action}.
+Per verificare la validità dell'abbonamento relativo al tuo dominio, clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Le mie offerte e servizi](/links/control-panel/billing-services).
+>>
+> **Passaggio 2**
+>>
+>> Rinnova il tuo dominio se necessario cliccando sul pulsante `...`{.action} e poi `Rinnova il servizio`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Passaggio 3**
+>>
+>> Una volta terminato il rinnovo, il tuo sito web sarà disponibile entro 48 ore massimo.
 
-Rinnova il tuo dominio se necessario cliccando `...`{.action} a destra dello schermo e poi `Rinnova il servizio`{.action}.
+### 2 - Verifica i server DNS
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+Per verificare la validità dei tuoi [server DNS](/pages/web_cloud/domains/dns_server_edit), accedi alla pagina [Domini](/links/control-panel/web-domains), poi seleziona il dominio interessato.
 
-Una volta terminato il rinnovo dell'offerta, il tuo sito Web sarà disponibile entro 48 ore.
+**Clicca sullo scenario corrispondente alla tua situazione per visualizzare il contenuto.**
 
-### 2: Verifica i server DNS
+/// details | Scenario 1 - Nessuna anomalia sui server DNS
 
-Per verificare la validità dei tuoi [server DNS](/pages/web_cloud/domains/dns_server_edit), clicca in tuo [Spazio Cliente OVHcloud](/links/manager) sui `Domini`{.action} e poi sul dominio del tuo sito.
+Per verificare i server DNS dichiarati, clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
-#### Scenario 1: Nessuna anomalia sui server DNS
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Domini](/links/control-panel/web-domains), poi seleziona il dominio interessato.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Verifica i server indicati nella scheda `Server DNS`{.action}:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Passaggio 3**
+>>
+>> Se sono identici agli obiettivi dei record di tipo `NS` nella **Zona DNS**, passa alla [parte 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Verifica i server indicati nella scheda `Server DNS`{.action}:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Scenario 2 - Sulla zona DNS compare un avviso
 
-Se sono identici agli obiettivi degli record di tipo `NS` nella `Zona DNS`{.action}, passa allo [Step 3](#step3):
-
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Scenario 2: Sulla zona DNS compare un avviso
-
-Un avviso nella scheda `Zona DNS`{.action} indica che i server DNS utilizzati dal tuo dominio non sono quelli indicati nella tua zona. Sono possibili due scenari:
+Un avviso nella scheda **Zona DNS** indica che i server DNS utilizzati dal tuo dominio non sono quelli indicati nella tua zona. Sono possibili due scenari:
 
 - Sotto la frase "Al momento utilizzi questi server DNS:", i server indicati sono del tipo "ns **?** .ovh.net" e "DNS **?** .ovh.net" (sostituisci "**?**" da qualsiasi numero):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Modificare i server DNS seguendo le istruzioni di [questa guida](/pages/web_cloud/domains/dns_server_edit) in modo che siano identici agli obiettivi di record di tipo `NS` nella `Zona DNS`{.action}.
+Modificare i server DNS seguendo le istruzioni di [questa guida](/pages/web_cloud/domains/dns_server_edit) in modo che siano identici agli obiettivi di record di tipo `NS` nella **Zona DNS**.
 
-Il tuo sito Web sarà disponibile entro 48 ore.
+Il tuo sito web sarà disponibile entro 48 ore.
 
 - Sotto la frase "Al momento utilizzi questi server DNS:", i server indicati non sono del tipo "ns **?** .ovh.net" e "DNS **?** .ovh.net".
 
@@ -97,54 +135,74 @@ Il tuo sito Web sarà disponibile entro 48 ore.
 > In questo caso, contatta l'hosting provider della tua Zona DNS, il tuo webmaster o i [partner OVHcloud](/links/partner) prima di effettuare qualsiasi operazione.
 >
 > È possibile che i server DNS utilizzati dal tuo dominio siano funzionali e che il problema di accesso al tuo sito sia legato ad un ingresso mancante o errato nella [zona DNS](/pages/web_cloud/domains/dns_zone_general_information). Qualsiasi modifica dei server DNS in questa situazione può rendere indisponibili i tuoi indirizzi email o altre applicazioni online.
->
 
-#### Scenario 3: Nella zona DNS non sono presenti record di tipo NS
+///
 
-La `Zona DNS`{.action} del tuo dominio non contiene alcun accesso di tipo `NS`:
+/// details | Scenario 3 - Nella zona DNS non sono presenti record di tipo NS
+
+La **Zona DNS** del tuo dominio non contiene alcun record di tipo `NS`:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Per eseguire un backup dell'area corrente, clicca sul pulsante `Utilizza l'editor di testo`{.action} a destra dello schermo:
-
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
-
-Copia/incolla il contenuto della tua `Zona DNS`{.action} in un documento di testo. Salva questo documento localmente.
-
-Clicca su `Reinizializza la zona DNS`{.action} e seleziona `No, ma voglio reinizializzare la mia zona DNS`{.action}, indica i tuoi server di posta e di hosting e clicca su `Conferma`{.action}.
-
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
-
-Il tuo sito Web sarà disponibile entro 24 ore.
-
-### 3: Verifica la zona DNS <a name="step3"></a>
-
-In questo step, visualizzerai l'indirizzo IP del tuo hosting e lo aggiungerai alla tua `Zona DNS`{.action}.
-
-Se il tuo sito non è ospitato sull'infrastruttura OVHcloud o se è gestito da un altro provider, contatta il supporto interessati.
-
-Se il tuo sito è ospitato su una delle nostre [soluzione di hosting Web](/links/web/hosting), clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passi.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
 > [!tabs]
 > **Passaggio 1**
 >>
->> Accedi alla pagina [Hosting plans](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
+>> Accedi alla pagina [Zone DNS](/links/control-panel/web-dns-zone), poi seleziona il dominio interessato.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Per eseguire un backup della zona corrente, clicca sul pulsante `Utilizza l'editor di testo`{.action}:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copia/incolla il contenuto della tua **Zona DNS** in un documento di testo. Salva questo documento localmente.
+>>
+> **Passaggio 3**
+>>
+>> Clicca su `Reinizializza la zona DNS`{.action} e seleziona `No, ma voglio reinizializzare la mia zona DNS`{.action}.
+>>
+>> Indica i tuoi server di posta e di hosting e clicca su `Conferma`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Passaggio 4**
+>>
+>> Il tuo sito web sarà disponibile entro 24 ore massimo.
+
+///
+
+### 3 - Verifica la zona DNS <a name="step3"></a>
+
+In questo passaggio, visualizzerai l'indirizzo IP del tuo hosting e lo aggiungerai alla tua **Zona DNS**.
+
+Se il tuo sito web non è ospitato sull'infrastruttura OVHcloud o se è gestito da un altro provider, contatta il supporto interessato.
+
+Se il tuo sito web è ospitato su una delle nostre [soluzioni di hosting Web](/links/web/hosting), clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting web interessato.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Passaggio 2**
 >>
->> Nel riquadro **Informazioni generali**, troverete le informazioni **IPv4** e **IPv6**.
+>> Nel riquadro **Informazioni generali**, troverai le informazioni **IPv4** e **IPv6**.
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> Copia l'indirizzo IPV4 e/o IPV6 del tuo dominio.
+>> Copia l'indirizzo IPv4 e/o IPv6 del tuo dominio.
 
 E riportala nella [Zona DNS](/pages/web_cloud/domains/dns_zone_edit) del tuo dominio, modificandola o creando uno o più record di tipo `A`.
 
 ![ipv4-DNSzone](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-a.png){.thumbnail}
 
-Il tuo sito Web sarà disponibile entro 24 ore.
+Il tuo sito web sarà disponibile entro 24 ore massimo.
 
 ## Per saperne di più <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Co zrobić, jeśli moja strona jest niedostępna?"
 excerpt: "Zdiagnozuj przyczyny niedostępności Twojej strony WWW"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.pl-pl.md
@@ -1,10 +1,24 @@
 ---
 title: "Co zrobić, jeśli moja strona jest niedostępna?"
 excerpt: "Zdiagnozuj przyczyny niedostępności Twojej strony WWW"
-updated: 2025-10-09
+updated: 2026-03-26
 ---
 
-## Wprowadzenie 
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
+
+## Wprowadzenie
 
 W przypadku niedostępności Twojej strony WWW może pojawić się kilka zwrotów błędu. Poniższe przykłady ilustrują błędną konfigurację Twoich [serwerów DNS](/pages/web_cloud/domains/dns_server_edit), Twojej [strefy DNS](/pages/web_cloud/domains/dns_zone_edit) lub domeny zawieszonej (jeśli Twoja strona nie wyświetla jednego z komunikatów o błędach opisanych tutaj, zobacz sekcję [Sprawdź również](#go-further)):
 
@@ -27,7 +41,6 @@ W przypadku niedostępności Twojej strony WWW może pojawić się kilka zwrotó
 ## Wymagania początkowe
 
 - Zarządzanie serwerami i [strefą DNS](/pages/web_cloud/domains/dns_zone_edit) domeny
-- Zalogowanie do [Panelu klienta OVHcloud](/links/manager)
 - Aktualizacja w [płatności](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) i [odnowienie](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) powiązanych usług (domena i hosting)
 
 <!-- CP-NAV-START:web-hosting -->
@@ -35,7 +48,7 @@ W przypadku niedostępności Twojej strony WWW może pojawić się kilka zwrotó
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -43,7 +56,7 @@ W przypadku niedostępności Twojej strony WWW może pojawić się kilka zwrotó
 
 ## W praktyce
 
-### 1: Sprawdź ważność Twojej domeny
+### 1 - Sprawdź ważność Twojej domeny
 
 > [!warning]
 >
@@ -53,39 +66,63 @@ W przypadku niedostępności Twojej strony WWW może pojawić się kilka zwrotó
 > W związku z tym zalecamy [włączenie automatycznego](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#w-praktyce) odnowienia wszystkich Twoich subskrypcji OVHcloud.
 >
 
-Aby sprawdzić poprawność subskrypcji Twojej domeny, w prawym górnym rogu [Panelu klienta OVHcloud](/links/manager) kliknij Twoją nazwę, aby wyświetlić menu PPM, następnie `Moje rozwiązania i usługi`{.action}.
+Aby sprawdzić poprawność subskrypcji Twojej domeny, kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Moje rozwiązania i usługi](/links/control-panel/billing-services).
+>>
+> **Krok 2**
+>>
+>> Odnów Twoją domenę, jeśli to konieczne, za pomocą przycisku `...`{.action}, a następnie `Odnów usługę`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Krok 3**
+>>
+>> Po odnowieniu domeny Twoja strona będzie dostępna w ciągu 48 godzin.
 
-Odnów Twoją domenę, jeśli to konieczne, za pomocą przycisku `...`{.action}. po prawej stronie ekranu, a następnie `Odnów usługę`{.action}.
+### 2 - Sprawdź serwery DNS
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+Aby sprawdzić poprawność Twoich [serwerów DNS](/pages/web_cloud/domains/dns_server_edit), przejdź na stronę [Domeny](/links/control-panel/web-domains), następnie wybierz odpowiednią domenę.
 
-Po odnowieniu domeny Twoja strona będzie dostępna w ciągu 48 godzin.
+**Kliknij scenariusz odpowiadający Twojej sytuacji, aby wyświetlić jego zawartość.**
 
-### 2: Sprawdź serwery DNS
+/// details | Scenariusz 1 - Brak anomalii na serwerach DNS
 
-Aby sprawdzić poprawność Twoich [serwerów DNS](/pages/web_cloud/domains/dns_server_edit), w [Panelu klienta OVHcloud](/links/manager) kliknij `Domeny`{.action}, a następnie domenę na Twojej stronie.
+Aby sprawdzić zadeklarowane serwery DNS, kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
 
-#### Scenariusz 1: Brak anomalii na serwerach DNS
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Domeny](/links/control-panel/web-domains), następnie wybierz odpowiednią domenę.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Sprawdź serwery podane w zakładce `Serwery DNS`{.action}:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Krok 3**
+>>
+>> Jeśli są identyczne z celami wpisów typu `NS` w **Strefie DNS**, przejdź do [części 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Sprawdź serwery podane w zakładce `Serwery DNS`{.action}:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Scenariusz 2 - Nad strefą DNS pojawi się ostrzeżenie
 
-Jeśli są identyczne z celami wpisów typu `NS` w `Strefa DNS`{.action}, przejdź do [Etap 3](#step3):
-
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Scenariusz 2: Nad strefą DNS pojawi się ostrzeżenie
-
-Ostrzeżenie w zakładce `Strefa DNS`{.action} wskazuje, że serwery DNS używane przez Twoją domenę nie są serwerami pokazywanymi w Twojej strefie. Możliwe są dwa scenariusze:
+Ostrzeżenie w zakładce **Strefa DNS** wskazuje, że serwery DNS używane przez Twoją domenę nie są serwerami pokazywanymi w Twojej strefie. Możliwe są dwa scenariusze:
 
 - Pod frazą "Aktualnie korzystasz z następujących serwerów DNS:", wskazane serwery są typu "ns **?** ovh.net" i "dns **?** ovh.net" (zastąp "**?**" na dowolny numer):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Zmień serwery DNS zgodnie z instrukcjami zawartymi w [tym przewodniku](/pages/web_cloud/domains/dns_server_edit), aby były one identyczne z celami wpisów typu `NS` w `Strefa DNS`{.action}.
+Zmień serwery DNS zgodnie z instrukcjami zawartymi w [tym przewodniku](/pages/web_cloud/domains/dns_server_edit), aby były one identyczne z celami wpisów typu `NS` w **Strefie DNS**.
 
 Twoja strona będzie dostępna w ciągu maksymalnie 48 godzin.
 
@@ -98,38 +135,58 @@ Twoja strona będzie dostępna w ciągu maksymalnie 48 godzin.
 > W takiej sytuacji przed przystąpieniem do jakichkolwiek czynności, należy skontaktować się z dostawcą usług hostowanych w strefie DNS, webmasterem lub [partnerami OVHcloud](/links/partner).
 >
 > Możliwe, że serwery DNS używane przez Twoją domenę działają i że problem z dostępem do Twojej strony jest związany z brakującym lub nieprawidłowym wpisem w [strefie DNS](/pages/web_cloud/domains/dns_zone_general_information). Każda zmiana serwerów DNS może spowodować niedostępność Twoich kont e-mail lub innych aplikacji online.
->
 
-#### Scenariusz 3: W strefie DNS nie pojawia się żaden wpis typu NS
+///
 
-W `Strefa DNS`{.action} Twojej domeny nie ma wpisu typu `NS`:
+/// details | Scenariusz 3 - W strefie DNS nie pojawia się żaden wpis typu NS
+
+W **Strefie DNS** Twojej domeny nie ma wpisu typu `NS`:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Wykonaj kopię zapasową aktualnej strefy, klikając przycisk `Modyfikacja w trybie tekstowym`{.action} po prawej stronie ekranu:
+Kliknij poniższe zakładki, aby wyświetlić kolejne **4** kroki.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Strefy DNS](/links/control-panel/web-dns-zone), następnie wybierz odpowiednią domenę.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Wykonaj kopię zapasową aktualnej strefy, klikając przycisk `Modyfikacja w trybie tekstowym`{.action}:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Skopiuj/wklej zawartość **Strefy DNS** do dokumentu tekstowego. Zapisz lokalnie ten dokument.
+>>
+> **Krok 3**
+>>
+>> Kliknij `Zresetuj strefę DNS`{.action} i wybierz `Nie, ale chcę zresetować strefę DNS.`{.action}.
+>>
+>> Wskaż serwery e-mail i hosting, a następnie kliknij `Zatwierdź`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Krok 4**
+>>
+>> Twoja strona będzie dostępna w ciągu maksymalnie 24 godzin.
 
-Następnie skopiuj/wklej zawartość `Strefa DNS`{.action} do dokumentu tekstowego. Zapisz lokalnie ten dokument.
+///
 
-Następnie kliknij `Zresetuj strefę DNS`{.action} i wybierz `Nie, ale chcę zresetować strefę DNS.`{.action}, wskaż serwery e-mail i hosting, a następnie kliknij `Zatwierdź`{.action}.
+### 3 - Sprawdź strefę DNS <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+Na tym etapie odnajdziesz adres IP Twojego hostingu, po czym dodaj go do Twojej **Strefy DNS**.
 
-Twoja strona będzie dostępna w ciągu maksymalnie 24 godzin.
-
-### 3: Sprawdź strefę DNS <a name="step3"></a>
-
-Na tym etapie odnajdziesz adres IP Twojego hostingu, po czym dodaj go do Twojej `Strefa DNS`{.action}.
-
-Jeśli Twoja strona nie jest hostowana w infrastrukturze OVHcloud lub jest zarządzana przez innego dostawcę, skontaktuj się z odpowiednią pomocą techniczną.
+Jeśli Twoja strona WWW nie jest hostowana w infrastrukturze OVHcloud lub jest zarządzana przez innego dostawcę, skontaktuj się z odpowiednią pomocą techniczną.
 
 Jeśli Twoja strona internetowa jest hostowana w ramach jednej z naszych [ofert hostingu WWW](/links/web/hosting), kliknij poniższe zakładki, aby wyświetlić kolejne **2** kroki.
 
 > [!tabs]
 > **Krok 1**
 >>
->> Przejdź na stronę [Hosting plans](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -139,7 +196,7 @@ Jeśli Twoja strona internetowa jest hostowana w ramach jednej z naszych [ofert 
 >>
 >> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> Skopiuj adres IPV4 i/lub IPV6 Twojej domeny.
+>> Skopiuj adres IPv4 i/lub IPv6 Twojej domeny.
 
 Następnie przenieś domenę do [strefy DNS](/pages/web_cloud/domains/dns_zone_edit), modyfikując lub dodając jeden lub więcej rekordów typu `A`.
 
@@ -149,7 +206,7 @@ Twoja strona będzie dostępna w ciągu maksymalnie 24 godzin.
 
 ## Sprawdź również <a name="go-further"></a>
 
-[Usunięcie błędu “Strona nie została zainstalowana”](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Usunięcie błędu "Strona nie została zainstalowana"](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [Co zrobić w przypadku błędu 500 Internal Server Error?](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.pt-pt.md
@@ -165,7 +165,7 @@ Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 >>
 >> Clique em `Reiniciar zona DNS`{.action} e selecione `Não, mas desejo reiniciar a minha zona DNS.`{.action}.
 >>
->> Indique os seus servidores de e-mail e de alojamento e clique em `Validar`{.action}.
+>> Indique os seus servidores de e-mail e de alojamento e clique em `Confirmar`{.action}.
 >>
 >> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
 >>
@@ -216,4 +216,4 @@ Para serviços especializados (referenciamento, desenvolvimento, etc.), contacte
 
 Se pretender usufruir de uma assistência na utilização e na configuração das suas soluções OVHcloud, consulte as nossas diferentes [ofertas de suporte](/links/support).
 
-Fale com nossa [comunidade de utilizadores](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.pt-pt.md
@@ -1,8 +1,22 @@
 ---
 title: "O que fazer se o meu site está inacessível?"
 excerpt: "Diagnóstico das causas da inacessibilidade do seu site"
-updated: 2025-10-09
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo
 
@@ -34,7 +48,7 @@ Vários feedbacks de erro podem aparecer no seu navegador em caso de inacessibil
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -42,7 +56,7 @@ Vários feedbacks de erro podem aparecer no seu navegador em caso de inacessibil
 
 ## Instruções
 
-### 1: Verificar a validade do seu domínio
+### 1 - Verificar a validade do seu domínio
 
 > [!warning]
 >
@@ -52,39 +66,63 @@ Vários feedbacks de erro podem aparecer no seu navegador em caso de inacessibil
 > Assim, recomendamos vivamente que ative a [renovação automática](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#instrucoes) em todas as subscrições da OVHcloud.
 >
 
-Para verificar a validade da assinatura relativa ao seu domínio, clique no seu nome (no canto superior direito do seu [Área de Cliente OVHcloud](/links/manager)) no menu contextual e, a seguir, em `As minhas ofertas e serviços`{.action}.
+Para verificar a validade da assinatura relativa ao seu domínio, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
-![control-panel](/pages/assets/screens/control_panel/product-selection/right-menu/my-solutions-and-services.png){.thumbnail}|
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [As minhas ofertas e serviços](/links/control-panel/billing-services).
+>>
+> **Etapa 2**
+>>
+>> Renove o domínio se necessário através do botão `...`{.action} e `Renovar o serviço`{.action}.
+>>
+>> ![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Uma vez terminada a renovação, o seu website estará disponível num prazo máximo de 48 horas.
 
-Renove o domínio se necessário através do botão `...`{.action} à direita do ecrã e `Renovar o serviço`{.action}.
+### 2 - Verificar os servidores DNS
 
-![renew-service-button](/pages/assets/screens/control_panel/product-selection/web-cloud/order/renew-service-button.png){.thumbnail}
+Para verificar a validade dos seus [servidores DNS](/pages/web_cloud/domains/dns_server_edit), aceda à página [Nomes de domínio](/links/control-panel/web-domains), e selecione o domínio correspondente.
 
-Uma vez terminada a renovação da sua oferta, o seu website estará disponível num prazo máximo de 48 horas.
+**Clique no cenário correspondente à sua situação para visualizar o conteúdo.**
 
-### 2: Verificar os servidores DNS
+/// details | Cenário 1 - Nenhuma anomalia nos servidores DNS
 
-Para verificar a validade dos seus [servidores DNS](/pages/web_cloud/domains/dns_server_edit), na [Área de Cliente OVHcloud](/links/manager) clique em `Nomes de domínio`{.action} e, a seguir, no domínio do seu site.
+Para verificar os servidores DNS declarados, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
-#### Cenário 1: Nenhuma anomalia nos servidores DNS
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Nomes de domínio](/links/control-panel/web-domains), e selecione o domínio correspondente.
+>>
+>> ![Domain Names](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-names.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Verifique os servidores indicados no separador `Servidores DNS`{.action}:
+>>
+>> ![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Se forem idênticos aos alvos das entradas do tipo `NS` na **Zona DNS**, consulte a [parte 3](#step3):
+>>
+>> ![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
 
-Verifique os servidores indicados no separador `Servidores DNS`{.action}:
+///
 
-![srv-dns-ok2](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-servers/name-dns-server.png){.thumbnail}
+/// details | Cenário 2 - Aparecer um aviso sobre a zona DNS
 
-Se forem idênticos aos alvos das entradas do tipo `NS` na `Zona DNS`{.action}, consulte o [Etapa 3](#step3):
-
-![srv-dns-ok](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns.png){.thumbnail}
-
-#### Cenário 2: Aparecer um aviso sobre a zona DNS
-
-Um aviso no separador `Zona DNS`{.action} indica que os servidores DNS utilizados pelo seu domínio não estão indicados na sua zona. Aqui, podem ocorrer dois cenários:
+Um aviso no separador **Zona DNS** indica que os servidores DNS utilizados pelo seu domínio não estão indicados na sua zona. Aqui, podem ocorrer dois cenários:
 
 - Na frase "Utiliza atualmente os seguintes servidores DNS:", os servidores indicados são do tipo "ns **?** .ovh.net" e "dns **?** .ovh.net" (substituir "**?**" por qualquer número):
 
 ![warning_other_ovh_dns_srv](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/message-other-ovh-dns-servers.png){.thumbnail}
 
-Altere os servidores DNS de acordo com as instruções [deste manual](/pages/web_cloud/domains/dns_server_edit), para que sejam idênticos aos alvos das entradas do tipo `NS` na `Zona DNS`{.action}.
+Altere os servidores DNS de acordo com as instruções [deste manual](/pages/web_cloud/domains/dns_server_edit), para que sejam idênticos aos alvos das entradas do tipo `NS` na **Zona DNS**.
 
 O seu website estará disponível num prazo máximo de 48 horas.
 
@@ -97,29 +135,49 @@ O seu website estará disponível num prazo máximo de 48 horas.
 > Nesta situação, contacte o alojador da sua Zona DNS, o seu webmaster ou os [parceiros OVHcloud](/links/partner) antes de qualquer manipulação.
 >
 > É possível que os servidores DNS utilizados pelo seu domínio estejam funcionais e que o problema de acesso ao seu site esteja associado a uma entrada inexistente ou errada na [zona DNS](/pages/web_cloud/domains/dns_zone_general_information). Se alterar os servidores DNS nesta situação, os seus endereços de e-mail ou outras aplicações online poderão ficar indisponíveis.
->
 
-#### Cenário 3: Nenhuma entrada do tipo NS aparece na zona DNS
+///
 
-A `Zona DNS`{.action} do seu domínio não contém nenhuma entrada do tipo `NS`:
+/// details | Cenário 3 - Nenhuma entrada do tipo NS aparece na zona DNS
+
+A **Zona DNS** do seu domínio não contém nenhuma entrada do tipo `NS`:
 
 ![srv_dns_missing](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/dashboard-entry-ns-missing.png){.thumbnail}
 
-Efetue um backup da zona atual ao clicar no botão `Editar em modo de texto`{.action} à direita do seu ecrã:
+Clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 
-![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Zonas DNS](/links/control-panel/web-dns-zone), e selecione o domínio correspondente.
+>>
+>> ![DNS zones](/pages/assets/screens/control_panel/product-selection/web-cloud/dns-zones.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Efetue um backup da zona atual ao clicar no botão `Editar em modo de texto`{.action}:
+>>
+>> ![change_DNS_zone_change_text_format](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/change-in-text-format.png){.thumbnail}
+>>
+>> Copie/cole o conteúdo da sua **Zona DNS** num documento em texto. Registe este documento localmente.
+>>
+> **Etapa 3**
+>>
+>> Clique em `Reiniciar zona DNS`{.action} e selecione `Não, mas desejo reiniciar a minha zona DNS.`{.action}.
+>>
+>> Indique os seus servidores de e-mail e de alojamento e clique em `Validar`{.action}.
+>>
+>> ![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
+>>
+> **Etapa 4**
+>>
+>> O seu website estará disponível num prazo máximo de 24 horas.
 
-De seguida, copie/cole o conteúdo da sua `Zona DNS`{.action} num documento em texto. Registe este documento localmente.
+///
 
-De seguida, clique em `Reiniciar zona DNS`{.action} e selecione `Não, mas desejo reiniciar a minha zona DNS.`{.action}, indique os seus servidores de e-mail e de alojamento e clique em `Validar`{.action}.
+### 3 - Verificar a zona DNS <a name="step3"></a>
 
-![change_DNS_zone_reset](/pages/assets/screens/control_panel/product-selection/web-cloud/domain-dns/dns-zone/reset-my-dns-zone.png){.thumbnail}
-
-O seu website estará disponível num prazo máximo de 24 horas.
-
-### 3: Verificar a zona DNS <a name="step3"></a>
-
-Nesta etapa, vai encontrar o endereço IP do seu alojamento e adicioná-lo à sua `Zona DNS`{.action}.
+Nesta etapa, vai encontrar o endereço IP do seu alojamento e adicioná-lo à sua **Zona DNS**.
 
 Se o seu site não está alojado na infraestrutura da OVHcloud ou é gerido por outro fornecedor, contacte o serviço de suporte em causa.
 
@@ -128,7 +186,7 @@ Se o seu site está alojado numa das nossas [planos de alojamento web](/links/we
 > [!tabs]
 > **Etapa 1**
 >>
->> Aceda à página [Hosting plans](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -136,9 +194,9 @@ Se o seu site está alojado numa das nossas [planos de alojamento web](/links/we
 >>
 >> No marco **Informações gerais**, encontrará as referências **IPv4** e **IPv6**.
 >>
->>  ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
+>> ![IPv4-IPv6](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-ipv4-and-ipv6.png){.thumbnail}
 >>
->> Copie o endereço IPV4 e/ou IPV6 do seu domínio.
+>> Copie o endereço IPv4 e/ou IPv6 do seu domínio.
 
 De seguida, aceda à [Zona DNS](/pages/web_cloud/domains/dns_zone_edit) do seu domínio alterando ou criando uma ou mais entradas de tipo `A`.
 
@@ -148,7 +206,7 @@ O seu website estará disponível num prazo máximo de 24 horas.
 
 ## Quer saber mais? <a name="go-further"></a>
 
-[Resolver o erro “Site não instalado”](/pages/web_cloud/web_hosting/multisites_website_not_installed)
+[Resolver o erro "Site não instalado"](/pages/web_cloud/web_hosting/multisites_website_not_installed)
 
 [O que fazer em caso de erro 500 Internal Server Error?](/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error)
 

--- a/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic-website-not-accessible/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "O que fazer se o meu site está inacessível?"
 excerpt: "Diagnóstico das causas da inacessibilidade do seu site"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.de-de.md
@@ -43,30 +43,20 @@ Mit der automatisierten Sperrung werden Sie auch vor möglichen rechtlichen Kons
 - Sie haben ein [OVHcloud Webhosting](/links/web/hosting).
 - Sie verfügen über die [Login-Daten](/pages/web_cloud/web_hosting/ftp_connection) für den FTP-Speicherplatz Ihres Hostings.
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Zugriff auf das OVHcloud Kundencenter
-
-- **Direkter Link:** [Hosting-Pakete](/links/control-panel/web-hosting)
-- **Navigationspfad:** `Web Cloud`{.action} > `Hosting-Pakete`{.action} > Wählen Sie Ihr Webhosting aus
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## In der praktischen Anwendung
 
-### Schritt 1: Die Situation analysieren
+### 1 - Die Situation analysieren
 
 Wenn die Seite "**403 forbidden**" nach einer Änderung an Ihrer Website erscheint, [setzen Sie den FTP-Speicherplatz Ihres Hostings ganz oder teilweise zu einem früheren Zeitpunkt zurück](/pages/web_cloud/web_hosting/ftp_save_and_backup).
 
 Wenn Sie mit den verfügbaren Backups den Zugang zu Ihrer Website nicht wiederherstellen können, kontaktieren Sie einen [spezialisierten Dienstleister](/links/partner).
 
-Wenn die Seite "**403 forbidden**" ohne Änderung Ihrer Website erscheint, prüfen Sie Ihren Posteingang. Wenn Sie eine E-Mail von unserem System erhalten haben, die eine Schließung Ihres Hostings aus Sicherheitsgründen meldet, gehen Sie zu [Schritt 2](#step-2) dieser Anleitung.
+Wenn die Seite "**403 forbidden**" ohne Änderung Ihrer Website erscheint, prüfen Sie Ihren Posteingang. Wenn Sie eine E-Mail von unserem System erhalten haben, die eine Schließung Ihres Hostings aus Sicherheitsgründen meldet, gehen Sie zu [Teil 2](#step-2) dieser Anleitung.
 
 Wenn die Seite "**403 forbidden**" ohne Aktion Ihrerseits erscheint und Sie diesbezüglich keine Benachrichtigung erhalten haben, überprüfen Sie zunächst die FTP-Zugriffsrechte (CHMOD) Ihrer Dateien und Ordner sowie den in Ihrer **.htaccess** enthaltenen Code. Überprüfen Sie auch, ob dieser Zustand ggf. von einem Sicherheitsplugin oder einer Application Firewall verursacht wird. Falls nötig, kontaktieren Sie einen [spezialisierten Dienstleister](/links/partner).
 
-### Schritt 2: Sicherheitsmaßnahmen auf Ihrer Seite durchführen <a name="step-2"></a>
+### 2 - Sicherheitsmaßnahmen auf Ihrer Seite durchführen <a name="step-2"></a>
 
 Überprüfen Sie zunächst die Sicherheit Ihrer Computer und Geräte:
 
@@ -87,7 +77,7 @@ Wenn die Seite "**403 forbidden**" ohne Aktion Ihrerseits erscheint und Sie dies
 > Sollten Sie Hilfe bei den durchzuführenden Maßnahmen benötigen, wenden Sie sich an die [OVHcloud Partner](/links/partner).
 >
 
-### Schritt 3: Ihr Hosting bearbeiten
+### 3 - Ihr Hosting bearbeiten
 
 Beachten Sie zunächst das Datum des Versands der E-Mail von OVHcloud, in der die Deaktivierung Ihres Hostings mitgeteilt wurde, sowie die Liste der Ordner, die auffällige Dateien enthalten.
 
@@ -122,10 +112,10 @@ Wenn Ihr Hosting vor mehr als zwei Wochen gesperrt wurde, kontaktieren Sie einen
 
 > [!success]
 >
-> Wenn Sie weitere Informationen zu den [Schritten 2 und 3](#step-2) benötigen, lesen Sie unsere Hilfe zu [Aktionen wenn Ihre Website von einem Hack betroffen ist](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> Wenn Sie weitere Informationen zu den [Teilen 2 und 3](#step-2) benötigen, lesen Sie unsere Hilfe zu [Aktionen wenn Ihre Website von einem Hack betroffen ist](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Schritt 4: Ihr Webhosting mit FileZilla reaktivieren <a name="reactivate-web-hosting"></a>
+### 4 - Ihr Webhosting mit FileZilla reaktivieren <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-asia.md
@@ -36,7 +36,7 @@ This device also legally protects you from actions resulting from a possible hac
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -44,30 +44,20 @@ This device also legally protects you from actions resulting from a possible hac
 - An [OVHcloud web hosting plan](/links/web/hosting)
 - The login details to access [your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
-### Step 1: Analyse the situation
+### 1 - Analyse the situation
 
 If the page "**403 forbidden**" appeared following a modification of your website, [restore all or part of the FTP storage space of your hosting](/pages/web_cloud/web_hosting/ftp_save_and_backup) to an earlier date.
 
 If the available backups do not allow you to restore access to your website, contact a [specialised provider](/links/partner).
 
-If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [step 2](#step-2) of this guide.
+If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [part 2](#step-2) of this guide.
 
 If the page "**403 forbidden**" appeared without any action on your part and you have not received any email from our services about it, check the FTP access rights (CHMOD) of your files and folders as well as the code contained in your **.htaccess** file(s). Also check if the restriction is caused by a security plugin or application firewall. If necessary, contact a [specialised provider](/links/partner).
 
-### Step 2: Apply security measures on your side <a name="step-2"></a>
+### 2 - Apply security measures on your side <a name="step-2"></a>
 
 First, check the security of your computers and devices:
 
@@ -88,7 +78,7 @@ First, check the security of your computers and devices:
 > If you have any doubts about the changes to be made, contact [OVHcloud partners](/links/partner).
 >
 
-### Step 3: Intervene on your web hosting plan
+### 3 - Intervene on your web hosting plan
 
 First, take note of the date on which the OVHcloud email regarding the deactivation of your hosting and the list of folder(s) containing the malicious files detected.
 
@@ -122,10 +112,10 @@ If your hosting plan was closed more than two weeks ago, please contact a [speci
 
 > [!success]
 >
-> If you would like more details on the previous [steps 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> If you would like more details on the previous [parts 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Step 4: Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-au.md
@@ -36,7 +36,7 @@ This device also legally protects you from actions resulting from a possible hac
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -44,30 +44,20 @@ This device also legally protects you from actions resulting from a possible hac
 - An [OVHcloud web hosting plan](/links/web/hosting)
 - The login details to access [your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
-### Step 1: Analyse the situation
+### 1 - Analyse the situation
 
 If the page "**403 forbidden**" appeared following a modification of your website, [restore all or part of the FTP storage space of your hosting](/pages/web_cloud/web_hosting/ftp_save_and_backup) to an earlier date.
 
 If the available backups do not allow you to restore access to your website, contact a [specialised provider](/links/partner).
 
-If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [step 2](#step-2) of this guide.
+If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [part 2](#step-2) of this guide.
 
 If the page "**403 forbidden**" appeared without any action on your part and you have not received any email from our services about it, check the FTP access rights (CHMOD) of your files and folders as well as the code contained in your **.htaccess** file(s). Also check if the restriction is caused by a security plugin or application firewall. If necessary, contact a [specialised provider](/links/partner).
 
-### Step 2: Apply security measures on your side <a name="step-2"></a>
+### 2 - Apply security measures on your side <a name="step-2"></a>
 
 First, check the security of your computers and devices:
 
@@ -88,7 +78,7 @@ First, check the security of your computers and devices:
 > If you have any doubts about the changes to be made, contact [OVHcloud partners](/links/partner).
 >
 
-### Step 3: Intervene on your web hosting plan
+### 3 - Intervene on your web hosting plan
 
 First, take note of the date on which the OVHcloud email regarding the deactivation of your hosting and the list of folder(s) containing the malicious files detected.
 
@@ -122,10 +112,10 @@ If your hosting plan was closed more than two weeks ago, please contact a [speci
 
 > [!success]
 >
-> If you would like more details on the previous [steps 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> If you would like more details on the previous [parts 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Step 4: Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-ca.md
@@ -36,7 +36,7 @@ This device also legally protects you from actions resulting from a possible hac
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -44,30 +44,20 @@ This device also legally protects you from actions resulting from a possible hac
 - An [OVHcloud web hosting plan](/links/web/hosting)
 - The login details to access [your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
-### Step 1: Analyse the situation
+### 1 - Analyse the situation
 
 If the page "**403 forbidden**" appeared following a modification of your website, [restore all or part of the FTP storage space of your hosting](/pages/web_cloud/web_hosting/ftp_save_and_backup) to an earlier date.
 
 If the available backups do not allow you to restore access to your website, contact a [specialised provider](/links/partner).
 
-If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [step 2](#step-2) of this guide.
+If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [part 2](#step-2) of this guide.
 
 If the page "**403 forbidden**" appeared without any action on your part and you have not received any email from our services about it, check the FTP access rights (CHMOD) of your files and folders as well as the code contained in your **.htaccess** file(s). Also check if the restriction is caused by a security plugin or application firewall. If necessary, contact a [specialised provider](/links/partner).
 
-### Step 2: Apply security measures on your side <a name="step-2"></a>
+### 2 - Apply security measures on your side <a name="step-2"></a>
 
 First, check the security of your computers and devices:
 
@@ -88,7 +78,7 @@ First, check the security of your computers and devices:
 > If you have any doubts about the changes to be made, contact [OVHcloud partners](/links/partner).
 >
 
-### Step 3: Intervene on your web hosting plan
+### 3 - Intervene on your web hosting plan
 
 First, take note of the date on which the OVHcloud email regarding the deactivation of your hosting and the list of folder(s) containing the malicious files detected.
 
@@ -122,10 +112,10 @@ If your hosting plan was closed more than two weeks ago, please contact a [speci
 
 > [!success]
 >
-> If you would like more details on the previous [steps 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> If you would like more details on the previous [parts 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Step 4: Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-gb.md
@@ -36,7 +36,7 @@ This device also legally protects you from actions resulting from a possible hac
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -44,30 +44,20 @@ This device also legally protects you from actions resulting from a possible hac
 - An [OVHcloud web hosting plan](/links/web/hosting)
 - The login details to access [your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
-### Step 1: Analyse the situation
+### 1 - Analyse the situation
 
 If the page "**403 forbidden**" appeared following a modification of your website, [restore all or part of the FTP storage space of your hosting](/pages/web_cloud/web_hosting/ftp_save_and_backup) to an earlier date.
 
 If the available backups do not allow you to restore access to your website, contact a [specialised provider](/links/partner).
 
-If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [step 2](#step-2) of this guide.
+If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [part 2](#step-2) of this guide.
 
 If the page "**403 forbidden**" appeared without any action on your part and you have not received any email from our services about it, check the FTP access rights (CHMOD) of your files and folders as well as the code contained in your **.htaccess** file(s). Also check if the restriction is caused by a security plugin or application firewall. If necessary, contact a [specialised provider](/links/partner).
 
-### Step 2: Apply security measures on your side <a name="step-2"></a>
+### 2 - Apply security measures on your side <a name="step-2"></a>
 
 First, check the security of your computers and devices:
 
@@ -88,7 +78,7 @@ First, check the security of your computers and devices:
 > If you have any doubts about the changes to be made, contact [OVHcloud partners](/links/partner).
 >
 
-### Step 3: Intervene on your web hosting plan
+### 3 - Intervene on your web hosting plan
 
 First, take note of the date on which the OVHcloud email regarding the deactivation of your hosting and the list of folder(s) containing the malicious files detected.
 
@@ -122,10 +112,10 @@ If your hosting plan was closed more than two weeks ago, please contact a [speci
 
 > [!success]
 >
-> If you would like more details on the previous [steps 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> If you would like more details on the previous [parts 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Step 4: Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-ie.md
@@ -36,7 +36,7 @@ This device also legally protects you from actions resulting from a possible hac
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -44,30 +44,20 @@ This device also legally protects you from actions resulting from a possible hac
 - An [OVHcloud web hosting plan](/links/web/hosting)
 - The login details to access [your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
-### Step 1: Analyse the situation
+### 1 - Analyse the situation
 
 If the page "**403 forbidden**" appeared following a modification of your website, [restore all or part of the FTP storage space of your hosting](/pages/web_cloud/web_hosting/ftp_save_and_backup) to an earlier date.
 
 If the available backups do not allow you to restore access to your website, contact a [specialised provider](/links/partner).
 
-If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [step 2](#step-2) of this guide.
+If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [part 2](#step-2) of this guide.
 
 If the page "**403 forbidden**" appeared without any action on your part and you have not received any email from our services about it, check the FTP access rights (CHMOD) of your files and folders as well as the code contained in your **.htaccess** file(s). Also check if the restriction is caused by a security plugin or application firewall. If necessary, contact a [specialised provider](/links/partner).
 
-### Step 2: Apply security measures on your side <a name="step-2"></a>
+### 2 - Apply security measures on your side <a name="step-2"></a>
 
 First, check the security of your computers and devices:
 
@@ -88,7 +78,7 @@ First, check the security of your computers and devices:
 > If you have any doubts about the changes to be made, contact [OVHcloud partners](/links/partner).
 >
 
-### Step 3: Intervene on your web hosting plan
+### 3 - Intervene on your web hosting plan
 
 First, take note of the date on which the OVHcloud email regarding the deactivation of your hosting and the list of folder(s) containing the malicious files detected.
 
@@ -122,10 +112,10 @@ If your hosting plan was closed more than two weeks ago, please contact a [speci
 
 > [!success]
 >
-> If you would like more details on the previous [steps 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> If you would like more details on the previous [parts 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Step 4: Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-sg.md
@@ -36,7 +36,7 @@ This device also legally protects you from actions resulting from a possible hac
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -44,30 +44,20 @@ This device also legally protects you from actions resulting from a possible hac
 - An [OVHcloud web hosting plan](/links/web/hosting)
 - The login details to access [your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
-### Step 1: Analyse the situation
+### 1 - Analyse the situation
 
 If the page "**403 forbidden**" appeared following a modification of your website, [restore all or part of the FTP storage space of your hosting](/pages/web_cloud/web_hosting/ftp_save_and_backup) to an earlier date.
 
 If the available backups do not allow you to restore access to your website, contact a [specialised provider](/links/partner).
 
-If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [step 2](#step-2) of this guide.
+If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [part 2](#step-2) of this guide.
 
 If the page "**403 forbidden**" appeared without any action on your part and you have not received any email from our services about it, check the FTP access rights (CHMOD) of your files and folders as well as the code contained in your **.htaccess** file(s). Also check if the restriction is caused by a security plugin or application firewall. If necessary, contact a [specialised provider](/links/partner).
 
-### Step 2: Apply security measures on your side <a name="step-2"></a>
+### 2 - Apply security measures on your side <a name="step-2"></a>
 
 First, check the security of your computers and devices:
 
@@ -88,7 +78,7 @@ First, check the security of your computers and devices:
 > If you have any doubts about the changes to be made, contact [OVHcloud partners](/links/partner).
 >
 
-### Step 3: Intervene on your web hosting plan
+### 3 - Intervene on your web hosting plan
 
 First, take note of the date on which the OVHcloud email regarding the deactivation of your hosting and the list of folder(s) containing the malicious files detected.
 
@@ -122,10 +112,10 @@ If your hosting plan was closed more than two weeks ago, please contact a [speci
 
 > [!success]
 >
-> If you would like more details on the previous [steps 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> If you would like more details on the previous [parts 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Step 4: Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.en-us.md
@@ -36,7 +36,7 @@ This device also legally protects you from actions resulting from a possible hac
 >
 > OVHcloud provides services that you are responsible for with regard to their configuration and management. It is therefore your responsibility to ensure that they function properly.
 >
-> This guide is designed to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
+> This guide is designed to help you with common tasks. However, we recommend contacting a [specialist provider](/links/partner) or reach out to the [OVHcloud community](/links/community) if you encounter any difficulties. We will not be able to assist you. You can find more information in the [Go further](#go-further) section of this guide.
 >
 
 ## Requirements
@@ -44,30 +44,20 @@ This device also legally protects you from actions resulting from a possible hac
 - An [OVHcloud web hosting plan](/links/web/hosting)
 - The login details to access [your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 
-### Step 1: Analyse the situation
+### 1 - Analyse the situation
 
 If the page "**403 forbidden**" appeared following a modification of your website, [restore all or part of the FTP storage space of your hosting](/pages/web_cloud/web_hosting/ftp_save_and_backup) to an earlier date.
 
 If the available backups do not allow you to restore access to your website, contact a [specialised provider](/links/partner).
 
-If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [step 2](#step-2) of this guide.
+If the page "**403 forbidden**" did not appear following a modification of your website, check your inbox. If you have received an email from OVHcloud notifying you that your web hosting plan has been closed for security reasons, please skip directly to [part 2](#step-2) of this guide.
 
 If the page "**403 forbidden**" appeared without any action on your part and you have not received any email from our services about it, check the FTP access rights (CHMOD) of your files and folders as well as the code contained in your **.htaccess** file(s). Also check if the restriction is caused by a security plugin or application firewall. If necessary, contact a [specialised provider](/links/partner).
 
-### Step 2: Apply security measures on your side <a name="step-2"></a>
+### 2 - Apply security measures on your side <a name="step-2"></a>
 
 First, check the security of your computers and devices:
 
@@ -88,7 +78,7 @@ First, check the security of your computers and devices:
 > If you have any doubts about the changes to be made, contact [OVHcloud partners](/links/partner).
 >
 
-### Step 3: Intervene on your web hosting plan
+### 3 - Intervene on your web hosting plan
 
 First, take note of the date on which the OVHcloud email regarding the deactivation of your hosting and the list of folder(s) containing the malicious files detected.
 
@@ -122,10 +112,10 @@ If your hosting plan was closed more than two weeks ago, please contact a [speci
 
 > [!success]
 >
-> If you would like more details on the previous [steps 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> If you would like more details on the previous [parts 2 and 3](#step-2), please refer to our tutorial on [what to do if your website is hacked](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Step 4: Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Reactivating your web hosting with FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.es-es.md
@@ -44,30 +44,20 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 - Tener contratado un plan de [hosting](/links/web/hosting) de OVHcloud.
 - Disponer de las [claves de conexión](/pages/web_cloud/web_hosting/ftp_connection) al espacio FTP de almacenamiento del alojamiento.
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acceso al área de cliente de OVHcloud
-
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedimiento
 
-### Etapa 1: analizar la situación
+### 1 - Analizar la situación
 
 Si la página **"403 forbidden"** ha aparecido como consecuencia de una modificación de su sitio web, [restaure la totalidad o parte del espacio de almacenamiento FTP de su alojamiento](/pages/web_cloud/web_hosting/ftp_save_and_backup) a una fecha anterior.
 
 Si las copias de seguridad disponibles no le permiten restablecer el acceso a su sitio web, contacte con un [proveedor especializado](/links/partner).
 
-Si la página **"403 forbidden"** no ha aparecido debido a una modificación de su sitio web, consulte su mensajería. Si, por motivos de seguridad, ha recibido un mensaje de correo electrónico de nuestros servicios informándole de que desea cerrar su alojamiento web, vaya directamente al [etapa 2](#step-2) de la presente guía.
+Si la página **"403 forbidden"** no ha aparecido debido a una modificación de su sitio web, consulte su mensajería. Si, por motivos de seguridad, ha recibido un mensaje de correo electrónico de nuestros servicios informándole de que desea cerrar su alojamiento web, vaya directamente a la [parte 2](#step-2) de la presente guía.
 
 Si la página **"403 forbidden"** ha aparecido sin ninguna acción por su parte y no ha recibido ningún email de nuestros servicios al respecto, compruebe los permisos de acceso FTP (CHMOD) de sus ficheros/carpetas así como el código contenido en su(s) archivo(s) **.htaccess**. Compruebe también si este fallo no se ha producido por un plugin de seguridad o por un firewall de aplicación. Si lo necesita, contacte con un [proveedor especializado](/links/partner).
 
-### Etapa 2: proteger sus soluciones <a name="step-2"></a>
+### 2 - Proteger sus soluciones <a name="step-2"></a>
 
 En primer lugar, compruebe la seguridad de sus equipos o dispositivos informáticos:
 
@@ -87,7 +77,7 @@ En primer lugar, compruebe la seguridad de sus equipos o dispositivos informáti
 >
 > En caso de duda sobre las operaciones a realizar, contacte con los [partners de OVHcloud](/links/partner).
 
-### Etapa 3: intervenir en su alojamiento
+### 3 - Intervenir en su alojamiento
 
 En primer lugar, la fecha de envío del mensaje de correo electrónico de OVHcloud indica la desactivación de su alojamiento web y la carpeta o carpetas que contienen ejemplos de archivos ilegítimos.
 
@@ -121,9 +111,9 @@ Si su alojamiento ha sido cerrado más de dos semanas antes, contacte con un [pr
 
 > [!success]
 >
-> Si desea más información sobre los [etapas 2 y 3](#step-2) anteriores, consulte nuestro tutorial sobre [las acciones a realizar en caso de pirateo de su sitio web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> Si desea más información sobre los [partes 2 y 3](#step-2) anteriores, consulte nuestro tutorial sobre [las acciones a realizar en caso de pirateo de su sitio web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
-### Etapa 4: reactivar el alojamiento con FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Reactivar el alojamiento con FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.es-us.md
@@ -47,7 +47,7 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 
 ## Procedimiento
 
-### 1 - analizar la situación
+### 1 - Analizar la situación
 
 Si la página **"403 forbidden"** ha aparecido como consecuencia de una modificación de su sitio web, [restaure la totalidad o parte del espacio de almacenamiento FTP de su alojamiento](/pages/web_cloud/web_hosting/ftp_save_and_backup) a una fecha anterior.
 
@@ -57,7 +57,7 @@ Si la página **"403 forbidden"** no ha aparecido debido a una modificación de 
 
 Si la página **"403 forbidden"** ha aparecido sin ninguna acción por su parte y no ha recibido ningún email de nuestros servicios al respecto, compruebe los permisos de acceso FTP (CHMOD) de sus ficheros/carpetas así como el código contenido en su(s) archivo(s) **.htaccess**. Compruebe también si este fallo no se ha producido por un plugin de seguridad o por un firewall de aplicación. Si lo necesita, contacte con un [proveedor especializado](/links/partner).
 
-### 2 - proteger sus soluciones <a name="step-2"></a>
+### 2 - Proteger sus soluciones <a name="step-2"></a>
 
 En primer lugar, compruebe la seguridad de sus equipos o dispositivos informáticos:
 
@@ -77,7 +77,7 @@ En primer lugar, compruebe la seguridad de sus equipos o dispositivos informáti
 >
 > En caso de duda sobre las operaciones a realizar, contacte con los [partners de OVHcloud](/links/partner).
 
-### 3 - intervenir en su alojamiento
+### 3 - Intervenir en su alojamiento
 
 En primer lugar, la fecha de envío del mensaje de correo electrónico de OVHcloud indica la desactivación de su alojamiento web y la carpeta o carpetas que contienen ejemplos de archivos ilegítimos.
 
@@ -113,7 +113,7 @@ Si su alojamiento ha sido cerrado más de dos semanas antes, contacte con un [pr
 >
 > Si desea más información sobre los [partes 2 y 3](#step-2) anteriores, consulte nuestro tutorial sobre [las acciones a realizar en caso de pirateo de su sitio web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
-### 4 - reactivar el alojamiento con FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Reactivar el alojamiento con FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.es-us.md
@@ -44,30 +44,20 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 - Tener contratado un plan de [hosting](/links/web/hosting) de OVHcloud.
 - Disponer de las [claves de conexión](/pages/web_cloud/web_hosting/ftp_connection) al espacio FTP de almacenamiento del alojamiento.
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acceso al área de cliente de OVHcloud
-
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedimiento
 
-### Etapa 1: analizar la situación
+### 1 - analizar la situación
 
 Si la página **"403 forbidden"** ha aparecido como consecuencia de una modificación de su sitio web, [restaure la totalidad o parte del espacio de almacenamiento FTP de su alojamiento](/pages/web_cloud/web_hosting/ftp_save_and_backup) a una fecha anterior.
 
 Si las copias de seguridad disponibles no le permiten restablecer el acceso a su sitio web, contacte con un [proveedor especializado](/links/partner).
 
-Si la página **"403 forbidden"** no ha aparecido debido a una modificación de su sitio web, consulte su mensajería. Si, por motivos de seguridad, ha recibido un mensaje de correo electrónico de nuestros servicios informándole de que desea cerrar su alojamiento web, vaya directamente al [etapa 2](#step-2) de la presente guía.
+Si la página **"403 forbidden"** no ha aparecido debido a una modificación de su sitio web, consulte su mensajería. Si, por motivos de seguridad, ha recibido un mensaje de correo electrónico de nuestros servicios informándole de que desea cerrar su alojamiento web, vaya directamente a la [parte 2](#step-2) de la presente guía.
 
 Si la página **"403 forbidden"** ha aparecido sin ninguna acción por su parte y no ha recibido ningún email de nuestros servicios al respecto, compruebe los permisos de acceso FTP (CHMOD) de sus ficheros/carpetas así como el código contenido en su(s) archivo(s) **.htaccess**. Compruebe también si este fallo no se ha producido por un plugin de seguridad o por un firewall de aplicación. Si lo necesita, contacte con un [proveedor especializado](/links/partner).
 
-### Etapa 2: proteger sus soluciones <a name="step-2"></a>
+### 2 - proteger sus soluciones <a name="step-2"></a>
 
 En primer lugar, compruebe la seguridad de sus equipos o dispositivos informáticos:
 
@@ -87,7 +77,7 @@ En primer lugar, compruebe la seguridad de sus equipos o dispositivos informáti
 >
 > En caso de duda sobre las operaciones a realizar, contacte con los [partners de OVHcloud](/links/partner).
 
-### Etapa 3: intervenir en su alojamiento
+### 3 - intervenir en su alojamiento
 
 En primer lugar, la fecha de envío del mensaje de correo electrónico de OVHcloud indica la desactivación de su alojamiento web y la carpeta o carpetas que contienen ejemplos de archivos ilegítimos.
 
@@ -121,9 +111,9 @@ Si su alojamiento ha sido cerrado más de dos semanas antes, contacte con un [pr
 
 > [!success]
 >
-> Si desea más información sobre los [etapas 2 y 3](#step-2) anteriores, consulte nuestro tutorial sobre [las acciones a realizar en caso de pirateo de su sitio web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> Si desea más información sobre los [partes 2 y 3](#step-2) anteriores, consulte nuestro tutorial sobre [las acciones a realizar en caso de pirateo de su sitio web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
-### Etapa 4: reactivar el alojamiento con FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - reactivar el alojamiento con FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.fr-ca.md
@@ -36,7 +36,7 @@ Suite à la détection d'un fonctionnement suspect, nos robots de sécurité peu
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou d'échanger avec notre [communauté d'utilisateurs](/links/community) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [« Aller plus loin »](#go-further) de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou d'échanger avec notre [communauté d'utilisateurs](/links/community) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [« Aller plus loin »](#go-further) de ce guide.
 >
 
 ## Prérequis
@@ -44,30 +44,20 @@ Suite à la détection d'un fonctionnement suspect, nos robots de sécurité peu
 - Disposer d'une [offre d'hébergement web](/links/web/hosting) OVHcloud.
 - Disposer des [identifiants de connexion](/pages/web_cloud/web_hosting/ftp_connection) à l'espace de stockage FTP de votre hébergement web.
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accès à l'espace client OVHcloud
-
-- **Lien direct :** [Hébergements](/links/control-panel/web-hosting)
-- **Pour accéder à vos services :** `Web Cloud`{.action} > `Hébergements`{.action} > Sélectionnez votre hébergement web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## En pratique
 
-### Étape 1 : analyser la situation
+### 1 - analyser la situation
 
 Si la page **« 403 forbidden »** est apparue suite à une modification de votre site web, [restaurez tout ou partie de l'espace de stockage FTP de votre hébergement](/pages/web_cloud/web_hosting/ftp_save_and_backup) à une date antérieure.
 
 Si les sauvegardes disponibles ne vous permettent pas de rétablir l'accès à votre site web, contactez un [prestataire spécialisé](/links/partner).
 
-Si la page **« 403 forbidden »** n'est pas apparue suite à une modification de votre site web, consultez votre messagerie. Si vous avez reçu un e-mail de nos services indiquant une fermeture de votre hébergement web pour des raisons de sécurité, passez directement à [l'étape 2](#step-2) du présent guide.
+Si la page **« 403 forbidden »** n'est pas apparue suite à une modification de votre site web, consultez votre messagerie. Si vous avez reçu un e-mail de nos services indiquant une fermeture de votre hébergement web pour des raisons de sécurité, passez directement à [la [partie 2](#step-2)](#step-2) du présent guide.
 
 Si la page **« 403 forbidden »** est apparue sans action de votre part et que vous n'avez pas reçu d'e-mail de nos services à ce sujet, vérifiez les droits d'accès FTP (CHMOD) de vos fichiers/dossiers ainsi que le code contenu dans votre (vos) fichier(s) **.htaccess**. Vérifiez également si cette situation n'est pas générée par un plugin de sécurité ou par un pare-feu applicatif. Si besoin, contactez un [prestataire spécialisé](/links/partner).
 
-### Étape 2 : sécuriser vos solutions <a name="step-2"></a>
+### 2 - sécuriser vos solutions <a name="step-2"></a>
 
 Vérifiez tout d'abord la sécurité de votre (vos) poste(s)/appareil(s) informatique(s) :
 
@@ -88,7 +78,7 @@ Vérifiez tout d'abord la sécurité de votre (vos) poste(s)/appareil(s) informa
 > En cas de doute sur les manipulations à réaliser, contactez les [partenaires OVHcloud](/links/partner).
 >
 
-### Étape 3 : intervenir sur votre hébergement web
+### 3 - intervenir sur votre hébergement web
 
 Notez tout d'abord la date d'envoi de l'e-mail d'OVHcloud indiquant la désactivation de votre hébergement web, ainsi que le ou les dossiers contenant les exemples de fichiers illégitimes.
 
@@ -122,10 +112,10 @@ Si votre hébergement a été fermé il y a plus de deux semaines, contactez un 
 
 > [!success]
 >
-> Si vous souhaitez plus de détails concernant les [étapes 2 et 3](#step-2) précédentes, consultez notre tutoriel sur [les actions à réaliser en cas de piratage de votre site web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> Si vous souhaitez plus de détails concernant les [parties 2 et 3](#step-2) précédentes, consultez notre tutoriel sur [les actions à réaliser en cas de piratage de votre site web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Étape 4 : réactiver votre hébergement web avec FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - réactiver votre hébergement web avec FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.fr-fr.md
@@ -36,7 +36,7 @@ Suite à la détection d'un fonctionnement suspect, nos robots de sécurité peu
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou d'échanger avec notre [communauté d'utilisateurs](/links/community) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [« Aller plus loin »](#go-further) de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou d'échanger avec notre [communauté d'utilisateurs](/links/community) si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [« Aller plus loin »](#go-further) de ce guide.
 >
 
 ## Prérequis
@@ -44,30 +44,19 @@ Suite à la détection d'un fonctionnement suspect, nos robots de sécurité peu
 - Disposer d'une [offre d'hébergement web](/links/web/hosting) OVHcloud.
 - Disposer des [identifiants de connexion](/pages/web_cloud/web_hosting/ftp_connection) à l'espace de stockage FTP de votre hébergement web.
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accès à l'espace client OVHcloud
-
-- **Lien direct :** [Hébergements](/links/control-panel/web-hosting)
-- **Pour accéder à vos services :** `Web Cloud`{.action} > `Hébergements`{.action} > Sélectionnez votre hébergement web
-
----
-<!-- CP-NAV-END:web-hosting -->
-
 ## En pratique
 
-### Étape 1 : analyser la situation
+### 1 - Analyser la situation
 
 Si la page **« 403 forbidden »** est apparue suite à une modification de votre site web, [restaurez tout ou partie de l'espace de stockage FTP de votre hébergement](/pages/web_cloud/web_hosting/ftp_save_and_backup) à une date antérieure.
 
 Si les sauvegardes disponibles ne vous permettent pas de rétablir l'accès à votre site web, contactez un [prestataire spécialisé](/links/partner).
 
-Si la page **« 403 forbidden »** n'est pas apparue suite à une modification de votre site web, consultez votre messagerie. Si vous avez reçu un e-mail de nos services indiquant une fermeture de votre hébergement web pour des raisons de sécurité, passez directement à [l'étape 2](#step-2) du présent guide.
+Si la page **« 403 forbidden »** n'est pas apparue suite à une modification de votre site web, consultez votre messagerie. Si vous avez reçu un e-mail de nos services indiquant une fermeture de votre hébergement web pour des raisons de sécurité, passez directement à la [partie 2](#step-2) du présent guide.
 
 Si la page **« 403 forbidden »** est apparue sans action de votre part et que vous n'avez pas reçu d'e-mail de nos services à ce sujet, vérifiez les droits d'accès FTP (CHMOD) de vos fichiers/dossiers ainsi que le code contenu dans votre (vos) fichier(s) **.htaccess**. Vérifiez également si cette situation n'est pas générée par un plugin de sécurité ou par un pare-feu applicatif. Si besoin, contactez un [prestataire spécialisé](/links/partner).
 
-### Étape 2 : sécuriser vos solutions <a name="step-2"></a>
+### 2 - Sécuriser vos solutions <a name="step-2"></a>
 
 Vérifiez tout d'abord la sécurité de votre (vos) poste(s)/appareil(s) informatique(s) :
 
@@ -88,7 +77,7 @@ Vérifiez tout d'abord la sécurité de votre (vos) poste(s)/appareil(s) informa
 > En cas de doute sur les manipulations à réaliser, contactez les [partenaires OVHcloud](/links/partner).
 >
 
-### Étape 3 : intervenir sur votre hébergement web
+### 3 - Intervenir sur votre hébergement web
 
 Notez tout d'abord la date d'envoi de l'e-mail d'OVHcloud indiquant la désactivation de votre hébergement web, ainsi que le ou les dossiers contenant les exemples de fichiers illégitimes.
 
@@ -122,10 +111,10 @@ Si votre hébergement a été fermé il y a plus de deux semaines, contactez un 
 
 > [!success]
 >
-> Si vous souhaitez plus de détails concernant les [étapes 2 et 3](#step-2) précédentes, consultez notre tutoriel sur [les actions à réaliser en cas de piratage de votre site web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> Si vous souhaitez plus de détails concernant les [parties 2 et 3](#step-2) précédentes, consultez notre tutoriel sur [les actions à réaliser en cas de piratage de votre site web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Étape 4 : réactiver votre hébergement web avec FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Réactiver votre hébergement web avec FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.it-it.md
@@ -44,30 +44,20 @@ In seguito al rilevamento di un funzionamento sospetto, i nostri sistemi di sicu
 - Disporre di una [soluzione di hosting Web](/links/web/hosting) OVHcloud
 - Disporre delle [credenziali di accesso](/pages/web_cloud/web_hosting/ftp_connection) allo spazio di storage FTP dell'hosting
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accesso allo Spazio Cliente OVHcloud
-
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedura
 
-### Step 1: analizzare la situazione
+### 1 - Analizzare la situazione
 
 Se la pagina **"403 forbidden"** è apparsa in seguito a una modifica del tuo sito Web, [ripristina totalmente o in parte lo spazio di storage FTP del tuo hosting](/pages/web_cloud/web_hosting/ftp_save_and_backup) a una data precedente.
 
 Se i backup disponibili non ti permettono di ripristinare l'accesso al tuo sito Web, contatta uno dei [provider specializzati](/links/partner).
 
-Se la pagina **"403 forbidden"** non è apparsa a seguito di una modifica del tuo sito web, consulta il tuo servizio di posta elettronica. Se hai ricevuto un'email dai nostri servizi che indica la chiusura del tuo hosting Web per motivi di sicurezza, passa direttamente allo Step 2 della presente guida.
+Se la pagina **"403 forbidden"** non è apparsa a seguito di una modifica del tuo sito web, consulta il tuo servizio di posta elettronica. Se hai ricevuto un'email dai nostri servizi che indica la chiusura del tuo hosting Web per motivi di sicurezza, passa direttamente alla [parte 2](#step-2) della presente guida.
 
 Se la pagina **"403 forbidden"** è apparsa senza azione da parte tua e non hai ricevuto alcuna email dai nostri servizi a questo proposito, verifica i diritti di accesso FTP (CHMOD) dei tuoi file/cartelle e il codice contenuto nei tuoi file **.htaccess**. Verifica che questa situazione non sia causata da un plugin di sicurezza o da un firewall applicativo. In caso di necessità, contatta un [fornitore specializzato](/links/partner).
 
-### Step 2: rendere sicure le tue soluzioni <a name="step-2"></a>
+### 2 - Rendere sicure le tue soluzioni <a name="step-2"></a>
 
 Verifica la sicurezza della tua o delle tue postazioni/dispositivi informatici:
 
@@ -88,7 +78,7 @@ Verifica la sicurezza della tua o delle tue postazioni/dispositivi informatici:
 > In caso di dubbi sulle operazioni da effettuare, contatta i [partner OVHcloud](/links/partner).
 >
 
-### Step 3: intervenire sul tuo hosting
+### 3 - Intervenire sul tuo hosting
 
 Annota innanzitutto la data di invio dell'email di OVHcloud che indica la disattivazione del tuo hosting Web, nonché la o le cartelle che contengono esempi di file illegittimi.
 
@@ -122,10 +112,10 @@ Se il tuo hosting è stato chiuso più di due settimane fa, contatta un [provide
 
 > [!success]
 >
-> Per maggiori informazioni sui [step 2 e 3](#step-2), consulta la nostra guida su [le azioni da effettuare in caso di hacking del tuo sito Web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> Per maggiori informazioni sui [parti 2 e 3](#step-2), consulta la nostra guida su [le azioni da effettuare in caso di hacking del tuo sito Web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Step 4: riattiva il tuo hosting con FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Riattiva il tuo hosting con FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.it-it.md
@@ -112,7 +112,7 @@ Se il tuo hosting è stato chiuso più di due settimane fa, contatta un [provide
 
 > [!success]
 >
-> Per maggiori informazioni sui [parti 2 e 3](#step-2), consulta la nostra guida su [le azioni da effettuare in caso di hacking del tuo sito Web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> Per maggiori informazioni sulle [parti 2 e 3](#step-2), consulta la nostra guida su [le azioni da effettuare in caso di hacking del tuo sito Web](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
 ### 4 - Riattiva il tuo hosting con FileZilla <a name="reactivate-web-hosting"></a>

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.pl-pl.md
@@ -78,7 +78,7 @@ Sprawdź najpierw bezpieczeństwo swoich stacji/urządzeń:
 > W przypadku wątpliwości dotyczących sposobu postępowania skontaktuj się z [partnerami OVHcloud](/links/partner).
 >
 
-### 3 - Interweniować na Twoim hostingu
+### 3 - Interweniuj na Twoim hostingu
 
 Najpierw zapisz datę wysłania wiadomości e-mail OVHcloud informującej o wyłączeniu hostingu WWW, a także folder lub foldery zawierające przykłady niezgodnych z prawem plików.
 
@@ -112,7 +112,7 @@ Jeśli Twój hosting został zamknięty ponad dwa tygodnie temu, skontaktuj się
 
 > [!success]
 >
-> Jeśli potrzebujesz więcej informacji na temat [części 2 i 3](#step-2), zapoznaj się z naszym tutorial [działań, które należy wykonać w przypadku włamania na Twojej stronie internetowej](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> Jeśli potrzebujesz więcej informacji na temat [części 2 i 3](#step-2), zapoznaj się z naszym tutorialem [działań, które należy wykonać w przypadku włamania na Twojej stronie internetowej](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 > 
 
 ### 4 - Reaktywuj Twój hosting za pomocą FileZilla <a name="reactivate-web-hosting"></a>

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.pl-pl.md
@@ -44,30 +44,20 @@ Po wykryciu podejrzanego działania nasze roboty związane z bezpieczeństwem mo
 - Posiadanie [hostingu](/links/web/hosting) OVHcloud
 - Posiadanie [danych do logowania](/pages/web_cloud/web_hosting/ftp_connection) do przestrzeni dyskowej FTP Twojego hostingu
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Dostęp do Panelu klienta OVHcloud
-
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## W praktyce
 
-### Etap 1: analiza sytuacji
+### 1 - Analiza sytuacji
 
 Jeśli strona **"403 forbidden"** pojawiła się po zmianie strony WWW, [przywróć całą lub część przestrzeni dyskowej FTP Twojego hostingu](/pages/web_cloud/web_hosting/ftp_save_and_backup) do wcześniejszej daty.
 
 Jeśli dostępne kopie zapasowe nie pozwolą Ci przywrócić dostępu do Twojej strony WWW, skontaktuj się z [wyspecjalizowanym dostawcą](/links/partner).
 
-Jeśli strona **"403 forbidden"** nie pojawiła się po zmianie strony, sprawdź swoją skrzynkę pocztową. Jeśli otrzymałeś e-mail z naszych usług wskazujący na zamknięcie Twojego hostingu ze względów bezpieczeństwa, przejdź bezpośrednio do [etap 2](#step-2) niniejszego przewodnika.
+Jeśli strona **"403 forbidden"** nie pojawiła się po zmianie strony, sprawdź swoją skrzynkę pocztową. Jeśli otrzymałeś e-mail z naszych usług wskazujący na zamknięcie Twojego hostingu ze względów bezpieczeństwa, przejdź bezpośrednio do [części 2](#step-2) niniejszego przewodnika.
 
 Jeśli strona **"403 forbidden"** pojawiła się bez podjęcia przez Ciebie działań i nie otrzymałeś e-maila od naszych usług w tym zakresie, sprawdź prawa dostępu FTP (CHMOD) do Twoich plików/folderów oraz kod zawarty w pliku(-ach) **.htaccess**. Sprawdź również, czy ta sytuacja nie jest generowana przez wtyczkę bezpieczeństwa lub zaporę aplikacyjną. W razie potrzeby należy skontaktować się z [wyspecjalizowanym dostawcą](/links/partner).
 
-### Etap 2: zabezpiecz swoje rozwiązania <a name="step-2"></a>
+### 2 - Zabezpiecz swoje rozwiązania <a name="step-2"></a>
 
 Sprawdź najpierw bezpieczeństwo swoich stacji/urządzeń:
 
@@ -88,7 +78,7 @@ Sprawdź najpierw bezpieczeństwo swoich stacji/urządzeń:
 > W przypadku wątpliwości dotyczących sposobu postępowania skontaktuj się z [partnerami OVHcloud](/links/partner).
 >
 
-### Etap 3: interweniować na Twoim hostingu
+### 3 - Interweniować na Twoim hostingu
 
 Najpierw zapisz datę wysłania wiadomości e-mail OVHcloud informującej o wyłączeniu hostingu WWW, a także folder lub foldery zawierające przykłady niezgodnych z prawem plików.
 
@@ -122,10 +112,10 @@ Jeśli Twój hosting został zamknięty ponad dwa tygodnie temu, skontaktuj się
 
 > [!success]
 >
-> Jeśli potrzebujesz więcej informacji na temat [etapów 2 i 3](#step-2), zapoznaj się z naszym tutorial [działań, które należy wykonać w przypadku włamania na Twojej stronie internetowej](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> Jeśli potrzebujesz więcej informacji na temat [części 2 i 3](#step-2), zapoznaj się z naszym tutorial [działań, które należy wykonać w przypadku włamania na Twojej stronie internetowej](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 > 
 
-### Etap 4: Reaktywuj Twój hosting za pomocą FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Reaktywuj Twój hosting za pomocą FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.pt-pt.md
@@ -110,7 +110,7 @@ Para restaurar todo ou parte do seu espaço de armazenamento FTP, consulte o [no
 
 Se o seu alojamento foi encerrado há mais de duas semanas, contacte um [fornecedor especializado](/links/partner) para efetuar uma auditoria de segurança dos seus websites. 
 
-> [!success
+> [!success]
 >
 > Para mais informações sobre os [partes 2 e 3](#step-2) anteriores, consulte o nosso manual sobre [ações a realizar em caso de pirataria do seu website](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.pt-pt.md
@@ -44,30 +44,20 @@ Após a deteção de um funcionamento suspeito, os nossos robôs de segurança p
 - Ter um [serviço de alojamento web](/links/web/hosting) OVHcloud.
 - Dispor dos [dados de acesso](/pages/web_cloud/web_hosting/ftp_connection) ao espaço FTP de armazenamento do seu alojamento.
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acesso à Área de Cliente OVHcloud
-
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
-- **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instruções
 
-### Etapa 1: analisar a situação
+### 1 - Analisar a situação
 
 Se a página **"403 forbidden"** surgiu na sequência de uma modificação do seu website, [restaure todo ou parte do espaço de armazenamento FTP do seu alojamento](/pages/web_cloud/web_hosting/ftp_save_and_backup) numa data anterior.
 
 Se os backups disponíveis não lhe permitem restabelecer o acesso ao seu website, contacte um [fornecedor especializado](/links/partner).
 
-Se a página **"403 forbidden"** não aparecer após uma modificação do seu website, consulte o seu e-mail. Se recebeu um e-mail dos nossos serviços indicando que o seu alojamento web foi encerrado por razões de segurança, passe diretamente para [etapa 2](#step-2) deste manual.
+Se a página **"403 forbidden"** não aparecer após uma modificação do seu website, consulte o seu e-mail. Se recebeu um e-mail dos nossos serviços indicando que o seu alojamento web foi encerrado por razões de segurança, passe diretamente para a [parte 2](#step-2) deste manual.
 
 Se a página **"403 forbidden"** aparecer sem ação da sua parte e não tiver recebido um e-mail dos nossos serviços sobre o assumpto, verifique as permissões de acesso FTP (CHMOD) dos seus ficheiros/pastas bem como o código contido no(s) seu(s) ficheiro(s) **.htaccess**. Verifique também se esta situação não é gerada por um plugin de segurança ou por uma firewall de aplicação. Se necessário, contacte um [fornecedor especializado](/links/partner).
 
-### Etapa 2: proteger as suas soluções <a name="step-2"></a>
+### 2 - Proteger as suas soluções <a name="step-2"></a>
 
 Em primeiro lugar, verifique a segurança do(s) seu(s) posto(s)/aparelho(s) informático(s):
 
@@ -88,7 +78,7 @@ Em primeiro lugar, verifique a segurança do(s) seu(s) posto(s)/aparelho(s) info
 > Em caso de dúvida sobre as operações a realizar, contacte os [parceiros OVHcloud](/links/partner).
 >
 
-### Etapa 3: intervir no seu alojamento
+### 3 - Intervir no seu alojamento
 
 Em primeiro lugar, tome nota da data de envio do e-mail da OVHcloud que indica a desativação do seu alojamento web, assim como da(s) pasta(s) que contém os exemplos de ficheiros ilegítimos.
 
@@ -122,10 +112,10 @@ Se o seu alojamento foi encerrado há mais de duas semanas, contacte um [fornece
 
 > [!success
 >
-> Para mais informações sobre os [passos 2 e 3](#step-2) anteriores, consulte o nosso manual sobre [ações a realizar em caso de pirataria do seu website](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> Para mais informações sobre os [partes 2 e 3](#step-2) anteriores, consulte o nosso manual sobre [ações a realizar em caso de pirataria do seu website](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
-### Etapa 4: reativar o alojamento com o FileZilla <a name="reactivate-web-hosting"></a>
+### 4 - Reativar o alojamento com o FileZilla <a name="reactivate-web-hosting"></a>
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic_403_forbidden/guide.pt-pt.md
@@ -112,7 +112,7 @@ Se o seu alojamento foi encerrado há mais de duas semanas, contacte um [fornece
 
 > [!success]
 >
-> Para mais informações sobre os [partes 2 e 3](#step-2) anteriores, consulte o nosso manual sobre [ações a realizar em caso de pirataria do seu website](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
+> Para mais informações sobre as [partes 2 e 3](#step-2) anteriores, consulte o nosso manual sobre [ações a realizar em caso de pirataria do seu website](/pages/web_cloud/web_hosting/cms_what_to_do_if_your_site_is_hacked).
 >
 
 ### 4 - Reativar o alojamento com o FileZilla <a name="reactivate-web-hosting"></a>

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.de-de.md
@@ -26,16 +26,6 @@ Diese Fehler können auch durch Updates entstehen, die **automatisch** von Kompo
 - Sie haben ein [OVHcloud Webhosting](/links/web/hosting) in Ihrem Kunden-Account.
 - Sie haben keine ausstehenden [Zahlungen](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) und [Verlängerungen](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) der dazugehörigen Dienstleistungen (Domainname und Webhosting).
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Zugriff auf das OVHcloud Kundencenter
-
-- **Direkter Link:** [Hosting-Pakete](/links/control-panel/web-hosting)
-- **Navigationspfad:** `Web Cloud`{.action} > `Hosting-Pakete`{.action} > Wählen Sie Ihr Webhosting aus
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## In der praktischen Anwendung
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-asia.md
@@ -26,16 +26,6 @@ These errors may also come from updates carried out **automatically** by compone
 - an [OVHcloud Web Hosting plan](/links/web/hosting)
 - being up-to-date in the [payments](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) and [renewals](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) of related services (domain name and web hosting plan)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-au.md
@@ -26,16 +26,6 @@ These errors may also come from updates carried out **automatically** by compone
 - an [OVHcloud Web Hosting plan](/links/web/hosting)
 - being up-to-date in the [payments](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) and [renewals](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) of related services (domain name and web hosting plan)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-ca.md
@@ -26,16 +26,6 @@ These errors may also come from updates carried out **automatically** by compone
 - an [OVHcloud Web Hosting plan](/links/web/hosting)
 - being up-to-date in the [payments](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) and [renewals](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) of related services (domain name and web hosting plan)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-gb.md
@@ -26,16 +26,6 @@ These errors may also come from updates carried out **automatically** by compone
 - an [OVHcloud Web Hosting plan](/links/web/hosting)
 - being up-to-date in the [payments](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) and [renewals](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) of related services (domain name and web hosting plan)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-ie.md
@@ -26,16 +26,6 @@ These errors may also come from updates carried out **automatically** by compone
 - an [OVHcloud Web Hosting plan](/links/web/hosting)
 - being up-to-date in the [payments](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) and [renewals](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) of related services (domain name and web hosting plan)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-sg.md
@@ -26,16 +26,6 @@ These errors may also come from updates carried out **automatically** by compone
 - an [OVHcloud Web Hosting plan](/links/web/hosting)
 - being up-to-date in the [payments](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) and [renewals](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) of related services (domain name and web hosting plan)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.en-us.md
@@ -26,16 +26,6 @@ These errors may also come from updates carried out **automatically** by compone
 - an [OVHcloud Web Hosting plan](/links/web/hosting)
 - being up-to-date in the [payments](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) and [renewals](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) of related services (domain name and web hosting plan)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.es-es.md
@@ -26,16 +26,6 @@ A veces también se actualizan **automáticamente** en un componente del sitio w
 - Tener un [plan de hosting](/links/web/hosting).
 - Estar actualizado en los [pagos](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) y [renovaciones](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) de los servicios asociados (dominio y alojamiento web).
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acceso al área de cliente de OVHcloud
-
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedimiento
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.es-us.md
@@ -26,16 +26,6 @@ A veces también se actualizan **automáticamente** en un componente del sitio w
 - Tener un [plan de hosting](/links/web/hosting).
 - Estar actualizado en los [pagos](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) y [renovaciones](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) de los servicios asociados (dominio y alojamiento web).
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acceso al área de cliente de OVHcloud
-
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedimiento
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.fr-ca.md
@@ -17,23 +17,13 @@ Elles proviennent parfois aussi d'une mise à jour effectuée **automatiquement*
 > [!warning]
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
 
 ## Prérequis
 
 - Disposer d'une [offre d'hébergement mutualisé](/links/web/hosting)
 - Être à jour dans les [paiements](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) et [renouvellements](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) des services liés (nom de domaine et hébergement web)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accès à l'espace client OVHcloud
-
-- **Lien direct :** [Hébergements](/links/control-panel/web-hosting)
-- **Pour accéder à vos services :** `Web Cloud`{.action} > `Hébergements`{.action} > Sélectionnez votre hébergement web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## En pratique
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.fr-fr.md
@@ -18,24 +18,13 @@ Elles proviennent parfois aussi d'une mise à jour effectuée **automatiquement*
 >
 > OVHcloud met à votre disposition des services dont la configuration, la gestion et la responsabilité vous incombent. Il vous revient de ce fait d'en assurer le bon fonctionnement.
 >
-> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Néanmoins, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
+> Nous mettons à votre disposition ce guide afin de vous accompagner au mieux sur des tâches courantes. Cependant, nous vous recommandons de faire appel à un [prestataire spécialisé](/links/partner) et/ou de contacter l'éditeur du service si vous éprouvez des difficultés. En effet, nous ne serons pas en mesure de vous fournir une assistance. Plus d'informations dans la section [Aller plus loin](#go-further) de ce guide.
 >
 
 ## Prérequis
 
 - Disposer d'une [offre d'hébergement mutualisé](/links/web/hosting)
 - Être à jour dans les [paiements](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) et [renouvellements](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) des services liés (nom de domaine et hébergement web)
-
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accès à l'espace client OVHcloud
-
-- **Lien direct :** [Hébergements](/links/control-panel/web-hosting)
-- **Pour accéder à vos services :** `Web Cloud`{.action} > `Hébergements`{.action} > Sélectionnez votre hébergement web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## En pratique
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.it-it.md
@@ -26,16 +26,6 @@ A volte provengono anche da un aggiornamento effettuato **automaticamente** da u
 - Disporre di un'[offerta di hosting condiviso](/links/web/hosting)
 - Essere aggiornato nei [pagamenti](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) e [rinnovi](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) dei servizi associati (dominio e hosting web)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accesso allo Spazio Cliente OVHcloud
-
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedura
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.pl-pl.md
@@ -26,16 +26,6 @@ Zdarza się to również w wyniku aktualizacji przeprowadzonej **automatycznie**
 - Posiadanie [hostingu](/links/web/hosting)
 - Aktualizacja w [płatności](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) i [odnowienie](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) powiązanych usług (domena i hosting)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Dostęp do Panelu klienta OVHcloud
-
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## W praktyce
 

--- a/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic_fix_500_internal_server_error/guide.pt-pt.md
@@ -26,16 +26,6 @@ Por vezes, provêm também de uma atualização efetuada **automaticamente** por
 - Dispor de uma [oferta de alojamento partilhado](/links/web/hosting)
 - Estar atualizado em [pagamentos](/pages/account_and_service_management/managing_billing_payments_and_services/invoice_management#pay-bills) e [renovações](/pages/account_and_service_management/managing_billing_payments_and_services/how_to_use_automatic_renewal#renewal-management) dos serviços associados (nome de domínio e alojamento web)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acesso à Área de Cliente OVHcloud
-
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
-- **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instruções
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.de-de.md
@@ -37,16 +37,6 @@ In seltenen Fällen können die Verzögerungen bei der Anzeige auch mit Ihrem In
 
 - Sie hosten eine Website auf einem [OVHcloud Webhosting](/links/web/hosting).
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Zugriff auf das OVHcloud Kundencenter
-
-- **Direkter Link:** [Hosting-Pakete](/links/control-panel/web-hosting)
-- **Navigationspfad:** `Web Cloud`{.action} > `Hosting-Pakete`{.action} > Wählen Sie Ihr Webhosting aus
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## In der praktischen Anwendung
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.de-de.md
@@ -89,7 +89,7 @@ Alle Diagnosen in Schritt 1 sind **ausnahmslos** durchzuführen, um festzustelle
 
 Um sicherzustellen, dass Ihre Dienste (Webhosting **und** Datenbank) derzeit von keiner Störung oder Wartung beeinträchtigt werden, benötigen Sie die Cluster- und Filer-Nummer des Hostings sowie die allgemeinen Daten zur entsprechenden Datenbank. Damit können Sie den Status auf [status.ovhcloud.com](https://web-cloud.status-ovhcloud.com/) überprüfen.
 
-Um den Cluster und den Filer zu ermitteln, auf dem sich Ihr Webhosting befindet, konsultieren Sie: „[Webhosting - Cluster und Filer eines Webhostings finden](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)“.
+Um den Cluster und den Filer zu ermitteln, auf dem sich Ihr Webhosting befindet, konsultieren Sie: "[Webhosting - Cluster und Filer eines Webhostings finden](/pages/web_cloud/web_hosting/how_to_know_cluster_and_filer)“.
 
 > [!success]
 >
@@ -141,7 +141,7 @@ Wenn Sie eine Datenbank mit **Web Cloud Databases** nutzen, lesen Sie unsere Anl
 
 Wenn die Verbindung erfolgreich war, gelangen Sie auf folgendes Interface:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >
@@ -185,7 +185,7 @@ Wenn Sie auf Ihrem Webhosting eine überholte PHP-Version einsetzen, sowie die E
 
 Um die verfügbaren PHP-Versionen je nach Ausführungsumgebung zu vergleichen, lesen Sie **Schritt 2** der Anleitung zur [Konfiguration der PHP-Version auf Ihrem Hosting](/pages/web_cloud/web_hosting/configure_your_web_hosting).
 
-Die Verwendung einer aktuellen PHP-Version, die Ausführungsumgebung **stable** oder **stable64** mit der Engine **PHP** (PHP FPM) macht Ihre Website deutlich flüssiger und schneller. Zur Information: Die Engine **PHP** (PHP FPM) kann bis zu 50 Mal leistungsfähiger bei Auführungen sein als die Engine **PHP CGI**.
+Die Verwendung einer aktuellen PHP-Version, die Ausführungsumgebung **stable** oder **stable64** mit der Engine **PHP** (PHP FPM) macht Ihre Website deutlich flüssiger und schneller. Zur Information: Die Engine **PHP** (PHP FPM) kann bis zu 50 Mal leistungsfähiger bei Ausführungen sein als die Engine **PHP CGI**.
 
 #### 2.2 - Analysieren Sie ausgehende Verbindungen / TCP Verbindungen von Ihrem Webhosting
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-asia.md
@@ -143,7 +143,7 @@ If you are using a database of a **Web Cloud Databases** solution, please refer 
 
 If the connection is successful, you will land on the following interface:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-asia.md
@@ -38,16 +38,6 @@ In rare cases, the slow display may also be caused by your Internet service prov
 - A website hosted on an [OVHcloud web hosting plan](/links/web/hosting)
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-au.md
@@ -143,7 +143,7 @@ If you are using a database of a **Web Cloud Databases** solution, please refer 
 
 If the connection is successful, you will land on the following interface:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-au.md
@@ -38,16 +38,6 @@ In rare cases, the slow display may also be caused by your Internet service prov
 - A website hosted on an [OVHcloud web hosting plan](/links/web/hosting)
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-ca.md
@@ -143,7 +143,7 @@ If you are using a database of a **Web Cloud Databases** solution, please refer 
 
 If the connection is successful, you will land on the following interface:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-ca.md
@@ -38,16 +38,6 @@ In rare cases, the slow display may also be caused by your Internet service prov
 - A website hosted on an [OVHcloud web hosting plan](/links/web/hosting)
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-gb.md
@@ -143,7 +143,7 @@ If you are using a database of a **Web Cloud Databases** solution, please refer 
 
 If the connection is successful, you will land on the following interface:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-gb.md
@@ -38,16 +38,6 @@ In rare cases, the slow display may also be caused by your Internet service prov
 - A website hosted on an [OVHcloud web hosting plan](/links/web/hosting)
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-ie.md
@@ -143,7 +143,7 @@ If you are using a database of a **Web Cloud Databases** solution, please refer 
 
 If the connection is successful, you will land on the following interface:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-ie.md
@@ -38,16 +38,6 @@ In rare cases, the slow display may also be caused by your Internet service prov
 - A website hosted on an [OVHcloud web hosting plan](/links/web/hosting)
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-sg.md
@@ -143,7 +143,7 @@ If you are using a database of a **Web Cloud Databases** solution, please refer 
 
 If the connection is successful, you will land on the following interface:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-sg.md
@@ -38,16 +38,6 @@ In rare cases, the slow display may also be caused by your Internet service prov
 - A website hosted on an [OVHcloud web hosting plan](/links/web/hosting)
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-us.md
@@ -143,7 +143,7 @@ If you are using a database of a **Web Cloud Databases** solution, please refer 
 
 If the connection is successful, you will land on the following interface:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.en-us.md
@@ -38,16 +38,6 @@ In rare cases, the slow display may also be caused by your Internet service prov
 - A website hosted on an [OVHcloud web hosting plan](/links/web/hosting)
 - A [domain name](/links/web/domains)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### OVHcloud Control Panel Access
-
-- **Direct link:** [Hosting plans](/links/control-panel/web-hosting)
-- **Navigation path:** `Web Cloud`{.action} > `Hosting plans`{.action} > Select your web hosting plan
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.es-es.md
@@ -142,7 +142,7 @@ Si utiliza una base de datos en una solución **Web Cloud Databases**, consulte 
 
 Si la conexión se ha realizado correctamente, acceda a la siguiente interfaz:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.es-es.md
@@ -37,16 +37,6 @@ En algunos casos, la lentitud de la visualización también puede provenir de su
 
 - Tener un sitio web alojado en uno de nuestros [planes de hosting de OVHcloud](/links/web/hosting)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acceso al área de cliente de OVHcloud
-
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedimiento
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.es-us.md
@@ -37,16 +37,6 @@ En algunos casos, la lentitud de la visualización también puede provenir de su
 
 - Tener un sitio web alojado en uno de nuestros planes de hosting de OVHcloud (/links/web/hosting)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acceso al área de cliente de OVHcloud
-
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedimiento
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.es-us.md
@@ -140,7 +140,7 @@ Conéctese a su base de datos siguiendo **el etapa 3** de nuestra guía sobre la
 
 Si la conexión se ha realizado correctamente, acceda a la siguiente interfaz:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.fr-ca.md
@@ -37,16 +37,6 @@ Dans de rares cas, les lenteurs d'affichage peuvent aussi provenir de votre four
 
 - Disposer d'un site hébergé sur l'une de nos offres d'[hébergement mutualisé OVHcloud](/links/web/hosting)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accès à l'espace client OVHcloud
-
-- **Lien direct :** [Hébergements](/links/control-panel/web-hosting)
-- **Pour accéder à vos services :** `Web Cloud`{.action} > `Hébergements`{.action} > Sélectionnez votre hébergement web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## En pratique
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.fr-ca.md
@@ -140,7 +140,7 @@ Connectez-vous à votre base de données en suivant **l'étape 3** de notre guid
 
 Si la connexion est réussie, vous arrivez sur l'interface suivante :
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.fr-fr.md
@@ -37,17 +37,6 @@ Dans de rares cas, les lenteurs d'affichage peuvent aussi provenir de votre four
 
 - Disposer d'un site hébergé sur l'une de nos offres d'[hébergement mutualisé OVHcloud](/links/web/hosting)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accès à l'espace client OVHcloud
-
-- **Lien direct :** [Hébergements](/links/control-panel/web-hosting)
-- **Pour accéder à vos services :** `Web Cloud`{.action} > `Hébergements`{.action} > Sélectionnez votre hébergement web
-
----
-<!-- CP-NAV-END:web-hosting -->
-
 ## En pratique
 
 > [!warning]

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.fr-fr.md
@@ -141,7 +141,7 @@ Si vous utilisez une base de données sur une offre **Web Cloud Databases**, con
 
 Si la connexion est réussie, vous arrivez sur l'interface suivante :
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.it-it.md
@@ -37,16 +37,6 @@ In rari casi, la visualizzazione lenta può anche provenire dal tuo provider Int
 
 - Disporre di un sito ospitato su una delle nostre offerte di [hosting condiviso OVHcloud](/links/web/hosting)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Accesso allo Spazio Cliente OVHcloud
-
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Procedura
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.it-it.md
@@ -142,7 +142,7 @@ Se utilizzi un database su un'offerta **Web Cloud Databases**, consulta la nostr
 
 Se la connessione è andata a buon fine, accedi all'interfaccia seguente:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.pl-pl.md
@@ -37,16 +37,6 @@ W rzadkich przypadkach informacje o powolnym wyświetlaczu mogą pochodzić od T
 
 - Posiadanie strony internetowej zainstalowanej w ramach jednej z naszych ofert[hosting OVHcloud](/links/web/hosting)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Dostęp do Panelu klienta OVHcloud
-
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## W praktyce
 

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.pl-pl.md
@@ -146,7 +146,7 @@ Jeśli korzystasz z bazy danych w ofercie **Web Cloud Databases**, zapoznaj się
 
 Jeśli logowanie się powiodło się, otrzymasz następujący interfejs:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.pt-pt.md
@@ -146,7 +146,7 @@ Se utiliza uma base de dados numa oferta **Web Cloud Databases**, consulte o nos
 
 Se a ligação for bem-sucedida, poderá aceder à seguinte interface:
 
-![PHPMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
+![phpMyAdmin](/pages/assets/screens/other/web-tools/phpmyadmin/pma-main-page.png){.thumbnail}
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/diagnostic_slownesses/guide.pt-pt.md
@@ -37,16 +37,6 @@ Em casos raros, os ecrãs também podem ser provocados pelo seu fornecedor de ac
 
 - Dispor de um site alojado numa das nossas ofertas de [alojamento partilhado OVHcloud](/links/web/hosting)
 
-<!-- CP-NAV-START:web-hosting -->
----
-
-### Acesso à Área de Cliente OVHcloud
-
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
-- **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
-
----
-<!-- CP-NAV-END:web-hosting -->
 
 ## Instruções
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.de-de.md
@@ -1,10 +1,24 @@
 ---
 title: "Passwort eines FTP-Benutzers ändern"
 excerpt: "Erfahren Sie hier, wie Sie das Passwort eines auf Ihrem OVHcloud Webhosting erstellten FTP-Benutzers ändern"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
 
-## Ziel 
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
+
+## Ziel
 
 Die OVHcloud Webhosting Angebote bieten Zugriff auf einen Online-Speicherplatz für Dateien, der über das **FTP**-Protokoll nutzbar ist: FTP-Speicherplatz.
 
@@ -37,7 +51,17 @@ Dieser Zugang erlaubt unter anderem [Ihre Website online zu stellen](/pages/web_
 
 ## In der praktischen Anwendung
 
-### 1 - Auf die FTP-Benutzerverwaltung zugreifen
+### Das Passwort eines FTP-Benutzers ändern
+
+> [!primary]
+>
+> Für weitere Informationen zu bewährten Praktiken bei der Passwortverwaltung lesen Sie die Anleitung „[Das Passwort Ihres Kunden-Accounts anlegen und verwalten](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+Je nach Ihrem [OVHcloud Webhosting](/links/web/hosting) erfolgt die Änderung des Passworts Ihres FTP-Benutzers auf zwei verschiedene Weisen.
+
+**Klicken Sie auf Ihr Angebot, um den Inhalt anzuzeigen.**
+
+/// details | Perso und kostenloses 100M Hosting (ein FTP-Benutzer)
 
 Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
 
@@ -52,47 +76,55 @@ Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
 >>
 >> Klicken Sie auf den Tab `FTP - SSH`{.action}.
 >>
->> ![FTP 6 SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Schritt 3**
 >>
->> Eine Tabelle zeigt die *FTP-Benutzer*, die auf Ihrem Webhosting erstellt wurden. Mit diesen Benutzern können Sie auf Ihren FTP-Speicherplatz zugreifen, um dort die Dateien Ihrer Website online zu stellen. Bei der Installation Ihres Webhostings wird automatisch ein Benutzer erstellt.
+>> Eine Tabelle zeigt die *FTP-Benutzer*, die auf Ihrem Webhosting erstellt wurden. Klicken Sie in der Spalte `Passwort`{.action} auf das *Stift-Symbol*, geben Sie das neue Passwort **unter Beachtung der Passwortrichtlinie** ein und bestätigen Sie die Änderung, indem Sie auf den *grünen Button* klicken.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Passwort eines FTP-Benutzers ändern
+///
 
-> [!primary]
->
-> Für weitere Informationen zu bewährten Praktiken bei der Passwortverwaltung folgen Sie den Anweisungen in [dieser Anleitung](/pages/account_and_service_management/account_information/manage-ovh-password).
->
+/// details | Pro und Performance (mehrere FTP-Benutzer)
 
-Je nach Ihrem [OVHcloud Webhosting](/links/web/hosting) erfolgt die Änderung des Passworts Ihres FTP-Benutzers im Tab `FTP - SSH`{.action} über zwei verschiedene Wege:
+Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
 
-- **Für Hosting-Pakete, die keinen zweiten FTP-Benutzer erstellen können** (*Kostenloses Hosting 100M* und *Basic Hosting*):
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting), und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `FTP - SSH`{.action}.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Schritt 3**
+>>
+>> Eine Tabelle zeigt die *FTP-Benutzer*, die auf Ihrem Webhosting erstellt wurden. Klicken Sie auf den Button `...`{.action} rechts neben dem betreffenden FTP-Benutzer und anschließend auf `Passwort ändern`{.action}. Geben Sie im angezeigten Fenster das neue Passwort **unter Beachtung der Passwortrichtlinie** ein, bestätigen Sie, indem Sie es ein zweites Mal eingeben, und klicken Sie dann auf den Button `Bestätigen`{.action}.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
 
-Klicken Sie in der Spalte `Passwort`{.action} der angezeigten Tabelle auf das *Stift-Symbol*, geben Sie das neue Passwort **unter Beachtung der Passwortrichtlinie** ein und bestätigen Sie die Änderung, indem Sie auf den *grünen Button* klicken.
-
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **Für Hosting-Pakete, die es erlauben, mehrere FTP-Benutzer zu erstellen** (*Pro* und *Performance*): 
-
-Klicken Sie auf den Button `...`{.action} rechts neben dem betreffenden FTP-Benutzer und anschließend auf `Passwort ändern`{.action}. Geben Sie im angezeigten Fenster das neue Passwort **unter Beachtung der Passwortrichtlinie** ein, bestätigen Sie, indem Sie es ein zweites Mal eingeben und klicken Sie dann auf den Button `Bestätigen`{.action}.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+///
 
 > [!primary]
 >
 > Ihr neues Passwort muss folgenden **Richtlinien** entsprechen:
 >
->- Mindestens 9 Zeichen
->- Maximal 30 Zeichen
->- Mindestens ein Großbuchstabe
->- Mindestens ein Kleinbuchstabe
->- Mindestens eine Ziffer
->- Nur Ziffern und Buchstaben
+> - Mindestens 9 Zeichen
+> - Maximal 30 Zeichen
+> - Mindestens ein Großbuchstabe
+> - Mindestens ein Kleinbuchstabe
+> - Mindestens eine Ziffer
+> - Nur Ziffern und Buchstaben
 
-Gehen Sie dann zum Tab `Aktuelle Tasks`{.action} und laden Sie die Seite ggf. neu um den Fortschritt zu überprüfen. Die Änderung benötigt einige Minuten, bis sie wirksam ist.
+Gehen Sie dann zum Tab `Aktuelle Tasks`{.action} und laden Sie die Seite ggf. neu, um den Fortschritt zu überprüfen. Die Änderung benötigt einige Minuten, bis sie wirksam ist.
 
-### 3 - Auf Ihren Speicherplatz zugreifen
+### Zugang zu Ihrem Speicherplatz
 
 Um auf Ihren FTP-Speicherplatz zuzugreifen, lesen Sie unsere Anleitung ["Mit dem Speicherplatz Ihres Webhostings verbinden"](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Passwort eines FTP-Benutzers ändern"
 excerpt: "Erfahren Sie hier, wie Sie das Passwort eines auf Ihrem OVHcloud Webhosting erstellten FTP-Benutzers ändern"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>
@@ -55,7 +55,7 @@ Dieser Zugang erlaubt unter anderem [Ihre Website online zu stellen](/pages/web_
 
 > [!primary]
 >
-> Für weitere Informationen zu bewährten Praktiken bei der Passwortverwaltung lesen Sie die Anleitung „[Das Passwort Ihres Kunden-Accounts anlegen und verwalten](/pages/account_and_service_management/account_information/manage-ovh-password)".
+> Für weitere Informationen zu bewährten Praktiken bei der Passwortverwaltung lesen Sie die Anleitung "[Das Passwort Ihres Kunden-Accounts anlegen und verwalten](/pages/account_and_service_management/account_information/manage-ovh-password)".
 
 Je nach Ihrem [OVHcloud Webhosting](/links/web/hosting) erfolgt die Änderung des Passworts Ihres FTP-Benutzers auf zwei verschiedene Weisen.
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-asia.md
@@ -1,8 +1,22 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -38,7 +52,17 @@ This access allows you to [put your website online](/pages/web_cloud/web_hosting
 
 ## Instructions
 
-### 1 - Access the FTP user management interface
+### Modify the FTP user password
+
+> [!primary]
+>
+> For more information on password management best practices, please refer to the guide "[Setting and managing an account password](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different ways to change your FTP user password.
+
+**Click on your plan to view the content.**
+
+/// details | Personal and 100M free hosting plans (single FTP user)
 
 Click on the tabs below to view each of the **3** steps.
 
@@ -51,45 +75,57 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `FTP - SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 >> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> A table will display the *FTP users* created on your Web Hosting plan. These users allow you to access your FTP storage space to put your website files online. When you set up your Web Hosting plan, a user account will be created automatically.
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the *pencil icon* in the `Password`{.action} column, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Modify the FTP user password
+///
 
-> [!primary]
->
-> For more information on password management best practices, follow the instructions in this [guide](/pages/account_and_service_management/account_information/manage-ovh-password).
->
+/// details | Pro and Performance plans (multiple FTP users)
 
-Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different paths for changing your FTP user password user via the `FTP - SSH`{.action} tab:
+Click on the tabs below to view each of the **3** steps.
 
-- **For Web Hosting plans that do not allow you to create a second FTP user** (*Personal hosting*): Click on the *pencil icon* in the `Password`{.action} column of the table that appears, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP - SSH`{.action} tab.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
 
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **For plans that allow you to create multiple FTP users** (*Pro* and *Performance*): Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+///
 
 > [!primary]
 >
 > Your new password must respect the following **password policy**:
 >
->- Minimum 9 characters
->- Maximum 30 characters
->- At least one capital letter
->- At least one lower-case letter
->- At least one number
->- Be composed only of numbers and letters
+> - Minimum 9 characters
+> - Maximum 30 characters
+> - At least one capital letter
+> - At least one lower-case letter
+> - At least one number
+> - Be composed only of numbers and letters
 
 Then go to the `Ongoing tasks`{.action} tab and refresh the page regularly. Your change will be effective within a few minutes.
 
-### 3 - Access your storage space
+### Access your storage space
 
 To access your FTP storage space, please refer to our guide ["Logging in to your Web Hosting plan’s storage space"](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-au.md
@@ -1,8 +1,22 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -38,7 +52,17 @@ This access allows you to [put your website online](/pages/web_cloud/web_hosting
 
 ## Instructions
 
-### 1 - Access the FTP user management interface
+### Modify the FTP user password
+
+> [!primary]
+>
+> For more information on password management best practices, please refer to the guide "[Setting and managing an account password](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different ways to change your FTP user password.
+
+**Click on your plan to view the content.**
+
+/// details | Personal and 100M free hosting plans (single FTP user)
 
 Click on the tabs below to view each of the **3** steps.
 
@@ -51,45 +75,57 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `FTP - SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 >> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> A table will display the *FTP users* created on your Web Hosting plan. These users allow you to access your FTP storage space to put your website files online. When you set up your Web Hosting plan, a user account will be created automatically.
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the *pencil icon* in the `Password`{.action} column, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Modify the FTP user password
+///
 
-> [!primary]
->
-> For more information on password management best practices, follow the instructions in this [guide](/pages/account_and_service_management/account_information/manage-ovh-password).
->
+/// details | Pro and Performance plans (multiple FTP users)
 
-Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different paths for changing your FTP user password user via the `FTP - SSH`{.action} tab:
+Click on the tabs below to view each of the **3** steps.
 
-- **For Web Hosting plans that do not allow you to create a second FTP user** (*Personal hosting*): Click on the *pencil icon* in the `Password`{.action} column of the table that appears, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP - SSH`{.action} tab.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
 
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **For plans that allow you to create multiple FTP users** (*Pro* and *Performance*): Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+///
 
 > [!primary]
 >
 > Your new password must respect the following **password policy**:
 >
->- Minimum 9 characters
->- Maximum 30 characters
->- At least one capital letter
->- At least one lower-case letter
->- At least one number
->- Be composed only of numbers and letters
+> - Minimum 9 characters
+> - Maximum 30 characters
+> - At least one capital letter
+> - At least one lower-case letter
+> - At least one number
+> - Be composed only of numbers and letters
 
 Then go to the `Ongoing tasks`{.action} tab and refresh the page regularly. Your change will be effective within a few minutes.
 
-### 3 - Access your storage space
+### Access your storage space
 
 To access your FTP storage space, please refer to our guide ["Logging in to your Web Hosting plan’s storage space"](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-ca.md
@@ -1,8 +1,22 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -38,7 +52,17 @@ This access allows you to [put your website online](/pages/web_cloud/web_hosting
 
 ## Instructions
 
-### 1 - Access the FTP user management interface
+### Modify the FTP user password
+
+> [!primary]
+>
+> For more information on password management best practices, please refer to the guide "[Setting and managing an account password](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different ways to change your FTP user password.
+
+**Click on your plan to view the content.**
+
+/// details | Personal and 100M free hosting plans (single FTP user)
 
 Click on the tabs below to view each of the **3** steps.
 
@@ -51,45 +75,57 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `FTP - SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 >> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> A table will display the *FTP users* created on your Web Hosting plan. These users allow you to access your FTP storage space to put your website files online. When you set up your Web Hosting plan, a user account will be created automatically.
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the *pencil icon* in the `Password`{.action} column, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Modify the FTP user password
+///
 
-> [!primary]
->
-> For more information on password management best practices, follow the instructions in this [guide](/pages/account_and_service_management/account_information/manage-ovh-password).
->
+/// details | Pro and Performance plans (multiple FTP users)
 
-Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different paths for changing your FTP user password user via the `FTP - SSH`{.action} tab:
+Click on the tabs below to view each of the **3** steps.
 
-- **For Web Hosting plans that do not allow you to create a second FTP user** (*Personal hosting*): Click on the *pencil icon* in the `Password`{.action} column of the table that appears, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP - SSH`{.action} tab.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
 
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **For plans that allow you to create multiple FTP users** (*Pro* and *Performance*): Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+///
 
 > [!primary]
 >
 > Your new password must respect the following **password policy**:
 >
->- Minimum 9 characters
->- Maximum 30 characters
->- At least one capital letter
->- At least one lower-case letter
->- At least one number
->- Be composed only of numbers and letters
+> - Minimum 9 characters
+> - Maximum 30 characters
+> - At least one capital letter
+> - At least one lower-case letter
+> - At least one number
+> - Be composed only of numbers and letters
 
 Then go to the `Ongoing tasks`{.action} tab and refresh the page regularly. Your change will be effective within a few minutes.
 
-### 3 - Access your storage space
+### Access your storage space
 
 To access your FTP storage space, please refer to our guide ["Logging in to your Web Hosting plan’s storage space"](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-gb.md
@@ -1,8 +1,22 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -38,7 +52,17 @@ This access allows you to [put your website online](/pages/web_cloud/web_hosting
 
 ## Instructions
 
-### 1 - Access the FTP user management interface
+### Modify the FTP user password
+
+> [!primary]
+>
+> For more information on password management best practices, please refer to the guide "[Setting and managing an account password](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different ways to change your FTP user password.
+
+**Click on your plan to view the content.**
+
+/// details | Personal and 100M free hosting plans (single FTP user)
 
 Click on the tabs below to view each of the **3** steps.
 
@@ -51,45 +75,57 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `FTP - SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 >> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> A table will display the *FTP users* created on your Web Hosting plan. These users allow you to access your FTP storage space to put your website files online. When you set up your Web Hosting plan, a user account will be created automatically.
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the *pencil icon* in the `Password`{.action} column, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Modify the FTP user password
+///
 
-> [!primary]
->
-> For more information on password management best practices, follow the instructions in this [guide](/pages/account_and_service_management/account_information/manage-ovh-password).
->
+/// details | Pro and Performance plans (multiple FTP users)
 
-Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different paths for changing your FTP user password user via the `FTP - SSH`{.action} tab:
+Click on the tabs below to view each of the **3** steps.
 
-- **For Web Hosting plans that do not allow you to create a second FTP user** (*100M free hosting* and *Personal hosting*): Click on the *pencil icon* in the `Password`{.action} column of the table that appears, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP - SSH`{.action} tab.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
 
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **For plans that allow you to create multiple FTP users** (*Pro* and *Performance*): Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+///
 
 > [!primary]
 >
 > Your new password must respect the following **password policy**:
 >
->- Minimum 9 characters
->- Maximum 30 characters
->- At least one capital letter
->- At least one lower-case letter
->- At least one number
->- Be composed only of numbers and letters
+> - Minimum 9 characters
+> - Maximum 30 characters
+> - At least one capital letter
+> - At least one lower-case letter
+> - At least one number
+> - Be composed only of numbers and letters
 
 Then go to the `Ongoing tasks`{.action} tab and refresh the page regularly. Your change will be effective within a few minutes.
 
-### 3 - Access your storage space
+### Access your storage space
 
 To access your FTP storage space, please refer to our guide ["Logging in to your Web Hosting plan’s storage space"](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-ie.md
@@ -1,8 +1,22 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -38,7 +52,17 @@ This access allows you to [put your website online](/pages/web_cloud/web_hosting
 
 ## Instructions
 
-### 1 - Access the FTP user management interface
+### Modify the FTP user password
+
+> [!primary]
+>
+> For more information on password management best practices, please refer to the guide "[Setting and managing an account password](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different ways to change your FTP user password.
+
+**Click on your plan to view the content.**
+
+/// details | Personal and 100M free hosting plans (single FTP user)
 
 Click on the tabs below to view each of the **3** steps.
 
@@ -51,45 +75,57 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `FTP - SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 >> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> A table will display the *FTP users* created on your Web Hosting plan. These users allow you to access your FTP storage space to put your website files online. When you set up your Web Hosting plan, a user account will be created automatically.
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the *pencil icon* in the `Password`{.action} column, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Modify the FTP user password
+///
 
-> [!primary]
->
-> For more information on password management best practices, follow the instructions in this [guide](/pages/account_and_service_management/account_information/manage-ovh-password).
->
+/// details | Pro and Performance plans (multiple FTP users)
 
-Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different paths for changing your FTP user password user via the `FTP - SSH`{.action} tab:
+Click on the tabs below to view each of the **3** steps.
 
-- **For Web Hosting plans that do not allow you to create a second FTP user** (*100M free hosting* and *Personal hosting*): Click on the *pencil icon* in the `Password`{.action} column of the table that appears, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP - SSH`{.action} tab.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
 
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **For plans that allow you to create multiple FTP users** (*Pro* and *Performance*): Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+///
 
 > [!primary]
 >
 > Your new password must respect the following **password policy**:
 >
->- Minimum 9 characters
->- Maximum 30 characters
->- At least one capital letter
->- At least one lower-case letter
->- At least one number
->- Must only contain letters and numbers
+> - Minimum 9 characters
+> - Maximum 30 characters
+> - At least one capital letter
+> - At least one lower-case letter
+> - At least one number
+> - Be composed only of numbers and letters
 
 Then go to the `Ongoing tasks`{.action} tab and refresh the page regularly. Your change will be effective within a few minutes.
 
-### 3 - Access your storage space
+### Access your storage space
 
 To access your FTP storage space, please refer to our guide ["Logging in to your Web Hosting plan’s storage space"](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-sg.md
@@ -1,8 +1,22 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -38,7 +52,17 @@ This access allows you to [put your website online](/pages/web_cloud/web_hosting
 
 ## Instructions
 
-### 1 - Access the FTP user management interface
+### Modify the FTP user password
+
+> [!primary]
+>
+> For more information on password management best practices, please refer to the guide "[Setting and managing an account password](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different ways to change your FTP user password.
+
+**Click on your plan to view the content.**
+
+/// details | Personal and 100M free hosting plans (single FTP user)
 
 Click on the tabs below to view each of the **3** steps.
 
@@ -51,45 +75,57 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `FTP - SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 >> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> A table will display the *FTP users* created on your Web Hosting plan. These users allow you to access your FTP storage space to put your website files online. When you set up your Web Hosting plan, a user account will be created automatically.
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the *pencil icon* in the `Password`{.action} column, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Modify the FTP user password
+///
 
-> [!primary]
->
-> For more information on password management best practices, follow the instructions in this [guide](/pages/account_and_service_management/account_information/manage-ovh-password).
->
+/// details | Pro and Performance plans (multiple FTP users)
 
-Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different paths for changing your FTP user password user via the `FTP - SSH`{.action} tab:
+Click on the tabs below to view each of the **3** steps.
 
-- **For Web Hosting plans that do not allow you to create a second FTP user** (*Personal hosting*): Click on the *pencil icon* in the `Password`{.action} column of the table that appears, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP - SSH`{.action} tab.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
 
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **For plans that allow you to create multiple FTP users** (*Pro* and *Performance*): Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+///
 
 > [!primary]
 >
 > Your new password must respect the following **password policy**:
 >
->- Minimum 9 characters
->- Maximum 30 characters
->- At least one capital letter
->- At least one lower-case letter
->- At least one number
->- Be composed only of numbers and letters
+> - Minimum 9 characters
+> - Maximum 30 characters
+> - At least one capital letter
+> - At least one lower-case letter
+> - At least one number
+> - Be composed only of numbers and letters
 
 Then go to the `Ongoing tasks`{.action} tab and refresh the page regularly. Your change will be effective within a few minutes.
 
-### 3 - Access your storage space
+### Access your storage space
 
 To access your FTP storage space, please refer to our guide ["Logging in to your Web Hosting plan’s storage space"](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.en-us.md
@@ -1,8 +1,22 @@
 ---
 title: "Changing an FTP user password"
 excerpt: "Find out how to change the password for an FTP user created on your OVHcloud Web Hosting plan"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objective
 
@@ -38,7 +52,17 @@ This access allows you to [put your website online](/pages/web_cloud/web_hosting
 
 ## Instructions
 
-### 1 - Access the FTP user management interface
+### Modify the FTP user password
+
+> [!primary]
+>
+> For more information on password management best practices, please refer to the guide "[Setting and managing an account password](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different ways to change your FTP user password.
+
+**Click on your plan to view the content.**
+
+/// details | Personal and 100M free hosting plans (single FTP user)
 
 Click on the tabs below to view each of the **3** steps.
 
@@ -51,45 +75,57 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> On the page that pops up, click on the `FTP - SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 >> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Step 3**
 >>
->> A table will display the *FTP users* created on your Web Hosting plan. These users allow you to access your FTP storage space to put your website files online. When you set up your Web Hosting plan, a user account will be created automatically.
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the *pencil icon* in the `Password`{.action} column, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Modify the FTP user password
+///
 
-> [!primary]
->
-> For more information on password management best practices, follow the instructions in this [guide](/pages/account_and_service_management/account_information/manage-ovh-password).
->
+/// details | Pro and Performance plans (multiple FTP users)
 
-Depending on which OVHcloud [Web Hosting plan](/links/web/hosting) you have, there are two different paths for changing your FTP user password user via the `FTP - SSH`{.action} tab:
+Click on the tabs below to view each of the **3** steps.
 
-- **For Web Hosting plans that do not allow you to create a second FTP user** (*Personal hosting*): Click on the *pencil icon* in the `Password`{.action} column of the table that appears, enter the new password **in accordance with the password policy**, then confirm the change by clicking on the *green* validation button.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP - SSH`{.action} tab.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Step 3**
+>>
+>> A table will display the *FTP users* created on your Web Hosting plan. Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
 
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **For plans that allow you to create multiple FTP users** (*Pro* and *Performance*): Click on the `...`{.action} button to the right of the FTP user concerned, then `Change password`{.action}. In the window that pops up, enter the new password you want **by following the password policy**, enter it again and click the `Confirm`{.action} button.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+///
 
 > [!primary]
 >
 > Your new password must respect the following **password policy**:
 >
->- Minimum 9 characters
->- Maximum 30 characters
->- At least one capital letter
->- At least one lower-case letter
->- At least one number
->- Be composed only of numbers and letters
+> - Minimum 9 characters
+> - Maximum 30 characters
+> - At least one capital letter
+> - At least one lower-case letter
+> - At least one number
+> - Be composed only of numbers and letters
 
 Then go to the `Ongoing tasks`{.action} tab and refresh the page regularly. Your change will be effective within a few minutes.
 
-### 3 - Access your storage space
+### Access your storage space
 
 To access your FTP storage space, please refer to our guide ["Logging in to your Web Hosting plan’s storage space"](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Cambiar la contraseña de un usuario FTP"
 excerpt: "Descubra cómo cambiar la contraseña de un usuario FTP en un alojamiento de OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.es-es.md
@@ -1,8 +1,22 @@
 ---
 title: "Cambiar la contraseña de un usuario FTP"
 excerpt: "Descubra cómo cambiar la contraseña de un usuario FTP en un alojamiento de OVHcloud"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo
 
@@ -29,7 +43,7 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -37,58 +51,80 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 
 ## Procedimiento
 
-### 1 - Acceder a la gestión de los usuarios FTP
+### Cambiar la contraseña de un usuario FTP
+
+> [!primary]
+>
+> Para más información sobre las buenas prácticas de gestión de contraseñas, consulte la guía "[Establecer y gestionar la contraseña de su cuenta](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+Según el plan de [hosting de OVHcloud](/links/web/hosting), la contraseña de su usuario FTP se modifica de dos formas diferentes.
+
+**Haga clic en su plan para ver el contenido.**
+
+/// details | Planes Perso y Alojamiento gratuito 100M (un solo usuario FTP)
 
 Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Etapa 2**
 >>
->> En la nueva página, haga clic en la pestaña `FTP - SSH`{.action}.
+>> Haga clic en la pestaña `FTP - SSH`{.action}.
 >>
 >> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Etapa 3**
 >>
->> Se mostrará una tabla con los *usuarios FTP* creados en su alojamiento web. Estos usuarios le permiten acceder a su espacio de almacenamiento FTP para publicar los archivos de su sitio web. Al instalar el alojamiento web, se crea un usuario automáticamente.
+>> Se mostrará una tabla con los *usuarios FTP* creados en su alojamiento web. Haga clic en el *pictograma con forma de lápiz* en la columna `Contraseña`{.action}, introduzca la nueva contraseña **respetando la política de contraseñas** y confirme el cambio haciendo clic en el *botón verde* de validación.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Cambiar la contraseña de un usuario FTP
+///
+
+/// details | Planes Pro y Performance (varios usuarios FTP)
+
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
+
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `FTP - SSH`{.action}.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Se mostrará una tabla con los *usuarios FTP* creados en su alojamiento web. Haga clic en el botón `...`{.action} a la derecha del usuario FTP correspondiente y luego en `Cambiar la contraseña`{.action}. En la ventana que se abre, introduzca la nueva contraseña **respetando la política de contraseñas**, confírmela introduciéndola por segunda vez y haga clic en el botón `Aceptar`{.action}.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+
+///
 
 > [!primary]
 >
-> Para más información sobre las buenas prácticas de gestión de contraseñas, consulte esta [guía](/pages/account_and_service_management/account_information/manage-ovh-password).
+> La nueva contraseña debe respetar la siguiente **política de contraseñas**:
 >
-
-Según el plan de [hosting de OVHcloud](/links/web/hosting), la modificación de la contraseña del usuario FTP a través de la pestaña `FTP - SSH`{.action} se realizará por dos caminos diferentes:
-
-- **productos que no permiten crear un segundo usuario FTP** (*Alojamiento gratuito 100M* y *Personal*): haga clic en el *pictograma con forma de lápiz* en la columna `Contraseña`{.action} de la tabla que aparece, introduzca la nueva contraseña **respetando la política de contraseñas** y luego confirme el cambio haciendo clic en *botón verde* de validación.
-
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **Planes que permiten crear varios usuarios FTP** (planes *Pro* y *Performance*): pulse el botón `...`{.action} a la derecha del usuario FTP correspondiente y luego `Cambiar la contraseña`{.action}. Se abrirá una ventana en la que deberá introducir la nueva contraseña **respetando la política de contraseñas**, confirmarla introduciéndola por segunda vez y haciendo clic en el botón `Aceptar`{.action}.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
-
-> [!primary]
->
-> La nueva contraseña debe respetar la **política de las siguientes contraseñas** :
->
->- Mínimo 9 caracteres;
->- Máximo 30 caracteres;
->- Al menos una letra mayúscula;
->- Al menos una letra minúscula;
->- Al menos una cifra.
->- Estar compuesto únicamente por números y letras.
+> - Mínimo 9 caracteres
+> - Máximo 30 caracteres
+> - Al menos una letra mayúscula
+> - Al menos una letra minúscula
+> - Al menos una cifra
+> - Estar compuesta únicamente por números y letras
 
 Por último, abra la pestaña `Tareas en curso`{.action} y vuelva a actualizar la página periódicamente. El cambio de contraseña tarda unos minutos en aplicarse.
 
-### 3 - Acceder al espacio de almacenamiento
+### Acceder a su espacio de almacenamiento
 
 Para acceder a su espacio de almacenamiento FTP, consulte nuestra guía ["Conectarse al espacio de almacenamiento de un alojamiento web"](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Cambiar la contraseña de un usuario FTP"
 excerpt: "Descubra cómo cambiar la contraseña de un usuario FTP en un alojamiento de OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.es-us.md
@@ -1,8 +1,22 @@
 ---
 title: "Cambiar la contraseña de un usuario FTP"
 excerpt: "Descubra cómo cambiar la contraseña de un usuario FTP en un alojamiento de OVHcloud"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo
 
@@ -29,7 +43,7 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -37,58 +51,80 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 
 ## Procedimiento
 
-### 1 - Acceder a la gestión de los usuarios FTP
+### Cambiar la contraseña de un usuario FTP
+
+> [!primary]
+>
+> Para más información sobre las buenas prácticas de gestión de contraseñas, consulte la guía "[Establecer y gestionar la contraseña de su cuenta](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+Según el plan de [hosting de OVHcloud](/links/web/hosting), la contraseña de su usuario FTP se modifica de dos formas diferentes.
+
+**Haga clic en su plan para ver el contenido.**
+
+/// details | Planes Perso y Alojamiento gratuito 100M (un solo usuario FTP)
 
 Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Etapa 2**
 >>
->> En la nueva página, haga clic en la pestaña `FTP - SSH`{.action}.
+>> Haga clic en la pestaña `FTP - SSH`{.action}.
 >>
 >> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Etapa 3**
 >>
->> Se mostrará una tabla con los *usuarios FTP* creados en su alojamiento web. Estos usuarios le permiten acceder a su espacio de almacenamiento FTP para publicar los archivos de su sitio web. Al instalar el alojamiento web, se crea un usuario automáticamente.
+>> Se mostrará una tabla con los *usuarios FTP* creados en su alojamiento web. Haga clic en el *pictograma con forma de lápiz* en la columna `Contraseña`{.action}, introduzca la nueva contraseña **respetando la política de contraseñas** y confirme el cambio haciendo clic en el *botón verde* de validación.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Cambiar la contraseña de un usuario FTP
+///
+
+/// details | Planes Pro y Performance (varios usuarios FTP)
+
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
+
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `FTP - SSH`{.action}.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Se mostrará una tabla con los *usuarios FTP* creados en su alojamiento web. Haga clic en el botón `...`{.action} a la derecha del usuario FTP correspondiente y luego en `Cambiar la contraseña`{.action}. En la ventana que se abre, introduzca la nueva contraseña **respetando la política de contraseñas**, confírmela introduciéndola por segunda vez y haga clic en el botón `Aceptar`{.action}.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+
+///
 
 > [!primary]
 >
-> Para más información sobre las buenas prácticas de gestión de contraseñas, consulte esta [guía](/pages/account_and_service_management/account_information/manage-ovh-password).
+> La nueva contraseña debe respetar la siguiente **política de contraseñas**:
 >
-
-Según el plan de [hosting de OVHcloud](/links/web/hosting), la modificación de la contraseña del usuario FTP a través de la pestaña `FTP - SSH`{.action} se realizará por dos caminos diferentes:
-
-- **productos que no permiten crear un segundo usuario FTP** (*Alojamiento gratuito 100M* y *Personal*): haga clic en el *pictograma con forma de lápiz* en la columna `Contraseña`{.action} de la tabla que aparece, introduzca la nueva contraseña **respetando la política de contraseñas** y luego confirme el cambio haciendo clic en *botón verde* de validación.
-
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **Planes que permiten crear varios usuarios FTP** (planes *Pro* y *Performance*): pulse el botón `...`{.action} a la derecha del usuario FTP correspondiente y luego `Cambiar la contraseña`{.action}. Se abrirá una ventana en la que deberá introducir la nueva contraseña **respetando la política de contraseñas**, confirmarla introduciéndola por segunda vez y haciendo clic en el botón `Aceptar`{.action}.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
-
-> [!primary]
->
-> La nueva contraseña debe respetar la **política de las siguientes contraseñas** :
->
->- Mínimo 9 caracteres;
->- Máximo 30 caracteres;
->- Al menos una letra mayúscula;
->- Al menos una letra minúscula;
->- Al menos una cifra.
->- Estar compuesto únicamente por números y letras.
+> - Mínimo 9 caracteres
+> - Máximo 30 caracteres
+> - Al menos una letra mayúscula
+> - Al menos una letra minúscula
+> - Al menos una cifra
+> - Estar compuesta únicamente por números y letras
 
 Por último, abra la pestaña `Tareas en curso`{.action} y vuelva a actualizar la página periódicamente. El cambio de contraseña tarda unos minutos en aplicarse.
 
-### 3 - Acceder al espacio de almacenamiento
+### Acceder a su espacio de almacenamiento
 
 Para acceder a su espacio de almacenamiento FTP, consulte nuestra guía ["Conectarse al espacio de almacenamiento de un alojamiento web"](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Modifier le mot de passe d'un utilisateur FTP"
 excerpt: "Découvrez comment changer le mot de passe d'un utilisateur FTP créé sur votre hébergement web OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.fr-ca.md
@@ -1,8 +1,22 @@
 ---
 title: "Modifier le mot de passe d'un utilisateur FTP"
 excerpt: "Découvrez comment changer le mot de passe d'un utilisateur FTP créé sur votre hébergement web OVHcloud"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objectif
 
@@ -38,7 +52,17 @@ Cet accès permet notamment de [mettre en ligne votre site](/pages/web_cloud/web
 
 ## En pratique
 
-### 1 - Accéder à la gestion des utilisateurs FTP
+### Modifier le mot de passe d'un utilisateur FTP
+
+> [!primary]
+>
+> Pour plus d'informations sur les bonnes pratiques en matière de gestion de mots de passe, consultez le guide « [Modifier le mot de passe de votre compte](/pages/account_and_service_management/account_information/manage-ovh-password) ».
+
+Selon votre offre d'[hébergement web OVHcloud](/links/web/hosting), le mot de passe de votre utilisateur FTP se modifie de deux façons différentes.
+
+**Cliquez sur votre offre pour afficher le contenu.**
+
+/// details | Offres Perso et Hébergement gratuit 100M (un seul utilisateur FTP)
 
 Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
@@ -51,45 +75,57 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 > **Étape 2**
 >>
->> Sur la page qui s'affiche, cliquez sur l'onglet `FTP - SSH`{.action}. 
+>> Cliquez sur l'onglet `FTP - SSH`{.action}.
 >>
->> ![FTP- SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
->> 
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
 > **Étape 3**
 >>
->> Un tableau affiche les *utilisateurs FTP* créés sur votre hébergement web. Ces utilisateurs vous permettent d'accéder à votre espace de stockage FTP afin d'y mettre en ligne les fichiers de votre site web. Un utilisateur est créé automatiquement lors de l'installation de votre hébergement web.
+>> Un tableau affiche les *utilisateurs FTP* créés sur votre hébergement web. Cliquez sur le *pictogramme en forme de crayon* dans la colonne `Mot de passe`{.action}, renseignez le nouveau mot de passe **en respectant la politique des mots de passe** puis confirmez le changement en cliquant sur le *bouton vert* de validation.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Modifier le mot de passe d'un utilisateur FTP
+///
+
+/// details | Offres Pro et Performance (plusieurs utilisateurs FTP)
+
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `FTP - SSH`{.action}.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Étape 3**
+>>
+>> Un tableau affiche les *utilisateurs FTP* créés sur votre hébergement web. Cliquez sur le bouton `...`{.action} à droite de l'utilisateur FTP concerné puis sur `Changer le mot de passe`{.action}. Dans la fenêtre qui s'affiche, renseignez le nouveau mot de passe souhaité **en respectant la politique des mots de passe**, confirmez en le saisissant une seconde fois puis cliquez sur le bouton `Valider`{.action}.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+
+///
 
 > [!primary]
 >
-> Pour plus d'informations sur les bonnes pratiques en matière de gestion de mots de passe, suivez les instructions de ce [guide](/pages/account_and_service_management/account_information/manage-ovh-password).
+> Votre nouveau mot de passe doit respecter la **politique des mots de passe** suivante :
 >
+> - Minimum 9 caractères ;
+> - Maximum 30 caractères ;
+> - Au moins une lettre majuscule ;
+> - Au moins une lettre minuscule ;
+> - Au moins un chiffre ;
+> - Être composé uniquement de chiffres et de lettres.
 
-Selon votre offre d'[hébergement web OVHcloud](/links/web/hosting), la modification du mot de passe de votre utilisateur FTP via l'onglet `FTP - SSH`{.action} se fera par deux chemins différents :
+Consultez l'onglet `Tâches en cours`{.action} et rafraîchissez la page régulièrement. Le changement ne nécessite que quelques minutes pour être effectif.
 
-- **pour les offres ne permettant pas de créer un second utilisateur FTP** (offres *Perso* et *Hébergement gratuit 100M*) : cliquez sur le *pictogramme en forme de crayon* dans la colonne `Mot de passe`{.action} du tableau qui s'affiche, renseignez le nouveau mot de passe **en respectant la politique des mots de passe** puis confirmez le changement en cliquant sur le *bouton vert* de validation.
-
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **pour les offres permettant de créer plusieurs utilisateurs FTP** (offres *Pro* et *Performance*) : cliquez sur le boutton `...`{.action} à droite de l'utilisateur FTP concerné puis sur `Changer le mot de passe`{.action}. Dans la fenêtre qui s'affiche, renseignez le nouveau mot de passe souhaité **en respectant la politique des mots de passe**, confirmez en le saisissant une seconde fois puis cliquez sur le bouton `Valider`{.action}.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
-
-> [!primary]
->
-> Votre nouveau mot de passe devra respecter la **politique des mots de passe** suivante :
->
->- Minimum 9 caractères ;
->- Maximum 30 caractères ;
->- Au moins une lettre majuscule ;
->- Au moins une lettre minuscule ;
->- Au moins un chiffre ;
->- Être composé uniquement de chiffres et de lettres.
-
-Consultez enfin l'onglet `Tâches en cours`{.action} et rafraîchissez la page régulièrement. Le changement ne nécessite que quelques minutes pour être effectif.
-
-### 3 - Accéder à votre espace de stockage
+### Accéder à votre espace de stockage
 
 Pour accéder à votre espace de stockage FTP, consultez notre guide [« Se connecter à l’espace de stockage de son hébergement web »](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.fr-fr.md
@@ -1,8 +1,22 @@
 ---
 title: "Modifier le mot de passe d'un utilisateur FTP"
 excerpt: "Découvrez comment changer le mot de passe d'un utilisateur FTP créé sur votre hébergement web OVHcloud"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objectif
 
@@ -38,7 +52,17 @@ Cet accès permet notamment de [mettre en ligne votre site](/pages/web_cloud/web
 
 ## En pratique
 
-### 1 - Accéder à la gestion des utilisateurs FTP
+### Modifier le mot de passe d'un utilisateur FTP
+
+> [!primary]
+>
+> Pour plus d'informations sur les bonnes pratiques en matière de gestion de mots de passe, suivez les instructions de ce [guide](/pages/account_and_service_management/account_information/manage-ovh-password).
+
+Selon votre offre d'[hébergement web OVHcloud](/links/web/hosting), la modification du mot de passe de votre utilisateur FTP se fera par deux chemins différents.
+
+**Cliquez sur votre offre pour afficher le contenu.**
+
+/// details | Offres Perso et Hébergement gratuit 100M (un seul utilisateur FTP)
 
 Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
@@ -51,45 +75,57 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 > **Étape 2**
 >>
->> Sur la page qui s'affiche, cliquez sur l'onglet `FTP - SSH`{.action}. 
+>> Cliquez sur l'onglet `FTP - SSH`{.action}.
 >>
 >> ![FTP- SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
->> 
+>>
 > **Étape 3**
 >>
->> Un tableau affiche les *utilisateurs FTP* créés sur votre hébergement web. Ces utilisateurs vous permettent d'accéder à votre espace de stockage FTP afin d'y mettre en ligne les fichiers de votre site web. Un utilisateur est créé automatiquement lors de l'installation de votre hébergement web.
+>> Un tableau affiche les *utilisateurs FTP* créés sur votre hébergement web. Cliquez sur le *pictogramme en forme de crayon* dans la colonne `Mot de passe`{.action}, renseignez le nouveau mot de passe **en respectant la politique des mots de passe** puis confirmez le changement en cliquant sur le *bouton vert* de validation.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Modifier le mot de passe d'un utilisateur FTP
+///
 
-> [!primary]
->
-> Pour plus d'informations sur les bonnes pratiques en matière de gestion de mots de passe, suivez les instructions de ce [guide](/pages/account_and_service_management/account_information/manage-ovh-password).
->
+/// details | Offres Pro et Performance (plusieurs utilisateurs FTP)
 
-Selon votre offre d'[hébergement web OVHcloud](/links/web/hosting), la modification du mot de passe de votre utilisateur FTP via l'onglet `FTP - SSH`{.action} se fera par deux chemins différents :
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-- **pour les offres ne permettant pas de créer un second utilisateur FTP** (offres *Perso* et *Hébergement gratuit 100M*) : cliquez sur le *pictogramme en forme de crayon* dans la colonne `Mot de passe`{.action} du tableau qui s'affiche, renseignez le nouveau mot de passe **en respectant la politique des mots de passe** puis confirmez le changement en cliquant sur le *bouton vert* de validation.
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `FTP - SSH`{.action}.
+>>
+>> ![FTP- SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Étape 3**
+>>
+>> Un tableau affiche les *utilisateurs FTP* créés sur votre hébergement web. Cliquez sur le bouton `...`{.action} à droite de l'utilisateur FTP concerné puis sur `Changer le mot de passe`{.action}. Dans la fenêtre qui s'affiche, renseignez le nouveau mot de passe souhaité **en respectant la politique des mots de passe**, confirmez en le saisissant une seconde fois puis cliquez sur le bouton `Valider`{.action}.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
 
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **pour les offres permettant de créer plusieurs utilisateurs FTP** (offres *Pro* et *Performance*) : cliquez sur le boutton `...`{.action} à droite de l'utilisateur FTP concerné puis sur `Changer le mot de passe`{.action}. Dans la fenêtre qui s'affiche, renseignez le nouveau mot de passe souhaité **en respectant la politique des mots de passe**, confirmez en le saisissant une seconde fois puis cliquez sur le bouton `Valider`{.action}.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+///
 
 > [!primary]
 >
 > Votre nouveau mot de passe devra respecter la **politique des mots de passe** suivante :
 >
->- Minimum 9 caractères ;
->- Maximum 30 caractères ;
->- Au moins une lettre majuscule ;
->- Au moins une lettre minuscule ;
->- Au moins un chiffre ;
->- Être composé uniquement de chiffres et de lettres.
+> - Minimum 9 caractères ;
+> - Maximum 30 caractères ;
+> - Au moins une lettre majuscule ;
+> - Au moins une lettre minuscule ;
+> - Au moins un chiffre ;
+> - Être composé uniquement de chiffres et de lettres.
 
 Consultez enfin l'onglet `Tâches en cours`{.action} et rafraîchissez la page régulièrement. Le changement ne nécessite que quelques minutes pour être effectif.
 
-### 3 - Accéder à votre espace de stockage
+### Accéder à votre espace de stockage
 
 Pour accéder à votre espace de stockage FTP, consultez notre guide [« Se connecter à l’espace de stockage de son hébergement web »](/pages/web_cloud/web_hosting/ftp_connection).
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Modifier le mot de passe d'un utilisateur FTP"
 excerpt: "Découvrez comment changer le mot de passe d'un utilisateur FTP créé sur votre hébergement web OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.fr-fr.md
@@ -56,9 +56,9 @@ Cet accès permet notamment de [mettre en ligne votre site](/pages/web_cloud/web
 
 > [!primary]
 >
-> Pour plus d'informations sur les bonnes pratiques en matière de gestion de mots de passe, suivez les instructions de ce [guide](/pages/account_and_service_management/account_information/manage-ovh-password).
+> Pour plus d'informations sur les bonnes pratiques en matière de gestion de mots de passe, consultez le guide « [Modifier le mot de passe de votre compte](/pages/account_and_service_management/account_information/manage-ovh-password) ».
 
-Selon votre offre d'[hébergement web OVHcloud](/links/web/hosting), la modification du mot de passe de votre utilisateur FTP se fera par deux chemins différents.
+Selon votre offre d'[hébergement web OVHcloud](/links/web/hosting), le mot de passe de votre utilisateur FTP se modifie de deux façons différentes.
 
 **Cliquez sur votre offre pour afficher le contenu.**
 
@@ -77,7 +77,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 >> Cliquez sur l'onglet `FTP - SSH`{.action}.
 >>
->> ![FTP- SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Étape 3**
 >>
@@ -102,7 +102,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 >> Cliquez sur l'onglet `FTP - SSH`{.action}.
 >>
->> ![FTP- SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Étape 3**
 >>
@@ -114,7 +114,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 
 > [!primary]
 >
-> Votre nouveau mot de passe devra respecter la **politique des mots de passe** suivante :
+> Votre nouveau mot de passe doit respecter la **politique des mots de passe** suivante :
 >
 > - Minimum 9 caractères ;
 > - Maximum 30 caractères ;
@@ -123,7 +123,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 > - Au moins un chiffre ;
 > - Être composé uniquement de chiffres et de lettres.
 
-Consultez enfin l'onglet `Tâches en cours`{.action} et rafraîchissez la page régulièrement. Le changement ne nécessite que quelques minutes pour être effectif.
+Consultez l'onglet `Tâches en cours`{.action} et rafraîchissez la page régulièrement. Le changement ne nécessite que quelques minutes pour être effectif.
 
 ### Accéder à votre espace de stockage
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Modificare la password di un utente FTP"
 excerpt: "Questa guida ti mostra come cambiare la password di un utente FTP creata sul tuo hosting Web OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.it-it.md
@@ -1,8 +1,22 @@
 ---
 title: "Modificare la password di un utente FTP"
 excerpt: "Questa guida ti mostra come cambiare la password di un utente FTP creata sul tuo hosting Web OVHcloud"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Obiettivo
 
@@ -29,7 +43,7 @@ Questo accesso permette in particolare di [pubblicare il vostro sito](/pages/web
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -37,58 +51,80 @@ Questo accesso permette in particolare di [pubblicare il vostro sito](/pages/web
 
 ## Procedura
 
-### 1 - Accedere alla gestione utenti FTP
+### Modificare la password di un utente FTP
 
-Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passi.
+> [!primary]
+>
+> Per maggiori informazioni sulle best practice di gestione delle password, consulta la guida "[Impostare e gestire la password di un account OVHcloud](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+In base al piano di [hosting Web OVHcloud](/links/web/hosting), la password del tuo utente FTP si modifica in due modi diversi.
+
+**Clicca sulla tua offerta per visualizzare il contenuto.**
+
+/// details | Offerte Perso e Hosting gratuito 100M (un solo utente FTP)
+
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
 > [!tabs]
 > **Passaggio 1**
 >>
->> Accedi alla pagina [Hosting plans](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Passaggio 2**
 >>
->> Nella nuova pagina clicca sulla scheda `FTP - SSH`{.action}.
+>> Clicca sulla scheda `FTP - SSH`{.action}.
 >>
->> ![FTP -SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Passaggio 3**
 >>
->> Una tabella mostra gli *utenti FTP* creati sul tuo hosting Web. Questi utenti ti permettono di accedere al tuo spazio di archiviazione FTP per mettere online i file del tuo sito web. Un utente viene creato automaticamente durante l'installazione del tuo hosting Web.
+>> Una tabella mostra gli *utenti FTP* creati sul tuo hosting Web. Clicca sul *pittogramma a forma di matita* nella colonna `Password`{.action}, inserisci la nuova password **seguendo la politica delle password** e confermala cliccando sul *pulsante verde* di conferma.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Modificare la password di un utente FTP
+///
+
+/// details | Offerte Pro e Performance (più utenti FTP)
+
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `FTP - SSH`{.action}.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Passaggio 3**
+>>
+>> Una tabella mostra gli *utenti FTP* creati sul tuo hosting Web. Clicca sul pulsante `...`{.action} a destra dell'utente FTP interessato e poi su `Modifica la password`{.action}. Nella nuova finestra, inserisci la nuova password **seguendo la politica delle password**, confermala inserendola una seconda volta e clicca su `Conferma`{.action}.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+
+///
 
 > [!primary]
 >
-> Per maggiori informazioni sulle best practice di gestione delle password, segui le indicazioni di questa [guida](/pages/account_and_service_management/account_information/manage-ovh-password).
+> La nuova password dovrà rispettare la seguente **politica delle password**:
 >
-
-In base al piano di [hosting Web OVHcloud](/links/web/hosting), la modifica della password dell'utente FTP tramite la scheda `FTP - SSH`{.action} sarà effettuata su due sentieri diversi:
-
-- **per le offerte che non permettono di creare un secondo utente FTP** (offerte *Personale* e *Hosting gratuito 100M*): clicca sul *pittogramma a forma di matita* nella colonna `Password`{.action} della tabella che appare, inserisci la nuova password **seguendo la politica delle password** e confermala cliccando sul *pulsante verde* di conferma.
-
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **per le offerte che permettono di creare diversi utenti FTP** (offerte *Pro* e *Performance*): clicca sul pulsante `...`{.action} a destra dell'utente FTP interessato e poi su `Modifica la password`{.action}. Nella nuova finestra, inserisci la nuova password**seguendo la politica delle password**, confermala inserendola una seconda volta e clicca su `Conferma`{.action}.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
-
-> [!primary]
->
-> La nuova password dovrà rispettare la **politica delle password** che segue :
->
->- Minimo 9 caratteri
->- Massimo 30 caratteri
->- Almeno una lettera maiuscola;
->- Almeno una lettera minuscola
->- Almeno una cifra
->- Essere composto esclusivamente da cifre e lettere.
+> - Minimo 9 caratteri
+> - Massimo 30 caratteri
+> - Almeno una lettera maiuscola
+> - Almeno una lettera minuscola
+> - Almeno una cifra
+> - Essere composta esclusivamente da cifre e lettere
 
 Consulta la scheda `Operazioni in corso`{.action} e aggiorna regolarmente la pagina. La modifica richiede solo pochi minuti per essere effettiva.
 
-### 3 - Accedere al tuo spazio di archiviazione
+### Accedere al tuo spazio di storage
 
 Per accedere al tuo spazio di storage FTP, consulta la nostra guida ["Connettersi allo spazio di storage di un hosting Web"](/pages/web_cloud/web_hosting/ftp_connection)".
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.it-it.md
@@ -105,7 +105,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
 >>
 > **Passaggio 3**
 >>
->> Una tabella mostra gli *utenti FTP* creati sul tuo hosting Web. Clicca sul pulsante `...`{.action} a destra dell'utente FTP interessato e poi su `Modifica la password`{.action}. Nella nuova finestra, inserisci la nuova password **seguendo la politica delle password**, confermala inserendola una seconda volta e clicca su `Conferma`{.action}.
+>> Una tabella mostra gli *utenti FTP* creati sul tuo hosting Web. Clicca sul pulsante `...`{.action} a destra dell'utente FTP interessato e poi su `Modificare la password`{.action}. Nella nuova finestra, inserisci la nuova password **seguendo la politica delle password**, confermala inserendola una seconda volta e clicca su `Conferma`{.action}.
 >>
 >> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.pl-pl.md
@@ -123,7 +123,7 @@ Kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
 > - Przynajmniej jedna cyfra
 > - Składać się wyłącznie z cyfr i liter
 
-Następnie przejdź do zakładki `Zadania w realizacji`{.action} i odśwież stronę regularnie. Zmiana wymaga zaledwie kilku minut, aby stała się skuteczna.
+Następnie przejdź do zakładki `Zadania w toku`{.action} i odśwież stronę regularnie. Zmiana wymaga zaledwie kilku minut, aby stała się skuteczna.
 
 ### Dostęp do przestrzeni dyskowej
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Zmiana hasła do konta FTP"
 excerpt: "Dowiedz się, jak zmienić hasło dla użytkownika FTP utworzonego na Twoim hostingu"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>
@@ -56,7 +56,7 @@ W szczególności dostęp ten umożliwia [umieszczenie strony w Internecie](/pag
 
 > [!primary]
 >
-> Aby uzyskać więcej informacji na temat dobrych praktyk w zakresie zarządzania hasłami, zapoznaj się z przewodnikiem „[Tworzenie i zarządzanie hasłem do konta](/pages/account_and_service_management/account_information/manage-ovh-password)".
+> Aby uzyskać więcej informacji na temat dobrych praktyk w zakresie zarządzania hasłami, zapoznaj się z przewodnikiem "[Tworzenie i zarządzanie hasłem do konta](/pages/account_and_service_management/account_information/manage-ovh-password)".
 
 W zależności od pakietu [hostingowego OVHcloud](/links/web/hosting) zmiana hasła do konta FTP odbywa się na dwa różne sposoby.
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.pl-pl.md
@@ -1,10 +1,24 @@
 ---
 title: "Zmiana hasła do konta FTP"
 excerpt: "Dowiedz się, jak zmienić hasło dla użytkownika FTP utworzonego na Twoim hostingu"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
 
-## Wprowadzenie 
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
+
+## Wprowadzenie
 
 Wraz z pakietami hostingowymi OVHcloud zyskujesz dostęp do przestrzeni dyskowej plików online dostępnej w protokole **FTP**: przestrzeni dyskowej FTP.
 
@@ -30,7 +44,7 @@ W szczególności dostęp ten umożliwia [umieszczenie strony w Internecie](/pag
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -38,58 +52,80 @@ W szczególności dostęp ten umożliwia [umieszczenie strony w Internecie](/pag
 
 ## W praktyce
 
-### 1 - Dostęp do zarządzania użytkownikami FTP
+### Zmiana hasła użytkownika FTP
+
+> [!primary]
+>
+> Aby uzyskać więcej informacji na temat dobrych praktyk w zakresie zarządzania hasłami, zapoznaj się z przewodnikiem „[Tworzenie i zarządzanie hasłem do konta](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+W zależności od pakietu [hostingowego OVHcloud](/links/web/hosting) zmiana hasła do konta FTP odbywa się na dwa różne sposoby.
+
+**Kliknij swoją ofertę, aby wyświetlić zawartość.**
+
+/// details | Oferty Perso i darmowy Hosting 100M (jeden użytkownik FTP)
 
 Kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
 
 > [!tabs]
 > **Krok 1**
 >>
->> Przejdź na stronę [Hosting plans](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Krok 2**
 >>
->> Na stronie, która się wyświetli kliknij zakładkę `FTP - SSH`{.action}.
+>> Kliknij zakładkę `FTP - SSH`{.action}.
 >>
 >> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Krok 3**
 >>
->> Tabela wyświetla *użytkowników FTP* utworzonych na Twoim hostingu. Użytkownicy ci umożliwiają dostęp do Twojej przestrzeni dyskowej FTP, aby umieścić w Internecie pliki z Twojej strony WWW. Użytkownik jest tworzony automatycznie podczas instalacji hostingu.
+>> Tabela wyświetla *użytkowników FTP* utworzonych na Twoim hostingu. Kliknij *piktogram w formie ołówka* w kolumnie `Hasło`{.action}, wprowadź nowe hasło **zgodnie z polityką haseł**, a następnie potwierdź zmianę, klikając *zielony przycisk* do zatwierdzenia.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Zmiana hasła użytkownika FTP
+///
+
+/// details | Oferty Pro i Performance (wielu użytkowników FTP)
+
+Kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
+
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `FTP - SSH`{.action}.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Krok 3**
+>>
+>> Tabela wyświetla *użytkowników FTP* utworzonych na Twoim hostingu. Kliknij przycisk `...`{.action} po prawej stronie odpowiedniego użytkownika FTP, a następnie kliknij `Zmień hasło`{.action}. W oknie, które się wyświetla, wprowadź nowe hasło **zgodnie z polityką haseł**, potwierdź, wprowadzając je ponownie, i kliknij przycisk `Zatwierdź`{.action}.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+
+///
 
 > [!primary]
 >
-> Aby uzyskać więcej informacji na temat dobrych praktyk w zakresie zarządzania hasłami, zapoznaj się z instrukcjami zawartymi w tym [przewodniku](/pages/account_and_service_management/account_information/manage-ovh-password).
+> Nowe hasło powinno być zgodne z następującą **polityką haseł**:
 >
+> - Minimum 9 znaków
+> - Maksymalnie 30 znaków
+> - Przynajmniej jedna wielka litera
+> - Przynajmniej jedna mała litera
+> - Przynajmniej jedna cyfra
+> - Składać się wyłącznie z cyfr i liter
 
-W zależności od pakietu [hostingowego OVHcloud](/links/web/hosting) zmiana hasła do konta FTP w zakładce `FTP - SSH`{.action} zostanie wykonana na dwie różne sposoby:
+Następnie przejdź do zakładki `Zadania w realizacji`{.action} i odśwież stronę regularnie. Zmiana wymaga zaledwie kilku minut, aby stała się skuteczna.
 
-- **w przypadku pakietów, które nie pozwalają na utworzenie drugiego użytkownika FTP** (oferty *Darmowy hosting 100M* i *Perso*): kliknij *piktogram w formie ołówka* w kolumnie `Hasło`{.action} tabeli, która się wyświetla, wprowadź nowe hasło **zgodnie z polityką haseł**, a następnie potwierdź zmianę, klikając *zielony przycisk* do zatwierdzenia.
-
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **w przypadku pakietów umożliwiających utworzenie kilku użytkowników FTP** (oferty *Pro* i *Performance*): kliknij przycisk `...`{.action} po prawej stronie odpowiedniego użytkownika FTP a następnie kliknij `Zmień hasło`{.action}. W oknie, które się wyświetla wprowadź nowe hasło **zgodnie z polityką haseł**, potwierdź, wprowadzając je ponownie i klikając przycisk `Zatwierdź`{.action}.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
-
-> [!primary]
->
-> Nowe hasło powinno być zgodne z następującą **polityką haseł** :
->
->- Minimum 9 znaki;
->- Maksymalnie 30 znaków;
->- Przynajmniej jedna wielka litera;
->- Przynajmniej jedna mała litera;
->- Przynajmniej jedną cyfrę;
->- Składać się wyłącznie z cyfr i liter.
-
-Następnie przejdź do zakładki `Zadania w realizacji`{.action} i odśwież stronę regularnie. Efekty modyfikacji to zaledwie kilka minut.
-
-### 3 - Dostęp do Twojej przestrzeni dyskowej
+### Dostęp do przestrzeni dyskowej
 
 Aby uzyskać dostęp do przestrzeni FTP, zapoznaj się z naszym przewodnikiem "[Logowanie do przestrzeni dyskowej Twojego hostingu](/pages/web_cloud/web_hosting/ftp_connection)".
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Alterar a palavra-passe de um utilizador FTP"
 excerpt: "Descubra como alterar a palavra-passe de um utilizador FTP criado num alojamento web da OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.pt-pt.md
@@ -105,7 +105,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 >>
 > **Etapa 3**
 >>
->> Um quadro apresenta os *utilizadores FTP* criados no seu alojamento web. Clique no botão `...`{.action} à direita do utilizador FTP em questão e depois em `Alterar a palavra-passe`{.action}. Na nova janela, introduza a nova palavra-passe pretendida **seguindo a política de palavras-passe**, confirme introduzindo-a uma segunda vez e clique no botão `Validar`{.action}.
+>> Um quadro apresenta os *utilizadores FTP* criados no seu alojamento web. Clique no botão `...`{.action} à direita do utilizador FTP em questão e depois em `Alterar palavra-passe`{.action}. Na nova janela, introduza a nova palavra-passe pretendida **seguindo a política de palavras-passe**, confirme introduzindo-a uma segunda vez e clique no botão `Confirmar`{.action}.
 >>
 >> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
 

--- a/pages/web_cloud/web_hosting/ftp_change_password/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/ftp_change_password/guide.pt-pt.md
@@ -1,8 +1,22 @@
 ---
 title: "Alterar a palavra-passe de um utilizador FTP"
 excerpt: "Descubra como alterar a palavra-passe de um utilizador FTP criado num alojamento web da OVHcloud"
-updated: 2025-10-14
+updated: 2026-03-26
 ---
+
+<style>
+details>summary {
+    color:rgb(33, 153, 232) !important;
+    cursor: pointer;
+}
+details>summary::before {
+    content:'\25B6';
+    padding-right:1ch;
+}
+details[open]>summary::before {
+    content:'\25BC';
+}
+</style>
 
 ## Objetivo
 
@@ -29,7 +43,7 @@ Este acesso permite nomeadamente [publicar o seu site](/pages/web_cloud/web_host
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -37,60 +51,80 @@ Este acesso permite nomeadamente [publicar o seu site](/pages/web_cloud/web_host
 
 ## Instruções
 
-### 1 - Aceder à gestão dos utilizadores FTP
+### Alterar a palavra-passe de um utilizador FTP
+
+> [!primary]
+>
+> Para mais informações sobre as boas práticas de gestão de palavras-passe, consulte o guia "[Definir e gerir a palavra-passe da sua conta](/pages/account_and_service_management/account_information/manage-ovh-password)".
+
+Dependendo do seu plano de [alojamento web da OVHcloud](/links/web/hosting), a palavra-passe do seu utilizador FTP é alterada de duas formas diferentes.
+
+**Clique no seu plano para ver o conteúdo.**
+
+/// details | Planos Perso e Alojamento gratuito 100M (um único utilizador FTP)
 
 Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Aceda à página [Hosting plans](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Etapa 2**
 >>
->> Na página que se abrir, clique no separador `FTP - SSH`{.action}.
+>> Clique no separador `FTP - SSH`{.action}.
 >>
 >> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >>
 > **Etapa 3**
 >>
->> Um quadro apresenta os *utilizadores FTP* criados no seu alojamento web. Estes utilizadores permitem-lhe aceder ao seu espaço de armazenamento FTP para que possa publicar os ficheiros do seu website. Um utilizador é automaticamente criado durante a instalação do alojamento web.
+>> Um quadro apresenta os *utilizadores FTP* criados no seu alojamento web. Clique no *pictograma em forma de lápis* na coluna `Palavra-passe`{.action}, introduza a nova palavra-passe **seguindo a política das palavras-passe** e confirme a alteração clicando no *botão verde* de validação.
+>>
+>> ![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
 
-### 2 - Alterar a palavra-passe de um utilizador FTP
+///
+
+/// details | Planos Pro e Performance (vários utilizadores FTP)
+
+Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
+
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Clique no separador `FTP - SSH`{.action}.
+>>
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>>
+> **Etapa 3**
+>>
+>> Um quadro apresenta os *utilizadores FTP* criados no seu alojamento web. Clique no botão `...`{.action} à direita do utilizador FTP em questão e depois em `Alterar a palavra-passe`{.action}. Na nova janela, introduza a nova palavra-passe pretendida **seguindo a política de palavras-passe**, confirme introduzindo-a uma segunda vez e clique no botão `Validar`{.action}.
+>>
+>> ![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
+
+///
 
 > [!primary]
 >
-> Para mais informações sobre as boas práticas de gestão de palavras-passe, siga as instruções deste [guia](/pages/account_and_service_management/account_information/manage-ovh-password).
+> A sua nova palavra-passe deverá respeitar a seguinte **política das palavras-passe**:
 >
-
-Dependendo do seu plano de [alojamento web da OVHcloud](/links/web/hosting), a alteração da palavra-passe do utilizador FTP através do separador `FTP - SSH`{.action} poderá ser efetuada de duas formas:
-
-- **para as ofertas que não permitem criar um segundo utilizador FTP** (ofertas *Alojamento gratuito 100M* e *Perso*): clique no *pictograma em forma de lápis* na coluna `Palavra-passe`{.action} do quadro que aparece, introduza a nova palavra-passe **seguindo a política das palavras-passe** e confirme a alteração clicando no *botão verde* de validação.
-
-![change-ftp-password-step1-perso](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-perso.png){.thumbnail}
-
-- **para as ofertas que permitem criar vários utilizadores FTP** (ofertas *Pro* e *Performance*): clique nos três pontos à direita do utilizador FTP em causa e, a seguir, em `Alterar palavra-passe`{.action}. Na nova janela, introduza a nova palavra-passe pretendida, confirme introduzindo-a uma segunda vez e clique no botão `Validar`{.action}.
-
-clique no botão `...`{.action} à direita do utilizador FTP em questão, depois por `Alterar a palavra-passe`{.action}. Na nova janela, introduza a nova palavra-passe desejada *** seguindo a política de palavras-passe**, confirme introduzindo-a novamente e clique no botão `Validar`{.action}.
-
-![change-ftp-password-pro](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password-pro.png){.thumbnail}
-
-> [!primary]
->
-> A sua nova password deverá respeitar a **política das palavras-passe** seguinte :
->
->- Mínimo de 9 caracteres;
->- Máximo de 30 caracteres;
->- Pelo menos uma letra maiúscula;
->- Pelo menos uma letra minúscula;
->- Pelo menos um número;
->- Ser composto unicamente por números e letras.
+> - Mínimo de 9 caracteres
+> - Máximo de 30 caracteres
+> - Pelo menos uma letra maiúscula
+> - Pelo menos uma letra minúscula
+> - Pelo menos um número
+> - Ser composta unicamente por números e letras
 
 Por fim, consulte o separador `Operações em curso`{.action} e atualize a página regularmente. A alteração demorará alguns minutos até ficar efetiva.
 
-### 3 - Aceder ao espaço de armazenamento
+### Aceder ao espaço de armazenamento
 
 Para aceder ao seu espaço de armazenamento FTP, consulte o nosso guia "[Aceder ao espaço de armazenamento do alojamento web](/pages/web_cloud/web_hosting/ftp_connection)".
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Mit dem FTP-Speicherplatz eines Webhostings verbinden"
 excerpt: "Erfahren Sie hier, wie Sie sich im FTP-Speicherplatz Ihres OVHcloud Webhostings einloggen"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Ziel 
@@ -115,9 +115,9 @@ Geben Sie in den dafür vorgesehenen Feldern die Verbindungsdaten ein.
 
 Hier eine Erinnerung an die Informationen, die Sie eingeben müssen:
 
-- **FTP- und SFTP-Server**: FTP-Server-Adresse, mit der auf Ihren FTP-Speicherplatz zugegriffen werden kann. Je nach verwendetem Client sind verschiedene Bezeichnungen möglich: „Server“, „Serveradresse“, „Host“ „Hostname“, etc.
-- **Haupt-Login**: ID für den Zugriff auf Ihren FTP Speicherplatz. Je nach verwendetem Client sind verschiedene Bezeichnungen möglich: „Benutzer“, „Benutzername“, „Kennung“, „Login“, „Username“, etc.
-- **Passwort des FTP-Benutzers**: Passwort für den FTP-Login. Je nach verwendetem Client sind verschiedene Bezeichnungen wie „Passwort“ oder „Password“ möglich.
+- **FTP- und SFTP-Server**: FTP-Server-Adresse, mit der auf Ihren FTP-Speicherplatz zugegriffen werden kann. Je nach verwendetem Client sind verschiedene Bezeichnungen möglich: "Server“, "Serveradresse“, "Host“ "Hostname“, etc.
+- **Haupt-Login**: ID für den Zugriff auf Ihren FTP Speicherplatz. Je nach verwendetem Client sind verschiedene Bezeichnungen möglich: "Benutzer“, "Benutzername“, "Kennung“, "Login“, "Username“, etc.
+- **Passwort des FTP-Benutzers**: Passwort für den FTP-Login. Je nach verwendetem Client sind verschiedene Bezeichnungen wie "Passwort“ oder "Password“ möglich.
 - **Verbindungsport**: Der Verbindungsport wird meistens automatisch angegeben. Falls Sie diesen jedoch selbst eingeben müssen:
     - Verwenden Sie den Port "21" für eine Verbindung über das FTP-Protokoll.
     - Verwenden Sie den Port "22" für eine Verbindung, die das SFTP-Protokoll verwendet (sofern dieses aktiviert ist).

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Mit dem FTP-Speicherplatz eines Webhostings verbinden"
 excerpt: "Erfahren Sie hier, wie Sie sich im FTP-Speicherplatz Ihres OVHcloud Webhostings einloggen"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Ziel 
@@ -47,7 +47,7 @@ Um sich mit Ihrem FTP-Speicherplatz zu verbinden, benötigen Sie folgende Inform
 >
 > **Wenn Sie diese Daten bereits haben**, gehen Sie direkt zu Teil 2: [Zugang zu Ihrem FTP-Speicherplatz](#ftp_storage_access).
 
-Wenn Sie die Verbindungsdaten nicht zur Hand haben, klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
+Wenn Sie die Verbindungsdaten nicht zur Hand haben, klicken Sie auf die Tabs, um die **4** Schritte anzuzeigen.
 
 > [!tabs]
 > **Schritt 1**
@@ -75,27 +75,26 @@ Wenn Sie die Verbindungsdaten nicht zur Hand haben, klicken Sie auf die Tabs, um
 >> > Wählen Sie ein Passwort für diesen neuen Benutzer-Account aus, klicken Sie auf `Weiter`{.action} und dann auf `Bestätigen`{.action}.
 >>
 >> Alle für die Verbindung mit dem FTP-Speicherplatz erforderlichen Elemente finden Sie auf dieser Seite.
-
-Nachstehend finden Sie eine Beschreibung der wesentlichen Informationen, die auf `FTP - SSH`{.action} angezeigt werden:
-
-- **FTP- und SFTP-Server**: Adresse des FTP-Servers Ihres Webhostings, damit Sie auf Ihren FTP-Speicherplatz zugreifen können. Hierzu wird beispielsweise eine Client-Software eingesetzt, die über das (S)FTP-Protokoll verfügt.
-
-> Der Standardport für SSH ist "21". Verwenden Sie den Port "22" für eine Verbindung über das SFTP-Protokoll (falls dieses aktiviert ist).
-
-- **SSH-Server**: SSH-Server-Adresse Ihres Webhostings, damit Sie auf Ihren FTP-Speicherplatz zugreifen können. Verwenden Sie hierzu das SSH-Protokoll in einer Kommandozeile.
-
-> Die Portnummer für SSH-Verbindungen ist "22".
-
-- **Haupt-Login**: Haupt-FTP-Kennung auf Ihrem Webhosting. Sie finden alle erstellten FTP-Benutzer Ihres Hostings in der Tabelle in der Spalte "Login".
-
-> [!primary]
->
-> Je nach Ihrem [OVHcloud Webhosting-Angebot](/links/web/hosting) werden einige der oben beschriebenen Informationen (insbesondere bezüglich SSH) möglicherweise nicht angezeigt.
->
+>>
+> **Schritt 4**
+>>
+>> Nachstehend finden Sie eine Beschreibung der wesentlichen Informationen, die auf der Seite `FTP - SSH` angezeigt werden:
+>>
+>> - **FTP- und SFTP-Server**: Adresse des FTP-Servers Ihres Webhostings, damit Sie über eine FTP- oder SFTP-Software auf Ihren FTP-Speicherplatz zugreifen können.
+>>
+>> > Der Standardport für die Verbindung ist "21". Verwenden Sie den Port "22" für eine Verbindung über das SFTP-Protokoll (falls dieses aktiviert ist).
+>>
+>> - **SSH-Server**: SSH-Server-Adresse Ihres Webhostings, damit Sie über ein Terminal und das SSH-Protokoll auf Ihren FTP-Speicherplatz zugreifen können.
+>>
+>> > Die Portnummer für SSH-Verbindungen ist "22".
+>>
+>> - **Haupt-Login**: Haupt-FTP-Kennung auf Ihrem Webhosting. Sie finden alle erstellten FTP-Benutzer Ihres Hostings in der Tabelle in der Spalte "Login".
+>>
+>> > [!primary]
+>> >
+>> > Je nach Ihrem [OVHcloud Webhosting-Angebot](/links/web/hosting) werden einige der oben beschriebenen Informationen (insbesondere bezüglich SSH) möglicherweise nicht angezeigt.
 
 Wenn Sie das Passwort eines FTP- oder SSH-Benutzers nicht mehr kennen, lesen Sie unsere Anleitung "[Passwort eines FTP-Benutzers ändern](/pages/web_cloud/web_hosting/ftp_change_password)".
-
-![ftp login](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
 
 An diesem Punkt verfügen Sie über alle notwendigen Elemente, um sich mit Ihrem FTP-Speicherplatz zu verbinden.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -47,7 +47,7 @@ To connect to your FTP storage space, you will need the following:
 >
 > **If you already have these items**, proceed directly to part 2 "[Access your storage space](#ftp_storage_access)" in this guide.
 
-If you do not have this information at hand, click on the tabs below to view each of the **3** steps.
+If you do not have this information at hand, click on the tabs below to view each of the **4** steps.
 
 > [!tabs]
 > **Step 1**
@@ -75,27 +75,26 @@ If you do not have this information at hand, click on the tabs below to view eac
 >> > Choose a password for this new user account, click `Next`{.action} and then click `Confirm`{.action}.
 >>
 >> All the elements required to log in to the FTP storage space are present on this page.
+>>
+> **Step 4**
+>>
+>> Below is a description of the essential information displayed on the `FTP - SSH` page:
+>>
+>> - **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space via FTP or SFTP software.
+>>
+>> > The standard connection port is “21”. Use port “22” for a connection via SFTP (if it is enabled).
+>>
+>> - **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space via a terminal and SSH protocol.
+>>
+>> > The SSH connection port is “22”.
+>>
+>> - **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
+>>
+>> > [!primary]
+>> >
+>> > Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
 
-Below is a description of the essential information displayed on the `FTP - SSH` page:
-
-- **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space. You can do this by using, for example, client software capable of the (S)FTP protocol.
-
-> The standard connection port is "21". Use port "22" for a connection via SFTP (if it is enabled).
-
-- **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space. This is done using a terminal via SSH protocol.
-
-> The SSH connection port is "22".
-
-- **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
-
-> [!primary]
->
-> Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
->
-
-If you have forgotten your FTP or SSH user password, please refer to our guide on [Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password).
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
+If you have forgotten your FTP or SSH user password, please refer to our guide “[Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password)”.
 
 At this stage, you have everything you need to log in to your FTP storage space.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -47,7 +47,7 @@ To connect to your FTP storage space, you will need the following:
 >
 > **If you already have these items**, proceed directly to part 2 "[Access your storage space](#ftp_storage_access)" in this guide.
 
-If you do not have this information at hand, click on the tabs below to view each of the **3** steps.
+If you do not have this information at hand, click on the tabs below to view each of the **4** steps.
 
 > [!tabs]
 > **Step 1**
@@ -75,27 +75,26 @@ If you do not have this information at hand, click on the tabs below to view eac
 >> > Choose a password for this new user account, click `Next`{.action} and then click `Confirm`{.action}.
 >>
 >> All the elements required to log in to the FTP storage space are present on this page.
+>>
+> **Step 4**
+>>
+>> Below is a description of the essential information displayed on the `FTP - SSH` page:
+>>
+>> - **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space via FTP or SFTP software.
+>>
+>> > The standard connection port is “21”. Use port “22” for a connection via SFTP (if it is enabled).
+>>
+>> - **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space via a terminal and SSH protocol.
+>>
+>> > The SSH connection port is “22”.
+>>
+>> - **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
+>>
+>> > [!primary]
+>> >
+>> > Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
 
-Below is a description of the essential information displayed on the `FTP - SSH` page:
-
-- **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space. You can do this by using, for example, client software capable of the (S)FTP protocol.
-
-> The standard connection port is "21". Use port "22" for a connection via SFTP (if it is enabled).
-
-- **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space. This is done using a terminal via SSH protocol.
-
-> The SSH connection port is "22".
-
-- **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
-
-> [!primary]
->
-> Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
->
-
-If you have forgotten your FTP or SSH user password, please refer to our guide on [Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password).
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
+If you have forgotten your FTP or SSH user password, please refer to our guide “[Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password)”.
 
 At this stage, you have everything you need to log in to your FTP storage space.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -47,7 +47,7 @@ To connect to your FTP storage space, you will need the following:
 >
 > **If you already have these items**, proceed directly to part 2 "[Access your storage space](#ftp_storage_access)" in this guide.
 
-If you do not have this information at hand, click on the tabs below to view each of the **3** steps.
+If you do not have this information at hand, click on the tabs below to view each of the **4** steps.
 
 > [!tabs]
 > **Step 1**
@@ -75,27 +75,26 @@ If you do not have this information at hand, click on the tabs below to view eac
 >> > Choose a password for this new user account, click `Next`{.action} and then click `Confirm`{.action}.
 >>
 >> All the elements required to log in to the FTP storage space are present on this page.
+>>
+> **Step 4**
+>>
+>> Below is a description of the essential information displayed on the `FTP - SSH` page:
+>>
+>> - **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space via FTP or SFTP software.
+>>
+>> > The standard connection port is “21”. Use port “22” for a connection via SFTP (if it is enabled).
+>>
+>> - **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space via a terminal and SSH protocol.
+>>
+>> > The SSH connection port is “22”.
+>>
+>> - **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
+>>
+>> > [!primary]
+>> >
+>> > Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
 
-Below is a description of the essential information displayed on the `FTP - SSH` page:
-
-- **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space. You can do this by using, for example, client software capable of the (S)FTP protocol.
-
-> The standard connection port is "21". Use port "22" for a connection via SFTP (if it is enabled).
-
-- **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space. This is done using a terminal via SSH protocol.
-
-> The SSH connection port is "22".
-
-- **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
-
-> [!primary]
->
-> Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
->
-
-If you have forgotten your FTP or SSH user password, please refer to our guide on [Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password).
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
+If you have forgotten your FTP or SSH user password, please refer to our guide “[Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password)”.
 
 At this stage, you have everything you need to log in to your FTP storage space.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -47,7 +47,7 @@ To connect to your FTP storage space, you will need the following:
 >
 > **If you already have these items**, proceed directly to part 2 "[Access your storage space](#ftp_storage_access)" in this guide.
 
-If you do not have this information at hand, click on the tabs below to view each of the **3** steps.
+If you do not have this information at hand, click on the tabs below to view each of the **4** steps.
 
 > [!tabs]
 > **Step 1**
@@ -75,27 +75,26 @@ If you do not have this information at hand, click on the tabs below to view eac
 >> > Choose a password for this new user account, click `Next`{.action} and then click `Confirm`{.action}.
 >>
 >> All the elements required to log in to the FTP storage space are present on this page.
+>>
+> **Step 4**
+>>
+>> Below is a description of the essential information displayed on the `FTP - SSH` page:
+>>
+>> - **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space via FTP or SFTP software.
+>>
+>> > The standard connection port is “21”. Use port “22” for a connection via SFTP (if it is enabled).
+>>
+>> - **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space via a terminal and SSH protocol.
+>>
+>> > The SSH connection port is “22”.
+>>
+>> - **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
+>>
+>> > [!primary]
+>> >
+>> > Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
 
-Below is a description of the essential information displayed on the `FTP - SSH` page:
-
-- **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space. You can do this by using, for example, client software capable of the (S)FTP protocol.
-
-> The standard connection port is "21". Use port "22" for a connection via SFTP (if it is enabled).
-
-- **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space. This is done using a terminal via SSH protocol.
-
-> The SSH connection port is "22".
-
-- **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
-
-> [!primary]
->
-> Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
->
-
-If you have forgotten your FTP or SSH user password, please refer to our guide on [Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password).
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
+If you have forgotten your FTP or SSH user password, please refer to our guide “[Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password)”.
 
 At this stage, you have everything you need to log in to your FTP storage space.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -47,7 +47,7 @@ To connect to your FTP storage space, you will need the following:
 >
 > **If you already have these items**, proceed directly to part 2 "[Access your storage space](#ftp_storage_access)" in this guide.
 
-If you do not have this information at hand, click on the tabs below to view each of the **3** steps.
+If you do not have this information at hand, click on the tabs below to view each of the **4** steps.
 
 > [!tabs]
 > **Step 1**
@@ -75,27 +75,26 @@ If you do not have this information at hand, click on the tabs below to view eac
 >> > Choose a password for this new user account, click `Next`{.action} and then click `Confirm`{.action}.
 >>
 >> All the elements required to log in to the FTP storage space are present on this page.
+>>
+> **Step 4**
+>>
+>> Below is a description of the essential information displayed on the `FTP - SSH` page:
+>>
+>> - **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space via FTP or SFTP software.
+>>
+>> > The standard connection port is “21”. Use port “22” for a connection via SFTP (if it is enabled).
+>>
+>> - **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space via a terminal and SSH protocol.
+>>
+>> > The SSH connection port is “22”.
+>>
+>> - **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
+>>
+>> > [!primary]
+>> >
+>> > Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
 
-Below is a description of the essential information displayed on the `FTP - SSH` page:
-
-- **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space. You can do this by using, for example, client software capable of the (S)FTP protocol.
-
-> The standard connection port is "21". Use port "22" for a connection via SFTP (if it is enabled).
-
-- **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space. This is done using a terminal via SSH protocol.
-
-> The SSH connection port is "22".
-
-- **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
-
-> [!primary]
->
-> Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
->
-
-If you have forgotten your FTP or SSH user password, please refer to our guide on [Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password).
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
+If you have forgotten your FTP or SSH user password, please refer to our guide “[Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password)”.
 
 At this stage, you have everything you need to log in to your FTP storage space.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -47,7 +47,7 @@ To connect to your FTP storage space, you will need the following:
 >
 > **If you already have these items**, proceed directly to part 2 "[Access your storage space](#ftp_storage_access)" in this guide.
 
-If you do not have this information at hand, click on the tabs below to view each of the **3** steps.
+If you do not have this information at hand, click on the tabs below to view each of the **4** steps.
 
 > [!tabs]
 > **Step 1**
@@ -75,27 +75,26 @@ If you do not have this information at hand, click on the tabs below to view eac
 >> > Choose a password for this new user account, click `Next`{.action} and then click `Confirm`{.action}.
 >>
 >> All the elements required to log in to the FTP storage space are present on this page.
+>>
+> **Step 4**
+>>
+>> Below is a description of the essential information displayed on the `FTP - SSH` page:
+>>
+>> - **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space via FTP or SFTP software.
+>>
+>> > The standard connection port is “21”. Use port “22” for a connection via SFTP (if it is enabled).
+>>
+>> - **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space via a terminal and SSH protocol.
+>>
+>> > The SSH connection port is “22”.
+>>
+>> - **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
+>>
+>> > [!primary]
+>> >
+>> > Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
 
-Below is a description of the essential information displayed on the `FTP - SSH` page:
-
-- **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space. You can do this by using, for example, client software capable of the (S)FTP protocol.
-
-> The standard connection port is "21". Use port "22" for a connection via SFTP (if it is enabled).
-
-- **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space. This is done using a terminal via SSH protocol.
-
-> The SSH connection port is "22".
-
-- **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
-
-> [!primary]
->
-> Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
->
-
-If you have forgotten your FTP or SSH user password, please refer to our guide on [Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password).
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
+If you have forgotten your FTP or SSH user password, please refer to our guide “[Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password)”.
 
 At this stage, you have everything you need to log in to your FTP storage space.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Logging in to your web hosting plan’s FTP storage space"
 excerpt: "Find out how to log in to your OVHcloud web hosting plan’s FTP storage space"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -47,7 +47,7 @@ To connect to your FTP storage space, you will need the following:
 >
 > **If you already have these items**, proceed directly to part 2 "[Access your storage space](#ftp_storage_access)" in this guide.
 
-If you do not have this information at hand, click on the tabs below to view each of the **3** steps.
+If you do not have this information at hand, click on the tabs below to view each of the **4** steps.
 
 > [!tabs]
 > **Step 1**
@@ -75,27 +75,26 @@ If you do not have this information at hand, click on the tabs below to view eac
 >> > Choose a password for this new user account, click `Next`{.action} and then click `Confirm`{.action}.
 >>
 >> All the elements required to log in to the FTP storage space are present on this page.
+>>
+> **Step 4**
+>>
+>> Below is a description of the essential information displayed on the `FTP - SSH` page:
+>>
+>> - **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space via FTP or SFTP software.
+>>
+>> > The standard connection port is “21”. Use port “22” for a connection via SFTP (if it is enabled).
+>>
+>> - **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space via a terminal and SSH protocol.
+>>
+>> > The SSH connection port is “22”.
+>>
+>> - **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
+>>
+>> > [!primary]
+>> >
+>> > Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
 
-Below is a description of the essential information displayed on the `FTP - SSH` page:
-
-- **FTP and SFTP server**: FTP server address of your web hosting plan to access your FTP storage space. You can do this by using, for example, client software capable of the (S)FTP protocol.
-
-> The standard connection port is "21". Use port "22" for a connection via SFTP (if it is enabled).
-
-- **SSH Server**: SSH server address of your web hosting plan to access your FTP storage space. This is done using a terminal via SSH protocol.
-
-> The SSH connection port is "22".
-
-- **Main login**: Primary FTP username created on your web hosting plan. You can find all of your web hosting plan’s FTP users in the “Login” column of the table.
-
-> [!primary]
->
-> Depending on which OVHcloud [web hosting plan](/links/web/hosting) you have, some of the information listed above (particularly concerning SSH) may not appear.
->
-
-If you have forgotten your FTP or SSH user password, please refer to our guide on [Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password).
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
+If you have forgotten your FTP or SSH user password, please refer to our guide “[Modifying a FTP user password](/pages/web_cloud/web_hosting/ftp_change_password)”.
 
 At this stage, you have everything you need to log in to your FTP storage space.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Conectarse al espacio de almacenamiento FTP de un alojamiento web"
 excerpt: "Descubra cómo conectarse al espacio de almacenamiento FTP de un alojamiento web de OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Conectarse al espacio de almacenamiento FTP de un alojamiento web"
 excerpt: "Descubra cómo conectarse al espacio de almacenamiento FTP de un alojamiento web de OVHcloud"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -23,7 +23,7 @@ Los planes de hosting de OVHcloud proporcionan acceso a un espacio de almacenami
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -46,12 +46,12 @@ Para conectarse a su espacio de almacenamiento FTP, descargue los siguientes ele
 >
 > **Si ya tiene estos elementos**, vaya directamente en la parte 2. "[Acceder a su espacio de almacenamiento](#ftp_storage_access)" de esta guía.
 
-Si no dispone de estos datos, haga clic en las fichas siguientes para ver cada una de las **3** etapas.
+Si no dispone de estos datos, haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -73,27 +73,26 @@ Si no dispone de estos datos, haga clic en las fichas siguientes para ver cada u
 >> > Seleccione una contraseña para la nueva cuenta de usuario, haga clic en `Siguiente`{.action} y, seguidamente, en `Confirmar`{.action}.
 >>
 >> Todos los elementos necesarios para conectarse al espacio de almacenamiento FTP están presentes en esta misma página.
-
-A continuación se muestra una descripción de la información esencial que se muestra en la página `FTP - SSH`{.action}:
-
-- **Servidor FTP y SFTP**: dirección del servidor FTP de su alojamiento web que permite acceder al espacio de almacenamiento FTP. Para ello, utilice, por ejemplo, un programa FTP a través del protocolo FTP o SFTP.
-
-> El puerto de conexión clásico es el puerto "21". Utilice el puerto "22" para conectarse mediante el protocolo SFTP (en caso de que esté activado).
-
-- **Servidor SSH**: dirección del servidor SSH de su alojamiento web que permite acceder al espacio de almacenamiento FTP. Para ello, utilice un terminal mediante el protocolo SSH.
-
-> El puerto de conexión SSH es el puerto "22".
-
-- **Usuario principal**: Identificador (S)FTP principal creado en su alojamiento web. Puede consultar todos los usuarios (S)FTP de su alojamiento en la columna "Usuario" de la tabla.
-
-> [!primary]
->
-> En función del plan de [hosting de OVHcloud](/links/web/hosting) que tenga, es posible que no aparezca alguna de las informaciones arriba descritas (en particular, relativas al SSH).
->
+>>
+> **Etapa 4**
+>>
+>> A continuación se muestra una descripción de la información esencial que se muestra en la página `FTP - SSH`:
+>>
+>> - **Servidor FTP y SFTP**: dirección del servidor FTP de su alojamiento web que permite acceder al espacio de almacenamiento FTP a través de un software FTP o SFTP.
+>>
+>> > El puerto de conexión clásico es el puerto "21". Utilice el puerto "22" para conectarse mediante el protocolo SFTP (en caso de que esté activado).
+>>
+>> - **Servidor SSH**: dirección del servidor SSH de su alojamiento web que permite acceder al espacio de almacenamiento FTP a través de un terminal y el protocolo SSH.
+>>
+>> > El puerto de conexión SSH es el puerto "22".
+>>
+>> - **Usuario principal**: Identificador (S)FTP principal creado en su alojamiento web. Puede consultar todos los usuarios (S)FTP de su alojamiento en la columna "Usuario" de la tabla.
+>>
+>> > [!primary]
+>> >
+>> > En función del plan de [hosting de OVHcloud](/links/web/hosting) que tenga, es posible que no aparezca alguna de las informaciones arriba descritas (en particular, relativas al SSH).
 
 Si ya no conoce la contraseña de un usuario FTP o SSH, consulte nuestra guía "[Cambiar la contraseña de un usuario FTP](/pages/web_cloud/web_hosting/ftp_change_password)".
-
-![Conexión FTP](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
 
 En este punto, dispondrá de todos los elementos necesarios para conectarse a su espacio de almacenamiento FTP.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Conectarse al espacio de almacenamiento FTP de un alojamiento web"
 excerpt: "Descubra cómo conectarse al espacio de almacenamiento FTP de un alojamiento web de OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Conectarse al espacio de almacenamiento FTP de un alojamiento web"
 excerpt: "Descubra cómo conectarse al espacio de almacenamiento FTP de un alojamiento web de OVHcloud"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -23,7 +23,7 @@ Los planes de hosting de OVHcloud proporcionan acceso a un espacio de almacenami
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -46,12 +46,12 @@ Para conectarse a su espacio de almacenamiento FTP, descargue los siguientes ele
 >
 > **Si ya tiene estos elementos**, vaya directamente en la parte 2. "[Acceder a su espacio de almacenamiento](#ftp_storage_access)" de esta guía.
 
-Si no dispone de estos datos, haga clic en las fichas siguientes para ver cada una de las **3** etapas.
+Si no dispone de estos datos, haga clic en las fichas siguientes para ver cada una de las **4** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -73,27 +73,26 @@ Si no dispone de estos datos, haga clic en las fichas siguientes para ver cada u
 >> > Seleccione una contraseña para la nueva cuenta de usuario, haga clic en `Siguiente`{.action} y, seguidamente, en `Confirmar`{.action}.
 >>
 >> Todos los elementos necesarios para conectarse al espacio de almacenamiento FTP están presentes en esta misma página.
-
-A continuación se muestra una descripción de la información esencial que se muestra en la página `FTP - SSH`{.action}:
-
-- **Servidor FTP y SFTP**: dirección del servidor FTP de su alojamiento web que permite acceder al espacio de almacenamiento FTP. Para ello, utilice, por ejemplo, un programa FTP a través del protocolo FTP o SFTP.
-
-> El puerto de conexión clásico es el puerto "21". Utilice el puerto "22" para conectarse mediante el protocolo SFTP (en caso de que esté activado).
-
-- **Servidor SSH**: dirección del servidor SSH de su alojamiento web que permite acceder al espacio de almacenamiento FTP. Para ello, utilice un terminal mediante el protocolo SSH.
-
-> El puerto de conexión SSH es el puerto "22".
-
-- **Usuario principal**: Identificador (S)FTP principal creado en su alojamiento web. Puede consultar todos los usuarios (S)FTP de su alojamiento en la columna "Usuario" de la tabla.
-
-> [!primary]
->
-> En función del plan de [hosting de OVHcloud](/links/web/hosting) que tenga, es posible que no aparezca alguna de las informaciones arriba descritas (en particular, relativas al SSH).
->
+>>
+> **Etapa 4**
+>>
+>> A continuación se muestra una descripción de la información esencial que se muestra en la página `FTP - SSH`:
+>>
+>> - **Servidor FTP y SFTP**: dirección del servidor FTP de su alojamiento web que permite acceder al espacio de almacenamiento FTP a través de un software FTP o SFTP.
+>>
+>> > El puerto de conexión clásico es el puerto "21". Utilice el puerto "22" para conectarse mediante el protocolo SFTP (en caso de que esté activado).
+>>
+>> - **Servidor SSH**: dirección del servidor SSH de su alojamiento web que permite acceder al espacio de almacenamiento FTP a través de un terminal y el protocolo SSH.
+>>
+>> > El puerto de conexión SSH es el puerto "22".
+>>
+>> - **Usuario principal**: Identificador (S)FTP principal creado en su alojamiento web. Puede consultar todos los usuarios (S)FTP de su alojamiento en la columna "Usuario" de la tabla.
+>>
+>> > [!primary]
+>> >
+>> > En función del plan de [hosting de OVHcloud](/links/web/hosting) que tenga, es posible que no aparezca alguna de las informaciones arriba descritas (en particular, relativas al SSH).
 
 Si ya no conoce la contraseña de un usuario FTP o SSH, consulte nuestra guía "[Cambiar la contraseña de un usuario FTP](/pages/web_cloud/web_hosting/ftp_change_password)".
-
-![Conexión FTP](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
 
 En este punto, dispondrá de todos los elementos necesarios para conectarse a su espacio de almacenamiento FTP.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Se connecter à l’espace de stockage FTP de son hébergement web"
 excerpt: "Découvrez comment vous connecter à l'espace de stockage FTP de votre hébergement web OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Se connecter à l’espace de stockage FTP de son hébergement web"
 excerpt: "Découvrez comment vous connecter à l'espace de stockage FTP de votre hébergement web OVHcloud"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -49,7 +49,7 @@ Pour vous connecter à votre espace de stockage FTP, récupérez les éléments 
 >
 > **Si vous disposez déjà de ces éléments**, poursuivez directement vers la partie 2 « [Accéder à votre espace de stockage](#ftp_storage_access) » de ce guide.
 
-Si vous ne disposez pas de ces éléments, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+Si vous ne disposez pas de ces éléments, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4** étapes.
 
 > [!tabs]
 > **Étape 1**
@@ -77,27 +77,26 @@ Si vous ne disposez pas de ces éléments, cliquez sur les onglets ci-dessous po
 >> > Choisissez un mot de passe pour ce nouveau compte utilisateur, cliquez sur `Suivant`{.action} puis cliquez sur `Confirmer`{.action}.
 >>
 >> Tous les éléments requis pour vous connecter à l'espace de stockage FTP sont présents sur cette même page.
+>>
+> **Étape 4**
+>>
+>> Voici les informations essentielles affichées sur la page `FTP - SSH` :
+>>
+>> - **Serveur FTP et SFTP** : adresse du serveur FTP de votre hébergement web permettant d'accéder à votre espace de stockage FTP via un logiciel FTP ou SFTP.
+>>
+>> > Le port classique de connexion est le port « 21 ». Utilisez le port « 22 » pour une connexion via le protocole SFTP (dans le cas où celui-ci est activé).
+>>
+>> - **Serveur SSH** : adresse du serveur SSH de votre hébergement web permettant d'accéder à votre espace de stockage FTP via un terminal et le protocole SSH.
+>>
+>> > Le port de connexion SSH est le port « 22 ».
+>>
+>> - **Login principal** : identifiant (S)FTP principal créé sur votre hébergement web. Vous pouvez retrouver l'intégralité des utilisateurs (S)FTP de votre hébergement dans la colonne « Login » du tableau.
+>>
+>> > [!primary]
+>> >
+>> > Selon l'offre d'[hébergement web OVHcloud](/links/web/hosting) que vous possédez, certaines des informations décrites ci-dessus (notamment concernant le SSH) peuvent ne pas apparaître.
 
-Retrouvez ci-dessous un descriptif des informations essentielles affichées sur la page `FTP - SSH` :
-
-- **Serveur FTP et SFTP** : adresse du serveur FTP de votre hébergement web permettant d'accéder à votre espace de stockage FTP. Ceci en utilisant, par exemple, un logiciel FTP via le protocole FTP ou SFTP.
-
-> Le port classique de connexion est le port « 21 ». Utilisez le port « 22 » pour une connexion via le protocole SFTP (dans le cas où celui-ci est activé)
-
-- **Serveur SSH** : adresse du serveur SSH de votre hébergement web permettant d'accéder à votre espace de stockage FTP. Ceci en utilisant un terminal via le protocole SSH.
-
-> Le port de connexion SSH est le port « 22 ».
-
-- **Login principal** : identifiant (S)FTP principal créé sur votre hébergement web. Vous pouvez retrouver l'intégralité des utilisateurs (S)FTP de votre hébergement dans la colonne « Login » du tableau.
-
-> [!primary]
->
-> Selon l'offre d'[hébergement web OVHcloud](/links/web/hosting) que vous possédez, certaines des informations décrites ci-dessus (notamment concernant le SSH) peuvent ne pas apparaître.
->
-
-Si vous ne connaissez plus le mot de passe d'un utilisateur FTP ou SSH, consultez notre guide « [Modifier le mot de passe d’un utilisateur FTP](/pages/web_cloud/web_hosting/ftp_change_password) ».
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
+Si vous ne connaissez plus le mot de passe d'un utilisateur FTP ou SSH, consultez notre guide « [Modifier le mot de passe d'un utilisateur FTP](/pages/web_cloud/web_hosting/ftp_change_password) ».
 
 À ce stade, vous disposez de tous les éléments permettant de vous connecter à votre espace de stockage FTP.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Se connecter à l’espace de stockage FTP de son hébergement web"
 excerpt: "Découvrez comment vous connecter à l'espace de stockage FTP de votre hébergement web OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Se connecter à l’espace de stockage FTP de son hébergement web"
 excerpt: "Découvrez comment vous connecter à l'espace de stockage FTP de votre hébergement web OVHcloud"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -49,7 +49,7 @@ Pour vous connecter à votre espace de stockage FTP, récupérez les éléments 
 >
 > **Si vous disposez déjà de ces éléments**, poursuivez directement vers la partie 2 « [Accéder à votre espace de stockage](#ftp_storage_access) » de ce guide.
 
-Si vous ne disposez pas de ces éléments, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+Si vous ne disposez pas de ces éléments, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **4** étapes.
 
 > [!tabs]
 > **Étape 1**
@@ -77,27 +77,26 @@ Si vous ne disposez pas de ces éléments, cliquez sur les onglets ci-dessous po
 >> > Choisissez un mot de passe pour ce nouveau compte utilisateur, cliquez sur `Suivant`{.action} puis cliquez sur `Confirmer`{.action}.
 >>
 >> Tous les éléments requis pour vous connecter à l'espace de stockage FTP sont présents sur cette même page.
-
-Retrouvez ci-dessous un descriptif des informations essentielles affichées sur la page `FTP - SSH` :
-
-- **Serveur FTP et SFTP** : adresse du serveur FTP de votre hébergement web permettant d'accéder à votre espace de stockage FTP. Ceci en utilisant, par exemple, un logiciel FTP via le protocole FTP ou SFTP.
-
-> Le port classique de connexion est le port « 21 ». Utilisez le port « 22 » pour une connexion via le protocole SFTP (dans le cas où celui-ci est activé)
-
-- **Serveur SSH** : adresse du serveur SSH de votre hébergement web permettant d'accéder à votre espace de stockage FTP. Ceci en utilisant un terminal via le protocole SSH.
-
-> Le port de connexion SSH est le port « 22 ».
-
-- **Login principal** : identifiant (S)FTP principal créé sur votre hébergement web. Vous pouvez retrouver l'intégralité des utilisateurs (S)FTP de votre hébergement dans la colonne « Login » du tableau.
-
-> [!primary]
->
-> Selon l'offre d'[hébergement web OVHcloud](/links/web/hosting) que vous possédez, certaines des informations décrites ci-dessus (notamment concernant le SSH) peuvent ne pas apparaître.
->
+>>
+> **Étape 4**
+>>
+>> Retrouvez ci-dessous un descriptif des informations essentielles affichées sur la page `FTP - SSH` :
+>>
+>> - **Serveur FTP et SFTP** : adresse du serveur FTP de votre hébergement web permettant d'accéder à votre espace de stockage FTP. Ceci en utilisant, par exemple, un logiciel FTP via le protocole FTP ou SFTP.
+>>
+>> > Le port classique de connexion est le port « 21 ». Utilisez le port « 22 » pour une connexion via le protocole SFTP (dans le cas où celui-ci est activé)
+>>
+>> - **Serveur SSH** : adresse du serveur SSH de votre hébergement web permettant d'accéder à votre espace de stockage FTP. Ceci en utilisant un terminal via le protocole SSH.
+>>
+>> > Le port de connexion SSH est le port « 22 ».
+>>
+>> - **Login principal** : identifiant (S)FTP principal créé sur votre hébergement web. Vous pouvez retrouver l'intégralité des utilisateurs (S)FTP de votre hébergement dans la colonne « Login » du tableau.
+>>
+>> > [!primary]
+>> >
+>> > Selon l'offre d'[hébergement web OVHcloud](/links/web/hosting) que vous possédez, certaines des informations décrites ci-dessus (notamment concernant le SSH) peuvent ne pas apparaître.
 
 Si vous ne connaissez plus le mot de passe d'un utilisateur FTP ou SSH, consultez notre guide « [Modifier le mot de passe d’un utilisateur FTP](/pages/web_cloud/web_hosting/ftp_change_password) ».
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
 
 À ce stade, vous disposez de tous les éléments permettant de vous connecter à votre espace de stockage FTP.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.fr-fr.md
@@ -62,7 +62,7 @@ Si vous ne disposez pas de ces éléments, cliquez sur les onglets ci-dessous po
 >>
 >> Sur la page qui s'affiche, cliquez sur l'onglet `FTP - SSH`{.action}. 
 >>
->> ![FTP- SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+>> ![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
 >> 
 > **Étape 3**
 >>
@@ -80,13 +80,13 @@ Si vous ne disposez pas de ces éléments, cliquez sur les onglets ci-dessous po
 >>
 > **Étape 4**
 >>
->> Retrouvez ci-dessous un descriptif des informations essentielles affichées sur la page `FTP - SSH` :
+>> Voici les informations essentielles affichées sur la page `FTP - SSH` :
 >>
->> - **Serveur FTP et SFTP** : adresse du serveur FTP de votre hébergement web permettant d'accéder à votre espace de stockage FTP. Ceci en utilisant, par exemple, un logiciel FTP via le protocole FTP ou SFTP.
+>> - **Serveur FTP et SFTP** : adresse du serveur FTP de votre hébergement web permettant d'accéder à votre espace de stockage FTP via un logiciel FTP ou SFTP.
 >>
->> > Le port classique de connexion est le port « 21 ». Utilisez le port « 22 » pour une connexion via le protocole SFTP (dans le cas où celui-ci est activé)
+>> > Le port classique de connexion est le port « 21 ». Utilisez le port « 22 » pour une connexion via le protocole SFTP (dans le cas où celui-ci est activé).
 >>
->> - **Serveur SSH** : adresse du serveur SSH de votre hébergement web permettant d'accéder à votre espace de stockage FTP. Ceci en utilisant un terminal via le protocole SSH.
+>> - **Serveur SSH** : adresse du serveur SSH de votre hébergement web permettant d'accéder à votre espace de stockage FTP via un terminal et le protocole SSH.
 >>
 >> > Le port de connexion SSH est le port « 22 ».
 >>

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Accedi allo spazio di storage FTP del tuo hosting Web"
 excerpt: "Questa guida ti mostra come connettersi allo spazio di storage FTP del tuo hosting Web OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Obiettivo

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.it-it.md
@@ -69,9 +69,9 @@ Se non disponi di questi elementi, clicca sulle schede qui sotto per visualizzar
 >>
 >> > [!primary]
 >> >
->> > Per creare un nuovo utente FTP/SSH dalla stessa pagina, clicca su `Crea utente`{.action} situato a destra.
->> > Definisci l'estensione del nome di questa nuova `Utente`{.action} e la `Cartella di root`{.action} in cui l'utente potrà agire e clicca su `Avanti`{.action}.
->> > Seleziona una password per questo nuovo account utente, clicca su `Avanti`{.action} e poi clicca su `Conferma`{.action}.
+>> > Per creare un nuovo utente FTP/SSH dalla stessa pagina, clicca su `Creare un utente`{.action} situato a destra.
+>> > Definisci l'estensione del nome di questa nuova `Utente`{.action} e la `Cartella di root`{.action} in cui l'utente potrà agire e clicca su `Continua`{.action}.
+>> > Seleziona una password per questo nuovo account utente, clicca su `Continua`{.action} e poi clicca su `Conferma`{.action}.
 >>
 >> Tutti gli elementi necessari per connetterti allo spazio di storage FTP sono presenti su questa stessa pagina.
 >>

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Accedi allo spazio di storage FTP del tuo hosting Web"
 excerpt: "Questa guida ti mostra come connettersi allo spazio di storage FTP del tuo hosting Web OVHcloud"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Obiettivo
@@ -23,7 +23,7 @@ Le offerte di hosting Web OVHcloud danno accesso a uno spazio di storage FTP che
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -46,12 +46,12 @@ Per accedere allo spazio di storage FTP, recupera questi elementi:
 >
 > **Se disponi già di questi elementi**, prosegui direttamente alla parte 2 "[Accedi al tuo spazio di storage](#ftp_storage_access)" di questa guida.
 
-Se non disponi di questi elementi, clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passi.
+Se non disponi di questi elementi, clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **4** passaggi.
 
 > [!tabs]
 > **Passaggio 1**
 >>
->> Accedi alla pagina [Hosting plans](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -74,27 +74,26 @@ Se non disponi di questi elementi, clicca sulle schede qui sotto per visualizzar
 >> > Seleziona una password per questo nuovo account utente, clicca su `Avanti`{.action} e poi clicca su `Conferma`{.action}.
 >>
 >> Tutti gli elementi necessari per connetterti allo spazio di storage FTP sono presenti su questa stessa pagina.
-
-Di seguito trovi una descrizione delle informazioni essenziali visualizzate sulla pagina `FTP - SSH`:
-
-- **Server FTP e SFTP**: indirizzo del server FTP del tuo hosting Web che permette di accedere al tuo spazio di archiviazione FTP, utilizzando, ad esempio, un software FTP tramite il protocollo FTP o SFTP.
-
-> La porta classica di connessione è la porta "21". Utilizza la porta "22" per una connessione tramite il protocollo SFTP (se attivo)
-
-- **Server SSH**: indirizzo del server SSH del tuo hosting Web che permette di accedere al tuo spazio di archiviazione FTP, utilizzando un terminale tramite il protocollo SSH.
-
-> La porta di connessione SSH è la porta "22".
-
-- **Login principale**: identificativo (S)FTP principale creato sul tuo hosting Web. Tutti gli utenti (S)FTP del tuo hosting sono disponibili nella colonna "Login" della tabella.
-
-> [!primary]
->
-> In base all'offerta di [hosting Web OVHcloud](/links/web/hosting), alcune delle informazioni descritte in precedenza (in particolare quelle relative all'SSH) potrebbero non comparire.
->
+>>
+> **Passaggio 4**
+>>
+>> Di seguito trovi una descrizione delle informazioni essenziali visualizzate sulla pagina `FTP - SSH`:
+>>
+>> - **Server FTP e SFTP**: indirizzo del server FTP del tuo hosting Web che permette di accedere al tuo spazio di archiviazione FTP tramite un software FTP o SFTP.
+>>
+>> > La porta classica di connessione è la porta "21". Utilizza la porta "22" per una connessione tramite il protocollo SFTP (se attivo).
+>>
+>> - **Server SSH**: indirizzo del server SSH del tuo hosting Web che permette di accedere al tuo spazio di archiviazione FTP tramite un terminale e il protocollo SSH.
+>>
+>> > La porta di connessione SSH è la porta "22".
+>>
+>> - **Login principale**: identificativo (S)FTP principale creato sul tuo hosting Web. Tutti gli utenti (S)FTP del tuo hosting sono disponibili nella colonna "Login" della tabella.
+>>
+>> > [!primary]
+>> >
+>> > In base all'offerta di [hosting Web OVHcloud](/links/web/hosting), alcune delle informazioni descritte in precedenza (in particolare quelle relative all'SSH) potrebbero non comparire.
 
 Se non conosci più la password di un utente FTP o SSH, consulta la nostra guida "[Modificare la password di un utente FTP](/pages/web_cloud/web_hosting/ftp_change_password)".
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
 
 A questo punto, disporrai di tutti gli elementi che ti permetteranno di accedere al tuo spazio di archiviazione FTP.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Logowanie do przestrzeni dyskowej FTP hostingu"
 excerpt: "Dowiedz się, jak się zalogować do przestrzeni dyskowej FTP Twojego hostingu WWW OVHcloud"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Wprowadzenie 
@@ -24,7 +24,7 @@ Wraz z pakietami hostingowymi OVHcloud zyskujesz dostęp do przestrzeni dyskowej
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -47,12 +47,12 @@ Aby zalogować się do przestrzeni dyskowej FTP, pobierz następujące elementy:
 > 
 > **Jeśli dysponujesz już tymi elementami**, przejdź bezpośrednio w części 2 [niniejszego przewodnika](#ftp_storage_access).
 
-Jeśli nie posiadasz tych elementów, kliknij poniższe zakładki, aby wyświetlić kolejne **3** kroki.
+Jeśli nie posiadasz tych elementów, kliknij poniższe zakładki, aby wyświetlić kolejne **4** kroki.
 
 > [!tabs]
 > **Krok 1**
 >>
->> Przejdź na stronę [Hosting plans](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -75,27 +75,26 @@ Jeśli nie posiadasz tych elementów, kliknij poniższe zakładki, aby wyświetl
 >> > Wybierz hasło dla tego nowego konta użytkownika, kliknij na `Dalej`{.action}, następnie kliknij na `Potwierdź`{.action}.
 >>
 >> Wszystkie elementy potrzebne do zalogowania się do przestrzeni dyskowej FTP znajdują się na tej samej stronie.
-
-Poniżej znajduje się opis najważniejszych informacji wyświetlanych na stronie `FTP - SSH`:
-
-- **Serwer FTP i SFTP** : adres serwera FTP hostingu pozwalający na dostęp do przestrzeni dyskowej FTP. Używając na przykład oprogramowania FTP za pomocą protokołu FTP lub SFTP.
-
-> Klasycznym portem połączenia jest port "21". Użyj portu "22", aby połączyć się przez protokół SFTP (w przypadku gdy jest on aktywny)
-
-- **Serwer SSH**: adres serwera SSH na hostingu umożliwiający dostęp do przestrzeni dyskowej FTP. Używając terminala przez protokół SSH.
-
-> Port połączenia SSH to port "22".
-
-- **Login główny**: główny identyfikator FTP utworzony na Twoim hostingu. Możesz znaleźć wszystkich użytkowników (S)FTP Twojego hostingu w kolumnie "Login" tabeli.
-
-> [!primary]
->
-> W zależności od oferty [hosting OVHcloud](/links/web/hosting), którą posiadasz, niektóre z informacji opisanych powyżej (zwłaszcza dotyczących SSH) mogą się nie pojawić.
->
+>>
+> **Krok 4**
+>>
+>> Poniżej znajduje się opis najważniejszych informacji wyświetlanych na stronie `FTP - SSH`:
+>>
+>> - **Serwer FTP i SFTP**: adres serwera FTP hostingu pozwalający na dostęp do przestrzeni dyskowej FTP za pomocą oprogramowania FTP lub SFTP.
+>>
+>> > Klasycznym portem połączenia jest port "21". Użyj portu "22", aby połączyć się przez protokół SFTP (w przypadku gdy jest on aktywny).
+>>
+>> - **Serwer SSH**: adres serwera SSH na hostingu umożliwiający dostęp do przestrzeni dyskowej FTP za pomocą terminala i protokołu SSH.
+>>
+>> > Port połączenia SSH to port "22".
+>>
+>> - **Login główny**: główny identyfikator FTP utworzony na Twoim hostingu. Możesz znaleźć wszystkich użytkowników (S)FTP Twojego hostingu w kolumnie "Login" tabeli.
+>>
+>> > [!primary]
+>> >
+>> > W zależności od oferty [hosting OVHcloud](/links/web/hosting), którą posiadasz, niektóre z informacji opisanych powyżej (zwłaszcza dotyczących SSH) mogą się nie pojawić.
 
 Jeśli nie znasz hasła użytkownika FTP lub SSH, zapoznaj się z naszym przewodnikiem "[Zmiana hasła do konta FTP](/pages/web_cloud/web_hosting/ftp_change_password)".
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
 
 W tym momencie dysponujesz wszystkimi elementami pozwalającymi na zalogowanie się do przestrzeni dyskowej FTP.
 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Logowanie do przestrzeni dyskowej FTP hostingu"
 excerpt: "Dowiedz się, jak się zalogować do przestrzeni dyskowej FTP Twojego hostingu WWW OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Wprowadzenie 

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Aceder ao espaço de armazenamento FTP do alojamento web"
 excerpt: "Descubra como aceder ao espaço de armazenamento FTP do alojamento web da OVHcloud"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/ftp_connection/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/ftp_connection/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Aceder ao espaço de armazenamento FTP do alojamento web"
 excerpt: "Descubra como aceder ao espaço de armazenamento FTP do alojamento web da OVHcloud"
-updated: 2025-06-15
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -23,7 +23,7 @@ As ofertas de alojamento web da OVHcloud dão acesso a um espaço de armazenamen
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -46,12 +46,12 @@ Para se ligar ao espaço de armazenamento FTP, recupere os seguintes elementos:
 >
 > **Se já dispõe destes elementos**, consulte na parte 2 "[Aceder ao espaço de armazenamento](#ftp_storage_access)" deste manual.
 
-Se não dispõe destes elementos, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
+Se não dispõe destes elementos, clique nos separadores abaixo para visualizar cada uma das **4** etapas.
 
 > [!tabs]
 > **Etapa 1**
 >>
->> Aceda à página [Hosting plans](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
@@ -74,27 +74,26 @@ Se não dispõe destes elementos, clique nos separadores abaixo para visualizar 
 >> > Escolha uma palavra-passe para esta nova conta de utilizador, clique em `Seguinte`{.action} e depois clique em `Confirmar`{.action}.
 >>
 >> Todos os elementos necessários para aceder ao espaço de armazenamento FTP estão presentes nesta página.
-
-Encontre aqui uma descrição das informações essenciais exibidas na página `FTP - SSH`:
-
-- **Servidor FTP e SFTP**: endereço do servidor FTP do seu alojamento web que permite aceder ao seu espaço de armazenamento FTP. Isto utilizando, por exemplo, um software FTP através do protocolo FTP ou SFTP.
-
-> A porta clássica de ligação é a porta "21". Utilize a porta "22" para uma ligação através do protocolo SFTP (caso este esteja ativado)
-
-- **Servidor SSH**: endereço do servidor SSH do seu alojamento web que permite aceder ao seu espaço de armazenamento FTP. Isto usando um terminal através do protocolo SSH.
-
-> A porta de ligação SSH é a porta "22".
-
-- **Login principal**: ID (S)FTP principal criado no seu alojamento web. Pode consultar todos os utilizadores (S)FTP do seu alojamento na coluna "Login" da tabela.
-
-> [!primary]
->
-> Dependendo da oferta de [alojamento web OVHcloud](/links/web/hosting) que possui, algumas das informações descritas acima (nomeadamente sobre o SSH) podem não aparecer.
->
+>>
+> **Etapa 4**
+>>
+>> Encontre aqui uma descrição das informações essenciais exibidas na página `FTP - SSH`:
+>>
+>> - **Servidor FTP e SFTP**: endereço do servidor FTP do seu alojamento web que permite aceder ao seu espaço de armazenamento FTP através de um software FTP ou SFTP.
+>>
+>> > A porta clássica de ligação é a porta "21". Utilize a porta "22" para uma ligação através do protocolo SFTP (caso este esteja ativado).
+>>
+>> - **Servidor SSH**: endereço do servidor SSH do seu alojamento web que permite aceder ao seu espaço de armazenamento FTP através de um terminal e do protocolo SSH.
+>>
+>> > A porta de ligação SSH é a porta "22".
+>>
+>> - **Login principal**: ID (S)FTP principal criado no seu alojamento web. Pode consultar todos os utilizadores (S)FTP do seu alojamento na coluna "Login" da tabela.
+>>
+>> > [!primary]
+>> >
+>> > Dependendo da oferta de [alojamento web OVHcloud](/links/web/hosting) que possui, algumas das informações descritas acima (nomeadamente sobre o SSH) podem não aparecer.
 
 Se já não sabe a palavra-passe de um utilizador FTP ou SSH, consulte o nosso guia "[Modificar a palavra-passe de um utilizador FTP](/pages/web_cloud/web_hosting/ftp_change_password)".
-
-![ftpconnect](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/change-password.png){.thumbnail}
 
 Nesta fase, dispõe de todos os elementos que lhe permitem aceder ao seu espaço de armazenamento FTP.
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.de-de.md
@@ -78,7 +78,7 @@ Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
 >>
 > **Schritt 2**
 >>
->> Klicken Sie auf den Tab `FTP-SSH`{.action}.
+>> Klicken Sie auf den Tab `FTP - SSH`{.action}.
 >>
 > **Schritt 3**
 >>
@@ -90,7 +90,7 @@ Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
 >>
 >> > [!primary]
 >> >
->> > Aus Sicherheitsgründen wird das Passwort eines Benutzers nicht auf der Seite `FTP-SSH`{.action} angezeigt. Wenn Sie es vergessen haben, lesen Sie [diese Anleitung](/pages/web_cloud/web_hosting/ftp_change_password), um es zu ändern.
+>> > Aus Sicherheitsgründen wird das Passwort eines Benutzers nicht auf der Seite `FTP - SSH`{.action} angezeigt. Wenn Sie es vergessen haben, lesen Sie [diese Anleitung](/pages/web_cloud/web_hosting/ftp_change_password), um es zu ändern.
 
 ### 2 - Mit FileZilla auf den Speicherplatz Ihres Hostings zugreifen
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Webhosting - Verwendung von FileZilla"
 excerpt: "Erfahren Sie, wie Sie sich mit dem Speicherplatz Ihres OVHcloud Webhostings verbinden und die darin enthaltenen Daten mithilfe der FileZilla Software verwalten"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -67,19 +67,30 @@ Sie können damit Dateien oder Ihre Website online stellen, indem Sie sich [mit 
 
 ### 1 - Login-Daten für den Speicherplatz des Webhostings abrufen <a name="part-1"></a>
 
-Führen Sie die folgenden Aktionen aus:
+Klicken Sie auf die Tabs, um die **3** Schritte anzuzeigen.
 
-1. Loggen Sie sich in Ihr [OVHcloud Kundencenter](/links/manager) ein und gehen Sie dann in den Bereich `Web Cloud`{.action}.
-2. Klicken Sie auf das Menü `Hosting-Pakete`{.action} und wählen Sie das betreffende Webhosting aus.
-3. Klicken Sie auf den Tab `FTP - SSH`{.action}.
-4. Auf der neuen Seite werden die Informationen zu Ihrem Speicherplatz angezeigt. Rufen Sie die folgenden Elemente ab:
-    - Der `FTP- und SFTP-Server`, als `ftp.clusterXXX.hosting.ovh.net` (wobei jedes `X` eine Zahl zwischen `0` und `9` ist).
-    - Einer der Benutzer in der Spalte `Login` der Tabelle unten auf der Seite. Sie können auch `Primäres Login` verwenden, wenn Sie möchten.
-    - Die Nummer des `FTP-Port` oder die Nummer des `SFTP-Port`, je nachdem, welches Verbindungsprotokoll Sie für die Verbindung mit Ihrem Speicherplatz verwenden möchten.
-
-> [!primary]
->
-> Aus Sicherheitsgründen wird das Passwort eines Benutzers nicht auf der Seite `FTP - SSH`{.action} angezeigt. Wenn Sie es vergessen haben, lesen Sie [diese Anleitung](/pages/web_cloud/web_hosting/ftp_change_password), um es zu ändern.
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `FTP-SSH`{.action}.
+>>
+> **Schritt 3**
+>>
+>> Die Informationen zu Ihrem Speicherplatz werden angezeigt. Rufen Sie die folgenden Elemente ab:
+>>
+>> - Der `FTP- und SFTP-Server`, als `ftp.clusterXXX.hosting.ovh.net` (wobei jedes `X` eine Zahl zwischen `0` und `9` ist).
+>> - Einer der Benutzer in der Spalte `Login` der Tabelle unten auf der Seite. Sie können auch `Primäres Login` verwenden, wenn Sie möchten.
+>> - Die Nummer des `FTP-Port` oder die Nummer des `SFTP-Port`, je nachdem, welches Verbindungsprotokoll Sie für die Verbindung mit Ihrem Speicherplatz verwenden möchten.
+>>
+>> > [!primary]
+>> >
+>> > Aus Sicherheitsgründen wird das Passwort eines Benutzers nicht auf der Seite `FTP-SSH`{.action} angezeigt. Wenn Sie es vergessen haben, lesen Sie [diese Anleitung](/pages/web_cloud/web_hosting/ftp_change_password), um es zu ändern.
 
 ### 2 - Mit FileZilla auf den Speicherplatz Ihres Hostings zugreifen
 
@@ -107,19 +118,7 @@ Die Verbindung kann über zwei Dateiübertragungsprotokolle hergestellt werden:
 
 **SFTP-Aktivierung überprüfen**
 
-Gehen Sie hierzu in Ihrem [OVHcloud Kundencenter](/links/manager) zum Tab `FTP - SSH`{.action} zurück, wie im [ersten Teil](#part-1) dieser Anleitung beschrieben.
-
-Suchen Sie in der Tabelle unten auf der Seite nach der Spalte `SFTP`, um sicherzustellen, dass der Benutzer (in der Spalte `Login` der Tabelle) über einen aktiven SFTP-Zugang verfügt. Ist dies nicht der Fall, erscheint der Hinweis `Deaktiviert`.
-
-Wenn der SFTP-Zugang des betreffenden Benutzers in der Tabelle `Deaktiviert` lautet, gehen Sie wie folgt vor:
-
-- Bei Basic Angeboten setzen Sie einen Haken links neben `Deaktiviert` in der Tabelle.
-
-- Für die Pro und Performance Angebote:
-
-    - 1: Klicken Sie auf den Button `...`{.action} rechts neben der Zeile für den Benutzer und dann auf `Ändern`{.action}.
-    - 2: Wählen Sie im angezeigten Fenster im Bereich `Verbindungsprotokolle` die Option `FTP und SFTP`{.action} aus und klicken Sie auf `Weiter`{.action}.
-    - 3: Überprüfen Sie die Zusammenfassung der angeforderten Änderung, und klicken Sie dann auf `Bestätigen`{.action}.
+Aktivieren Sie das SFTP-Protokoll mithilfe unserer Anleitung "[Webhosting - SFTP-Zugang aktivieren](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **SFTP-Verbindung mit FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Webhosting - Verwendung von FileZilla"
 excerpt: "Erfahren Sie, wie Sie sich mit dem Speicherplatz Ihres OVHcloud Webhostings verbinden und die darin enthaltenen Daten mithilfe der FileZilla Software verwalten"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -66,19 +66,30 @@ You can use it to put files or your website online by [connecting to your web ho
 
 ### 1 - Retrieve the login information for the web hosting plan storage space <a name="part-1"></a>
 
-Perform the following actions:
+Click on the tabs below to view each of the **3** steps.
 
-1. Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
-2. Click the `Hosting plans`{.action} menu, then select the web hosting plan concerned.
-3. On the page that pops up, click on the `FTP - SSH`{.action} tab.
-4. On the new page, information related to your storage space will appear. In it, you can retrieve the following elements:
-    - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
-    - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
-    - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
-
-> [!primary]
->
-> For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP-SSH`{.action} tab.
+>>
+> **Step 3**
+>>
+>> The information related to your storage space will appear. Retrieve the following elements:
+>>
+>> - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
+>> - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
+>> - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
+>>
+>> > [!primary]
+>> >
+>> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 
@@ -106,19 +117,7 @@ The **SFTP** uses, like SSH, port 22 by default instead of port 21. If you are u
 
 **Check SFTP protocol activation**
 
-To do this, go back to the `FTP - SSH`{.action} tab in your [OVHcloud Control Panel](/links/manager), as detailed in the [first part](#part-1) of this guide.
-
-In the table at the bottom of the page, locate the `SFTP` column to check that the user (in the `Login` column of the table) concerned has active SFTP access. If this is not the case, `Disabled` will appear.
-
-If the SFTP access of the user concerned is `Disabled` in the table, perform the following steps:
-
-- For Personal offers, tick the box to the left of `Disabled` in the table.
-
-- For Professional and Performance plans:
-
-    - 1: Click the `...`{.action} button to the right of the line corresponding to the user, then `Edit`{.action}.
-    - 2: In the window that pops up, in the `Connection protocols` section, select the `FTP and SFTP`{.action} choice, then click `Next`{.action}.
-    - 3: Check the summary of the requested modification, then click `Confirm`{.action}.
+To do this, refer to our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Log in via SFTP with FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-asia.md
@@ -77,7 +77,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> Click on the `FTP-SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 > **Step 3**
 >>
@@ -89,7 +89,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> > [!primary]
 >> >
->> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+>> > For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -66,19 +66,30 @@ You can use it to put files or your website online by [connecting to your web ho
 
 ### 1 - Retrieve the login information for the web hosting plan storage space <a name="part-1"></a>
 
-Perform the following actions:
+Click on the tabs below to view each of the **3** steps.
 
-1. Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
-2. Click the `Hosting plans`{.action} menu, then select the web hosting plan concerned.
-3. On the page that pops up, click on the `FTP - SSH`{.action} tab.
-4. On the new page, information related to your storage space will appear. In it, you can retrieve the following elements:
-    - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
-    - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
-    - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
-
-> [!primary]
->
-> For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP-SSH`{.action} tab.
+>>
+> **Step 3**
+>>
+>> The information related to your storage space will appear. Retrieve the following elements:
+>>
+>> - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
+>> - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
+>> - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
+>>
+>> > [!primary]
+>> >
+>> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 
@@ -106,19 +117,7 @@ The **SFTP** uses, like SSH, port 22 by default instead of port 21. If you are u
 
 **Check SFTP protocol activation**
 
-To do this, go back to the `FTP - SSH`{.action} tab in your [OVHcloud Control Panel](/links/manager), as detailed in the [first part](#part-1) of this guide.
-
-In the table at the bottom of the page, locate the `SFTP` column to check that the user (in the `Login` column of the table) concerned has active SFTP access. If this is not the case, `Disabled` will appear.
-
-If the SFTP access of the user concerned is `Disabled` in the table, perform the following steps:
-
-- For Personal offers, tick the box to the left of `Disabled` in the table.
-
-- For Professional and Performance plans:
-
-    - 1: Click the `...`{.action} button to the right of the line corresponding to the user, then `Edit`{.action}.
-    - 2: In the window that pops up, in the `Connection protocols` section, select the `FTP and SFTP`{.action} choice, then click `Next`{.action}.
-    - 3: Check the summary of the requested modification, then click `Confirm`{.action}.
+To do this, refer to our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Log in via SFTP with FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-au.md
@@ -77,7 +77,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> Click on the `FTP-SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 > **Step 3**
 >>
@@ -89,7 +89,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> > [!primary]
 >> >
->> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+>> > For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -66,19 +66,30 @@ You can use it to put files or your website online by [connecting to your web ho
 
 ### 1 - Retrieve the login information for the web hosting plan storage space <a name="part-1"></a>
 
-Perform the following actions:
+Click on the tabs below to view each of the **3** steps.
 
-1. Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
-2. Click the `Hosting plans`{.action} menu, then select the web hosting plan concerned.
-3. On the page that pops up, click on the `FTP - SSH`{.action} tab.
-4. On the new page, information related to your storage space will appear. In it, you can retrieve the following elements:
-    - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
-    - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
-    - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
-
-> [!primary]
->
-> For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP-SSH`{.action} tab.
+>>
+> **Step 3**
+>>
+>> The information related to your storage space will appear. Retrieve the following elements:
+>>
+>> - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
+>> - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
+>> - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
+>>
+>> > [!primary]
+>> >
+>> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 
@@ -106,19 +117,7 @@ The **SFTP** uses, like SSH, port 22 by default instead of port 21. If you are u
 
 **Check SFTP protocol activation**
 
-To do this, go back to the `FTP - SSH`{.action} tab in your [OVHcloud Control Panel](/links/manager), as detailed in the [first part](#part-1) of this guide.
-
-In the table at the bottom of the page, locate the `SFTP` column to check that the user (in the `Login` column of the table) concerned has active SFTP access. If this is not the case, `Disabled` will appear.
-
-If the SFTP access of the user concerned is `Disabled` in the table, perform the following steps:
-
-- For Personal offers, tick the box to the left of `Disabled` in the table.
-
-- For Professional and Performance plans:
-
-    - 1: Click the `...`{.action} button to the right of the line corresponding to the user, then `Edit`{.action}.
-    - 2: In the window that pops up, in the `Connection protocols` section, select the `FTP and SFTP`{.action} choice, then click `Next`{.action}.
-    - 3: Check the summary of the requested modification, then click `Confirm`{.action}.
+To do this, refer to our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Log in via SFTP with FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ca.md
@@ -77,7 +77,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> Click on the `FTP-SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 > **Step 3**
 >>
@@ -89,7 +89,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> > [!primary]
 >> >
->> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+>> > For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -66,19 +66,30 @@ You can use it to put files or your website online by [connecting to your web ho
 
 ### 1 - Retrieve the login information for the web hosting plan storage space <a name="part-1"></a>
 
-Perform the following actions:
+Click on the tabs below to view each of the **3** steps.
 
-1. Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
-2. Click the `Hosting plans`{.action} menu, then select the web hosting plan concerned.
-3. On the page that pops up, click on the `FTP - SSH`{.action} tab.
-4. On the new page, information related to your storage space will appear. In it, you can retrieve the following elements:
-    - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
-    - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
-    - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
-
-> [!primary]
->
-> For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP-SSH`{.action} tab.
+>>
+> **Step 3**
+>>
+>> The information related to your storage space will appear. Retrieve the following elements:
+>>
+>> - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
+>> - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
+>> - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
+>>
+>> > [!primary]
+>> >
+>> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 
@@ -106,19 +117,7 @@ The **SFTP** uses, like SSH, port 22 by default instead of port 21. If you are u
 
 **Check SFTP protocol activation**
 
-To do this, go back to the `FTP - SSH`{.action} tab in your [OVHcloud Control Panel](/links/manager), as detailed in the [first part](#part-1) of this guide.
-
-In the table at the bottom of the page, locate the `SFTP` column to check that the user (in the `Login` column of the table) concerned has active SFTP access. If this is not the case, `Disabled` will appear.
-
-If the SFTP access of the user concerned is `Disabled` in the table, perform the following steps:
-
-- For Personal offers, tick the box to the left of `Disabled` in the table.
-
-- For Professional and Performance plans:
-
-    - 1: Click the `...`{.action} button to the right of the line corresponding to the user, then `Edit`{.action}.
-    - 2: In the window that pops up, in the `Connection protocols` section, select the `FTP and SFTP`{.action} choice, then click `Next`{.action}.
-    - 3: Check the summary of the requested modification, then click `Confirm`{.action}.
+To do this, refer to our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Log in via SFTP with FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-gb.md
@@ -77,7 +77,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> Click on the `FTP-SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 > **Step 3**
 >>
@@ -89,7 +89,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> > [!primary]
 >> >
->> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+>> > For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -66,19 +66,30 @@ You can use it to put files or your website online by [connecting to your web ho
 
 ### 1 - Retrieve the login information for the web hosting plan storage space <a name="part-1"></a>
 
-Perform the following actions:
+Click on the tabs below to view each of the **3** steps.
 
-1. Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
-2. Click the `Hosting plans`{.action} menu, then select the web hosting plan concerned.
-3. On the page that pops up, click on the `FTP - SSH`{.action} tab.
-4. On the new page, information related to your storage space will appear. In it, you can retrieve the following elements:
-    - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
-    - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
-    - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
-
-> [!primary]
->
-> For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP-SSH`{.action} tab.
+>>
+> **Step 3**
+>>
+>> The information related to your storage space will appear. Retrieve the following elements:
+>>
+>> - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
+>> - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
+>> - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
+>>
+>> > [!primary]
+>> >
+>> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 
@@ -106,19 +117,7 @@ The **SFTP** uses, like SSH, port 22 by default instead of port 21. If you are u
 
 **Check SFTP protocol activation**
 
-To do this, go back to the `FTP - SSH`{.action} tab in your [OVHcloud Control Panel](/links/manager), as detailed in the [first part](#part-1) of this guide.
-
-In the table at the bottom of the page, locate the `SFTP` column to check that the user (in the `Login` column of the table) concerned has active SFTP access. If this is not the case, `Disabled` will appear.
-
-If the SFTP access of the user concerned is `Disabled` in the table, perform the following steps:
-
-- For Personal offers, tick the box to the left of `Disabled` in the table.
-
-- For Professional and Performance plans:
-
-    - 1: Click the `...`{.action} button to the right of the line corresponding to the user, then `Edit`{.action}.
-    - 2: In the window that pops up, in the `Connection protocols` section, select the `FTP and SFTP`{.action} choice, then click `Next`{.action}.
-    - 3: Check the summary of the requested modification, then click `Confirm`{.action}.
+To do this, refer to our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Log in via SFTP with FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ie.md
@@ -77,7 +77,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> Click on the `FTP-SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 > **Step 3**
 >>
@@ -89,7 +89,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> > [!primary]
 >> >
->> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+>> > For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -66,19 +66,30 @@ You can use it to put files or your website online by [connecting to your web ho
 
 ### 1 - Retrieve the login information for the web hosting plan storage space <a name="part-1"></a>
 
-Perform the following actions:
+Click on the tabs below to view each of the **3** steps.
 
-1. Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
-2. Click the `Hosting plans`{.action} menu, then select the web hosting plan concerned.
-3. On the page that pops up, click on the `FTP - SSH`{.action} tab.
-4. On the new page, information related to your storage space will appear. In it, you can retrieve the following elements:
-    - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
-    - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
-    - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
-
-> [!primary]
->
-> For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP-SSH`{.action} tab.
+>>
+> **Step 3**
+>>
+>> The information related to your storage space will appear. Retrieve the following elements:
+>>
+>> - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
+>> - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
+>> - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
+>>
+>> > [!primary]
+>> >
+>> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 
@@ -106,19 +117,7 @@ The **SFTP** uses, like SSH, port 22 by default instead of port 21. If you are u
 
 **Check SFTP protocol activation**
 
-To do this, go back to the `FTP - SSH`{.action} tab in your [OVHcloud Control Panel](/links/manager), as detailed in the [first part](#part-1) of this guide.
-
-In the table at the bottom of the page, locate the `SFTP` column to check that the user (in the `Login` column of the table) concerned has active SFTP access. If this is not the case, `Disabled` will appear.
-
-If the SFTP access of the user concerned is `Disabled` in the table, perform the following steps:
-
-- For Personal offers, tick the box to the left of `Disabled` in the table.
-
-- For Professional and Performance plans:
-
-    - 1: Click the `...`{.action} button to the right of the line corresponding to the user, then `Edit`{.action}.
-    - 2: In the window that pops up, in the `Connection protocols` section, select the `FTP and SFTP`{.action} choice, then click `Next`{.action}.
-    - 3: Check the summary of the requested modification, then click `Confirm`{.action}.
+To do this, refer to our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Log in via SFTP with FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-sg.md
@@ -77,7 +77,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> Click on the `FTP-SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 > **Step 3**
 >>
@@ -89,7 +89,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> > [!primary]
 >> >
->> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+>> > For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-us.md
@@ -77,7 +77,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 > **Step 2**
 >>
->> Click on the `FTP-SSH`{.action} tab.
+>> Click on the `FTP - SSH`{.action} tab.
 >>
 > **Step 3**
 >>
@@ -89,7 +89,7 @@ Click on the tabs below to view each of the **3** steps.
 >>
 >> > [!primary]
 >> >
->> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+>> > For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Web Hosting - How to use FileZilla"
 excerpt: "Find out how to log in to your OVHcloud Web Hosting plan’s storage space, and manage the data stored on it, using FileZilla software"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -66,19 +66,30 @@ You can use it to put files or your website online by [connecting to your web ho
 
 ### 1 - Retrieve the login information for the web hosting plan storage space <a name="part-1"></a>
 
-Perform the following actions:
+Click on the tabs below to view each of the **3** steps.
 
-1. Log in to the [OVHcloud Control Panel](/links/manager), then go to the `Web Cloud`{.action} section.
-2. Click the `Hosting plans`{.action} menu, then select the web hosting plan concerned.
-3. On the page that pops up, click on the `FTP - SSH`{.action} tab.
-4. On the new page, information related to your storage space will appear. In it, you can retrieve the following elements:
-    - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
-    - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
-    - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
-
-> [!primary]
->
-> For security reasons, a user’s password does not appear on the page of the `FTP - SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `FTP-SSH`{.action} tab.
+>>
+> **Step 3**
+>>
+>> The information related to your storage space will appear. Retrieve the following elements:
+>>
+>> - The `FTP and SFTP server` represented as follows: `ftp.clusterXXX.hosting.ovh.net` (where each of the 3 `X` corresponds to a number between `0` and `9`).
+>> - One of the users listed in the `Login` column of the table at the bottom of the page. You can also use the `Main login` if you wish.
+>> - The number of the `FTP port` or the number of the `SFTP port` depending on the connection protocol you will want to use to connect to your storage space.
+>>
+>> > [!primary]
+>> >
+>> > For security reasons, a user’s password does not appear on the page of the `FTP-SSH`{.action} tab. If you have forgotten it, please refer to [this guide](/pages/web_cloud/web_hosting/ftp_change_password) to modify it.
 
 ### 2 - Log in to your hosting plan’s storage space using FileZilla
 
@@ -106,19 +117,7 @@ The **SFTP** uses, like SSH, port 22 by default instead of port 21. If you are u
 
 **Check SFTP protocol activation**
 
-To do this, go back to the `FTP - SSH`{.action} tab in your [OVHcloud Control Panel](/links/manager), as detailed in the [first part](#part-1) of this guide.
-
-In the table at the bottom of the page, locate the `SFTP` column to check that the user (in the `Login` column of the table) concerned has active SFTP access. If this is not the case, the words `Disabled` will appear.
-
-If the SFTP access of the user concerned is `Disabled` in the table, perform the following steps:
-
-- For Personal offers, tick the box to the left of the mention `Disabled` in the table.
-
-- For Professional and Performance plans:
-
-    - 1: Click the `...`{.action} button to the right of the line corresponding to the user, then `Edit`{.action}.
-    - 2: In the window that pops up, in the `Connection protocols` section, select the `FTP and SFTP`{.action} choice, then click `Next`{.action}.
-    - 3: Check the summary of the requested modification, then click `Confirm`{.action}.
+To do this, refer to our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Log in via SFTP with FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Web hosting - Cómo utilizar FileZilla"
 excerpt: "Descubra cómo conectarse al espacio de almacenamiento de un alojamiento web de OVHcloud y gestionar los datos alojados con el programa FileZilla"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -41,7 +41,7 @@ Permite subir archivos o su sitio web [conectándose al espacio de almacenamient
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -67,19 +67,30 @@ Permite subir archivos o su sitio web [conectándose al espacio de almacenamient
 
 ### 1 - Obtener la información de conexión al espacio de almacenamiento del alojamiento web <a name="part-1"></a>
 
-Realice las siguientes acciones:
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
-1. Conéctese a su [área de cliente de OVHcloud](/links/manager) y acceda a la sección `Web Cloud`{.action}.
-2. Haga clic en el menú `Alojamientos`{.action} y seleccione el alojamiento web correspondiente.
-3. En la nueva página, haga clic en la pestaña `FTP - SSH`{.action}.
-4. En la nueva página, aparecerá la información relativa al espacio de almacenamiento. Descubra los siguientes elementos:
-    - El `Servidor FTP y SFTP` representado con el siguiente formato: `ftp.clusterXXX.hosting.ovh.net` (donde cada uno de los 3 `X` corresponde a un número comprendido entre `0` y `9`).
-    - Uno de los usuarios presentes en la columna `Usuario` de la tabla situada en la parte inferior de la página. Si lo desea, puede utilizar el `Usuario principal`.
-    - El número del `Puerto FTP` o el número del `Puerto SFTP` en función del protocolo de conexión que quiera utilizar para conectarse a su espacio de almacenamiento.
-
-> [!primary]
->
-> Por motivos de seguridad, la contraseña de un usuario no aparece en la pestaña `FTP - SSH`{.action}. Si ha olvidado la contraseña, consulte [esta guía](/pages/web_cloud/web_hosting/ftp_change_password) para modificarla.
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `FTP-SSH`{.action}.
+>>
+> **Etapa 3**
+>>
+>> Aparecerá la información relativa al espacio de almacenamiento. Recupere los siguientes elementos:
+>>
+>> - El `Servidor FTP y SFTP` representado con el siguiente formato: `ftp.clusterXXX.hosting.ovh.net` (donde cada uno de los 3 `X` corresponde a un número comprendido entre `0` y `9`).
+>> - Uno de los usuarios presentes en la columna `Usuario` de la tabla situada en la parte inferior de la página. Si lo desea, puede utilizar el `Usuario principal`.
+>> - El número del `Puerto FTP` o el número del `Puerto SFTP` en función del protocolo de conexión que quiera utilizar para conectarse a su espacio de almacenamiento.
+>>
+>> > [!primary]
+>> >
+>> > Por motivos de seguridad, la contraseña de un usuario no aparece en la pestaña `FTP-SSH`{.action}. Si ha olvidado la contraseña, consulte [esta guía](/pages/web_cloud/web_hosting/ftp_change_password) para modificarla.
 
 ### 2 - Conectarse al espacio de almacenamiento de su alojamiento gracias a FileZilla
 
@@ -107,19 +118,7 @@ El **SFTP** utiliza, al igual que el SSH, el puerto 22 por defecto en lugar del 
 
 **Comprobar la activación del protocolo SFTP**
 
-Para ello, vuelva a la pestaña `FTP-SSH`{.action} de su [área de cliente de OVHcloud](/links/manager), tal y como se indica en la [primera parte](#part-1) de esta guía.
-
-En la tabla que aparece en la parte inferior de la página, localice la columna `SFTP` para comprobar que el usuario (presente en la columna `Usuario` de la tabla) dispone de un acceso SFTP activo. En caso contrario, aparecerá la indicación `Desactivado`.
-
-Si el acceso SFTP del usuario correspondiente es `Desactivado`, lleve a cabo los siguientes pasos:
-
-- Para los planes Personal, marque la casilla situada a la izquierda de la mención `Desactivado` en la tabla.
-
-- Para los planes Profesional y Performance:
-
-    - 1: Haga clic en el botón `...`{.action} a la derecha de la línea correspondiente al usuario y luego en `Editar`{.action}.
-    - 2: En la nueva ventana, en la sección `Protocolos de conexión`, seleccione la opción `FTP y SFTP`{.action} y haga clic en `Siguiente`{.action}.
-    - 3: Compruebe el resumen del cambio solicitado y haga clic en `Aceptar`{.action}.
+Para ello, consulte nuestra guía "[Alojamiento web - Cómo activar el acceso SFTP](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Conectarse por SFTP con FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-es.md
@@ -78,7 +78,7 @@ Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 >>
 > **Etapa 2**
 >>
->> Haga clic en la pestaña `FTP-SSH`{.action}.
+>> Haga clic en la pestaña `FTP - SSH`{.action}.
 >>
 > **Etapa 3**
 >>
@@ -90,7 +90,7 @@ Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 >>
 >> > [!primary]
 >> >
->> > Por motivos de seguridad, la contraseña de un usuario no aparece en la pestaña `FTP-SSH`{.action}. Si ha olvidado la contraseña, consulte [esta guía](/pages/web_cloud/web_hosting/ftp_change_password) para modificarla.
+>> > Por motivos de seguridad, la contraseña de un usuario no aparece en la pestaña `FTP - SSH`{.action}. Si ha olvidado la contraseña, consulte [esta guía](/pages/web_cloud/web_hosting/ftp_change_password) para modificarla.
 
 ### 2 - Conectarse al espacio de almacenamiento de su alojamiento gracias a FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Web hosting - Cómo utilizar FileZilla"
 excerpt: "Descubra cómo conectarse al espacio de almacenamiento de un alojamiento web de OVHcloud y gestionar los datos alojados con el programa FileZilla"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Web hosting - Cómo utilizar FileZilla"
 excerpt: "Descubra cómo conectarse al espacio de almacenamiento de un alojamiento web de OVHcloud y gestionar los datos alojados con el programa FileZilla"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -41,7 +41,7 @@ Permite subir archivos o su sitio web [conectándose al espacio de almacenamient
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -67,19 +67,30 @@ Permite subir archivos o su sitio web [conectándose al espacio de almacenamient
 
 ### 1 - Obtener la información de conexión al espacio de almacenamiento del alojamiento web <a name="part-1"></a>
 
-Realice las siguientes acciones:
+Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 
-1. Conéctese a su [área de cliente de OVHcloud](/links/manager) y acceda a la sección `Web Cloud`{.action}.
-2. Haga clic en el menú `Alojamientos`{.action} y seleccione el alojamiento web correspondiente.
-3. En la nueva página, haga clic en la pestaña `FTP - SSH`{.action}.
-4. En la nueva página, aparecerá la información relativa al espacio de almacenamiento. Descubra los siguientes elementos:
-    - El `Servidor FTP y SFTP` representado con el siguiente formato: `ftp.clusterXXX.hosting.ovh.net` (donde cada uno de los 3 `X` corresponde a un número comprendido entre `0` y `9`).
-    - Uno de los usuarios presentes en la columna `Usuario` de la tabla situada en la parte inferior de la página. Si lo desea, puede utilizar el `Usuario principal`.
-    - El número del `Puerto FTP` o el número del `Puerto SFTP` en función del protocolo de conexión que quiera utilizar para conectarse a su espacio de almacenamiento.
-
-> [!primary]
->
-> Por motivos de seguridad, la contraseña de un usuario no aparece en la pestaña `FTP - SSH`{.action}. Si ha olvidado la contraseña, consulte [esta guía](/pages/web_cloud/web_hosting/ftp_change_password) para modificarla.
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `FTP-SSH`{.action}.
+>>
+> **Etapa 3**
+>>
+>> Aparecerá la información relativa al espacio de almacenamiento. Recupere los siguientes elementos:
+>>
+>> - El `Servidor FTP y SFTP` representado con el siguiente formato: `ftp.clusterXXX.hosting.ovh.net` (donde cada uno de los 3 `X` corresponde a un número comprendido entre `0` y `9`).
+>> - Uno de los usuarios presentes en la columna `Usuario` de la tabla situada en la parte inferior de la página. Si lo desea, puede utilizar el `Usuario principal`.
+>> - El número del `Puerto FTP` o el número del `Puerto SFTP` en función del protocolo de conexión que quiera utilizar para conectarse a su espacio de almacenamiento.
+>>
+>> > [!primary]
+>> >
+>> > Por motivos de seguridad, la contraseña de un usuario no aparece en la pestaña `FTP-SSH`{.action}. Si ha olvidado la contraseña, consulte [esta guía](/pages/web_cloud/web_hosting/ftp_change_password) para modificarla.
 
 ### 2 - Conectarse al espacio de almacenamiento de su alojamiento gracias a FileZilla
 
@@ -107,19 +118,7 @@ El **SFTP** utiliza, al igual que el SSH, el puerto 22 por defecto en lugar del 
 
 **Comprobar la activación del protocolo SFTP**
 
-Para ello, vuelva a la pestaña `FTP-SSH`{.action} de su [área de cliente de OVHcloud](/links/manager), tal y como se indica en la [primera parte](#part-1) de esta guía.
-
-En la tabla que aparece en la parte inferior de la página, localice la columna `SFTP` para comprobar que el usuario (presente en la columna `Usuario` de la tabla) dispone de un acceso SFTP activo. En caso contrario, aparecerá la indicación `Desactivado`.
-
-Si el acceso SFTP del usuario correspondiente es `Desactivado`, lleve a cabo los siguientes pasos:
-
-- Para los planes Personal, marque la casilla situada a la izquierda de la mención `Desactivado` en la tabla.
-
-- Para los planes Profesional y Performance:
-
-    - 1: Haga clic en el botón `...`{.action} a la derecha de la línea correspondiente al usuario y luego en `Editar`{.action}.
-    - 2: En la nueva ventana, en la sección `Protocolos de conexión`, seleccione la opción `FTP y SFTP`{.action} y haga clic en `Siguiente`{.action}.
-    - 3: Compruebe el resumen del cambio solicitado y haga clic en `Aceptar`{.action}.
+Para ello, consulte nuestra guía "[Alojamiento web - Cómo activar el acceso SFTP](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Conectarse por SFTP con FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-us.md
@@ -78,7 +78,7 @@ Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 >>
 > **Etapa 2**
 >>
->> Haga clic en la pestaña `FTP-SSH`{.action}.
+>> Haga clic en la pestaña `FTP - SSH`{.action}.
 >>
 > **Etapa 3**
 >>
@@ -90,7 +90,7 @@ Haga clic en las fichas siguientes para ver cada una de las **3** etapas.
 >>
 >> > [!primary]
 >> >
->> > Por motivos de seguridad, la contraseña de un usuario no aparece en la pestaña `FTP-SSH`{.action}. Si ha olvidado la contraseña, consulte [esta guía](/pages/web_cloud/web_hosting/ftp_change_password) para modificarla.
+>> > Por motivos de seguridad, la contraseña de un usuario no aparece en la pestaña `FTP - SSH`{.action}. Si ha olvidado la contraseña, consulte [esta guía](/pages/web_cloud/web_hosting/ftp_change_password) para modificarla.
 
 ### 2 - Conectarse al espacio de almacenamiento de su alojamiento gracias a FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Web hosting - Cómo utilizar FileZilla"
 excerpt: "Descubra cómo conectarse al espacio de almacenamiento de un alojamiento web de OVHcloud y gestionar los datos alojados con el programa FileZilla"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Hébergement web - Comment utiliser FileZilla"
 excerpt: "Découvrez comment vous connecter à l'espace de stockage de votre hébergement web OVHcloud et gérer les données qu'il contient grâce au logiciel FileZilla"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -69,19 +69,30 @@ Il permet de mettre en ligne des fichiers ou votre site Internet en vous [connec
 
 ### 1 - Récupérer les informations de connexion à l'espace de stockage de l'hébergement web <a name="part-1"></a>
 
-Effectuez les actions suivantes :
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-1. Connectez-vous à votre [espace client OVHcloud](/links/manager), puis rendez-vous dans la partie `Web Cloud`{.action}.
-2. Cliquez sur le menu `Hébergements`{.action}, puis choisissez l'hébergement web concerné.
-3. Sur la page qui s'affiche, cliquez sur l'onglet `FTP-SSH`{.action}. 
-4. Sur la nouvelle page, les informations liées à votre espace de stockage apparaissent. Récupérez-y les éléments suivants :
-    - Le `Serveur FTP et SFTP` représenté sous la forme suivante : `ftp.clusterXXX.hosting.ovh.net` (où chacun des 3 `X` correspond à un chiffre compris entre `0` et `9`).
-    - L'un des utilisateurs présents dans la colonne `Login` du tableau situé en bas de page. Vous pouvez aussi utiliser le `Login principal` si vous le souhaitez.
-    - Le numéro du `Port FTP` ou le numéro du `Port SFTP` en fonction du protocole de connexion que vous souhaiterez utiliser pour vous connecter à votre espace de stockage.
-
-> [!primary]
->
-> Pour des raisons de sécurité, le mot de passe d'un utilisateur n'apparaît pas sur la page de l'onglet `FTP-SSH`{.action}. Si vous l'avez oublié, consultez [ce guide](/pages/web_cloud/web_hosting/ftp_change_password) pour le modifier.
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `FTP-SSH`{.action}.
+>>
+> **Étape 3**
+>>
+>> Les informations liées à votre espace de stockage apparaissent. Récupérez les éléments suivants :
+>>
+>> - Le `Serveur FTP et SFTP` représenté sous la forme suivante : `ftp.clusterXXX.hosting.ovh.net` (où chacun des 3 `X` correspond à un chiffre compris entre `0` et `9`).
+>> - L'un des utilisateurs présents dans la colonne `Login` du tableau situé en bas de page. Vous pouvez aussi utiliser le `Login principal` si vous le souhaitez.
+>> - Le numéro du `Port FTP` ou le numéro du `Port SFTP` en fonction du protocole de connexion que vous souhaiterez utiliser pour vous connecter à votre espace de stockage.
+>>
+>> > [!primary]
+>> >
+>> > Pour des raisons de sécurité, le mot de passe d'un utilisateur n'apparaît pas sur la page de l'onglet `FTP-SSH`{.action}. Si vous l'avez oublié, consultez [ce guide](/pages/web_cloud/web_hosting/ftp_change_password) pour le modifier.
 
 ### 2 - Se connecter à l'espace de stockage de votre hébergement grâce à FileZilla
 
@@ -109,19 +120,7 @@ Le **SFTP** utilise, comme le SSH, le port 22 par défaut au lieu du port 21. Si
 
 **Verifier l'activation du protocole SFTP**
 
-Pour cela, retournez dans l'onglet `FTP-SSH`{.action} de votre [espace client OVHcloud](/links/manager) comme indiqué dans la [première partie](#part-1) de ce guide.
-
-Dans le tableau situé en bas de page, repérez la colonne `SFTP` afin de vérifier que l'utilisateur (présent dans la colonne `Login` du tableau) concerné dispose bien d'un accès SFTP actif. La mention `Désactivé` apparaît si ce n'est pas le cas.
-
-Si l'accès SFTP de l'utilisateur concerné est `Désactivé` dans le tableau, effectuez les opérations suivantes:
-
-- Pour les offres Perso, cochez la case située à gauche de la mention `Désactivé` dans le tableau.
-
- - Pour les offres Pro et Performance :
-
-    - 1 : Cliquez sur le bouton `...`{.action} à droite de la ligne correspondant à l'utilisateur, puis sur `Modifier`{.action}.
-    - 2 : Dans la fenêtre qui s'affiche, section `Protocoles de connexion`, sélectionnez le choix `FTP et SFTP`{.action}, puis cliquez sur `Suivant`{.action}.
-    - 3 : Vérifiez le résumé de la modification demandée, puis cliquez sur `Valider`{.action}.
+Pour cela, consultez notre guide « [Hébergement web - Comment activer l'accès SFTP](/pages/web_cloud/web_hosting/enable_sftp) ».
 
 **Se connecter en SFTP avec FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Hébergement web - Comment utiliser FileZilla"
 excerpt: "Découvrez comment vous connecter à l'espace de stockage de votre hébergement web OVHcloud et gérer les données qu'il contient grâce au logiciel FileZilla"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-ca.md
@@ -80,7 +80,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 > **Étape 2**
 >>
->> Cliquez sur l'onglet `FTP-SSH`{.action}.
+>> Cliquez sur l'onglet `FTP - SSH`{.action}.
 >>
 > **Étape 3**
 >>
@@ -92,7 +92,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 >> > [!primary]
 >> >
->> > Pour des raisons de sécurité, le mot de passe d'un utilisateur n'apparaît pas sur la page de l'onglet `FTP-SSH`{.action}. Si vous l'avez oublié, consultez [ce guide](/pages/web_cloud/web_hosting/ftp_change_password) pour le modifier.
+>> > Pour des raisons de sécurité, le mot de passe d'un utilisateur n'apparaît pas sur la page de l'onglet `FTP - SSH`{.action}. Si vous l'avez oublié, consultez [ce guide](/pages/web_cloud/web_hosting/ftp_change_password) pour le modifier.
 
 ### 2 - Se connecter à l'espace de stockage de votre hébergement grâce à FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-fr.md
@@ -76,7 +76,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -120,7 +120,7 @@ Le **SFTP** utilise, comme le SSH, le port 22 par défaut au lieu du port 21. Si
 
 **Verifier l'activation du protocole SFTP**
 
-Pour cela, consultez notre guide « [Activer la connexion SFTP sur son hébergement web](/pages/web_cloud/web_hosting/enable_sftp) ».
+Pour cela, consultez notre guide « [Hébergement web - Comment activer l'accès SFTP](/pages/web_cloud/web_hosting/enable_sftp) ».
 
 **Se connecter en SFTP avec FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Hébergement web - Comment utiliser FileZilla"
 excerpt: "Découvrez comment vous connecter à l'espace de stockage de votre hébergement web OVHcloud et gérer les données qu'il contient grâce au logiciel FileZilla"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -69,19 +69,30 @@ Il permet de mettre en ligne des fichiers ou votre site Internet en vous [connec
 
 ### 1 - Récupérer les informations de connexion à l'espace de stockage de l'hébergement web <a name="part-1"></a>
 
-Effectuez les actions suivantes :
+Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-1. Connectez-vous à votre [espace client OVHcloud](/links/manager), puis rendez-vous dans la partie `Web Cloud`{.action}.
-2. Cliquez sur le menu `Hébergements`{.action}, puis choisissez l'hébergement web concerné.
-3. Sur la page qui s'affiche, cliquez sur l'onglet `FTP-SSH`{.action}. 
-4. Sur la nouvelle page, les informations liées à votre espace de stockage apparaissent. Récupérez-y les éléments suivants :
-    - Le `Serveur FTP et SFTP` représenté sous la forme suivante : `ftp.clusterXXX.hosting.ovh.net` (où chacun des 3 `X` correspond à un chiffre compris entre `0` et `9`).
-    - L'un des utilisateurs présents dans la colonne `Login` du tableau situé en bas de page. Vous pouvez aussi utiliser le `Login principal` si vous le souhaitez.
-    - Le numéro du `Port FTP` ou le numéro du `Port SFTP` en fonction du protocole de connexion que vous souhaiterez utiliser pour vous connecter à votre espace de stockage.
-
-> [!primary]
->
-> Pour des raisons de sécurité, le mot de passe d'un utilisateur n'apparaît pas sur la page de l'onglet `FTP-SSH`{.action}. Si vous l'avez oublié, consultez [ce guide](/pages/web_cloud/web_hosting/ftp_change_password) pour le modifier.
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `FTP-SSH`{.action}.
+>>
+> **Étape 3**
+>>
+>> Les informations liées à votre espace de stockage apparaissent. Récupérez les éléments suivants :
+>>
+>> - Le `Serveur FTP et SFTP` représenté sous la forme suivante : `ftp.clusterXXX.hosting.ovh.net` (où chacun des 3 `X` correspond à un chiffre compris entre `0` et `9`).
+>> - L'un des utilisateurs présents dans la colonne `Login` du tableau situé en bas de page. Vous pouvez aussi utiliser le `Login principal` si vous le souhaitez.
+>> - Le numéro du `Port FTP` ou le numéro du `Port SFTP` en fonction du protocole de connexion que vous souhaiterez utiliser pour vous connecter à votre espace de stockage.
+>>
+>> > [!primary]
+>> >
+>> > Pour des raisons de sécurité, le mot de passe d'un utilisateur n'apparaît pas sur la page de l'onglet `FTP-SSH`{.action}. Si vous l'avez oublié, consultez [ce guide](/pages/web_cloud/web_hosting/ftp_change_password) pour le modifier.
 
 ### 2 - Se connecter à l'espace de stockage de votre hébergement grâce à FileZilla
 
@@ -109,19 +120,7 @@ Le **SFTP** utilise, comme le SSH, le port 22 par défaut au lieu du port 21. Si
 
 **Verifier l'activation du protocole SFTP**
 
-Pour cela, retournez dans l'onglet `FTP-SSH`{.action} de votre [espace client OVHcloud](/links/manager) comme indiqué dans la [première partie](#part-1) de ce guide.
-
-Dans le tableau situé en bas de page, repérez la colonne `SFTP` afin de vérifier que l'utilisateur (présent dans la colonne `Login` du tableau) concerné dispose bien d'un accès SFTP actif. La mention `Désactivé` apparaît si ce n'est pas le cas.
-
-Si l'accès SFTP de l'utilisateur concerné est `Désactivé` dans le tableau, effectuez les opérations suivantes:
-
-- Pour les offres Perso, cochez la case située à gauche de la mention `Désactivé` dans le tableau.
-
-- Pour les offres Pro et Performance :
-
-    - 1 : Cliquez sur le bouton `...`{.action} à droite de la ligne correspondant à l'utilisateur, puis sur `Modifier`{.action}.
-    - 2 : Dans la fenêtre qui s'affiche, section `Protocoles de connexion`, sélectionnez le choix `FTP et SFTP`{.action}, puis cliquez sur `Suivant`{.action}.
-    - 3 : Vérifiez le résumé de la modification demandée, puis cliquez sur `Valider`{.action}.
+Pour cela, consultez notre guide « [Activer la connexion SFTP sur son hébergement web](/pages/web_cloud/web_hosting/enable_sftp) ».
 
 **Se connecter en SFTP avec FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Hébergement web - Comment utiliser FileZilla"
 excerpt: "Découvrez comment vous connecter à l'espace de stockage de votre hébergement web OVHcloud et gérer les données qu'il contient grâce au logiciel FileZilla"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.fr-fr.md
@@ -80,7 +80,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 > **Étape 2**
 >>
->> Cliquez sur l'onglet `FTP-SSH`{.action}.
+>> Cliquez sur l'onglet `FTP - SSH`{.action}.
 >>
 > **Étape 3**
 >>
@@ -92,7 +92,7 @@ Cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3*
 >>
 >> > [!primary]
 >> >
->> > Pour des raisons de sécurité, le mot de passe d'un utilisateur n'apparaît pas sur la page de l'onglet `FTP-SSH`{.action}. Si vous l'avez oublié, consultez [ce guide](/pages/web_cloud/web_hosting/ftp_change_password) pour le modifier.
+>> > Pour des raisons de sécurité, le mot de passe d'un utilisateur n'apparaît pas sur la page de l'onglet `FTP - SSH`{.action}. Si vous l'avez oublié, consultez [ce guide](/pages/web_cloud/web_hosting/ftp_change_password) pour le modifier.
 
 ### 2 - Se connecter à l'espace de stockage de votre hébergement grâce à FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Hosting Web - Come utilizzare FileZilla"
 excerpt: "Questa guida ti mostra come accedere allo spazio di storage dell’hosting Web OVHcloud e gestire i dati in esso contenuti grazie al software FileZilla"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -41,7 +41,7 @@ Permette di mettere online file o siti Internet [accedendo allo spazio di storag
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -67,19 +67,30 @@ Permette di mettere online file o siti Internet [accedendo allo spazio di storag
 
 ### 1 - Recupera le informazioni di connessione allo spazio di storage dell’hosting Web <a name="part-1"></a>
 
-Eseguire le operazioni seguenti:
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** passaggi.
 
-1. Accedi allo [Spazio Cliente OVHcloud](/links/manager) e clicca su `Web Cloud`{.action}.
-2. Clicca sul menu `Hosting`{.action} e seleziona l’hosting Web interessato.
-3. Nella nuova pagina clicca sulla scheda `FTP - SSH`{.action}.
-4. Nella nuova pagina, visualizzi le informazioni relative allo spazio di storage. Recupera questi elementi:
-    - Il `Server FTP e SFTP` rappresentato nel formato seguente: `ftp.clusterXXX.hosting.ovh.net` (dove ciascuno dei 3 `X` corrisponde a una cifra compresa tra `0` e `9`).
-    - Uno degli utenti presenti nella colonna `Login` della tabella situata a piè di pagina. In alternativa, è possibile utilizzare il `Login principale`.
-    - Il numero della `Porta FTP` o il numero della `Porta SFTP` in base al protocollo di connessione che si desidera utilizzare per connettersi allo spazio di storage.
-
-> [!primary]
->
-> Per motivi di sicurezza, la password di un utente non appare sulla pagina della scheda `FTP - SSH`{.action}. Se l’hai dimenticato, consulta [questa guida](/pages/web_cloud/web_hosting/ftp_change_password) per modificarlo.
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting) e seleziona l’hosting Web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `FTP-SSH`{.action}.
+>>
+> **Passaggio 3**
+>>
+>> Le informazioni relative allo spazio di storage vengono visualizzate. Recupera questi elementi:
+>>
+>> - Il `Server FTP e SFTP` rappresentato nel formato seguente: `ftp.clusterXXX.hosting.ovh.net` (dove ciascuno dei 3 `X` corrisponde a una cifra compresa tra `0` e `9`).
+>> - Uno degli utenti presenti nella colonna `Login` della tabella situata a piè di pagina. In alternativa, è possibile utilizzare il `Login principale`.
+>> - Il numero della `Porta FTP` o il numero della `Porta SFTP` in base al protocollo di connessione che si desidera utilizzare per connettersi allo spazio di storage.
+>>
+>> > [!primary]
+>> >
+>> > Per motivi di sicurezza, la password di un utente non appare sulla pagina della scheda `FTP-SSH`{.action}. Se l’hai dimenticato, consulta [questa guida](/pages/web_cloud/web_hosting/ftp_change_password) per modificarlo.
 
 ### 2 - Accedere allo spazio di storage dell’hosting grazie a FileZilla
 
@@ -107,19 +118,7 @@ Il **SFTP** utilizza, come l'SSH, la porta 22 di default al posto della porta 21
 
 **Verifica l'attivazione del protocollo SFTP**
 
-Per farlo, torna alla scheda `FTP-SSH`{.action} dello [Spazio Cliente OVHcloud](/links/manager) come indicato nella [prima parte](#part-1) di questa guida.
-
-Nella tabella a piè di pagina, individua la colonna `SFTP` e verifica che l’utente (presente nella colonna `Login` della tabella) interessato disponga di un accesso SFTP attivo. In caso contrario, comparirà la voce `Disattivato`.
-
-Se l’accesso SFTP dell’utente interessato è `Disattivato` nella tabella, effettuare le seguenti operazioni:
-
-- Per le offerte Personale, spunta la casella a sinistra della voce `Disattivato` nella tabella.
-
-- Per le offerte Pro e Performance:
-
-    - 1: Clicca sul pulsante `...`{.action} a destra della riga corrispondente all’utente e poi su `Modificare`{.action}.
-    - 2: Nella finestra che appare, sezione `Protocolli di connessione`, seleziona la scelta `FTP e SFTP`{.action}, poi clicca su `Continua`{.action}.
-    - 3: Verifica il riepilogo della modifica richiesta e clicca su `Conferma`{.action}.
+Per farlo, consulta la nostra guida "[Hosting Web - Come attivare l’accesso SFTP](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Connettersi in SFTP con FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Hosting Web - Come utilizzare FileZilla"
 excerpt: "Questa guida ti mostra come accedere allo spazio di storage dell’hosting Web OVHcloud e gestire i dati in esso contenuti grazie al software FileZilla"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.it-it.md
@@ -78,7 +78,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
 >>
 > **Passaggio 2**
 >>
->> Clicca sulla scheda `FTP-SSH`{.action}.
+>> Clicca sulla scheda `FTP - SSH`{.action}.
 >>
 > **Passaggio 3**
 >>
@@ -90,7 +90,7 @@ Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **3** pa
 >>
 >> > [!primary]
 >> >
->> > Per motivi di sicurezza, la password di un utente non appare sulla pagina della scheda `FTP-SSH`{.action}. Se l’hai dimenticato, consulta [questa guida](/pages/web_cloud/web_hosting/ftp_change_password) per modificarlo.
+>> > Per motivi di sicurezza, la password di un utente non appare sulla pagina della scheda `FTP - SSH`{.action}. Se l’hai dimenticato, consulta [questa guida](/pages/web_cloud/web_hosting/ftp_change_password) per modificarlo.
 
 ### 2 - Accedere allo spazio di storage dell’hosting grazie a FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Hosting WWW - Jak używać programu FileZilla"
 excerpt: "Dowiedz się, jak zalogować się do przestrzeni dyskowej hostingu OVHcloud i zarządzać danymi w niej zawartymi za pomocą oprogramowania FileZilla"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Hosting WWW - Jak używać programu FileZilla"
 excerpt: "Dowiedz się, jak zalogować się do przestrzeni dyskowej hostingu OVHcloud i zarządzać danymi w niej zawartymi za pomocą oprogramowania FileZilla"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -41,7 +41,7 @@ Umożliwia wgranie plików lub Twojej strony WWW do trybu online poprzez [zalogo
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -67,19 +67,30 @@ Umożliwia wgranie plików lub Twojej strony WWW do trybu online poprzez [zalogo
 
 ### 1 - Pobieranie danych do logowania do przestrzeni dyskowej hostingu WWW <a name="part-1"></a>
 
-Wykonaj następujące czynności:
+Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 
-1. Zaloguj się do [Panelu klienta OVHcloud](/links/manager) i przejdź do sekcji `Web Cloud`{.action}.
-2. Kliknij menu `Hosting`{.action}, następnie wybierz odpowiedni hosting.
-3. Na stronie, która się wyświetli kliknij zakładkę `FTP - SSH`{.action}.
-4. Na nowej stronie wyświetlają się informacje dotyczące Twojej przestrzeni dyskowej. W mailu znajdziesz następujące elementy:
-    - `Serwer FTP i SFTP` przedstawiony w następującej formie: `ftp.clusterXXX.hosting.ovh.net` (gdzie każda z 3 `X` odpowiada cyfrze między `0` i `9`).
-    - Jeden z użytkowników w kolumnie `Login` tabeli na dole strony. Możesz również użyć `Login główny`, jeśli chcesz.
-    - Numer `Port FTP` lub numer `Port SFTP` w zależności od protokołu połączenia, którego będziesz chciał użyć do zalogowania się do przestrzeni dyskowej.
-
-> [!primary]
->
-> Ze względów bezpieczeństwa hasło użytkownika nie pojawia się na stronie zakładki `FTP - SSH`{.action}. Jeśli nie pamiętasz hasła, zapoznaj się z [tym przewodnikiem](/pages/web_cloud/web_hosting/ftp_change_password), aby wprowadzić zmiany.
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `FTP-SSH`{.action}.
+>>
+> **Krok 3**
+>>
+>> Wyświetlą się informacje dotyczące Twojej przestrzeni dyskowej. Pobierz następujące elementy:
+>>
+>> - `Serwer FTP i SFTP` przedstawiony w następującej formie: `ftp.clusterXXX.hosting.ovh.net` (gdzie każda z 3 `X` odpowiada cyfrze między `0` i `9`).
+>> - Jeden z użytkowników w kolumnie `Login` tabeli na dole strony. Możesz również użyć `Login główny`, jeśli chcesz.
+>> - Numer `Port FTP` lub numer `Port SFTP` w zależności od protokołu połączenia, którego chcesz użyć do zalogowania się do przestrzeni dyskowej.
+>>
+>> > [!primary]
+>> >
+>> > Ze względów bezpieczeństwa hasło użytkownika nie pojawia się na stronie zakładki `FTP-SSH`{.action}. Jeśli nie pamiętasz hasła, zapoznaj się z [tym przewodnikiem](/pages/web_cloud/web_hosting/ftp_change_password), aby wprowadzić zmiany.
 
 ### 2 - Logowanie do przestrzeni dyskowej hostingu za pomocą FileZilla
 
@@ -107,19 +118,7 @@ Połączenie może być realizowane przez dwa protokoły transferu plików:
 
 **Sprawdź aktywację protokołu SFTP**
 
-W tym celu wróć do zakładki `FTP-SSH`{.action} w [Panelu klienta OVHcloud](/links/manager), jak pokazano w [pierwszej części](#part-1) tego przewodnika.
-
-W tabeli na dole strony znajdź kolumnę `SFTP`, aby sprawdzić, czy dany użytkownik (w kolumnie `Login` tabeli) posiada aktywny dostęp SFTP. Jeśli tak nie jest, pojawi się informacja `Wyłączona`.
-
-Jeśli dostęp SFTP danego użytkownika jest w tabeli wyłączony `Wyłączona`, wykonaj następujące czynności:
-
-- W przypadku oferty Perso zaznacz kratkę po lewej stronie komendy `Wyłączona` w tabeli.
-
-- Dla ofert Pro i Performance:
-
-    - 1: Kliknij przycisk `...`{.action} po prawej stronie wiersza odpowiadającego użytkownikowi, a następnie kliknij `Zmodyfikuj`{.action}.
-    - 2 : W oknie, które się wyświetli, wybierz opcję `Protokoły logowania`, wybierz opcję `FTP i SFTP`{.action}, następnie kliknij `Dalej`{.action}.
-    - 3: Przejrzyj podsumowanie żądanej zmiany, następnie kliknij `Zatwierdź`{.action}.
+W tym celu zapoznaj się z naszym przewodnikiem "[Hosting - Jak włączyć dostęp SFTP](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Logowanie przez SFTP przy użyciu FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pl-pl.md
@@ -78,7 +78,7 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 >>
 > **Krok 2**
 >>
->> Kliknij zakładkę `FTP-SSH`{.action}.
+>> Kliknij zakładkę `FTP - SSH`{.action}.
 >>
 > **Krok 3**
 >>
@@ -90,7 +90,7 @@ Kliknij poniższe karty, aby wyświetlić kolejne **3** kroki.
 >>
 >> > [!primary]
 >> >
->> > Ze względów bezpieczeństwa hasło użytkownika nie pojawia się na stronie zakładki `FTP-SSH`{.action}. Jeśli nie pamiętasz hasła, zapoznaj się z [tym przewodnikiem](/pages/web_cloud/web_hosting/ftp_change_password), aby wprowadzić zmiany.
+>> > Ze względów bezpieczeństwa hasło użytkownika nie pojawia się na stronie zakładki `FTP - SSH`{.action}. Jeśli nie pamiętasz hasła, zapoznaj się z [tym przewodnikiem](/pages/web_cloud/web_hosting/ftp_change_password), aby wprowadzić zmiany.
 
 ### 2 - Logowanie do przestrzeni dyskowej hostingu za pomocą FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Alojamento web - Como utilizar o FileZilla"
 excerpt: "Saiba como aceder ao espaço de armazenamento do seu alojamento web OVHcloud e gerir os dados nele contidos graças ao software FileZilla"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pt-pt.md
@@ -78,7 +78,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 >>
 > **Etapa 2**
 >>
->> Clique no separador `FTP-SSH`{.action}.
+>> Clique no separador `FTP - SSH`{.action}.
 >>
 > **Etapa 3**
 >>
@@ -90,7 +90,7 @@ Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 >>
 >> > [!primary]
 >> >
->> > Por razões de segurança, a palavra-passe de um utilizador não aparece na página do separador `FTP-SSH`{.action}. Se se esquecer da palavra-passe, consulte [este manual](/pages/web_cloud/web_hosting/ftp_change_password) para obter mais informações.
+>> > Por razões de segurança, a palavra-passe de um utilizador não aparece na página do separador `FTP - SSH`{.action}. Se se esquecer da palavra-passe, consulte [este manual](/pages/web_cloud/web_hosting/ftp_change_password) para obter mais informações.
 
 ### 2 - Ligue-se ao espaço de armazenamento do seu alojamento graças ao FileZilla
 

--- a/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/ftp_filezilla_user_guide/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Alojamento web - Como utilizar o FileZilla"
 excerpt: "Saiba como aceder ao espaço de armazenamento do seu alojamento web OVHcloud e gerir os dados nele contidos graças ao software FileZilla"
-updated: 2025-09-12
+updated: 2026-03-26
 ---
 
 <style>
@@ -41,7 +41,7 @@ Permite publicar ficheiros ou o seu website [ligando-se ao espaço de armazename
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -67,19 +67,30 @@ Permite publicar ficheiros ou o seu website [ligando-se ao espaço de armazename
 
 ### 1 - Obter as informações de ligação ao espaço de armazenamento do alojamento web <a name="part-1"></a>
 
-Efetue as seguintes ações:
+Clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
-1. Aceda à [Área de Cliente OVHcloud](/links/manager) e aceda à secção `Web Cloud`{.action}.
-2. Clique no menu `Alojamentos`{.action} e escolha o alojamento web em causa.
-3. Na página que se abrir, clique no separador `FTP - SSH`{.action}.
-4. Na nova página, serão apresentadas as informações relativas ao seu espaço de armazenamento. Inclua os seguintes itens:
-    - O `Servidor FTP e SFTP` representado sob a seguinte forma: `ftp.clusterXXX.hosting.ovh.net` (em que cada um dos 3 `X` corresponde a um número compreendido entre `0` e `9`).
-    - Um dos utilizadores presentes na coluna `Login` da tabela situada na parte inferior da página. Também pode utilizar o `Login principal` se desejar.
-    - O número do `Port FTP` ou o número do `Port SFTP` em função do protocolo de ligação que pretende utilizar para se ligar ao seu espaço de armazenamento.
-
-> [!primary]
->
-> Por razões de segurança, a palavra-passe de um utilizador não aparece na página do separador `FTP - SSH`{.action}. Se se esquecer da palavra-passe, consulte [este manual](/pages/web_cloud/web_hosting/ftp_change_password) para obter mais informações.
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em causa.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Clique no separador `FTP-SSH`{.action}.
+>>
+> **Etapa 3**
+>>
+>> As informações relativas ao seu espaço de armazenamento são apresentadas. Recupere os seguintes elementos:
+>>
+>> - O `Servidor FTP e SFTP` representado sob a seguinte forma: `ftp.clusterXXX.hosting.ovh.net` (em que cada um dos 3 `X` corresponde a um número compreendido entre `0` e `9`).
+>> - Um dos utilizadores presentes na coluna `Login` da tabela situada na parte inferior da página. Também pode utilizar o `Login principal` se desejar.
+>> - O número do `Port FTP` ou o número do `Port SFTP` em função do protocolo de ligação que pretende utilizar para se ligar ao seu espaço de armazenamento.
+>>
+>> > [!primary]
+>> >
+>> > Por razões de segurança, a palavra-passe de um utilizador não aparece na página do separador `FTP-SSH`{.action}. Se se esquecer da palavra-passe, consulte [este manual](/pages/web_cloud/web_hosting/ftp_change_password) para obter mais informações.
 
 ### 2 - Ligue-se ao espaço de armazenamento do seu alojamento graças ao FileZilla
 
@@ -107,19 +118,7 @@ O **SFTP** utiliza, tal como o SSH, a porta 22 predefinida em vez da porta 21. S
 
 **Verificar a ativação do protocolo SFTP**
 
-Para isso, volte ao separador FTP-SSH`{.action} do seu [Área de Cliente OVHcloud](/links/manager) tal como indicado na [primeira parte](#part-1) deste guia.
-
-Na tabela que se encontra na parte inferior da página, repare na coluna `SFTP` para verificar se o utilizador (presente na coluna `Nome de utilizador` da tabela) em questão dispõe de um acesso SFTP ativo. Se não for o caso, será apresentada a menção `Desativado`.
-
-Se o acesso SFTP do utilizador em questão estiver `Desativado` na tabela, efetue as seguintes etapas:
-
-- Para as ofertas Perso, selecione a opção situada à esquerda da menção `Desativado` na tabela.
-
-- Para as ofertas Pro e Performance:
-
-    - 1 : Clique no botão `...`{.action} à direita da linha correspondente ao utilizador, depois em `Alterar`{.action}.
-    - 2: Na janela que se abrir, secção `Protocolos de ligação`, selecione a escolha `FTP e SFTP`{.action} e, em seguida, clique em `Seguinte`{.action}.
-    - 3: Verifique o resumo da modificação solicitada e depois clique em `Validar`{.action}.
+Para isso, consulte o nosso guia "[Alojamento web - Como ativar o acesso SFTP](/pages/web_cloud/web_hosting/enable_sftp)".
 
 **Ligar-se em SFTP com FileZilla**
 

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Häufige FTP-Probleme beheben"
 excerpt: "Diese Anleitung erklärt, wie Sie Fehlermeldungen bei FTP-Verbindungen beheben"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Ziel 
@@ -41,18 +41,11 @@ Diese Nachricht im [FileZilla-Programm](/pages/web_cloud/web_hosting/ftp_filezil
 
 Wenn die Daten, die Sie über diese Verbindung austauschen möchten, nicht vertraulich sind, klicken Sie auf `OK`{.action}.
 
-Ist das nicht der Fall, gehen Sie in Ihr [OVHcloud Kundencenter](/links/manager), dann auf `Web Cloud`{.action} und `Hosting-Pakete`{.action}. Wählen Sie das betreffende Hosting aus und öffnen Sie den Tab `FTP-SSH`{.action}.
-
-Wenn Sie über ein Webhosting [Basic](/links/web/hosting-personal-offer) verfügen, setzen Sie in der Spalte `SFTP`{.action} den Haken bei der Feld `Deaktiviert`{.action} und warten Sie einige Minuten.
-
-Wenn Sie über ein Webhosting [Pro](/links/web/hosting-professional-offer) oder [Performance](/links/web/hosting-performance-offer) verfügen, klicken Sie auf die Schaltfläche `...`{.action} rechts neben dem betreffenden FTP-Benutzer und dann auf `Ändern`{.action}.
-
-Wählen Sie `SFTP`{.action} oder `Aktiviert`{.action} aus (um das SSH-Protokoll auf Ihrem Hosting zu aktivieren), klicken Sie auf `Weiter`{.action}, dann auf `Bestätigen`{.action}. Die Umstellung dauert einige Minuten.
+Aktivieren Sie andernfalls das SFTP-Protokoll mithilfe unserer Anleitung "[Webhosting - SFTP-Zugang aktivieren](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >
 > Für sonstige Fehlermeldungen beachten Sie den Bereich `Diagnose` unserer [Webhosting-Anleitungen](/products/web-cloud-hosting).
->
 
 ### Ich habe meine Dateien mit einem FTP-Programm übertragen, aber meine Seite wird nicht angezeigt
 

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Häufige FTP-Probleme beheben"
 excerpt: "Diese Anleitung erklärt, wie Sie Fehlermeldungen bei FTP-Verbindungen beheben"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Ziel 
@@ -76,7 +76,7 @@ Um den verbleibenden Speicherplatz auf Ihrem Webhosting zu überprüfen, klicken
 >>
 >> ![disk_space](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/general-information/find-disk-space.png){.thumbnail}
 
-### Ich kann meine Dateien nicht auf den FTP Server übertragen
+### Ich kann meine Dateien nicht auf den FTP-Server übertragen
 
 Überprüfen Sie, dass Ihr FTP-Programm im “Passivmodus“ (Konfigurationsmodus eines FTP-Servers, in dem der Server den Verbindungsport bestimmt) verbunden ist.
 
@@ -92,7 +92,7 @@ Dieser Link ist standardmäßig auf den Shared Hosting Paketen von OVHcloud inst
 
 ![site-under-construction](/pages/assets/screens/other/browsers/errors/site-under-construction.png){.thumbnail}
 
-Wenn Sie die Funktion “[1-Klick-Modul](/pages/web_cloud/web_hosting/cms_install_1_click_modules)“ nicht für Ihre Website verwendet haben, müssen Sie sich [mit dem FTP-Speicherplatz verbinden](/pages/web_cloud/web_hosting/ftp_connection) Ihres Webhostings einloggen, um die Seite „Site under construction“ manuell zu löschen.
+Wenn Sie die Funktion “[1-Klick-Modul](/pages/web_cloud/web_hosting/cms_install_1_click_modules)“ nicht für Ihre Website verwendet haben, müssen Sie sich [mit dem FTP-Speicherplatz verbinden](/pages/web_cloud/web_hosting/ftp_connection) Ihres Webhostings einloggen, um die Seite "Site under construction“ manuell zu löschen.
 
 ## Weiterführende Informationen <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,13 +41,7 @@ This message coming from [FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_
 
 If the data you want to exchange via this link is not confidential, click `OK`{.action}.
 
-Otherwise, go to the [OVHcloud Control Panel](/links/manager), go to the `Web Cloud`{.action} section, then `Hosting plans`{.action}. Select the hosting plan concerned, then choose the `FTP-SSH`{.action} tab.
-
-If you have a [Personal](/links/web/hosting-personal-offer) Web Hosting plan, tick the `Disabled`{.action} box in the `SFTP`{.action} column, then wait a few minutes.
-
-If you have a [Pro](/links/web/hosting-professional-offer) or [Performance](/links/web/hosting-performance-offer) Web Hosting plan, click on the `...`{.action} button to the right of the FTP user concerned, then on `Edit`{.action}.
-
-Choose `SFTP`{.action} or `Enabled`{.action} (to enable SSH on your hosting), click `Next`{.action} and then click on `Confirm`{.action}. Wait a few minutes.
+Otherwise, enable the SFTP protocol by following our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,13 +41,7 @@ This message coming from [FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_
 
 If the data you want to exchange via this link is not confidential, click `OK`{.action}.
 
-Otherwise, go to the [OVHcloud Control Panel](/links/manager), go to the `Web Cloud`{.action} section, then `Hosting plans`{.action}. Select the hosting plan concerned, then choose the `FTP-SSH`{.action} tab.
-
-If you have a [Personal](/links/web/hosting-personal-offer) Web Hosting plan, tick the `Disabled`{.action} box in the `SFTP`{.action} column, then wait a few minutes.
-
-If you have a [Pro](/links/web/hosting-professional-offer) or [Performance](/links/web/hosting-performance-offer) Web Hosting plan, click on the `...`{.action} button to the right of the FTP user concerned, then on `Edit`{.action}.
-
-Choose `SFTP`{.action} or `Enabled`{.action} (to enable SSH on your hosting), click `Next`{.action} and then click on `Confirm`{.action}. Wait a few minutes.
+Otherwise, enable the SFTP protocol by following our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,13 +41,7 @@ This message coming from [FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_
 
 If the data you want to exchange via this link is not confidential, click `OK`{.action}.
 
-Otherwise, go to the [OVHcloud Control Panel](/links/manager), go to the `Web Cloud`{.action} section, then `Hosting plans`{.action}. Select the hosting plan concerned, then choose the `FTP-SSH`{.action} tab.
-
-If you have a [Personal](/links/web/hosting-personal-offer) Web Hosting plan, tick the `Disabled`{.action} box in the `SFTP`{.action} column, then wait a few minutes.
-
-If you have a [Pro](/links/web/hosting-professional-offer) or [Performance](/links/web/hosting-performance-offer) Web Hosting plan, click on the `...`{.action} button to the right of the FTP user concerned, then on `Edit`{.action}.
-
-Choose `SFTP`{.action} or `Enabled`{.action} (to enable SSH on your hosting), click `Next`{.action} and then click on `Confirm`{.action}. Wait a few minutes.
+Otherwise, enable the SFTP protocol by following our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,18 +41,11 @@ This message coming from [FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_
 
 If the data you want to exchange via this link is not confidential, click `OK`{.action}.
 
-Otherwise, go to the [OVHcloud Control Panel](/links/manager), go to the `Web Cloud`{.action} section, then `Hosting plans`{.action}. Select the hosting plan concerned, then choose the `FTP-SSH`{.action} tab.
-
-If you have a [Personal](/links/web/hosting-personal-offer) Web Hosting plan, tick the `Disabled`{.action} box in the `SFTP`{.action} column, then wait a few minutes.
-
-If you have a [Pro](/links/web/hosting-professional-offer) or [Performance](/links/web/hosting-performance-offer) Web Hosting plan, click on the `...`{.action} button to the right of the FTP user concerned, then on `Edit`{.action}.
-
-Choose `SFTP`{.action} or `Enabled`{.action} (to enable SSH on your hosting), click `Next`{.action} and then click on `Confirm`{.action}. Wait a few minutes.
+Otherwise, enable the SFTP protocol by following our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >
 > For any other error messages, see the `Troubleshooting` section of our [Web Hosting guides](/products/web-cloud-hosting).
->
 
 ### I transferred my files with FTP software, but my website does not appear.
 

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,13 +41,7 @@ This message coming from [FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_
 
 If the data you want to exchange via this link is not confidential, click `OK`{.action}.
 
-Otherwise, go to the [OVHcloud Control Panel](/links/manager), go to the `Web Cloud`{.action} section, then `Hosting plans`{.action}. Select the hosting plan concerned, then choose the `FTP-SSH`{.action} tab.
-
-If you have a [Personal](/links/web/hosting-personal-offer) Web Hosting plan, tick the `Disabled`{.action} box in the `SFTP`{.action} column, then wait a few minutes.
-
-If you have a [Pro](/links/web/hosting-professional-offer) or [Performance](/links/web/hosting-performance-offer) Web Hosting plan, click on the `...`{.action} button to the right of the FTP user concerned, then on `Edit`{.action}.
-
-Choose `SFTP`{.action} or `Enabled`{.action} (to enable SSH on your hosting), click `Next`{.action} and then click on `Confirm`{.action}. Wait a few minutes.
+Otherwise, enable the SFTP protocol by following our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,13 +41,7 @@ This message coming from [FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_
 
 If the data you want to exchange via this link is not confidential, click `OK`{.action}.
 
-Otherwise, go to the [OVHcloud Control Panel](/links/manager), go to the `Web Cloud`{.action} section, then `Hosting plans`{.action}. Select the hosting plan concerned, then choose the `FTP-SSH`{.action} tab.
-
-If you have a [Personal](/links/web/hosting-personal-offer) Web Hosting plan, tick the `Disabled`{.action} box in the `SFTP`{.action} column, then wait a few minutes.
-
-If you have a [Pro](/links/web/hosting-professional-offer) or [Performance](/links/web/hosting-performance-offer) Web Hosting plan, click on the `...`{.action} button to the right of the FTP user concerned, then on `Edit`{.action}.
-
-Choose `SFTP`{.action} or `Enabled`{.action} (to enable SSH on your hosting), click `Next`{.action} and then click on `Confirm`{.action}. Wait a few minutes.
+Otherwise, enable the SFTP protocol by following our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Troubleshooting recurring errors when using FTP software"
 excerpt: "Find out how to resolve the most common FTP software related issues"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,13 +41,7 @@ This message coming from [FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla_
 
 If the data you want to exchange via this link is not confidential, click `OK`{.action}.
 
-Otherwise, go to the [OVHcloud Control Panel](/links/manager), go to the `Web Cloud`{.action} section, then `Hosting plans`{.action}. Select the hosting plan concerned, then choose the `FTP-SSH`{.action} tab.
-
-If you have a [Personal](/links/web/hosting-personal-offer) Web Hosting plan, tick the `Disabled`{.action} box in the `SFTP`{.action} column, then wait a few minutes.
-
-If you have a [Pro](/links/web/hosting-professional-offer) or [Performance](/links/web/hosting-performance-offer) Web Hosting plan, click on the `...`{.action} button to the right of the FTP user concerned, then on `Edit`{.action}.
-
-Choose `SFTP`{.action} or `Enabled`{.action} (to enable SSH on your hosting), click `Next`{.action} and then click on `Confirm`{.action}. Wait a few minutes.
+Otherwise, enable the SFTP protocol by following our guide "[Web Hosting - How to enable SFTP access](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Resolver los errores recurrentes durante el uso de un programa FTP"
 excerpt: "Encuentre aquí las anomalías más frecuentes asociadas a su programa FTP"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -25,7 +25,7 @@ El uso de software FTP durante la conexión a su [hosting Web Cloud](/links/web/
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -41,18 +41,11 @@ Este mensaje en el programa [FileZilla](/pages/web_cloud/web_hosting/ftp_filezil
 
 Si los datos que desea intercambiar por este medio no son confidenciales, haga clic en `Aceptar`{.action}.
 
-En caso contrario, acceda al [área de cliente de OVHcloud](/links/manager), en la sección `Web Cloud`{.action} y, seguidamente, `Alojamientos`{.action}. Seleccione el alojamiento correspondiente y abra la pestaña `FTP-SSH`{.action}.
-
-Si dispone de un alojamiento [Personal](/links/web/hosting-personal-offer), marque la casilla `Desactivado`{.action} en la columna `SFTP`{.action} y espere unos minutos.
-
-Si dispone de un alojamiento [Pro](/links/web/hosting-professional-offer) o [Performance](/links/web/hosting-performance-offer), haga clic en el botón `...`{.action} a la derecha del usuario FTP correspondiente y seleccione `Editar`{.action}.
-
-Seleccione `SFTP`{.action} o `Activado`{.action} (para activar el protocolo SSH en su alojamiento), haga clic en `Siguiente`{.action} y luego en `Aceptar`{.action}. Espere unos minutos.
+En caso contrario, active el protocolo SFTP consultando nuestra guía "[Alojamiento web - Cómo activar el acceso SFTP](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >
 > Para más información sobre los errores, consulte la sección `Diagnóstico` de nuestras guías de [Hosting](/products/web-cloud-hosting).
->
 
 ### He transferido mis archivos con un programa FTP, pero mi sitio web no aparece.
 
@@ -73,7 +66,7 @@ Para comprobar el espacio de almacenamiento restante del alojamiento, haga clic 
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Resolver los errores recurrentes durante el uso de un programa FTP"
 excerpt: "Encuentre aquí las anomalías más frecuentes asociadas a su programa FTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Resolver los errores recurrentes durante el uso de un programa FTP"
 excerpt: "Encuentre aquí las anomalías más frecuentes asociadas a su programa FTP"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -25,7 +25,7 @@ El uso de software FTP durante la conexión a su [hosting Web Cloud](/links/web/
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -41,18 +41,11 @@ Este mensaje en el programa [FileZilla](/pages/web_cloud/web_hosting/ftp_filezil
 
 Si los datos que desea intercambiar por este medio no son confidenciales, haga clic en `Aceptar`{.action}.
 
-En caso contrario, acceda al [área de cliente de OVHcloud](/links/manager), en la sección `Web Cloud`{.action} y, seguidamente, `Alojamientos`{.action}. Seleccione el alojamiento correspondiente y abra la pestaña `FTP-SSH`{.action}.
-
-Si dispone de un alojamiento [Personal](/links/web/hosting-personal-offer), marque la casilla `Desactivado`{.action} en la columna `SFTP`{.action} y espere unos minutos.
-
-Si dispone de un alojamiento [Pro](/links/web/hosting-professional-offer) o [Performance](/links/web/hosting-performance-offer), haga clic en el botón `...`{.action} a la derecha del usuario FTP correspondiente y seleccione `Editar`{.action}.
-
-Seleccione `SFTP`{.action} o `Activado`{.action} (para activar el protocolo SSH en su alojamiento), haga clic en `Siguiente`{.action} y luego en `Aceptar`{.action}. Espere unos minutos.
+En caso contrario, active el protocolo SFTP consultando nuestra guía "[Alojamiento web - Cómo activar el acceso SFTP](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >
 > Para más información sobre los errores, consulte la sección `Diagnóstico` de nuestras guías de [Hosting](/products/web-cloud-hosting).
->
 
 ### He transferido mis archivos con un programa FTP, pero mi sitio web no aparece.
 
@@ -73,7 +66,7 @@ Para comprobar el espacio de almacenamiento restante del alojamiento, haga clic 
 > [!tabs]
 > **Etapa 1**
 >>
->> Acceda a la página [Hosting plans](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Resolver los errores recurrentes durante el uso de un programa FTP"
 excerpt: "Encuentre aquí las anomalías más frecuentes asociadas a su programa FTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Résoudre les erreurs récurrentes lors de l’utilisation d’un logiciel FTP"
 excerpt: "Retrouvez ici les anomalies les plus fréquentes liées à votre logiciel FTP"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -42,18 +42,11 @@ Ce message sur le logiciel [FileZilla](/pages/web_cloud/web_hosting/ftp_filezill
 
 Si les données que vous souhaitez échanger par ce biais ne sont pas confidentielles, cliquez sur `OK`{.action}.
 
-Dans le cas contraire, rendez-vous dans votre [espace client OVHcloud](/links/manager), partie `Web Cloud`{.action} puis `Hébergements`{.action}. Sélectionnez l'hébergement concerné puis choisissez l'onglet `FTP-SSH`{.action}.
-
-Si vous disposez d'un hébergement [Perso](/links/web/hosting-personal-offer), cochez la case `Désactivé`{.action} dans la colonne `SFTP`{.action} puis patientez quelques minutes.
-
-Si vous disposez d'un hébergement [Pro](/links/web/hosting-professional-offer) ou [Performance](/links/web/hosting-performance-offer), cliquez sur le bouton `...`{.action} à droite de l'utilisateur FTP concerné puis sur `Modifier`{.action}.
-
-Choisissez `SFTP`{.action} ou `Activé`{.action} (pour activer le protocole SSH sur votre hébergement), cliquez sur `Suivant`{.action} puis sur `Valider`{.action}. Patientez quelques minutes.
+Dans le cas contraire, activez le protocole SFTP en consultant notre guide « [Hébergement web - Comment activer l'accès SFTP](/pages/web_cloud/web_hosting/enable_sftp) ».
 
 > [!primary]
 >
 > Pour tout autre message d'erreur, consultez la section `Diagnostic` de nos guides [Hébergements Web](/products/web-cloud-hosting).
->
 
 ### J'ai transféré mes fichiers avec un logiciel FTP, mais mon site ne s'affiche pas.
 

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Résoudre les erreurs récurrentes lors de l’utilisation d’un logiciel FTP"
 excerpt: "Retrouvez ici les anomalies les plus fréquentes liées à votre logiciel FTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.fr-fr.md
@@ -42,7 +42,7 @@ Ce message sur le logiciel [FileZilla](/pages/web_cloud/web_hosting/ftp_filezill
 
 Si les données que vous souhaitez échanger par ce biais ne sont pas confidentielles, cliquez sur `OK`{.action}.
 
-Dans le cas contraire, activez le protocole SFTP grâce à [ce guide](/pages/web_cloud/web_hosting/enable_sftp).
+Dans le cas contraire, activez le protocole SFTP en consultant notre guide « [Hébergement web - Comment activer l'accès SFTP](/pages/web_cloud/web_hosting/enable_sftp) ».
 
 > [!primary]
 >

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Résoudre les erreurs récurrentes lors de l’utilisation d’un logiciel FTP"
 excerpt: "Retrouvez ici les anomalies les plus fréquentes liées à votre logiciel FTP"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -42,18 +42,11 @@ Ce message sur le logiciel [FileZilla](/pages/web_cloud/web_hosting/ftp_filezill
 
 Si les données que vous souhaitez échanger par ce biais ne sont pas confidentielles, cliquez sur `OK`{.action}.
 
-Dans le cas contraire, rendez-vous dans votre [espace client OVHcloud](/links/manager), partie `Web Cloud`{.action} puis `Hébergements`{.action}. Sélectionnez l'hébergement concerné puis choisissez l'onglet `FTP-SSH`{.action}.
-
-Si vous disposez d'un hébergement **Starter** ou [Perso](/links/web/hosting-personal-offer), cochez la case `Désactivé`{.action} dans la colonne `SFTP`{.action} puis patientez quelques minutes.
-
-Si vous disposez d'un hébergement [Pro](https://www.ovh.com/fr/hebergement-web/hebergement-pro.xml) ou [Performance](https://www.ovh.com/fr/hebergement-web/hebergement-performance.xml), cliquez sur le bouton `...`{.action} à droite de l'utilisateur FTP concerné puis sur `Modifier`{.action}.
-
-Choisissez `SFTP`{.action} ou `Activé`{.action} (pour activer le protocole SSH sur votre hébergement), cliquez sur `Suivant`{.action} puis sur `Valider`{.action}. Patientez quelques minutes.
+Dans le cas contraire, activez le protocole SFTP grâce à [ce guide](/pages/web_cloud/web_hosting/enable_sftp).
 
 > [!primary]
 >
 > Pour tout autre message d'erreur, consultez la section `Diagnostic` de nos guides [Hébergements Web](/products/web-cloud-hosting).
->
 
 ### J'ai transféré mes fichiers avec un logiciel FTP, mais mon site ne s'affiche pas.
 

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Résoudre les erreurs récurrentes lors de l’utilisation d’un logiciel FTP"
 excerpt: "Retrouvez ici les anomalies les plus fréquentes liées à votre logiciel FTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Risolvere gli errori ricorrenti nell'utilizzo di un software FTP"
 excerpt: "Ritrova qui le anomalie più frequenti associate al tuo software FTP"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Obiettivo
@@ -25,7 +25,7 @@ L'utilizzo di software FTP durante la connessione al tuo [hosting Web Cloud](/li
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -41,18 +41,11 @@ Questo messaggio sul software [FileZilla](/pages/web_cloud/web_hosting/ftp_filez
 
 Se i dati che vuoi scambiare tramite questo canale non sono riservati, clicca su `OK`{.action}.
 
-In caso contrario, accedi alla sezione Web del tuo [Spazio Cliente OVHcloud](/links/manager), seleziona la sezione `Web Cloud`{.action} e poi `Hosting`{.action}. Seleziona l'hosting interessato e clicca sulla scheda `FTP-SSH`{.action}.
-
-Se disponi di un hosting [Personale](/links/web/hosting-personal-offer), seleziona la casella `Disattivato`{.action} nella colonna `SFTP`{.action} e attendi qualche minuto.
-
-Se disponi di un hosting [Pro](/links/web/hosting-professional-offer) o [Performance](/links/web/hosting-performance-offer), clicca sul pulsante `...`{.action} a destra dell'utente FTP interessato e poi su `Modifica`{.action}.
-
-Scegli `SFTP`{.action} o `Attivo`{.action} (per attivare il protocollo SSH sul tuo hosting), clicca su `Continua`{.action} e infine su `Conferma`{.action}. Attendi qualche minuto.
+In caso contrario, attiva il protocollo SFTP consultando la nostra guida "[Hosting Web - Come attivare l'accesso SFTP](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >
 > Per ulteriori messaggi di errore, consulta la sezione `Diagnostica` delle nostre guide [Hosting](/products/web-cloud-hosting).
->
 
 ### Ho trasferito i miei file con un software FTP, ma il mio sito non appare.
 
@@ -73,7 +66,7 @@ Per verificare lo spazio di storage rimasto sul tuo hosting, clicca sulle schede
 > [!tabs]
 > **Passaggio 1**
 >>
->> Accedi alla pagina [Hosting plans](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Web interessato.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Risolvere gli errori ricorrenti nell'utilizzo di un software FTP"
 excerpt: "Ritrova qui le anomalie più frequenti associate al tuo software FTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Obiettivo

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Usuwanie powtarzających się błędów podczas korzystania z programu FTP"
 excerpt: "Odnajdziesz tutaj najczęstsze nieprawidłowości związane z Twoim oprogramowaniem FTP"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Wprowadzenie 
@@ -26,7 +26,7 @@ Korzystanie z oprogramowania FTP podczas logowania do [hostingu Cloud](/links/we
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -42,18 +42,11 @@ Ten komunikat w programie [FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla
 
 Jeśli dane, które chcesz wymienić za pomocą tego kanału nie są poufne, kliknij `OK`{.action}.
 
-W przeciwnym razie przejdź do [Panelu klienta OVHcloud](/links/manager), sekcja `Web Cloud`{.action}, a następnie wybierz `Hosting`{.action}. Wybierz odpowiedni hosting i wybierz kartę `FTP-SSH`{.action}.
-
-Jeśli dysponujesz hostingiem [Perso](/links/web/hosting-personal-offer), zaznacz kratkę `Wyłączone`{.action} w kolumnie `SFTP`{.action}, następnie odczekaj kilka minut.
-
-Jeśli dysponujesz hostingiem [Pro](/links/web/hosting-professional-offer) lub [Performance](/links/web/hosting-performance-offer), kliknij przycisk `...`{.action} po prawej stronie odpowiedniego użytkownika FTP a następnie kliknij `Zmien`{.action}.
-
-Wybierz `SFTP`{.action} lub `Aktywny`{.action} (aby aktywować protokół SSH na Twoim hostingu), kliknij `Dalej`{.action} i `Zatwierdź`{.action}. Odczekaj kilka minut.
+W przeciwnym razie aktywuj protokół SFTP, korzystając z naszego przewodnika "[Hosting - Jak włączyć dostęp SFTP](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >
 > W przypadku innych wiadomości o błędzie sprawdź sekcję `Diagnostyka` naszych przewodników dotyczących [Hosting](/products/web-cloud-hosting).
->
 
 ### Przeniosłem pliki za pomocą programu FTP, ale moja strona nie wyświetla się.
 
@@ -74,7 +67,7 @@ Aby sprawdzić pozostałą przestrzeń dyskową Twojego hostingu, kliknij poniż
 > [!tabs]
 > **Krok 1**
 >>
->> Przejdź na stronę [Hosting plans](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting), następnie wybierz odpowiedni hosting.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Usuwanie powtarzających się błędów podczas korzystania z programu FTP"
 excerpt: "Odnajdziesz tutaj najczęstsze nieprawidłowości związane z Twoim oprogramowaniem FTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Wprowadzenie 

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Resolver os erros recorrentes durante a utilização de um programa FTP"
 excerpt: "Encontre aqui as anomalias mais frequentes associadas ao seu software FTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/ftp_recurring_ftp_problems/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Resolver os erros recorrentes durante a utilização de um programa FTP"
 excerpt: "Encontre aqui as anomalias mais frequentes associadas ao seu software FTP"
-updated: 2025-10-20
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -25,7 +25,7 @@ A utilização de software FTP durante a ligação ao seu [alojamento Web Cloud]
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -41,18 +41,11 @@ Esta mensagem no software [FileZilla](/pages/web_cloud/web_hosting/ftp_filezilla
 
 Se os dados que deseja trocar por esta via não são confidenciais, clique em `OK`{.action}.
 
-Caso contrário, aceda à [Área de Cliente OVHcloud](/links/manager), na secção `Web Cloud`{.action} e, a seguir, clique em `Alojamentos`{.action}. Selecione o alojamento correspondente e escolha o separador `FTP-SSH`{.action}.
-
-Se dispõe de um alojamento [Perso](/links/web/hosting-personal-offer), selecione a casa `Desativado`{.action} na coluna `SFTP`{.action} e aguarde alguns minutos.
-
-Se dispõe de um alojamento [Pro](/links/web/hosting-professional-offer) ou [Performance](/links/web/hosting-performance-offer), clique no botão `...`{.action} à direita do utilizador FTP em causa, depois por `Alterar`{.action}.
-
-Escolha `SFTP`{.action} ou `Ativado`{.action} (para ativar o protocolo SSH no seu alojamento), clique em `Seguinte`{.action} e depois em `Validar`{.action}. Aguarde alguns minutos.
+Caso contrário, ative o protocolo SFTP consultando o nosso guia "[Alojamento web - Como ativar o acesso SFTP](/pages/web_cloud/web_hosting/enable_sftp)".
 
 > [!primary]
 >
 > Para qualquer outra mensagem de erro, consulte a secção `Diagnóstico` dos nossos guias de [Hosting](/products/web-cloud-hosting).
->
 
 ### Transferi os meus ficheiros com um software FTP, mas o meu site não aparece.
 
@@ -73,7 +66,7 @@ Para verificar o espaço de armazenamento restante no alojamento, clique nos sep
 > [!tabs]
 > **Etapa 1**
 >>
->> Aceda à página [Hosting plans](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e escolha o alojamento web correspondente.
 >>
 >> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.de-de.md
@@ -65,7 +65,7 @@ Um zu den Runtime Engines Ihres [Cloud Web](/links/web/hosting-cloud-web-offer) 
 >>
 >> Klicken Sie auf den Tab `Runtime Engines`{.action}. Bei der Installation Ihres Hostings wird automatisch eine Engine erstellt und als `Standardauswahl` in der zugehörigen Tabelle angezeigt.
 >>
->> Um eine bereits eingerichtete Runtime Engine zu bearbeiten, klicken Sie auf den Button `...`{.action} rechts daneben und anschließend auf `Bearbeiten`{.action}.
+>> Um eine bereits eingerichtete Runtime Engine zu bearbeiten, klicken Sie auf den Button `...`{.action} rechts daneben und anschließend auf `Ändern`{.action}.
 >>
 > **Schritt 3**
 >>
@@ -150,7 +150,7 @@ Nun da die technische Umgebung Ihres Cloud Web Hostings fertig ist, können Sie 
 >>
 >> Klicken Sie auf den Tab `Multisite`{.action}. Die angezeigte Tabelle listet alle Domains auf, die Ihrem Hosting zugewiesen sind. Einige wurden bei der Installation Ihres Hostings automatisch hinzugefügt.
 >>
->> Um weitere hinzuzufügen, klicken Sie auf den Button `Eine Domain oder Subdomain hinzufügen`{.action} und folgen Sie den Anweisungen. Die Vorgehensweise kann variieren, je nachdem, ob Ihre Domain bei OVHcloud gehostet ist oder nicht.
+>> Um weitere hinzuzufügen, klicken Sie auf den Button `Domain oder Subdomain hinzufügen`{.action} und folgen Sie den Anweisungen. Die Vorgehensweise kann variieren, je nachdem, ob Ihre Domain bei OVHcloud gehostet ist oder nicht.
 >>
 > **Schritt 3**
 >>
@@ -185,7 +185,7 @@ Wenn Sie sich für die Verwendung eines unserer 1-Klick-Module entscheiden, klic
 >>
 > **Schritt 2**
 >>
->> Klicken Sie auf den Tab `1 Klick Module`{.action} und anschließend auf `Ein Modul hinzufügen`{.action}.
+>> Klicken Sie auf den Tab `1-Klick-Module`{.action} und anschließend auf `Modul hinzufügen`{.action}.
 >>
 > **Schritt 3**
 >>

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Erste Schritte mit Cloud Web Hosting"
 excerpt: "Diese Anleitung erklärt, wie Sie richtig mit Ihrem Cloud Web Hosting starten"
-updated: 2025-05-22
+updated: 2026-03-26
 ---
 
 ## Ziel
@@ -29,7 +29,7 @@ Unser Cloud Web Hosting Angebot kombiniert 20 Jahre Webhosting-Erfahrung mit der
 
 ## In der praktischen Anwendung
 
-### Schritt 1: Ihr Projekt definieren
+### 1 - Ihr Projekt definieren
 
 Cloud Web Hosting bietet mehr Konfigurationsmöglichkeiten als ein klassisches Webhosting, damit Sie Ihr Angebot möglichst genau an Ihr Projekt anpassen können. Um dieses erfolgreich umzusetzen, ist es wichtig, dass Sie Ihr Ziel klar vor Augen haben. Das sind unsere Empfehlungen:
 
@@ -41,9 +41,9 @@ Cloud Web Hosting bietet mehr Konfigurationsmöglichkeiten als ein klassisches W
 
 Nachdem Sie sich die verschiedenen Optionen angesehen und Ihr Projekt genau definiert haben, können Sie mit der Umsetzung beginnen.
 
-### Schritt 2: Runtime Engine auswählen
+### 2 - Runtime Engine auswählen
 
-Bei Cloud Web stehen Ihnen für Ihr Projekt verschiedene Entwicklungssprachen zur Verfügung. Falls Sie eine andere Sprache als das standardmäßig ausgewählte PHP verwenden möchten, wählen Sie die entsprechende „Runtime Engine“ aus.
+Bei Cloud Web stehen Ihnen für Ihr Projekt verschiedene Entwicklungssprachen zur Verfügung. Falls Sie eine andere Sprache als das standardmäßig ausgewählte PHP verwenden möchten, wählen Sie die entsprechende „Runtime Engine" aus.
 
 Aktuell sind folgende Programmiersprachen verfügbar:
 
@@ -52,27 +52,64 @@ Aktuell sind folgende Programmiersprachen verfügbar:
 - Python
 - Ruby
 
-Um zu den Runtime Engines Ihres [Cloud Web](/links/web/hosting-cloud-web-offer) Hostings zu gelangen, loggen Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager) ein. Klicken Sie links im Menü auf `Web Cloud`{.action} und dann auf `Hosting-Pakete`{.action}. Klicken Sie auf den Namen des betreffenden Cloud Web Hostings und gehen Sie zum Tab `Runtime Engines`{.action}.
+Um zu den Runtime Engines Ihres [Cloud Web](/links/web/hosting-cloud-web-offer) Hostings zu gelangen, klicken Sie auf die Tabs, um nacheinander jeden der **3** Schritte anzuzeigen.
 
-Bei der Installation Ihres Hostings wird automatisch eine Engine erstellt und als `Standardauswahl` in der zugehörigen Tabelle angezeigt. Um eine bereits eingerichtete Runtime Engine zu bearbeiten, klicken Sie auf die drei Punkte rechts daneben und anschließend auf `Bearbeiten`{.action}. 
-
-Wenn Sie das Angebot [Cloud Web](/links/web/hosting-cloud-web-offer) mit 2 vCores nutzen, können Sie zusätzliche Runtime Engines hinzufügen (maximal 2 verschiedene Runtime Engines pro Angebot), indem Sie auf den Button `Aktionen`{.action} und dann auf `Runtime Engine hinzufügen`{.action} klicken.
-
-Um zu überprüfen, dass Sie über 2 vCores für Ihr Cloud Web Hosting verfügen, loggen Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager) ein, klicken Sie links im Menü auf `Hosting-Pakete`{.action} und wählen Sie das betreffende Cloud Web Hosting aus. Überprüfen Sie auf der angezeigten Seite, in der Randleiste **Abo** und unter `Angebot`, dass die Referenz `Cloud Web 3`{.action} vorhanden ist.
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Cloud Web Hosting aus.
+>>
+>> ![Webhosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `Runtime Engines`{.action}. Bei der Installation Ihres Hostings wird automatisch eine Engine erstellt und als `Standardauswahl` in der zugehörigen Tabelle angezeigt.
+>>
+>> Um eine bereits eingerichtete Runtime Engine zu bearbeiten, klicken Sie auf den Button `...`{.action} rechts daneben und anschließend auf `Bearbeiten`{.action}.
+>>
+> **Schritt 3**
+>>
+>> Wenn Sie das Angebot [Cloud Web](/links/web/hosting-cloud-web-offer) mit 2 vCores nutzen, können Sie eine zweite Runtime Engine hinzufügen (maximal 2 pro Angebot), indem Sie auf den Button `Aktionen`{.action} und dann auf `Runtime Engine hinzufügen`{.action} klicken.
 
 Überprüfen Sie daher, bevor Sie fortfahren, dass Sie über die für Ihr Projekt notwendigen Runtime Engines verfügen.
 
-![Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/runtime-software-application/edit-runtime.png){.thumbnail}
+Um zu überprüfen, dass Sie über 2 vCores für Ihr Cloud Web Hosting verfügen, klicken Sie auf die Tabs, um nacheinander jeden der **2** Schritte anzuzeigen.
 
-### Schritt 3: Umgebungsvariablen erstellen (optional)
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Cloud Web Hosting aus.
+>>
+>> ![Webhosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Überprüfen Sie in der Randleiste **Abo** und unter `Angebot`, dass die Referenz `Cloud Web 3` vorhanden ist.
+
+### 3 - Umgebungsvariablen erstellen (optional)
 
 Wenn Sie Ihr Projekt mehrfach in verschiedenen Umgebungen einrichten möchten (zum Beispiel: Entwicklung, Test oder Produktion), brauchen Sie Variablen, damit Ihr Code entsprechend reagiert. Hierfür können Sie mit Cloud Web verschiedene Umgebungsvariablen definieren, die über den Code Ihrer Website oder Webanwendung verfügbar sind.
 
-Dadurch ist es zum Beispiel möglich, keine .env-Datei im PHP-Framework Laravel festzulegen, wie es in der zugehörigen Dokumentation beschrieben ist: <https://laravel.com/docs/5.6/configuration>.
+Dadurch ist es zum Beispiel möglich, keine .env-Datei im PHP-Framework Laravel festzulegen, wie es in der zugehörigen Dokumentation beschrieben ist: <https://laravel.com/docs/master/configuration>.
 
-Um eine Umgebungsvariable hinzuzufügen, gehen Sie zum betreffenden Cloud Web Hosting und klicken Sie anschließend auf `Umgebungsvariablen`{.action}. Es wird eine Tabelle mit den für Ihr Angebot erstellten Umgebungsvariablen angezeigt. Um eine neue Variable hinzuzufügen, klicken Sie auf den Button `Aktionen`{.action} und anschließend auf `Umgebungsvariable hinzufügen`{.action}. Folgen Sie nun den Anweisungen für die Variable, die Sie erstellen möchten.
+Um eine Umgebungsvariable hinzuzufügen, klicken Sie auf die Tabs, um nacheinander jeden der **3** Schritte anzuzeigen.
 
-![Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Cloud Web Hosting aus.
+>>
+>> ![Webhosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `Umgebungsvariablen`{.action}. Es wird eine Tabelle mit den für Ihr Angebot erstellten Umgebungsvariablen angezeigt.
+>>
+> **Schritt 3**
+>>
+>> Um eine neue Variable hinzuzufügen, klicken Sie auf den Button `Aktionen`{.action} und anschließend auf `Umgebungsvariable hinzufügen`{.action}. Folgen Sie nun den Anweisungen für die Variable, die Sie erstellen möchten.
+>>
+>> ![Hinzufügen einer Umgebungsvariable auf einem Cloud Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
 
 Wenn Sie kein Entwicklungsframework mit Umgebungsvariablen verwenden oder überprüfen möchten, ob Ihre Umgebungsvariablen funktionieren, können Sie hierfür ein Skript erstellen. Im Folgenden finden Sie zwei Beispiele, um Ihnen bei diesem Vorgang zu helfen. Sie ersetzen allerdings nicht die Hilfe eines Webmasters.
 
@@ -87,79 +124,101 @@ Wenn Sie kein Entwicklungsframework mit Umgebungsvariablen verwenden oder überp
 ```sh
 var http = require('http');
 
-http.createServer(function(request, response) {  
-    response.writeHeader(200, {"Content-Type": "text/html"});  
+http.createServer(function(request, response) {
+    response.writeHeader(200, {"Content-Type": "text/html"});
 
     response.write( process.env.DB_DATABASE);
 
-    response.end();  
+    response.end();
 }).listen(80);
 ```
 
-Vergessen Sie nicht, die allgemeinen Angaben in diesen Skripten („DB_DATABASE“) durch die entsprechende Umgebungsvariable zu ersetzen.
+Vergessen Sie nicht, die allgemeinen Angaben in diesen Skripten („DB_DATABASE") durch die entsprechende Umgebungsvariable zu ersetzen.
 
-### Schritt 4: Zusätzliche Domains und Multisite konfigurieren (optional)
+### 4 - Zusätzliche Domains und Multisite konfigurieren (optional)
 
-Nun da die technische Umgebung Ihres Cloud Web Hostings fertig ist, können Sie zusätzliche Domains konfigurieren und als Multisite einrichten. So können Sie Ihren Bereich aufteilen und beispielsweise mehrere Websites darauf hosten. Wenn Sie dies für Ihr Projekt einrichten möchten, gehen Sie erneut zum entsprechenden Cloud Web Hosting und klicken Sie anschließend auf den Tab `Multisite`{.action}.
+Nun da die technische Umgebung Ihres Cloud Web Hostings fertig ist, können Sie zusätzliche Domains konfigurieren und als Multisite einrichten. So können Sie Ihren Bereich aufteilen und beispielsweise mehrere Websites darauf hosten. Wenn Sie dies für Ihr Projekt einrichten möchten, klicken Sie auf die Tabs, um nacheinander jeden der **3** Schritte anzuzeigen.
 
-Die angezeigte Tabelle listet alle Domains auf, die Ihrem Hosting zugewiesen sind. Einige wurden bei der Installation Ihres Hostings automatisch hinzugefügt. Um weitere hinzuzufügen, klicken Sie auf den Button `Eine Domain oder Subdomain hinzufügen`{.action} und folgen Sie den Anweisungen. Die Vorgehensweise kann variieren, je nachdem, ob Ihre Domain bei OVHcloud gehostet ist oder nicht. 
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Cloud Web Hosting aus.
+>>
+>> ![Webhosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `Multisite`{.action}. Die angezeigte Tabelle listet alle Domains auf, die Ihrem Hosting zugewiesen sind. Einige wurden bei der Installation Ihres Hostings automatisch hinzugefügt.
+>>
+>> Um weitere hinzuzufügen, klicken Sie auf den Button `Eine Domain oder Subdomain hinzufügen`{.action} und folgen Sie den Anweisungen. Die Vorgehensweise kann variieren, je nachdem, ob Ihre Domain bei OVHcloud gehostet ist oder nicht.
+>>
+> **Schritt 3**
+>>
+>> Füllen Sie die folgenden Informationen sorgfältig aus:
+>>
+>> - **Wurzelverzeichnis**: Verzeichnis, in dem die angegebene Domain auf einem Speicherplatz Ihres Cloud Web Hostings gehostet sein muss.
+>>
+>> - **Runtime Engine**: Zuvor eingerichtete Runtime Engine, die für die Multisite verwendet wird, die Sie gerade erstellen.
+>>
+>> > [!warning]
+>> >
+>> > Wenn Sie eine externe Domain hinzugefügt haben, muss zusätzlich ein TXT-Feld mit dem Namen **ovhcontrol** in der DNS-Konfiguration der Domain erstellt werden. Über dieses Feld kann OVHcloud überprüfen, dass die Domain tatsächlich hinzugefügt werden darf. Wurde kein TXT-Feld erstellt, wird der Vorgang abgebrochen.
 
-Füllen Sie die folgenden Informationen sorgfältig aus:
+Wiederholen Sie diesen Schritt, falls Sie mehrere Domains zu Ihrem Cloud Web Hosting hinzufügen möchten. Weitere Informationen zum Hinzufügen einer Domain als Multisite finden Sie in unserer Anleitung: [„Mehrere Websites auf einem Webhosting einrichten"](/pages/web_cloud/web_hosting/multisites_configure_multisite).
 
-- **Wurzelverzeichnis**: Verzeichnis, in dem die angegebene Domain auf einem Speicherplatz Ihres Cloud Web Hostings gehostet sein muss. 
-
-- **Runtime Engine**: Zuvor eingerichtete Runtime Engine, die für die Multisite verwendet wird, die Sie gerade erstellen.
-
-> [!warning]
->
-> Wenn Sie eine externe Domain hinzugefügt haben, muss zusätzlich ein TXT-Feld mit dem Namen **ovhcontrol** in der DNS-Konfiguration der Domain erstellt werden. Über dieses Feld kann OVHcloud überprüfen, dass die Domain tatsächlich hinzugefügt werden darf. Wurde kein TXT-Feld erstellt, wird der Vorgang abgebrochen.
->
-
-Wiederholen Sie diesen Schritt, falls Sie mehrere Domains zu Ihrem Cloud Web Hosting hinzufügen möchten. Weitere Informationen zum Hinzufügen einer Domain als Multisite finden Sie in unserer Anleitung: [„Mehrere Websites auf einem Webhosting einrichten“](/pages/web_cloud/web_hosting/multisites_configure_multisite).
-
-![Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/multisite/add-domain-or-subdomain.png){.thumbnail}
-
-### Schritt 5: Projekt auf Cloud Web Hosting einrichten
+### 5 - Projekt auf Cloud Web Hosting einrichten
 
 Es gibt zwei mögliche Vorgehensweisen, um Ihr Projekt einzurichten. Wenn Sie mehrere Projekte einrichten möchten, wiederholen Sie die gewählte Vorgehensweise sooft wie nötig.
 
 #### 1. OVHcloud 1-Klick-Module verwenden
 
-Mit dieser Lösung können Sie auf einer gebrauchsfertigen Websitestruktur aufbauen und diese nach Belieben anpassen (Themes, Texte usw.). OVHcloud stellt Ihnen 4 verschiedene 1-Klick-Module zur Verfügung. Nähere Informationen finden Sie auf der Webseite [„Erstellen Sie Ihre Website mit 1-Klick-Modulen“](/links/web/hosting-website).
+Mit dieser Lösung können Sie auf einer gebrauchsfertigen Websitestruktur aufbauen und diese nach Belieben anpassen (Themes, Texte usw.). OVHcloud stellt Ihnen 4 verschiedene 1-Klick-Module zur Verfügung. Nähere Informationen finden Sie auf der Webseite [„Erstellen Sie Ihre Website mit 1-Klick-Modulen"](/links/web/hosting-website).
 
-Wenn Sie sich für die Verwendung eines unserer 1-Klick-Module entscheiden, klicken Sie bei dem entsprechenden Cloud Web Hosting auf den Tab `1 Klick Module`{.action} und anschließend auf `Ein Modul hinzufügen`{.action}. Nun können Sie auswählen, ob Sie eine „einfache“ (nicht personalisierbare) Installation oder die Installation „im Experten-Modus“ (mit anpassbaren Optionen) durchführen möchten.
+Wenn Sie sich für die Verwendung eines unserer 1-Klick-Module entscheiden, klicken Sie auf die Tabs, um nacheinander jeden der **3** Schritte anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Cloud Web Hosting aus.
+>>
+>> ![Webhosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie auf den Tab `1 Klick Module`{.action} und anschließend auf `Ein Modul hinzufügen`{.action}.
+>>
+> **Schritt 3**
+>>
+>> Nun können Sie auswählen, ob Sie eine „einfache" (nicht personalisierbare) Installation oder die Installation „im Experten-Modus" (mit anpassbaren Optionen) durchführen möchten.
 
 Wenn Sie mehr über die 1-Klick-Module von OVHcloud wissen möchten, werfen Sie einen Blick in unsere Dokumentation: ["Installation Ihrer Website mit 1-Klick-Modulen"](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 
 > [!primary]
 >
 > Wenn Sie 1-Klick-Module nutzen möchten, muss unbedingt die PHP-Runtime-Engine verwendet werden.
->
-
-![Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/1-click-modules/add-a-module.png){.thumbnail}
 
 #### 2. Projekt manuell einrichten
 
-Die manuelle Einrichtung Ihres Projekts ist um einiges technischer und erfordert zusätzliche Kenntnisse Ihrerseits − egal ob Sie eine neue Website erstellen oder eine bereits existierende migrieren möchten. Deshalb empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber der Software zu kontaktieren. 
+Die manuelle Einrichtung Ihres Projekts ist um einiges technischer und erfordert zusätzliche Kenntnisse Ihrerseits — egal ob Sie eine neue Website erstellen oder eine bereits existierende migrieren möchten. Deshalb empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Dienstleister](/links/partner) und/oder den Herausgeber der Software zu kontaktieren.
 
 Wenn Sie sich für die manuelle Installation entschieden haben, benötigen Sie alle Dateien der Website oder Anwendung, die Sie einrichten möchten. Falls Sie zuvor eine Datenbank auf Ihrem Cloud Web Hosting angelegt haben, brauchen Sie außerdem die zugehörigen Angaben und Login-Daten. Wenn Sie eine Website migrieren, erstellen Sie zunächst ein komplettes Backup aller zugehörigen Daten.
 
-Da nicht alle Projekte gleich sind, gibt es auch keine universelle Vorgehensweise. Unsere Anleitungen [„Webhosting: Meine Seite online stellen“](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) und [„Migration Ihrer Website und E-Mails zu OVH“](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh) enthalten jedoch einige hilfreiche Informationen zum weiteren Vorgehen.
+Da nicht alle Projekte gleich sind, gibt es auch keine universelle Vorgehensweise. Unsere Anleitungen [„Webhosting: Meine Seite online stellen"](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) und [„Migration Ihrer Website und E-Mails zu OVH"](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh) enthalten jedoch einige hilfreiche Informationen zum weiteren Vorgehen.
 
-### Schritt 6: Konfiguration Ihrer Domain bearbeiten
+### 6 - Konfiguration Ihrer Domain bearbeiten
 
 Wenn Sie bei diesem Schritt angelangt sind, ist Ihr Projekt auf Ihrem Cloud Web Hosting installiert und Ihre E-Mail-Adressen sind eingerichtet. Sollten die E-Mail-Adressen noch nicht funktionieren, ist Ihre Domain möglicherweise nicht richtig konfiguriert. Ist das der Fall, oder sind Sie sich nicht sicher, ob Änderungen vorgenommen wurden, befolgen Sie den aktuellen Schritt.
 
 Wenn Sie dabei sind, Ihre Dienste zu OVHcloud zu migrieren, beachten Sie bitte, dass diese möglicherweise nicht verfügbar sind, falls die Änderungen der DNS-Zone nicht im richtigen Moment durchgeführt wurden. Folgen Sie den entsprechenden Schritten unserer Anleitung [Migration Ihrer Website und E-Mails zu OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh) und bearbeiten Sie die DNS-Server Ihrer Domain erst am Ende des Prozesses.
 
-#### 1. OVHcloud DNS-Einträge verstehen 
+#### 1. OVHcloud DNS-Einträge verstehen
 
 Es gibt mehrere zu OVHcloud gehörige DNS-Einträge. Wir interessieren uns an dieser Stelle für zwei Einträge, mit denen die Erreichbarkeit Ihrer Website und der Empfang von Nachrichten auf Ihren OVHcloud E-Mail-Adressen sichergestellt werden. Folgen Sie den nachstehenden Schritten, um die entsprechenden Einträge zu finden:
 
 |DNS-Eintrag|Zugehöriger Dienst|Wo finde ich den Eintrag?|
 |---|---|---|
-|A|Für die Website|Begeben Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager) im Bereich `Hosting-Pakete`{.action} zum betreffenden Cloud Web Hosting. Suchen Sie dann im Tab `Allgemeine Informationen`{.action} die IP-Adresse, die neben „IPv4“ steht.|
-|MX|Für E-Mails|Begeben Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager) im Bereich `E-Mails`{.action} zur betreffenden Domain. Dann suchen Sie in dem Tab `Allgemeine Informationen`{.action} die Angaben, die neben dem Punkt „MX Einträge“ stehen.|
+|A|Für die Website|Lesen Sie unsere Anleitung [„Webhosting — Liste der IP-Adressen nach Cluster"](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|
+|MX|Für E-Mails|Lesen Sie unsere Anleitung [„MX-Eintrag zur Konfiguration Ihrer Domain hinzufügen"](/pages/web_cloud/domains/dns_zone_mx).|
 
 #### 2. DNS-Einträge überprüfen oder bearbeiten
 
@@ -168,26 +227,26 @@ Nun, da Sie die DNS-Einträge für Ihr Cloud Web Hosting und Ihr OVHcloud E-Mail
 > [!warning]
 >
 > - Wenn Ihre Domain nicht die DNS-Konfiguration von OVHcloud verwendet, muss die Änderung über das Interface des Anbieters vorgenommen werden, bei dem die Konfiguration verwaltet wird.
-> 
-> - Wenn Ihre Domain bei OVHcloud registriert ist, können Sie überprüfen, ob sie unsere DNS-Konfiguration verwendet. Gehen Sie hierzu in Ihrem [OVHcloud Kundencenter](/links/manager) zur betreffenden Domain und klicken Sie anschließend auf den Tab `DNS Server`{.action}.
+>
+> - Wenn Ihre Domain bei OVHcloud registriert ist, können Sie überprüfen, ob sie unsere DNS-Konfiguration verwendet. Lesen Sie hierzu unsere Anleitung [„DNS-Server einer OVHcloud Domain ändern"](/pages/web_cloud/domains/dns_server_edit).
 >
 
 Lesen Sie in der folgenden Tabelle, wo Sie die entsprechenden Änderungen vornehmen:
 
 |Verwendete DNS-Konfiguration|Wo nehme ich die Änderungen vor?|
 |---|---|
-|OVHcloud|Gehen Sie in Ihrem [OVHcloud Kundencenter](/links/manager) in den Bereich `Web Cloud`{.action}. Klicken Sie auf das Menü `DNS-Zone`{.action} und wählen Sie die betreffende Domain aus. Weitere Informationen finden Sie in unserer Dokumentation [„Bearbeiten der OVHcloud DNS-Zone“](/pages/web_cloud/domains/dns_zone_edit).|
+|OVHcloud|Gehen Sie auf die Seite [DNS-Zone](/links/control-panel/web-dns-zone) und wählen Sie die betreffende Domain aus. Weitere Informationen finden Sie in unserer Dokumentation [„Bearbeiten der OVHcloud DNS-Zone"](/pages/web_cloud/domains/dns_zone_edit).|
 |Andere|Verwenden Sie das Interface des Anbieters, der die DNS-Konfiguration Ihrer Domain verwaltet. Bei Problemen wenden Sie sich bitte an Ihren Anbieter.|
 
-Die Änderung der DNS-Konfiguration Ihrer Domain erfordert eine Propagationszeit von bis zu 24 Stunden, bis sie voll wirksam ist. Falls Sie mehrere Domains als Multisite mit Ihrem Cloud Web Hosting verbunden haben, müssen die notwendigen Änderungen für jede Domain einzeln durchgeführt werden. 
+Die Änderung der DNS-Konfiguration Ihrer Domain erfordert eine Propagationszeit von bis zu 24 Stunden, bis sie voll wirksam ist. Falls Sie mehrere Domains als Multisite mit Ihrem Cloud Web Hosting verbunden haben, müssen die notwendigen Änderungen für jede Domain einzeln durchgeführt werden.
 
-### Schritt 7: Website personalisieren
+### 7 - Website personalisieren
 
 Dieser Schritt ist optional, wenn Sie eine Website migriert haben, die bereits angepasst wurde. Wenn Sie jedoch zum Beispiel gerade mithilfe unserer Module eine neue Website installiert haben, können Sie diese durch Anpassung des Themes und die Veröffentlichung erster Inhalte personalisieren.
 
 Wenn Sie Hilfe bei der Nutzung spezieller Funktionen Ihrer Website benötigen, gehen Sie bitte auf die offizielle Website des jeweiligen Herausgebers. Dort finden Sie ergänzende Dokumentation zu Ihrer Unterstützung.
 
-### Schritt 8: E-Mail-Adressen verwenden
+### 8 - E-Mail-Adressen verwenden
 
 Sie können nun auch Ihre E-Mail-Adressen verwenden. Dafür stellt OVHcloud Ihnen eine Webanwendung (Webmail) zur Verfügung: RoundCube. Diese App ist über die Adresse <https://www.ovh.de/mail/> erreichbar, auf der Sie die Login-Daten für Ihre von OVHcloud angelegte E-Mail-Adresse eingeben.
 

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Erste Schritte mit Cloud Web Hosting"
 excerpt: "Diese Anleitung erklärt, wie Sie richtig mit Ihrem Cloud Web Hosting starten"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Ziel
@@ -43,7 +43,7 @@ Nachdem Sie sich die verschiedenen Optionen angesehen und Ihr Projekt genau defi
 
 ### 2 - Runtime Engine auswählen
 
-Bei Cloud Web stehen Ihnen für Ihr Projekt verschiedene Entwicklungssprachen zur Verfügung. Falls Sie eine andere Sprache als das standardmäßig ausgewählte PHP verwenden möchten, wählen Sie die entsprechende „Runtime Engine" aus.
+Bei Cloud Web stehen Ihnen für Ihr Projekt verschiedene Entwicklungssprachen zur Verfügung. Falls Sie eine andere Sprache als das standardmäßig ausgewählte PHP verwenden möchten, wählen Sie die entsprechende "Runtime Engine" aus.
 
 Aktuell sind folgende Programmiersprachen verfügbar:
 
@@ -133,7 +133,7 @@ http.createServer(function(request, response) {
 }).listen(80);
 ```
 
-Vergessen Sie nicht, die allgemeinen Angaben in diesen Skripten („DB_DATABASE") durch die entsprechende Umgebungsvariable zu ersetzen.
+Vergessen Sie nicht, die allgemeinen Angaben in diesen Skripten ("DB_DATABASE") durch die entsprechende Umgebungsvariable zu ersetzen.
 
 ### 4 - Zusätzliche Domains und Multisite konfigurieren (optional)
 
@@ -164,7 +164,7 @@ Nun da die technische Umgebung Ihres Cloud Web Hostings fertig ist, können Sie 
 >> >
 >> > Wenn Sie eine externe Domain hinzugefügt haben, muss zusätzlich ein TXT-Feld mit dem Namen **ovhcontrol** in der DNS-Konfiguration der Domain erstellt werden. Über dieses Feld kann OVHcloud überprüfen, dass die Domain tatsächlich hinzugefügt werden darf. Wurde kein TXT-Feld erstellt, wird der Vorgang abgebrochen.
 
-Wiederholen Sie diesen Schritt, falls Sie mehrere Domains zu Ihrem Cloud Web Hosting hinzufügen möchten. Weitere Informationen zum Hinzufügen einer Domain als Multisite finden Sie in unserer Anleitung: [„Mehrere Websites auf einem Webhosting einrichten"](/pages/web_cloud/web_hosting/multisites_configure_multisite).
+Wiederholen Sie diesen Schritt, falls Sie mehrere Domains zu Ihrem Cloud Web Hosting hinzufügen möchten. Weitere Informationen zum Hinzufügen einer Domain als Multisite finden Sie in unserer Anleitung: ["Mehrere Websites auf einem Webhosting einrichten"](/pages/web_cloud/web_hosting/multisites_configure_multisite).
 
 ### 5 - Projekt auf Cloud Web Hosting einrichten
 
@@ -172,7 +172,7 @@ Es gibt zwei mögliche Vorgehensweisen, um Ihr Projekt einzurichten. Wenn Sie me
 
 #### 1. OVHcloud 1-Klick-Module verwenden
 
-Mit dieser Lösung können Sie auf einer gebrauchsfertigen Websitestruktur aufbauen und diese nach Belieben anpassen (Themes, Texte usw.). OVHcloud stellt Ihnen 4 verschiedene 1-Klick-Module zur Verfügung. Nähere Informationen finden Sie auf der Webseite [„Erstellen Sie Ihre Website mit 1-Klick-Modulen"](/links/web/hosting-website).
+Mit dieser Lösung können Sie auf einer gebrauchsfertigen Websitestruktur aufbauen und diese nach Belieben anpassen (Themes, Texte usw.). OVHcloud stellt Ihnen 4 verschiedene 1-Klick-Module zur Verfügung. Nähere Informationen finden Sie auf der Webseite ["Erstellen Sie Ihre Website mit 1-Klick-Modulen"](/links/web/hosting-website).
 
 Wenn Sie sich für die Verwendung eines unserer 1-Klick-Module entscheiden, klicken Sie auf die Tabs, um nacheinander jeden der **3** Schritte anzuzeigen.
 
@@ -189,7 +189,7 @@ Wenn Sie sich für die Verwendung eines unserer 1-Klick-Module entscheiden, klic
 >>
 > **Schritt 3**
 >>
->> Nun können Sie auswählen, ob Sie eine „einfache" (nicht personalisierbare) Installation oder die Installation „im Experten-Modus" (mit anpassbaren Optionen) durchführen möchten.
+>> Nun können Sie auswählen, ob Sie eine "einfache" (nicht personalisierbare) Installation oder die Installation "im Experten-Modus" (mit anpassbaren Optionen) durchführen möchten.
 
 Wenn Sie mehr über die 1-Klick-Module von OVHcloud wissen möchten, werfen Sie einen Blick in unsere Dokumentation: ["Installation Ihrer Website mit 1-Klick-Modulen"](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 
@@ -203,7 +203,7 @@ Die manuelle Einrichtung Ihres Projekts ist um einiges technischer und erfordert
 
 Wenn Sie sich für die manuelle Installation entschieden haben, benötigen Sie alle Dateien der Website oder Anwendung, die Sie einrichten möchten. Falls Sie zuvor eine Datenbank auf Ihrem Cloud Web Hosting angelegt haben, brauchen Sie außerdem die zugehörigen Angaben und Login-Daten. Wenn Sie eine Website migrieren, erstellen Sie zunächst ein komplettes Backup aller zugehörigen Daten.
 
-Da nicht alle Projekte gleich sind, gibt es auch keine universelle Vorgehensweise. Unsere Anleitungen [„Webhosting: Meine Seite online stellen"](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) und [„Migration Ihrer Website und E-Mails zu OVH"](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh) enthalten jedoch einige hilfreiche Informationen zum weiteren Vorgehen.
+Da nicht alle Projekte gleich sind, gibt es auch keine universelle Vorgehensweise. Unsere Anleitungen ["Webhosting: Meine Seite online stellen"](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) und ["Migration Ihrer Website und E-Mails zu OVH"](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh) enthalten jedoch einige hilfreiche Informationen zum weiteren Vorgehen.
 
 ### 6 - Konfiguration Ihrer Domain bearbeiten
 
@@ -217,8 +217,8 @@ Es gibt mehrere zu OVHcloud gehörige DNS-Einträge. Wir interessieren uns an di
 
 |DNS-Eintrag|Zugehöriger Dienst|Wo finde ich den Eintrag?|
 |---|---|---|
-|A|Für die Website|Lesen Sie unsere Anleitung [„Webhosting — Liste der IP-Adressen nach Cluster"](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|
-|MX|Für E-Mails|Lesen Sie unsere Anleitung [„MX-Eintrag zur Konfiguration Ihrer Domain hinzufügen"](/pages/web_cloud/domains/dns_zone_mx).|
+|A|Für die Website|Lesen Sie unsere Anleitung ["Webhosting — Liste der IP-Adressen nach Cluster"](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|
+|MX|Für E-Mails|Lesen Sie unsere Anleitung ["MX-Eintrag zur Konfiguration Ihrer Domain hinzufügen"](/pages/web_cloud/domains/dns_zone_mx).|
 
 #### 2. DNS-Einträge überprüfen oder bearbeiten
 
@@ -228,14 +228,14 @@ Nun, da Sie die DNS-Einträge für Ihr Cloud Web Hosting und Ihr OVHcloud E-Mail
 >
 > - Wenn Ihre Domain nicht die DNS-Konfiguration von OVHcloud verwendet, muss die Änderung über das Interface des Anbieters vorgenommen werden, bei dem die Konfiguration verwaltet wird.
 >
-> - Wenn Ihre Domain bei OVHcloud registriert ist, können Sie überprüfen, ob sie unsere DNS-Konfiguration verwendet. Lesen Sie hierzu unsere Anleitung [„DNS-Server einer OVHcloud Domain ändern"](/pages/web_cloud/domains/dns_server_edit).
+> - Wenn Ihre Domain bei OVHcloud registriert ist, können Sie überprüfen, ob sie unsere DNS-Konfiguration verwendet. Lesen Sie hierzu unsere Anleitung ["DNS-Server einer OVHcloud Domain ändern"](/pages/web_cloud/domains/dns_server_edit).
 >
 
 Lesen Sie in der folgenden Tabelle, wo Sie die entsprechenden Änderungen vornehmen:
 
 |Verwendete DNS-Konfiguration|Wo nehme ich die Änderungen vor?|
 |---|---|
-|OVHcloud|Gehen Sie auf die Seite [DNS-Zone](/links/control-panel/web-dns-zone) und wählen Sie die betreffende Domain aus. Weitere Informationen finden Sie in unserer Dokumentation [„Bearbeiten der OVHcloud DNS-Zone"](/pages/web_cloud/domains/dns_zone_edit).|
+|OVHcloud|Gehen Sie auf die Seite [DNS-Zone](/links/control-panel/web-dns-zone) und wählen Sie die betreffende Domain aus. Weitere Informationen finden Sie in unserer Dokumentation ["Bearbeiten der OVHcloud DNS-Zone"](/pages/web_cloud/domains/dns_zone_edit).|
 |Andere|Verwenden Sie das Interface des Anbieters, der die DNS-Konfiguration Ihrer Domain verwaltet. Bei Problemen wenden Sie sich bitte an Ihren Anbieter.|
 
 Die Änderung der DNS-Konfiguration Ihrer Domain erfordert eine Propagationszeit von bis zu 24 Stunden, bis sie voll wirksam ist. Falls Sie mehrere Domains als Multisite mit Ihrem Cloud Web Hosting verbunden haben, müssen die notwendigen Änderungen für jede Domain einzeln durchgeführt werden.

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting started with a Cloud Web hosting plan"
 excerpt: "Find out how to get started with a Cloud Web hosting plan"
-updated: 2025-05-22
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -29,11 +29,11 @@ For our new [Cloud Web](/links/web/hosting-cloud-web-offer) solution, we have co
 
 ## Instructions
 
-### Step 1: Define your project.
+### 1 - Define your project
 
 OVHcloud [Cloud Web](/links/web/hosting-cloud-web-offer) hosting offers a wider range of configuration options than standard web hosting plans, so that you can tailor your plan to suit your project. To ensure that your project is a success, it is important to have a clear idea of your objective. To do this, you should:
 
-- **Define what you want to set up.** Are you creating a blog, or an online store? Do you want to share your passion, or boost your company’s online profile? It is best to define your project clearly before you get started.
+- **Define what you want to set up.** Are you creating a blog, or an online store? Do you want to share your passion, or boost your company's online profile? It is best to define your project clearly before you get started.
 
 - **Research the technical requirements for setting up your project.** Your project may have specific technical requirements. Make sure you are aware of them in advance.
 
@@ -41,7 +41,7 @@ OVHcloud [Cloud Web](/links/web/hosting-cloud-web-offer) hosting offers a wider 
 
 Once you have explored the various options available and carefully defined your project, you can then start getting it online.
 
-### Step 2: Choose a runtime software application.
+### 2 - Choose a runtime software application
 
 With [Cloud Web](/links/web/hosting-cloud-web-offer), you can choose from a range of different coding languages to build your project. If you would like to use a language other than PHP, which is the default selection, you will need to select a runtime software application that corresponds to your coding language.
 
@@ -52,29 +52,64 @@ The languages currently available are:
 - Python
 - Ruby
 
-To access the runtime software applications for your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan, log in to the [OVHcloud Control Panel](/links/manager). Click `Web Cloud`{.action} in the services bar on the left-hand side, then click `Hosting plans`{.action}. Select the name of the Cloud Web hosting plan concerned, and go to the `Runtime software`{.action} tab.
+To access the runtime software applications for your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan, click on the tabs below to view each of the **3** steps.
 
-To access the runtime software applications for your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan, log in to the [OVHcloud Control Panel](/links/manager), click `Hosting plans`{.action} in the services bar on the left-hand side, then select the name of the Cloud Web hosting plan concerned. Next, go to the `Runtime software`{.action} tab.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web hosting plan concerned.
+>>
+>> ![Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Runtime software`{.action} tab. When you set up your hosting plan, a runtime software application is created automatically. It is listed as `Default choice` in the table that appears.
+>>
+>> To modify a runtime software that has already been set, click on the `...`{.action} button to the right, then `Modify`{.action}.
+>>
+> **Step 3**
+>>
+>> If you have the [Cloud Web](/links/web/hosting-cloud-web-offer) offer with 2 vCores, you can add a second runtime environment (maximum 2 per plan) by clicking on the `Actions`{.action} button, then on `Add a runtime software application`{.action}.
 
-When you set up your hosting plan, a runtime software application will be created automatically. It is included as the `Default choice` in the table that appears. To modify a runtime software that has already been set, click on the three dots next to it, then `Modify`{.action}. 
+Once you have done this, please ensure that you have the runtime software application (or applications) required for your project before you continue.
 
-If you have the [Cloud Web](/links/web/hosting-cloud-web-offer) offer with 2 vCores, you can add a second runtime environment (maximum 2 different runtime environments per service) by clicking on the `Actions`{.action} button, then on `Add a runtime software application`{.action}.
+To check that you have 2 vCores with your Cloud Web hosting plan, click on the tabs below to view each of the **2** steps.
 
-To check that you have 2 vCores with your Cloud Web hosting plan, log in to the [OVHcloud Control Panel](/links/manager), click `Hosting plans`{.action} in the services bar on the left-hand side, then select the name of the Cloud Web hosting plan concerned. In the box **Plan** and under `Service plan`, check that the reference `Cloud Web 3`{.action} is present.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web hosting plan concerned.
+>>
+>> ![Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the **Plan** box and under `Service plan`, check that the reference `Cloud Web 3` is present.
 
-Once you have done this, please ensure that you have the runtime software application (or applications) required for your project before you continue:
-
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/runtime-software-application/edit-runtime.png){.thumbnail}
-
-### Step 3: Create environment variables (optional).
+### 3 - Create environment variables (optional)
 
 If you would like to deploy your project several times in different environments (e.g. development, test and production), you will need to provide variables in order for your code to run properly. To do this, [Cloud Web](/links/web/hosting-cloud-web-offer) prompts you to define environment variables that can be accessed by the code for your website or web application.
 
-For example, this way you can leave out the .env file in the PHP Laravel framework, as described in this guide: <https://laravel.com/docs/5.6/configuration>.
+For example, this way you can leave out the .env file in the PHP Laravel framework, as described in this guide: <https://laravel.com/docs/master/configuration>.
 
-To add an environment variable, stay in the section for the Cloud Web hosting plan concerned, and click on the `Environment variables`{.action} tab. A table will display the environment variables created for your solution. To add a new one, click on the `Actions`{.action} button, then `Add an environment variable`{.action}. Follow the appropriate instructions for the variable you would like to create:
+To add an environment variable, click on the tabs below to view each of the **3** steps.
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web hosting plan concerned.
+>>
+>> ![Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Environment variables`{.action} tab. A table will display the environment variables created for your solution.
+>>
+> **Step 3**
+>>
+>> To add a new one, click on the `Actions`{.action} button, then `Add an environment variable`{.action}. Follow the appropriate instructions for the variable you would like to create.
+>>
+>> ![Adding an environment variable on a Cloud Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
 
 If you do not use a development framework that includes the environment variables, or would simply like to check that your variables are working properly, you can create a script to do this. Below are examples of two scripts that can help you with this process, although they are no substitute for the assistance of a webmaster:
 
@@ -89,107 +124,129 @@ If you do not use a development framework that includes the environment variable
 ```sh
 var http = require('http');
 
-http.createServer(function(request, response) {  
-    response.writeHeader(200, {"Content-Type": "text/html"});  
+http.createServer(function(request, response) {
+    response.writeHeader(200, {"Content-Type": "text/html"});
 
     response.write( process.env.DB_DATABASE);
 
-    response.end();  
+    response.end();
 }).listen(80);
 ```
 
 Make sure you replace the generic information included in these scripts (e.g. DB_DATABASE) with the environment variable concerned.
 
-### Step 4: Configure the additional domains as multisites (optional).
+### 4 - Configure additional domains as multisites (optional)
 
-Now that the technical environment of your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan is ready, you can configure additional domain names on it as multisites. This way, you can partition your space in order to host several websites on it, for example. If you would like to do this for your project, in the section for the Cloud Web hosting plan concerned, click on the `Multisite`{.action} tab.
+Now that the technical environment of your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan is ready, you can configure additional domain names on it as multisites. This way, you can partition your space in order to host several websites on it, for example. If you would like to do this for your project, click on the tabs below to view each of the **3** steps.
 
-The table displayed will contain all of the domain names that have been added to your hosting plan. Some of these will have been created automatically, when your hosting plan was set up. To add a new one, click on the `Add a domain or subdomain`{.action} button, and follow the instructions that appear. The method may be different, depending on whether the domain name concerned is registered with OVHcloud. 
-
-We strongly advise taking special care when you enter the following information:
-
-- **Root directory.** The directory where the domain name entered must be hosted on the storage space for your Cloud Web hosting plan. 
-
-- **Runtime software application.** The runtime software application previously set, which will be used by the multisite you are currently configuring.
-
-> [!warning]
->
-> If you have added a domain name that is considered to be external, you will need to add a TXT record called **ovhcontrol** to its DNS configuration. This way, OVHcloud can ensure that the domain addition is approved. If you do not do this, your domain addition will be cancelled. Adding this TXT record is therefore an essential step. 
->
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web hosting plan concerned.
+>>
+>> ![Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Multisite`{.action} tab. The table displayed will contain all of the domain names that have been added to your hosting plan. Some of these will have been created automatically, when your hosting plan was set up.
+>>
+>> To add a new one, click on the `Add a domain or subdomain`{.action} button, and follow the instructions that appear. The method may be different, depending on whether the domain name concerned is registered with OVHcloud.
+>>
+> **Step 3**
+>>
+>> We strongly advise taking special care when you enter the following information:
+>>
+>> - **Root directory**: the directory where the domain name entered must be hosted on the storage space for your Cloud Web hosting plan.
+>>
+>> - **Runtime software application**: the runtime software application previously set, which will be used by the multisite you are currently configuring.
+>>
+>> > [!warning]
+>> >
+>> > If you have added a domain name that is considered to be external, you will need to add a TXT record called **ovhcontrol** to its DNS configuration. This way, OVHcloud can ensure that the domain addition is approved. If you do not do this, your domain addition will be cancelled.
 
 Repeat this step if you would like to add several domain names to your Cloud Web hosting plan. For more information on adding a domain name as a multisite, please read the following guide: [Hosting multiple websites on your Web Hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite).
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/multisite/add-domain-or-subdomain.png){.thumbnail}
-
-### Step 5: Set up your project on the Cloud Web hosting plan.
+### 5 - Set up your project on the Cloud Web hosting plan
 
 There are two ways of setting up your project. Once you have picked the technique that best suits you, please repeat the process as needed if you are putting several websites online.
 
-#### 1. Use our 1-click modules.
+#### 1. Use our 1-click modules
 
 By using our 1-click modules, you will get a ready-to-use website template that you can customise with a variety of themes, texts, and much more. OVHcloud offers four structures with its 1-click modules. You can find out more about them by browsing our webpage on [Creating a website with 1-click modules](/links/web/hosting-website).
 
-If your choice of method involves using our 1-click modules, stay on the section for the [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan concerned, click on the  `1-click modules`{.action} tab, then click `Add a module`{.action}. You can then choose whether to install it in ‘basic’ mode (non-customisable), or ‘advanced’ mode (customisable).
+If your choice of method involves using our 1-click modules, click on the tabs below to view each of the **3** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web hosting plan concerned.
+>>
+>> ![Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `1-click modules`{.action} tab, then click `Add a module`{.action}.
+>>
+> **Step 3**
+>>
+>> You can then choose whether to install it in 'basic' mode (non-customisable), or 'advanced' mode (customisable).
 
 If you need more information on OVHcloud 1-click modules, please read our guide: [Setting up your website with 1-click modules](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 
 > [!primary]
 >
 > In order to use these modules, you must use the PHP runtime software application.
->
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/1-click-modules/add-a-module.png){.thumbnail}
+#### 2. Set up your project manually
 
-#### 2. Set up your project manually.
-
-Whether you are building a website from scratch or migrating an existing website, manual setup may require a much higher degree of technical skill, and you will need to rely on your own knowledge. We recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. 
+Whether you are building a website from scratch or migrating an existing website, manual setup may require a much higher degree of technical skill, and you will need to rely on your own knowledge. We recommend contacting a [specialist provider](/links/partner) and/or the service's software publisher if you encounter any difficulties.
 
 If you have chosen to set up your website manually, you must have all of the website or application files that you would like to set up on your hosting plan. If you have created any databases on your Cloud Web hosting plan, you will also need to have their details and credentials to hand. If you are migrating a website, please ensure that you create a backup copy of all your website files.
 
 There is no clear-cut, single approach to take since every project is different, but our guides to [Publishing a website on your Web Hosting space](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) and [Migrating your website and emails to OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh) should be able to help you establish how to proceed.
 
-### Step 6: Modify your domain name’s configuration.
+### 6 - Modify your domain name's configuration
 
 At this stage, your project must be set up on your OVHcloud Cloud Web hosting plan, and if applicable, your email addresses must be created. If your email addresses do not work, it may be because your domain name is not correctly configured. If this is the case, or you are unsure about where the error is, we would recommend following this step.
 
-However, please note that if you are in the process of migrating your services to OVHcloud, the changes associated with the DNS may result in your services becoming unavailable if they are not completed at the right time. As described in our guide to [Migrating your website and emails to OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh), please note that you must edit your domain’s DNS servers as a final part of the process.
+However, please note that if you are in the process of migrating your services to OVHcloud, the changes associated with the DNS may result in your services becoming unavailable if they are not completed at the right time. As described in our guide to [Migrating your website and emails to OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh), please note that you must edit your domain's DNS servers as a final part of the process.
 
-#### 1. Familiarise yourself with OVHcloud DNS records. 
+#### 1. Familiarise yourself with OVHcloud DNS records
 
 There are several OVHcloud DNS records. We will focus on two particular records, which keep your website accessible and allow you to receive emails on your OVHcloud email addresses. Please follow the instructions below to find out where to find them:
 
 |DNS record|Associated service|Where to find it|
 |---|---|---|
-|A|For the website|In the [OVHcloud Control Panel](/links/manager), go to the `Hosting`{.action} section for the hosting plan concerned. Copy the IP address that appears next to "IPv4" in the `General information`{.action} tab.|
-|MX|For emails|In the [OVHcloud Control Panel](/links/manager), go to the `Emails`{.action} section for the domain name concerned. Copy the information that appears next to “MX records” in the `General information`{.action} tab.|
+|A|For the website|Refer to our guide [Web Hosting - List of IP addresses by cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|
+|MX|For emails|Refer to our guide [Adding an MX record](/pages/web_cloud/domains/dns_zone_mx).|
 
-#### 2. Check and/or modify the DNS records.
+#### 2. Check and/or modify the DNS records
 
-Now that you are more familiar with the OVHcloud DNS records for your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan and your OVHcloud email solution, you can check if they have been configured properly, and edit them if required. These two changes must be made with the service provider managing your domain name’s DNS configuration (DNS zone).
+Now that you are more familiar with the OVHcloud DNS records for your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan and your OVHcloud email solution, you can check if they have been configured properly, and edit them if required. These two changes must be made with the service provider managing your domain name's DNS configuration (DNS zone).
 
 > [!warning]
 >
 > - If your domain name does not use the OVHcloud DNS configuration, you will need to make changes using the interface given by the service provider managing your domain name.
-> 
-> - If your domain name is registered with OVHcloud, you can check if the domain name is using our DNS configuration. To do this, go to the [Control Panel](/links/manager), select the domain name concerned, and go to the `DNS servers`{.action} tab.
+>
+> - If your domain name is registered with OVHcloud, you can check if the domain name is using our DNS configuration. To do this, refer to our guide [Modifying the DNS servers for an OVHcloud domain name](/pages/web_cloud/domains/dns_server_edit).
 >
 
 Please read the instructions below to see where you should make the changes:
 
 |DNS configuration used|Where to make the changes|
 |---|---|
-|OVHcloud|In your [OVHcloud Control Panel](/links/manager), go to the `Web Cloud`{.action} section. Click on the `DNS zones`{.action} menu, then choose the domain name concerned. Read our documentation "[Editing an OVHcloud DNS zone](/pages/web_cloud/domains/dns_zone_edit)" if necessary.|
-|Other|From the interface given by the service provider managing your domain name’s DNS configuration. Please contact your service provider if you encounter any difficulties making these changes.|
+|OVHcloud|Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned. Read our documentation "[Editing an OVHcloud DNS zone](/pages/web_cloud/domains/dns_zone_edit)" if necessary.|
+|Other|From the interface given by the service provider managing your domain name's DNS configuration. Please contact your service provider if you encounter any difficulties making these changes.|
 
-Once you have modified your domain name’s DNS configuration, you will need to allow a maximum of 24 hours for the changes to fully propagate and take effect. If you have added several domain names to your Cloud Web hosting plan as a multisite, you will need to make these two changes for each individual domain name. 
+Once you have modified your domain name's DNS configuration, you will need to allow a maximum of 24 hours for the changes to fully propagate and take effect. If you have added several domain names to your Cloud Web hosting plan as a multisite, you will need to make these two changes for each individual domain name.
 
-### Step 7: Customise your website.
+### 7 - Customise your website
 
 This stage is optional if you have migrated an existing website that is already customised! However, if you have just set up a new website using our modules, you can customise it by editing the theme, and start publishing your content on it.
 
-If you need help with your website’s features, we would recommend that you go to the CMS publisher’s official website, which will contain documentation to support you in this regard.
+If you need help with your website's features, we would recommend that you go to the CMS publisher's official website, which will contain documentation to support you in this regard.
 
-### Step 8: Use your email addresses.
+### 8 - Use your email addresses
 
 Now, you just need to use your email addresses. To do this, OVHcloud offers an online application (webmail): RoundCube. RoundCube is available at the following address: <https://www.ovh.co.uk/mail/>. You will need to enter the credentials for the email address that you created with OVHcloud.
 
@@ -209,4 +266,4 @@ For specialised services (SEO, development, etc.), contact [OVHcloud partners](/
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).
 
-Join our [community of users](/links/community). 
+Join our [community of users](/links/community).

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-gb.md
@@ -63,7 +63,7 @@ To access the runtime software applications for your [Cloud Web](/links/web/host
 >>
 > **Step 2**
 >>
->> Click on the `Runtime software`{.action} tab. When you set up your hosting plan, a runtime software application is created automatically. It is listed as `Default choice` in the table that appears.
+>> Click on the `Runtime software applications`{.action} tab. When you set up your hosting plan, a runtime software application is created automatically. It is listed as `Default choice` in the table that appears.
 >>
 >> To modify a runtime software that has already been set, click on the `...`{.action} button to the right, then `Modify`{.action}.
 >>
@@ -150,7 +150,7 @@ Now that the technical environment of your [Cloud Web](/links/web/hosting-cloud-
 >>
 >> Click on the `Multisite`{.action} tab. The table displayed will contain all of the domain names that have been added to your hosting plan. Some of these will have been created automatically, when your hosting plan was set up.
 >>
->> To add a new one, click on the `Add a domain or subdomain`{.action} button, and follow the instructions that appear. The method may be different, depending on whether the domain name concerned is registered with OVHcloud.
+>> To add a new one, click on the `Add a domain or sub-domain`{.action} button, and follow the instructions that appear. The method may be different, depending on whether the domain name concerned is registered with OVHcloud.
 >>
 > **Step 3**
 >>
@@ -162,7 +162,7 @@ Now that the technical environment of your [Cloud Web](/links/web/hosting-cloud-
 >>
 >> > [!warning]
 >> >
->> > If you have added a domain name that is considered to be external, you will need to add a TXT record called **ovhcontrol** to its DNS configuration. This way, OVHcloud can ensure that the domain addition is approved. If you do not do this, your domain addition will be cancelled.
+>> > If you have added a domain name that is considered to be external, you will need to add a TXT record called **ovhcontrol** to its DNS configuration. This way, OVHcloud can ensure that the domain addition is approved. If you skip this step, your domain will not be added.
 
 Repeat this step if you would like to add several domain names to your Cloud Web hosting plan. For more information on adding a domain name as a multisite, please read the following guide: [Hosting multiple websites on your Web Hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite).
 

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting started with a Cloud Web hosting plan"
 excerpt: "Find out how to get started with a Cloud Web hosting plan"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-ie.md
@@ -63,7 +63,7 @@ To access the runtime software applications for your [Cloud Web](/links/web/host
 >>
 > **Step 2**
 >>
->> Click on the `Runtime software`{.action} tab. When you set up your hosting plan, a runtime software application is created automatically. It is listed as `Default choice` in the table that appears.
+>> Click on the `Runtime software applications`{.action} tab. When you set up your hosting plan, a runtime software application is created automatically. It is listed as `Default choice` in the table that appears.
 >>
 >> To modify a runtime software that has already been set, click on the `...`{.action} button to the right, then `Modify`{.action}.
 >>
@@ -150,7 +150,7 @@ Now that the technical environment of your [Cloud Web](/links/web/hosting-cloud-
 >>
 >> Click on the `Multisite`{.action} tab. The table displayed will contain all of the domain names that have been added to your hosting plan. Some of these will have been created automatically, when your hosting plan was set up.
 >>
->> To add a new one, click on the `Add a domain or subdomain`{.action} button, and follow the instructions that appear. The method may be different, depending on whether the domain name concerned is registered with OVHcloud.
+>> To add a new one, click on the `Add a domain or sub-domain`{.action} button, and follow the instructions that appear. The method may be different, depending on whether the domain name concerned is registered with OVHcloud.
 >>
 > **Step 3**
 >>
@@ -162,7 +162,7 @@ Now that the technical environment of your [Cloud Web](/links/web/hosting-cloud-
 >>
 >> > [!warning]
 >> >
->> > If you have added a domain name that is considered to be external, you will need to add a TXT record called **ovhcontrol** to its DNS configuration. This way, OVHcloud can ensure that the domain addition is approved. If you do not do this, your domain addition will be cancelled.
+>> > If you have added a domain name that is considered to be external, you will need to add a TXT record called **ovhcontrol** to its DNS configuration. This way, OVHcloud can ensure that the domain addition is approved. If you skip this step, your domain will not be added.
 
 Repeat this step if you would like to add several domain names to your Cloud Web hosting plan. For more information on adding a domain name as a multisite, please read the following guide: [Hosting multiple websites on your Web Hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite).
 

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting started with a Cloud Web hosting plan"
 excerpt: "Find out how to get started with a Cloud Web hosting plan"
-updated: 2025-05-22
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -29,11 +29,11 @@ For our new [Cloud Web](/links/web/hosting-cloud-web-offer) solution, we have co
 
 ## Instructions
 
-### Step 1: Define your project.
+### 1 - Define your project
 
 OVHcloud [Cloud Web](/links/web/hosting-cloud-web-offer) hosting offers a wider range of configuration options than standard web hosting plans, so that you can tailor your plan to suit your project. To ensure that your project is a success, it is important to have a clear idea of your objective. To do this, you should:
 
-- **Define what you want to set up.** Are you creating a blog, or an online store? Do you want to share your passion, or boost your company’s online profile? It is best to define your project clearly before you get started.
+- **Define what you want to set up.** Are you creating a blog, or an online store? Do you want to share your passion, or boost your company's online profile? It is best to define your project clearly before you get started.
 
 - **Research the technical requirements for setting up your project.** Your project may have specific technical requirements. Make sure you are aware of them in advance.
 
@@ -41,7 +41,7 @@ OVHcloud [Cloud Web](/links/web/hosting-cloud-web-offer) hosting offers a wider 
 
 Once you have explored the various options available and carefully defined your project, you can then start getting it online.
 
-### Step 2: Choose a runtime software application.
+### 2 - Choose a runtime software application
 
 With [Cloud Web](/links/web/hosting-cloud-web-offer), you can choose from a range of different coding languages to build your project. If you would like to use a language other than PHP, which is the default selection, you will need to select a runtime software application that corresponds to your coding language.
 
@@ -52,27 +52,64 @@ The languages currently available are:
 - Python
 - Ruby
 
-To access the runtime software applications for your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan, log in to the [OVHcloud Control Panel](/links/manager). Click `Web Cloud`{.action} in the services bar on the left-hand side, then click `Hosting plans`{.action}. Select the name of the Cloud Web hosting plan concerned, and go to the `Runtime software`{.action} tab.
+To access the runtime software applications for your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan, click on the tabs below to view each of the **3** steps.
 
-When you set up your hosting plan, a runtime software application will be created automatically. It is included as the `Default choice` in the table that appears. To modify a runtime software that has already been set, click on the three dots next to it, then `Modify`{.action}. 
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web hosting plan concerned.
+>>
+>> ![Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Runtime software`{.action} tab. When you set up your hosting plan, a runtime software application is created automatically. It is listed as `Default choice` in the table that appears.
+>>
+>> To modify a runtime software that has already been set, click on the `...`{.action} button to the right, then `Modify`{.action}.
+>>
+> **Step 3**
+>>
+>> If you have the [Cloud Web](/links/web/hosting-cloud-web-offer) offer with 2 vCores, you can add a second runtime environment (maximum 2 per plan) by clicking on the `Actions`{.action} button, then on `Add a runtime software application`{.action}.
 
-If you have the [Cloud Web](/links/web/hosting-cloud-web-offer) offer with 2 vCores, you can add a second runtime environment (maximum 2 different runtime environments per service) by clicking on the `Actions`{.action} button, then on `Add a runtime software application`{.action}.
+Once you have done this, please ensure that you have the runtime software application (or applications) required for your project before you continue.
 
-To check that you have 2 vCores with your Cloud Web hosting plan, log in to the [OVHcloud Control Panel](/links/manager), click `Hosting plans`{.action} in the services bar on the left-hand side, then select the name of the Cloud Web hosting plan concerned. In the box **Plan** and under `Service plan`, check that the reference `Cloud Web 3`{.action} is present.
+To check that you have 2 vCores with your Cloud Web hosting plan, click on the tabs below to view each of the **2** steps.
 
-Once you have done this, please ensure that you have the runtime software application (or applications) required for your project before you continue:
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web hosting plan concerned.
+>>
+>> ![Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the **Plan** box and under `Service plan`, check that the reference `Cloud Web 3` is present.
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/runtime-software-application/edit-runtime.png){.thumbnail}
-
-### Step 3: Create environment variables (optional).
+### 3 - Create environment variables (optional)
 
 If you would like to deploy your project several times in different environments (e.g. development, test and production), you will need to provide variables in order for your code to run properly. To do this, [Cloud Web](/links/web/hosting-cloud-web-offer) prompts you to define environment variables that can be accessed by the code for your website or web application.
 
-For example, this way you can leave out the .env file in the PHP Laravel framework, as described in this guide: <https://laravel.com/docs/5.6/configuration>.
+For example, this way you can leave out the .env file in the PHP Laravel framework, as described in this guide: <https://laravel.com/docs/master/configuration>.
 
-To add an environment variable, stay in the section for the Cloud Web hosting plan concerned, and click on the `Environment variables`{.action} tab. A table will display the environment variables created for your solution. To add a new one, click on the `Actions`{.action} button, then `Add an environment variable`{.action}. Follow the appropriate instructions for the variable you would like to create:
+To add an environment variable, click on the tabs below to view each of the **3** steps.
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web hosting plan concerned.
+>>
+>> ![Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Environment variables`{.action} tab. A table will display the environment variables created for your solution.
+>>
+> **Step 3**
+>>
+>> To add a new one, click on the `Actions`{.action} button, then `Add an environment variable`{.action}. Follow the appropriate instructions for the variable you would like to create.
+>>
+>> ![Adding an environment variable on a Cloud Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
 
 If you do not use a development framework that includes the environment variables, or would simply like to check that your variables are working properly, you can create a script to do this. Below are examples of two scripts that can help you with this process, although they are no substitute for the assistance of a webmaster:
 
@@ -87,107 +124,129 @@ If you do not use a development framework that includes the environment variable
 ```sh
 var http = require('http');
 
-http.createServer(function(request, response) {  
-    response.writeHeader(200, {"Content-Type": "text/html"});  
+http.createServer(function(request, response) {
+    response.writeHeader(200, {"Content-Type": "text/html"});
 
     response.write( process.env.DB_DATABASE);
 
-    response.end();  
+    response.end();
 }).listen(80);
 ```
 
 Make sure you replace the generic information included in these scripts (e.g. DB_DATABASE) with the environment variable concerned.
 
-### Step 4: Configure the additional domains as multisites (optional).
+### 4 - Configure additional domains as multisites (optional)
 
-Now that the technical environment of your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan is ready, you can configure additional domain names on it as multisites. This way, you can partition your space in order to host several websites on it, for example. If you would like to do this for your project, in the section for the Cloud Web hosting plan concerned, click on the `Multisite`{.action} tab.
+Now that the technical environment of your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan is ready, you can configure additional domain names on it as multisites. This way, you can partition your space in order to host several websites on it, for example. If you would like to do this for your project, click on the tabs below to view each of the **3** steps.
 
-The table displayed will contain all of the domain names that have been added to your hosting plan. Some of these will have been created automatically, when your hosting plan was set up. To add a new one, click on the `Add a domain or subdomain`{.action} button, and follow the instructions that appear. The method may be different, depending on whether the domain name concerned is registered with OVHcloud. 
-
-We strongly advise taking special care when you enter the following information:
-
-- **Root directory.** The directory where the domain name entered must be hosted on the storage space for your Cloud Web hosting plan. 
-
-- **Runtime software application.** The runtime software application previously set, which will be used by the multisite you are currently configuring.
-
-> [!warning]
->
-> If you have added a domain name that is considered to be external, you will need to add a TXT record called **ovhcontrol** to its DNS configuration. This way, OVHcloud can ensure that the domain addition is approved. If you do not do this, your domain addition will be cancelled. Adding this TXT record is therefore an essential step. 
->
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web hosting plan concerned.
+>>
+>> ![Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `Multisite`{.action} tab. The table displayed will contain all of the domain names that have been added to your hosting plan. Some of these will have been created automatically, when your hosting plan was set up.
+>>
+>> To add a new one, click on the `Add a domain or subdomain`{.action} button, and follow the instructions that appear. The method may be different, depending on whether the domain name concerned is registered with OVHcloud.
+>>
+> **Step 3**
+>>
+>> We strongly advise taking special care when you enter the following information:
+>>
+>> - **Root directory**: the directory where the domain name entered must be hosted on the storage space for your Cloud Web hosting plan.
+>>
+>> - **Runtime software application**: the runtime software application previously set, which will be used by the multisite you are currently configuring.
+>>
+>> > [!warning]
+>> >
+>> > If you have added a domain name that is considered to be external, you will need to add a TXT record called **ovhcontrol** to its DNS configuration. This way, OVHcloud can ensure that the domain addition is approved. If you do not do this, your domain addition will be cancelled.
 
 Repeat this step if you would like to add several domain names to your Cloud Web hosting plan. For more information on adding a domain name as a multisite, please read the following guide: [Hosting multiple websites on your Web Hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite).
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/multisite/add-domain-or-subdomain.png){.thumbnail}
-
-### Step 5: Set up your project on the Cloud Web hosting plan.
+### 5 - Set up your project on the Cloud Web hosting plan
 
 There are two ways of setting up your project. Once you have picked the technique that best suits you, please repeat the process as needed if you are putting several websites online.
 
-#### 1. Use our 1-click modules.
+#### 1. Use our 1-click modules
 
 By using our 1-click modules, you will get a ready-to-use website template that you can customise with a variety of themes, texts, and much more. OVHcloud offers four structures with its 1-click modules. You can find out more about them by browsing our webpage on [Creating a website with 1-click modules](/links/web/hosting-website).
 
-If your choice of method involves using our 1-click modules, stay on the section for the [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan concerned, click on the  `1-click modules`{.action} tab, then click `Add a module`{.action}. You can then choose whether to install it in ‘basic’ mode (non-customisable), or ‘advanced’ mode (customisable).
+If your choice of method involves using our 1-click modules, click on the tabs below to view each of the **3** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the Cloud Web hosting plan concerned.
+>>
+>> ![Web hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Click on the `1-click modules`{.action} tab, then click `Add a module`{.action}.
+>>
+> **Step 3**
+>>
+>> You can then choose whether to install it in 'basic' mode (non-customisable), or 'advanced' mode (customisable).
 
 If you need more information on OVHcloud 1-click modules, please read our guide: [Setting up your website with 1-click modules](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 
 > [!primary]
 >
 > In order to use these modules, you must use the PHP runtime software application.
->
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/1-click-modules/add-a-module.png){.thumbnail}
+#### 2. Set up your project manually
 
-#### 2. Set up your project manually.
-
-Whether you are building a website from scratch or migrating an existing website, manual setup may require a much higher degree of technical skill, and you will need to rely on your own knowledge. We recommend contacting a specialist provider and/or the service’s software publisher if you encounter any difficulties. 
+Whether you are building a website from scratch or migrating an existing website, manual setup may require a much higher degree of technical skill, and you will need to rely on your own knowledge. We recommend contacting a [specialist provider](/links/partner) and/or the service's software publisher if you encounter any difficulties.
 
 If you have chosen to set up your website manually, you must have all of the website or application files that you would like to set up on your hosting plan. If you have created any databases on your Cloud Web hosting plan, you will also need to have their details and credentials to hand. If you are migrating a website, please ensure that you create a backup copy of all your website files.
 
 There is no clear-cut, single approach to take since every project is different, but our guides to [Publishing a website on your Web Hosting space](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) and [Migrating your website and emails to OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh) should be able to help you establish how to proceed.
 
-### Step 6: Modify your domain name’s configuration.
+### 6 - Modify your domain name's configuration
 
 At this stage, your project must be set up on your OVHcloud Cloud Web hosting plan, and if applicable, your email addresses must be created. If your email addresses do not work, it may be because your domain name is not correctly configured. If this is the case, or you are unsure about where the error is, we would recommend following this step.
 
-However, please note that if you are in the process of migrating your services to OVHcloud, the changes associated with the DNS may result in your services becoming unavailable if they are not completed at the right time. As described in our guide to [Migrating your website and emails to OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh), please note that you must edit your domain’s DNS servers as a final part of the process.
+However, please note that if you are in the process of migrating your services to OVHcloud, the changes associated with the DNS may result in your services becoming unavailable if they are not completed at the right time. As described in our guide to [Migrating your website and emails to OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh), please note that you must edit your domain's DNS servers as a final part of the process.
 
-#### 1. Familiarise yourself with OVHcloud DNS records. 
+#### 1. Familiarise yourself with OVHcloud DNS records
 
 There are several OVHcloud DNS records. We will focus on two particular records, which keep your website accessible and allow you to receive emails on your OVHcloud email addresses. Please follow the instructions below to find out where to find them:
 
 |DNS record|Associated service|Where to find it|
 |---|---|---|
-|A|For the website|In the [OVHcloud Control Panel](/links/manager), go to the `Hosting`{.action} section for the hosting plan concerned. Copy the IP address that appears next to "IPv4" in the `General information`{.action} tab.|
-|MX|For emails|In the [OVHcloud Control Panel](/links/manager), go to the `Emails`{.action} section for the domain name concerned. Copy the information that appears next to “MX records” in the `General information`{.action} tab.|
+|A|For the website|Refer to our guide [Web Hosting - List of IP addresses by cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|
+|MX|For emails|Refer to our guide [Adding an MX record](/pages/web_cloud/domains/dns_zone_mx).|
 
-#### 2. Check and/or modify the DNS records.
+#### 2. Check and/or modify the DNS records
 
-Now that you are more familiar with the OVHcloud DNS records for your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan and your OVHcloud email solution, you can check if they have been configured properly, and edit them if required. These two changes must be made with the service provider managing your domain name’s DNS configuration (DNS zone).
+Now that you are more familiar with the OVHcloud DNS records for your [Cloud Web](/links/web/hosting-cloud-web-offer) hosting plan and your OVHcloud email solution, you can check if they have been configured properly, and edit them if required. These two changes must be made with the service provider managing your domain name's DNS configuration (DNS zone).
 
 > [!warning]
 >
 > - If your domain name does not use the OVHcloud DNS configuration, you will need to make changes using the interface given by the service provider managing your domain name.
-> 
-> - If your domain name is registered with OVHcloud, you can check if the domain name is using our DNS configuration. To do this, go to the [Control Panel](/links/manager), select the domain name concerned, and go to the `DNS servers`{.action} tab.
+>
+> - If your domain name is registered with OVHcloud, you can check if the domain name is using our DNS configuration. To do this, refer to our guide [Modifying the DNS servers for an OVHcloud domain name](/pages/web_cloud/domains/dns_server_edit).
 >
 
 Please read the instructions below to see where you should make the changes:
 
 |DNS configuration used|Where to make the changes|
 |---|---|
-|OVHcloud|In your [OVHcloud Control Panel](/links/manager), go to the `Web Cloud`{.action} section. Click on the `DNS zones`{.action} menu, then choose the domain name concerned. Read our documentation "[Editing an OVHcloud DNS zone](/pages/web_cloud/domains/dns_zone_edit)" if necessary.|
-|Other|From the interface given by the service provider managing your domain name’s DNS configuration. Please contact your service provider if you encounter any difficulties making these changes.|
+|OVHcloud|Go to the [DNS zones](/links/control-panel/web-dns-zone) page, then select the domain name concerned. Read our documentation "[Editing an OVHcloud DNS zone](/pages/web_cloud/domains/dns_zone_edit)" if necessary.|
+|Other|From the interface given by the service provider managing your domain name's DNS configuration. Please contact your service provider if you encounter any difficulties making these changes.|
 
-Once you have modified your domain name’s DNS configuration, you will need to allow a maximum of 24 hours for the changes to fully propagate and take effect. If you have added several domain names to your Cloud Web hosting plan as a multisite, you will need to make these two changes for each individual domain name. 
+Once you have modified your domain name's DNS configuration, you will need to allow a maximum of 24 hours for the changes to fully propagate and take effect. If you have added several domain names to your Cloud Web hosting plan as a multisite, you will need to make these two changes for each individual domain name.
 
-### Step 7: Customise your website.
+### 7 - Customise your website
 
 This stage is optional if you have migrated an existing website that is already customised! However, if you have just set up a new website using our modules, you can customise it by editing the theme, and start publishing your content on it.
 
-If you need help with your website’s features, we would recommend that you go to the CMS publisher’s official website, which will contain documentation to support you in this regard.
+If you need help with your website's features, we would recommend that you go to the CMS publisher's official website, which will contain documentation to support you in this regard.
 
-### Step 8: Use your email addresses.
+### 8 - Use your email addresses
 
 Now, you just need to use your email addresses. To do this, OVHcloud offers an online application (webmail): RoundCube. RoundCube is available at the following address: <https://www.ovh.ie/mail/>. You will need to enter the credentials for the email address that you created with OVHcloud.
 

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Getting started with a Cloud Web hosting plan"
 excerpt: "Find out how to get started with a Cloud Web hosting plan"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Primeros pasos con un hosting Cloud Web"
 excerpt: "Descubra cómo empezar con un alojamiento Cloud Web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Primeros pasos con un hosting Cloud Web"
 excerpt: "Descubra cómo empezar con un alojamiento Cloud Web"
-updated: 2025-05-22
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -21,7 +21,7 @@ El plan de hosting Cloud Web de OVHcloud es el resultado de combinar veinte año
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -29,7 +29,7 @@ El plan de hosting Cloud Web de OVHcloud es el resultado de combinar veinte año
 
 ## Procedimiento
 
-### 1. Definir el proyecto
+### 1 - Definir el proyecto
 
 Con el fin de adaptarse lo mejor posible a cada proyecto, el plan de hosting Cloud Web ofrece más posibilidades de configuración que un alojamiento web convencional. Para llevar su proyecto a buen puerto, es importante tener una visión clara de su objetivo. Para ello, le ofrecemos las siguientes recomendaciones:
 
@@ -37,11 +37,11 @@ Con el fin de adaptarse lo mejor posible a cada proyecto, el plan de hosting Clo
 
 - **Establezca los requisitos técnicos para la instalación:** Es posible que el proyecto que quiera desplegar tenga requerimientos técnicos concretos. Asegúrese de conocerlos previamente.
 
-- **Asegúrese de que su proyecto es técnicamente compatible con el hosting  Cloud Web:** ¿Necesita un motor de ejecución o un SQL concretos? Si todavía no lo ha hecho, asegúrese de que están disponibles con el [hosting Cloud Web](/links/web/hosting-cloud-web-offer).
+- **Asegúrese de que su proyecto es técnicamente compatible con el hosting Cloud Web:** ¿Necesita un motor de ejecución o un SQL concretos? Si todavía no lo ha hecho, asegúrese de que están disponibles con el [hosting Cloud Web](/links/web/hosting-cloud-web-offer).
 
 Una vez que haya evaluado las distintas posibilidades y haya delimitado el proyecto con precisión, puede empezar a publicarlo en internet.
 
-### 2. Elegir el motor de ejecución
+### 2 - Elegir el motor de ejecución
 
 El hosting Cloud Web ofrece la posibilidad de desarrollar un proyecto en distintos lenguajes de programación. Si quiere utilizar un lenguaje distinto de PHP, que es el lenguaje por defecto, deberá seleccionar el motor de ejecución correspondiente.
 
@@ -52,27 +52,64 @@ Los lenguajes disponibles actualmente son:
 - Python
 - Ruby
 
-Para acceder a los motores de ejecución de su hosting [Cloud Web](/links/web/hosting-cloud-web-offer), conéctese al [área de cliente de OVHcloud](/links/manager). Haga clic en `Web Cloud`{.action} en la columna izquierda y seleccione `Alojamientos`{.action}. Seleccione el alojamiento Cloud Web correspondiente y abra la pestaña `Motores de ejecución`{.action}.
+Para acceder a los motores de ejecución de su hosting [Cloud Web](/links/web/hosting-cloud-web-offer), haga clic en las pestañas siguientes para visualizar cada una de las **3** etapas.
 
-Al instalar el alojamiento, se crea automáticamente un motor, que aparece en la tabla como **Opción por defecto**. Para cambiar de motor, haga clic en el botón `...`{.action} situado al final de la línea correspondiente y seleccione `Editar`{.action}. 
-
-Si dispone del plan [Cloud Web](/links/web/hosting-cloud-web-offer) con 2 vCores, puede añadir un segundo motor de ejecución a su plan (máximo 2 motores de ejecución diferentes por plan) haciendo clic en el botón `Acciones`{.action} y luego en `Añadir un motor de ejecución`{.action}.
-
-Para comprobar que dispone de 2 vCores con su hosting Cloud Web, conéctese a su [área de cliente de OVHcloud](/links/manager), haga clic en `Alojamientos`{.action} en la columna izquierda y seleccione el alojamiento Cloud Web correspondiente. En la página que aparece, en el recuadro **Suscripción** y bajo la indicación `Solución`, compruebe que la referencia `Cloud Web 3`{.action} aparece en ella.
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento Cloud Web correspondiente.
+>>
+>> ![Alojamientos web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `Motores de ejecución`{.action}. Al instalar el alojamiento, se crea automáticamente un motor, que aparece en la tabla como **Opción por defecto**.
+>>
+>> Para cambiar de motor, haga clic en el botón `...`{.action} situado a la derecha y seleccione `Editar`{.action}.
+>>
+> **Etapa 3**
+>>
+>> Si dispone del plan [Cloud Web](/links/web/hosting-cloud-web-offer) con 2 vCores, puede añadir un segundo motor de ejecución (máximo 2 por plan) haciendo clic en el botón `Acciones`{.action} y luego en `Añadir un motor de ejecución`{.action}.
 
 Por lo tanto, asegúrese de disponer del motor o motores de ejecución necesarios para su proyecto antes de continuar.
 
-![Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/runtime-software-application/edit-runtime.png){.thumbnail}
+Para comprobar que dispone de 2 vCores con su hosting Cloud Web, haga clic en las pestañas siguientes para visualizar cada una de las **2** etapas.
 
-### 3. Crear variables de entorno (opcional)
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento Cloud Web correspondiente.
+>>
+>> ![Alojamientos web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> En el recuadro **Suscripción** y bajo la indicación `Solución`, compruebe que la referencia `Cloud Web 3` aparece en ella.
+
+### 3 - Crear variables de entorno (opcional)
 
 Si desea desplegar su proyecto en varios entornos (por ejemplo, en desarrollo, testeo o producción), deberá establecer la configuración correspondiente para que el código pueda identificarlos. Para ello, en un hosting Cloud Web es posible configurar variables de entorno, que estarán disponibles para el código del sitio o aplicación web.
 
-Esto permite, por ejemplo, no definir un archivo «.env» en el framework PHP Laravel, tal como indica la documentación de Laravel: <https://laravel.com/docs/5.6/configuration>.
+Esto permite, por ejemplo, no definir un archivo «.env» en el framework PHP Laravel, tal como indica la documentación de Laravel: <https://laravel.com/docs/master/configuration>.
 
-Para añadir una variable de entorno, una vez seleccionado el alojamiento Cloud Web en el área de cliente de OVHcloud, abra la pestaña `Variables de entorno`{.action}. Se mostrará una tabla que contiene las variables de entorno creadas en su alojamiento. Para añadir una nueva, haga clic en el botón `Acciones`{.action} y seleccione `Añadir una variable de entorno`{.action}. Siga las indicaciones en función de la variable que desee crear.
+Para añadir una variable de entorno, haga clic en las pestañas siguientes para visualizar cada una de las **3** etapas.
 
-![Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento Cloud Web correspondiente.
+>>
+>> ![Alojamientos web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `Variables de entorno`{.action}. Se mostrará una tabla que contiene las variables de entorno creadas en su alojamiento.
+>>
+> **Etapa 3**
+>>
+>> Para añadir una nueva, haga clic en el botón `Acciones`{.action} y seleccione `Añadir una variable de entorno`{.action}. Siga las indicaciones en función de la variable que desee crear.
+>>
+>> ![Añadir una variable de entorno en un hosting Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
 
 Si no utiliza ningún framework de desarrollo que incluya las variables de entorno, o si simplemente quiere comprobar que las variables funcionen correctamente, puede crear un script que realice dicha comprobación. A continuación ofrecemos dos ejemplos que le ayudarán en esta tarea (sin que estos sustituyan la ayuda de un webmaster).
 
@@ -87,107 +124,129 @@ Si no utiliza ningún framework de desarrollo que incluya las variables de entor
 ```sh
 var http = require('http');
 
-http.createServer(function(request, response) {  
-    response.writeHeader(200, {"Content-Type": "text/html"});  
+http.createServer(function(request, response) {
+    response.writeHeader(200, {"Content-Type": "text/html"});
 
     response.write( process.env.DB_DATABASE);
 
-    response.end();  
+    response.end();
 }).listen(80);
 ```
 
 No olvide sustituir el valor «DB_DATABASE» por la variable de entorno correspondiente.
 
-### 4. Configurar dominios adicionales como multisitio (opcional)
+### 4 - Configurar dominios adicionales como multisitio (opcional)
 
-Con el entorno técnico del hosting Cloud Web ya listo, es posible configurar dominios adicionales como multisitio para poder alojar varios sitios web en el mismo alojamiento. Para ello, una vez seleccionado el alojamiento Cloud Web en el área de cliente de OVHcloud, abra la pestaña `Multisitio`{.action}.
+Con el entorno técnico del hosting Cloud Web ya listo, es posible configurar dominios adicionales como multisitio para poder alojar varios sitios web en el mismo alojamiento. Si esto se ajusta a su proyecto, haga clic en las pestañas siguientes para visualizar cada una de las **3** etapas.
 
-Se mostrará una tabla que contiene todos los dominios añadidos al alojamiento. Algunos de ellos se habrán creado automáticamente al instalarlo. Para añadir un nuevo dominio, haga clic en el botón `Añadir un dominio o subdominio`{.action} y siga las indicaciones. El procedimiento puede variar si el dominio no está registrado en OVHcloud. 
-
-Cuando introduzca los datos, tenga en cuenta lo siguiente:
-
-- **Carpeta raíz:** Directorio en el que deberá alojar el dominio en el espacio de almacenamiento de su hosting Cloud Web. 
-
-- **Motor de ejecución:** Motor de ejecución, previamente configurado, que utilizará el multisitio.
-
-> [!warning]
->
-> Si ha añadido un dominio externo, deberá crear un registro TXT llamado **ovhcontrol** en su configuración DNS. Dicho registro permite a OVHcloud asegurarse de que la adición del dominio es legítima. Por lo tanto, es un requisito indispensable. De no cumplirlo, no será posible añadir el dominio. 
->
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento Cloud Web correspondiente.
+>>
+>> ![Alojamientos web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `Multisitio`{.action}. Se mostrará una tabla que contiene todos los dominios añadidos al alojamiento. Algunos de ellos se habrán creado automáticamente al instalarlo.
+>>
+>> Para añadir un nuevo dominio, haga clic en el botón `Añadir un dominio o subdominio`{.action} y siga las indicaciones. El procedimiento puede variar si el dominio no está registrado en OVHcloud.
+>>
+> **Etapa 3**
+>>
+>> Cuando introduzca los datos, tenga en cuenta lo siguiente:
+>>
+>> - **Carpeta raíz:** Directorio en el que deberá alojar el dominio en el espacio de almacenamiento de su hosting Cloud Web.
+>>
+>> - **Motor de ejecución:** Motor de ejecución, previamente configurado, que utilizará el multisitio.
+>>
+>> > [!warning]
+>> >
+>> > Si ha añadido un dominio externo, deberá crear un registro TXT llamado **ovhcontrol** en su configuración DNS. Dicho registro permite a OVHcloud asegurarse de que la adición del dominio es legítima. De no cumplirlo, no será posible añadir el dominio.
 
 Repita la operación para cada dominio que quiera añadir a su hosting Cloud Web, en su caso. Para más información sobre cómo añadir un dominio como multisitio, consulte la guía [Alojar varios sitios web en un mismo hosting](/pages/web_cloud/web_hosting/multisites_configure_multisite).
 
-![Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/multisite/add-domain-or-subdomain.png){.thumbnail}
-
-### 5. Instalar el proyecto en el hosting Cloud Web
+### 5 - Instalar el proyecto en el hosting Cloud Web
 
 Existen dos formas de instalar un proyecto. Si quiere instalar más de uno, deberá repetir los pasos correspondientes al procedimiento elegido para cada proyecto.
 
-#### 5.1. Utilizar los módulos en un clic
+#### 1. Utilizar los módulos en un clic
 
 Los módulos en un clic permiten tener la estructura de un sitio web lista para usar, que podrá personalizar a su gusto (diseño, contenido, etc.). OVHcloud ofrece cuatro módulos en un clic, que puede consultar en la página [Crear un sitio web con los CMS más populares](/links/web/hosting-website).
 
-Si elige esta opción, una vez seleccionado el alojamiento Cloud Web en el área de cliente de OVHcloud, abra la pestaña `Módulos en un clic`{.action} y seleccione `Añadir un módulo`{.action}. A continuación podrá comenzar la instalación en modo estándar (no personalizable) o avanzado (que permite personalizar determinados elementos).
+Si elige esta opción, haga clic en las pestañas siguientes para visualizar cada una de las **3** etapas.
 
-Si desea más información sobre los módulos en un clic de OVHcloud, consulte la guía [Instalar un sitio web con un módulo en un clic](/pages/web_cloud/web_hosting/cms_install_1_click_modules)
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento Cloud Web correspondiente.
+>>
+>> ![Alojamientos web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Haga clic en la pestaña `Módulos en un clic`{.action} y seleccione `Añadir un módulo`{.action}.
+>>
+> **Etapa 3**
+>>
+>> A continuación podrá comenzar la instalación en modo estándar (no personalizable) o avanzado (que permite personalizar determinados elementos).
+
+Si desea más información sobre los módulos en un clic de OVHcloud, consulte la guía [Instalar un sitio web con un módulo en un clic](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 
 > [!primary]
 >
 > Para utilizar los módulos, es necesario utilizar el motor de ejecución PHP.
->
 
-![Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/1-click-modules/add-a-module.png){.thumbnail}
+#### 2. Instalar el proyecto manualmente
 
-#### 5.2. Instalar el proyecto manualmente
-
-La instalación manual, tanto para un nuevo sitio web como para migrar uno existente, es más técnica y requiere ciertos conocimientos. Le recomendamos que, si necesita ayuda, contacte con un proveedor de servicios especializado o con el editor del servicio. 
+La instalación manual, tanto para un nuevo sitio web como para migrar uno existente, es más técnica y requiere ciertos conocimientos. Le recomendamos que, si necesita ayuda, contacte con un [proveedor de servicios especializado](/links/partner) o con el editor del servicio.
 
 Si opta por realizar la instalación manual, deberá tener en su poder los archivos del sitio web o aplicación que quiera instalar, así como las claves de la base de datos, en su caso, que deberá haber creado previamente en su hosting Cloud Web. Si se trata de la migración de un sitio web, deberá disponer de una copia completa del mismo.
 
 Aunque no existe un procedimiento universal, ya que cada proyecto es distinto, nuestras guías [Publicar un sitio web en internet](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) y [Migrar un sitio web y el correo a OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh) pueden ayudarle a realizar las operaciones necesarias.
 
-### 6. Modificar la configuración del dominio
+### 6 - Modificar la configuración del dominio
 
 En este punto, ya habrá instalado su proyecto en su hosting Cloud Web y habrá creado sus direcciones de correo. Si dichas direcciones no funcionan, es posible que la configuración del dominio no sea correcta. En ese caso, o si no está seguro, le recomendamos que lea con atención la siguiente información.
 
 Si está migrando sus servicios a OVHcloud, tenga en cuenta que las operaciones relacionadas con los DNS, si no se realizan en el momento adecuado, pueden provocar que los servicios dejen de estar disponibles. Tal como se indica en la guía [Migrar un sitio web y el correo a OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh), deberá modificar los servidores DNS del dominio al final del proceso.
 
-#### 6.1. Conocer los registros de la zona DNS de OVHcloud 
+#### 1. Conocer los registros de la zona DNS de OVHcloud
 
 Existen varios registros DNS específicos de OVHcloud. A continuación explicamos dos de ellos, que permiten que sea posible acceder a su sitio web y recibir mensajes en las direcciones de correo electrónico de OVHcloud. En la siguiente tabla se indica dónde puede consultarlos:
 
 |Registro DNS|Servicio asociado|Dónde consultarlo|
 |---|---|---|
-|A|El sitio web|En el [área de cliente de OVHcloud](/links/manager), haga clic en `Alojamientos`{.action} en la columna izquierda y seleccione el hosting Cloud Web. A continuación, en la pestaña `Información general`{.action}, consulte la dirección IP que aparece en el apartado **IPv4**.|
-|MX|El correo electrónico |En el [área de cliente de OVHcloud](/links/manager), haga clic en `Correo electrónico`{.action} y seleccione el dominio correspondiente. A continuación, en la pestaña `Información general`{.action}, consulte la información que aparece en el apartado **Registros MX**.|
+|A|El sitio web|Consulte nuestra guía [Alojamiento web: lista de direcciones IP por cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|
+|MX|El correo electrónico|Consulte nuestra guía [Añadir un registro MX a la configuración del dominio](/pages/web_cloud/domains/dns_zone_mx).|
 
-#### 6.2. Comprobar y/o modificar los registros DNS
+#### 2. Comprobar y/o modificar los registros DNS
 
 Una vez que conozca los registros DNS específicos de su hosting Cloud Web y su servicio de correo en OVHcloud, compruebe que estos están bien configurados y, si no lo están, corríjalos. Estas operaciones siempre deben realizarse en el proveedor que gestione la configuración DNS (la zona DNS) de su dominio.
 
 > [!warning]
 >
 > - Si el dominio no utiliza la configuración DNS de OVHcloud, deberá realizar los cambios necesarios desde el panel que le ofrezca el proveedor que gestione dicha configuración.
-> 
-> - Si el dominio está registrado con OVHcloud, compruebe que utiliza nuestra configuración DNS. Para ello, en el [área de cliente de OVHcloud](/links/manager), seleccione el dominio en la columna izquierda y abra la pestaña `Servidores DNS`{.action}.
+>
+> - Si el dominio está registrado con OVHcloud, compruebe que utiliza nuestra configuración DNS. Para ello, consulte nuestra guía [Cambiar los servidores DNS de un dominio en OVHcloud](/pages/web_cloud/domains/dns_server_edit).
 >
 
 A continuación se indica dónde realizar las operaciones correspondientes:
 
 |Configuración DNS utilizada|Dónde realizar las operaciones|
 |---|---|
-|OVHcloud|Desde su [área de cliente de OVHcloud](/links/manager), acceda a la sección `Web Cloud`{.action}. Haga clic en el menú `Zonas DNS`{.action} y seleccione el dominio correspondiente. Consulte nuestra documentación "[Editar una zona DNS de OVHcloud](/pages/web_cloud/domains/dns_zone_edit)" si es necesario.|
+|OVHcloud|Acceda a la página [Zonas DNS](/links/control-panel/web-dns-zone) y seleccione el dominio correspondiente. Consulte nuestra documentación "[Editar una zona DNS de OVHcloud](/pages/web_cloud/domains/dns_zone_edit)" si es necesario.|
 |Otros|Utilice el panel que le ofrezca el proveedor que gestione la configuración DNS de su dominio. Contacte con este último si tiene dificultades para realizar las operaciones.|
 
-Una vez que haya editado la configuración DNS del dominio, los cambios tardarán un máximo de 24 horas en propagarse y ser efectivos. Si ha añadido varios dominios a su hosting Cloud Web como multisitio, deberá realizar las dos operaciones anteriores para cada uno de ellos. 
+Una vez que haya editado la configuración DNS del dominio, los cambios tardarán un máximo de 24 horas en propagarse y ser efectivos. Si ha añadido varios dominios a su hosting Cloud Web como multisitio, deberá realizar las dos operaciones anteriores para cada uno de ellos.
 
-### 7. Personalizar el sitio web
+### 7 - Personalizar el sitio web
 
 Puede omitir este paso si ha migrado un sitio web existente y que, por tanto, ya está personalizado. Sin embargo, si acaba de instalar un nuevo sitio web mediante nuestros módulos, por ejemplo, puede personalizarlo cambiando el tema y publicando contenido.
 
 Para más información sobre las distintas funcionalidades de su nuevo sitio web, consulte la documentación oficial del CMS correspondiente.
 
-### 8. Utilizar las direcciones de correo
+### 8 - Utilizar las direcciones de correo
 
 Para utilizar sus direcciones de correo electrónico, OVHcloud pone a su disposición un cliente de correo web (webmail): Roundcube. Puede conectarse desde <https://www.ovh.es/mail/>, donde deberá introducir la contraseña de la dirección de correo electrónico creada con OVHcloud.
 

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.fr-fr.md
@@ -59,7 +59,7 @@ Pour accéder aux moteurs d'exécution de votre hébergement [Cloud Web](/links/
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement Cloud Web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -80,11 +80,11 @@ Pour vérifier que vous disposez bien de 2 vCores avec votre hébergement Cloud 
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement Cloud Web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
->> Dans l'encadré **Abonnement** et sous la mention `Offre`, vérifiez que la référence `Cloud Web 3`{.action} y est indiquée.
+>> Dans l'encadré **Abonnement** et sous la mention `Offre`, vérifiez que la référence `Cloud Web 3` y est indiquée.
 
 ### 3 - Créer des variables d'environnement (facultatif)
 
@@ -99,7 +99,7 @@ Pour ajouter une variable d'environnement, cliquez sur les onglets ci-dessous po
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement Cloud Web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -109,7 +109,7 @@ Pour ajouter une variable d'environnement, cliquez sur les onglets ci-dessous po
 >>
 >> Pour en ajouter une nouvelle, cliquez sur le bouton `Actions`{.action}, puis sur `Ajouter une variable d'environnement`{.action}. Suivez alors les indications en fonction de la variable que vous souhaitez créer.
 >>
->> ![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
+>> ![Ajout d'une variable d'environnement sur un hébergement Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
 
 Si vous n’utilisez pas de framework de développement intégrant les variables d’environnement ou si vous souhaitez simplement vérifier le bon fonctionnement de vos variables, vous pouvez créer un script qui effectuera cette vérification. Vous trouverez, ci-dessous, deux exemples pouvant vous aider dans votre démarche, mais ils ne se substituent pas à l’aide d’un webmaster.
 
@@ -144,7 +144,7 @@ Maintenant que l’environnement technique de votre hébergement Cloud Web est p
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l’hébergement Cloud Web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -156,9 +156,9 @@ Maintenant que l’environnement technique de votre hébergement Cloud Web est p
 >>
 >> Soyez vigilant lors de la complétion des informations suivantes :
 >>
->> - **dossier racine** : il s’agit du répertoire où le nom de domaine renseigné devra être hébergé sur l’espace de stockage de votre hébergement Cloud Web ;
+>> - **dossier racine** : il s’agit du répertoire où le nom de domaine renseigné devra être hébergé sur l’espace de stockage de votre hébergement Cloud Web ;
 >>
->> - **Moteur d’exécution** : il s’agit du moteur d’exécution, préalablement paramétré, qui sera utilisé par le Multisite que vous êtes en train de configurer.
+>> - **Moteur d’exécution** : il s’agit du moteur d’exécution, préalablement paramétré, qui sera utilisé par le Multisite que vous êtes en train de configurer.
 >>
 >> > [!warning]
 >> >
@@ -181,7 +181,7 @@ Si votre choix se porte sur l'utilisation de nos modules en 1 clic, cliquez sur 
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement Cloud Web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -189,7 +189,7 @@ Si votre choix se porte sur l'utilisation de nos modules en 1 clic, cliquez sur 
 >>
 > **Étape 3**
 >>
->> Vous pourrez alors initier une installation en mode « simple » (non personnalisable) ou en mode « avancé » (possibilité de personnaliser certains éléments).
+>> Vous pouvez alors initier une installation en mode « simple » (non personnalisable) ou en mode « avancé » (possibilité de personnaliser certains éléments).
 
 Si vous désirez obtenir plus d'informations sur les modules en 1 clic OVHcloud, consultez notre documentation : [« Installer son site avec les modules en 1 clic »](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 
@@ -217,7 +217,7 @@ Il existe plusieurs enregistrements DNS inhérents à OVHcloud. Nous allons nous
 
 |Enregistrement DNS|Service associé|Où le récupérer ?|
 |---|---|---|
-|A|Pour le site internet|Récupérez l'adresse IP de votre hébergement Cloud Web en consultant [ce guide](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|
+|A|Pour le site internet|Récupérez l'adresse IP de votre hébergement Cloud Web en consultant notre guide « [Hébergement web - Liste des adresses IP par cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP) ».|
 |MX|Pour les e-mails|Récupérez les informations MX en consultant notre guide « [Ajouter un champ MX à la configuration de son nom de domaine](/pages/web_cloud/domains/dns_zone_mx) ».|
 
 #### 2. Vérifier et/ou modifier les enregistrement DNS

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Premiers pas avec un hébergement Cloud Web"
 excerpt: "Découvrez comment bien débuter avec un hébergement Cloud Web"
-updated: 2025-05-22
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -29,7 +29,7 @@ Notre offre d’hébergement Cloud Web allie nos vingt ans d’expérience dans 
 
 ## En pratique
 
-### Étape 1 : définir votre projet
+### 1 - Définir votre projet
 
 L'hébergement Cloud Web offre davantage de possibilités de configuration qu'un hébergement web classique. Avant de débuter votre projet, nous vous conseillons de :
 
@@ -41,7 +41,7 @@ L'hébergement Cloud Web offre davantage de possibilités de configuration qu'un
 
 Après avoir évalué les différentes possibilités et délimité avec précision votre projet, vous pouvez à présent mettre en place votre projet.
 
-### Étape 2 : choisir le moteur d'exécution
+### 2 - Choisir le moteur d'exécution
 
 L'offre Cloud Web met à votre disposition de multiples langages de développement pour construire votre projet. Si vous souhaitez utiliser un autre langage que PHP, qui est le choix par défaut, vous devrez sélectionner un « moteur d’exécution » correspondant à votre langage.
 
@@ -52,27 +52,64 @@ Les langages actuellement disponibles sont :
 - Python
 - Ruby
 
-Pour accéder aux moteurs d'exécution de votre hébergement [Cloud Web](/links/web/hosting-cloud-web-offer), connectez-vous à votre [espace client OVHcloud](/links/manager). Cliquez sur `Web Cloud`{.action} dans la barre de services à gauche, puis sur `Hébergements`{.action}. Choisissez le nom de l'hébergement Cloud Web concerné et positionnez-vous sur l'onglet `Moteurs d'exécution`{.action}.
+Pour accéder aux moteurs d'exécution de votre hébergement [Cloud Web](/links/web/hosting-cloud-web-offer), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-Un moteur est automatiquement créé lors de l'installation de votre hébergement. Il est renseigné comme `Choix par défaut` dans le tableau qui s'affiche. Pour modifier un moteur déjà paramétré, cliquez sur le bouton `...`{.action} à droite, puis sur `Modifier`{.action}. 
-
-Si vous disposez de l'offre [Cloud Web](/links/web/hosting-cloud-web-offer) avec 2 vCores, vous pouvez ajouter un second moteur d'exécution à votre offre (maximum 2 moteurs d'exécution différents par offre) en cliquant sur le bouton `Actions`{.action}, puis sur `Ajouter un moteur d'exécution`{.action}.
-
-Pour vérifier que vous disposez bien de 2 vCores avec votre hébergement Cloud Web, connectez-vous à votre [espace client OVHcloud](/links/manager), cliquez sur `Hébergements`{.action} dans la barre de services à gauche, puis choisissez le nom de l'hébergement Cloud Web concerné. Sur la page qui s'affiche, dans l'encadré **Abonnement** et sous la mention `Offre`, vérifiez que la référence `Cloud Web 3`{.action} y est indiquée.
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement Cloud Web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Moteurs d'exécution`{.action}. Un moteur est automatiquement créé lors de l'installation de votre hébergement. Il est renseigné comme `Choix par défaut` dans le tableau qui s'affiche.
+>>
+>> Pour modifier un moteur déjà paramétré, cliquez sur le bouton `...`{.action} à droite, puis sur `Modifier`{.action}.
+>>
+> **Étape 3**
+>>
+>> Si vous disposez de l'offre [Cloud Web](/links/web/hosting-cloud-web-offer) avec 2 vCores, vous pouvez ajouter un second moteur d'exécution (maximum 2 par offre) en cliquant sur le bouton `Actions`{.action}, puis sur `Ajouter un moteur d'exécution`{.action}.
 
 Dès lors, assurez-vous de disposer du ou des moteurs d'exécution nécessaires à votre projet avant de poursuivre.
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/runtime-software-application/edit-runtime.png){.thumbnail}
+Pour vérifier que vous disposez bien de 2 vCores avec votre hébergement Cloud Web, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
-### Étape 3 : créer des variables d'environnement (facultatif)
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement Cloud Web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'encadré **Abonnement** et sous la mention `Offre`, vérifiez que la référence `Cloud Web 3`{.action} y est indiquée.
+
+### 3 - Créer des variables d'environnement (facultatif)
 
 Lorsque vous souhaitez déployer plusieurs fois votre projet dans des environnements différents (par exemple : développement, test ou production), vous devez fournir des variables afin que votre code réagisse en conséquence. Pour cela, Cloud Web propose la définition de variables d’environnement accessibles par le code de votre site ou de votre application web.
 
 Par exemple, cela permet de ne pas définir de fichier « .env » dans le framework, comme sur PHP Laravel : <https://laravel.com/docs/master/configuration>.
 
-Pour ajouter une variable d'environnement, cliquez sur l'onglet `Variables d'environnement`{.action}. Un tableau affiche les variables d'environnement créées sur votre offre. Pour en ajouter une nouvelle, cliquez sur le bouton `Actions`{.action}, puis sur `Ajouter une variable d'environnement`{.action}. Suivez alors les indications en fonction de la variable que vous souhaitez créer.
+Pour ajouter une variable d'environnement, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement Cloud Web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Variables d'environnement`{.action}. Un tableau affiche les variables d'environnement créées sur votre offre.
+>>
+> **Étape 3**
+>>
+>> Pour en ajouter une nouvelle, cliquez sur le bouton `Actions`{.action}, puis sur `Ajouter une variable d'environnement`{.action}. Suivez alors les indications en fonction de la variable que vous souhaitez créer.
+>>
+>> ![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
 
 Si vous n’utilisez pas de framework de développement intégrant les variables d’environnement ou si vous souhaitez simplement vérifier le bon fonctionnement de vos variables, vous pouvez créer un script qui effectuera cette vérification. Vous trouverez, ci-dessous, deux exemples pouvant vous aider dans votre démarche, mais ils ne se substituent pas à l’aide d’un webmaster.
 
@@ -98,28 +135,38 @@ http.createServer(function(request, response) {
 
 Prenez soin de remplacer l'information générique présente dans ces scripts « DB_DATABASE » par la variable d'environnement concernée.
 
-### Étape 4 : configurer des domaines additionnels en tant que Multisite (facultatif)
+### 4 - Configurer des domaines additionnels en tant que Multisite (facultatif)
 
-Maintenant que l'environnement technique de votre hébergement Cloud Web est prêt, vous pouvez configurer des noms de domaine additionnels à celui-ci en tant que Multisite. Ceci vous permet de partager votre espace afin d'y héberger plusieurs sites internet par exemple. Si cela correspond à votre projet, toujours positionné sur l'hébergement Cloud Web concerné, cliquez sur l'onglet `Multisite`{.action}.
+Maintenant que l’environnement technique de votre hébergement Cloud Web est prêt, vous pouvez configurer des noms de domaine additionnels à celui-ci en tant que Multisite. Ceci vous permet de partager votre espace afin d’y héberger plusieurs sites internet par exemple. Si cela correspond à votre projet, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-Le tableau qui s’affiche contient les noms de domaine ajoutés à votre hébergement. Certains d’entre eux ont été créés automatiquement lors de l’installation de votre hébergement. Pour en ajouter un nouveau, cliquez sur le bouton `Ajouter un domaine ou sous-domaine`{.action} et suivez les indications qui apparaissent. La manipulation peut être différente si le nom de domaine concerné est enregistré chez OVHcloud ou non. 
-
-Nous vous invitons à être vigilant lors de la complétion des informations suivantes :
-
-- **dossier racine** : il s'agit du répertoire où le nom de domaine renseigné devra être hébergé sur l'espace de stockage de votre hébergement Cloud Web ; 
-
-- **Moteur d'exécution** : il s'agit du moteur d'exécution, préalablement paramétré, qui sera utilisé par le Multisite que vous êtes en train de configurer.
-
-> [!warning]
->
-> Si vous avez ajouté un nom de domaine considéré comme externe, vous devrez paramétrer un champ TXT appelé **ovhcontrol** à sa configuration DNS. Il permet à OVHcloud de s'assurer que l'ajout est légitime. Il s'avère donc indispensable et s'il n’est pas réalisé, l’ajout sera annulé. 
->
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l’hébergement Cloud Web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l’onglet `Multisite`{.action}. Le tableau qui s’affiche contient les noms de domaine ajoutés à votre hébergement. Certains d’entre eux ont été créés automatiquement lors de l’installation de votre hébergement.
+>>
+>> Pour en ajouter un nouveau, cliquez sur le bouton `Ajouter un domaine ou sous-domaine`{.action} et suivez les indications qui apparaissent. La manipulation peut être différente si le nom de domaine concerné est enregistré chez OVHcloud ou non.
+>>
+> **Étape 3**
+>>
+>> Soyez vigilant lors de la complétion des informations suivantes :
+>>
+>> - **dossier racine** : il s’agit du répertoire où le nom de domaine renseigné devra être hébergé sur l’espace de stockage de votre hébergement Cloud Web ;
+>>
+>> - **Moteur d’exécution** : il s’agit du moteur d’exécution, préalablement paramétré, qui sera utilisé par le Multisite que vous êtes en train de configurer.
+>>
+>> > [!warning]
+>> >
+>> > Si vous avez ajouté un nom de domaine considéré comme externe, vous devrez paramétrer un champ TXT appelé **ovhcontrol** à sa configuration DNS. Il permet à OVHcloud de s’assurer que l’ajout est légitime. Il s’avère donc indispensable et s’il n’est pas réalisé, l’ajout sera annulé.
 
 Répétez cette manipulation si vous souhaitez ajouter plusieurs noms de domaine à votre hébergement Cloud Web. Pour obtenir plus d'informations sur l'ajout d'un nom de domaine en tant que Multisite, consultez notre documentation : [« Partager son hébergement entre plusieurs sites »](/pages/web_cloud/web_hosting/multisites_configure_multisite).
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/multisite/add-domain-or-subdomain.png){.thumbnail}
-
-### Étape 5 : installer votre projet sur l'hébergement Cloud Web
+### 5 - Installer votre projet sur l'hébergement Cloud Web
 
 Deux démarches sont possibles pour réaliser l'installation de votre projet. Répétez les éléments de la démarche la plus adéquate si vous souhaitez en mettre en ligne plusieurs.
 
@@ -127,16 +174,28 @@ Deux démarches sont possibles pour réaliser l'installation de votre projet. R�
 
 Cette solution vous permet de bénéficier d’une structure de site prête à l’emploi à personnaliser (thème, textes, etc.). OVHcloud en propose quatre avec ses modules en 1 clic à découvrir sur la page [« Créer un site internet avec les modules en 1 clic »](/links/web/hosting-website).
 
-Si votre choix se porte sur l'utilisation de nos modules en 1 clic, toujours positionné sur l'hébergement Cloud Web concerné, cliquez sur l'onglet `Modules en 1 clic`{.action}, puis sur `Ajouter un module`{.action}. Vous pourrez alors initier une installation en mode « simple » (non personnalisable) ou en mode « avancé » (possibilité de personnaliser certains éléments).
+Si votre choix se porte sur l'utilisation de nos modules en 1 clic, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement Cloud Web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Cliquez sur l'onglet `Modules en 1 clic`{.action}, puis sur `Ajouter un module`{.action}.
+>>
+> **Étape 3**
+>>
+>> Vous pourrez alors initier une installation en mode « simple » (non personnalisable) ou en mode « avancé » (possibilité de personnaliser certains éléments).
 
 Si vous désirez obtenir plus d'informations sur les modules en 1 clic OVHcloud, consultez notre documentation : [« Installer son site avec les modules en 1 clic »](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 
 > [!primary]
 >
 > Pour utiliser ces derniers, vous devez impérativement utiliser le moteur d'exécution PHP.
->
-
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/1-click-modules/add-a-module.png){.thumbnail}
 
 #### 2. Installer manuellement votre projet
 
@@ -146,7 +205,7 @@ Si votre choix se porte sur l'installation manuelle, vous devrez être en posses
 
 Il n'existe pas de marche à suivre universelle tant les projets peuvent être différents les uns des autres, mais nos documentations [« Mettre mon site en ligne »](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) et [« Migrer mon site chez OVHcloud »](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh) peuvent vous aider concernant les manipulations à réaliser.
 
-### Étape 6 : modifier la configuration du nom de domaine
+### 6 - Modifier la configuration du nom de domaine
 
 À cette étape, votre projet doit être installé sur votre hébergement Cloud Web et vos adresses e-mail créées. Si ceux-ci ne sont pas encore fonctionnels, il se peut que la configuration de votre nom de domaine ne soit pas correcte. Si tel est le cas, ou si vous n’êtes pas sûr de vous, nous vous recommandons de poursuivre l’étape actuelle.
 
@@ -158,8 +217,8 @@ Il existe plusieurs enregistrements DNS inhérents à OVHcloud. Nous allons nous
 
 |Enregistrement DNS|Service associé|Où le récupérer ?|
 |---|---|---|
-|A|Pour le site internet|Dans votre [espace client OVHcloud](/links/manager), positionné dans la section `Hébergements`{.action} sur l'hébergement Cloud Web concerné. Récupérez l'adresse IP qui apparaît à côté de « IPv4 » depuis l'onglet `Informations générales`{.action}.|
-|MX|Pour les e-mails|Dans votre [espace client OVHcloud](/links/manager), positionné dans la section `Emails`{.action} sur le nom de domaine concerné. Récupérez les informations qui apparaissent à côté de « Champs MX » depuis l'onglet `Informations générales`{.action}.|
+|A|Pour le site internet|Récupérez l'adresse IP de votre hébergement Cloud Web en consultant [ce guide](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|
+|MX|Pour les e-mails|Récupérez les informations MX en consultant notre guide « [Ajouter un champ MX à la configuration de son nom de domaine](/pages/web_cloud/domains/dns_zone_mx) ».|
 
 #### 2. Vérifier et/ou modifier les enregistrement DNS
 
@@ -169,25 +228,25 @@ Maintenant que vous connaissez les enregistrements DNS inhérents à votre hébe
 >
 > - Si votre nom de domaine n'utilise pas la configuration DNS OVHcloud, vous devez réaliser la modification depuis l'interface du prestataire gérant cette dernière.
 > 
-> - Si votre nom de domaine est enregistré chez OVHcloud, vous pouvez vérifier si ce dernier utilise notre configuration DNS. Pour cela, rendez-vous dans votre [espace client](/links/manager), onglet `Serveurs DNS`{.action} une fois positionné sur le nom de domaine concerné.
+> - Si votre nom de domaine est enregistré chez OVHcloud, vous pouvez vérifier si ce dernier utilise notre configuration DNS. Pour cela, consultez notre guide « [Modifier les serveurs DNS d'un nom de domaine OVHcloud](/pages/web_cloud/domains/dns_server_edit) ».
 >
 
 Reportez-vous aux indications ci-dessous pour savoir où effectuer les manipulations :
 
 |Configuration DNS utilisée|Où réaliser les manipulations ?|
 |---|---|
-|OVHcloud|Depuis votre [espace client OVHcloud](/links/manager), rendez-vous dans la partie `Web Cloud`{.action}. Cliquez sur le menu `Zones DNS`{.action}, puis choisissez le nom de domaine concerné. Consultez notre documentation «[Éditer une zone DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit)» si nécessaire.|
+|OVHcloud|Accédez à la page [Zones DNS](/links/control-panel/web-dns-zone), puis choisissez le nom de domaine concerné. Consultez notre documentation « [Éditer une zone DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit) » si nécessaire.|
 |Autre|Depuis l'interface du prestataire gérant la configuration DNS de votre nom de domaine. Nous vous invitons à prendre contact avec ce dernier si vous éprouvez des difficultés pour réaliser les manipulations.|
 
 Une fois la configuration DNS de votre nom de domaine modifiée, un temps de propagation de 24 heures maximum est nécessaire afin que les modifications soient effectives. Si vous avez ajouté plusieurs noms de domaine à votre hébergement Cloud Web en tant que Multisite, vous devrez réaliser ces deux manipulations pour chacun d'entre eux. 
 
-### Étape 7 : personnaliser votre site
+### 7 - Personnaliser votre site
 
 Cette étape peut être facultative si vous avez migré un site déjà existant et personnalisé ! Cependant, dans le cas où vous venez d'installer un nouveau site internet via nos modules par exemple, vous pouvez le personnaliser en modifiant le thème et en y publiant vos premiers contenus.
 
 Si vous désirez obtenir de l’aide concernant les fonctionnalités de votre site, nous vous invitons à vous rapprocher du site de l’éditeur de ce dernier où vous trouverez de la documentation pour vous accompagner.
 
-### Étape 8 : utiliser vos adresses e-mail
+### 8 - Utiliser vos adresses e-mail
 
 Il ne reste plus qu'à utiliser vos adresses e-mail. Pour cela, OVHcloud met à votre disposition un applicatif en ligne (webmail) : Roundcube. Ce dernier est accessible à l'adresse <https://www.ovh.com/fr/mail/> où vous devrez y renseigner les identifiants relatifs à votre adresse e-mail créée chez OVHcloud.
 

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Premiers pas avec un hébergement Cloud Web"
 excerpt: "Découvrez comment bien débuter avec un hébergement Cloud Web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Iniziare a utilizzare un hosting Cloud Web"
 excerpt: "Questa guida ti mostra come eseguire le prime operazioni su un Cloud Web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Obiettivo

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Iniziare a utilizzare un hosting Cloud Web"
 excerpt: "Questa guida ti mostra come eseguire le prime operazioni su un Cloud Web"
-updated: 2025-05-22
+updated: 2026-03-26
 ---
 
 ## Obiettivo
@@ -14,14 +14,14 @@ La nuova soluzione di hosting Cloud Web combina i nostri 20 anni di esperienza n
 
 - Disporre di un piano di hosting [Cloud Web](/links/web/hosting-cloud-web-offer) attivo
 - Aver ricevuto l'email di conferma dell'installazione del tuo hosting Cloud Web
-- Disporre di un [dominio](/links/web/domains) attivo, che corrisponderà all’indirizzo del tuo sito
+- Disporre di un [dominio](/links/web/domains) attivo, che corrisponderà all'indirizzo del tuo sito
 
 <!-- CP-NAV-START:web-hosting -->
 ---
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -29,21 +29,21 @@ La nuova soluzione di hosting Cloud Web combina i nostri 20 anni di esperienza n
 
 ## Procedura
 
-### Step 1: definisci il tuo progetto
+### 1 - Definisci il tuo progetto
 
-Al fine di adattarsi al meglio alle tue esigenze, il Cloud Web offre più opzioni di configurazione rispetto a un classico hosting Web. Pertanto, per poter realizzare al meglio il tuo progetto, è importante avere una visione chiara dell’obiettivo da raggiungere. Per questo il nostro consiglio è di:
+Al fine di adattarsi al meglio alle tue esigenze, il Cloud Web offre più opzioni di configurazione rispetto a un classico hosting Web. Pertanto, per poter realizzare al meglio il tuo progetto, è importante avere una visione chiara dell'obiettivo da raggiungere. Per questo il nostro consiglio è di:
 
-- **definire cosa si vuoi installare**: creare un blog o un e-commerce? Condividere una passione o promuovere un’attività professionale online? Stabilisci in modo chiaro il tuo progetto prima di cominciare;
+- **definire cosa vuoi installare**: creare un blog o un e-commerce? Condividere una passione o promuovere un'attività professionale online? Stabilisci in modo chiaro il tuo progetto prima di cominciare;
 
-- **recuperare i prerequisiti tecnici per l’installazione**: è possibile che il progetto che hai in mente necessiti di prerequisiti particolari, pertanto assicurati di esserne a conoscenza;
+- **recuperare i prerequisiti tecnici per l'installazione**: è possibile che il progetto che hai in mente necessiti di prerequisiti particolari, pertanto assicurati di esserne a conoscenza;
 
-- **verificare la compatibilità tecnica del tuo progetto con il Cloud Web**: hai bisogno di un programma d’esecuzione o di un database in particolare? Se non l’hai ancora fatto, accertati che sia disponibile con la tua soluzione di hosting [Cloud Web](/links/web/hosting-cloud-web-offer).
+- **verificare la compatibilità tecnica del tuo progetto con il Cloud Web**: hai bisogno di un programma d'esecuzione o di un database in particolare? Se non l'hai ancora fatto, accertati che sia disponibile con la tua soluzione di hosting [Cloud Web](/links/web/hosting-cloud-web-offer).
 
 Dopo aver valutato le diverse possibilità tra cui scegliere, puoi iniziare a metterlo online.
 
-### Step 2: scegli il programma d’esecuzione
+### 2 - Scegli il programma d'esecuzione
 
-Cloud Web mette a tua disposizione diversi linguaggi di programmazione per consentirti di costruire il tuo progetto. Se vuoi utilizzare un linguaggio di programmazione diverso da PHP (opzione predefinita), è necessario selezionare un “programma d’esecuzione” corrispondente al tuo linguaggio.
+Cloud Web mette a tua disposizione diversi linguaggi di programmazione per consentirti di costruire il tuo progetto. Se vuoi utilizzare un linguaggio di programmazione diverso da PHP (opzione predefinita), è necessario selezionare un "programma d'esecuzione" corrispondente al tuo linguaggio.
 
 I linguaggi di programmazione disponibili sono:
 
@@ -52,29 +52,66 @@ I linguaggi di programmazione disponibili sono:
 - Python
 - Ruby
 
-Per accedere al programma d’esecuzione del tuo hosting [Cloud Web](/links/web/hosting-cloud-web-offer), effettua l’accesso allo [Spazio Cliente OVHcloud](/links/manager). Clicca su `Web Cloud`{.action} nel menu a sinistra e poi su `Hosting`{.action}. Seleziona il nome dell’hosting Cloud Web interessato e seleziona la scheda `Programma d’esecuzione`{.action}.
+Per accedere ai programmi d'esecuzione del tuo hosting [Cloud Web](/links/web/hosting-cloud-web-offer), clicca sulle schede seguenti per visualizzare ciascuno dei **3** passaggi.
 
-Nel momento in cui installi il tuo hosting, un programma viene utilizzato automaticamente e inserito come `Opzione predefinita`. Per modificare il programma d’esecuzione già configurato, clicca sui 3 puntini a destra, poi su `Modificare`{.action}. 
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Cloud Web interessato.
+>>
+>> ![Hosting web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `Programma d'esecuzione`{.action}. Nel momento in cui installi il tuo hosting, un programma viene utilizzato automaticamente e inserito come `Opzione predefinita`.
+>>
+>> Per modificare il programma d'esecuzione già configurato, clicca sul pulsante `...`{.action} a destra, poi su `Modificare`{.action}.
+>>
+> **Passaggio 3**
+>>
+>> Se disponi dell'offerta [Cloud Web](/links/web/hosting-cloud-web-offer) con 2 vCore, puoi aggiungere un secondo programma d'esecuzione (massimo 2 per offerta) cliccando sul pulsante `Azioni`{.action} e poi su `Aggiungi un programma d'esecuzione`{.action}.
 
-Se disponi dell’offerta [Cloud Web](/links/web/hosting-cloud-web-offer) con 2 vCore, puoi aggiungere un secondo programma d’esecuzione alla tua offerta (massimo 2 programmi d’esecuzione diversi per offerta) cliccando sul pulsante `Azioni`{.action} e poi su `Aggiungi un programma d’esecuzione`{.action}
+Da questo momento, prima di proseguire, assicurati di disporre del programma o più programmi d'esecuzione necessari al tuo progetto.
 
-Per verificare di disporre di 2 vCore con il tuo hosting Cloud Web, accedi allo [Spazio Cliente OVHcloud](/links/manager), clicca su `Hosting`{.action} nella barra dei servizi a sinistra, poi seleziona il nome dell’hosting Cloud Web in questione. Nella nuova pagina, nel riquadro **Abbonamento** e sotto la voce `Piano`, verifica che il nome `Cloud Web 3`{.action} sia indicato.
+Per verificare di disporre di 2 vCore con il tuo hosting Cloud Web, clicca sulle schede seguenti per visualizzare ciascuno dei **2** passaggi.
 
-Da questo momento, prima di proseguire, assicurati di disporre del programma o più programmi d’esecuzione necessari al tuo progetto.
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Cloud Web interessato.
+>>
+>> ![Hosting web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Nel riquadro **Abbonamento** e sotto la voce `Piano`, verifica che il nome `Cloud Web 3` sia indicato.
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/runtime-software-application/edit-runtime.png){.thumbnail}
+### 3 - Crea alcune variabili d'ambiente (facoltativo)
 
-### Step 3: crea alcune variabili d’ambiente (facoltativo)
+Se hai intenzione di distribuire il tuo progetto più volte in ambienti diversi (ad es. sviluppo, test, produzione, ecc.), è necessario fornire delle variabili in modo che il tuo codice risponda di conseguenza. Per questo, Cloud Web propone la definizione delle variabili d'ambiente accessibili al codice del tuo sito o della tua applicazione Web.
 
-Se hai intenzione di distribuire il tuo progetto più volte in ambienti diversi (ad es. sviluppo, test, produzione, ecc.), è necessario fornire delle variabili in modo che il tuo codice risponda di conseguenza. Per questo, Cloud Web propone la definizione delle variabili d’ambiente accessibili al codice del tuo sito o della tua applicazione Web.
+Per esempio, questo consente di non definire file ".env" nel framework PHP Laravel come indicato nella documentazione del framework: <https://laravel.com/docs/master/configuration>.
 
-Per esempio, questo consente di non definire file “.env” nel framework PHP Laravel come indicato nella documentazione del framework: <https://laravel.com/docs/5.6/configuration>.
+Per aggiungere una variabile d'ambiente, clicca sulle schede seguenti per visualizzare ciascuno dei **3** passaggi.
 
-Per aggiungere una variabile d’ambiente, clicca quindi sulla scheda `Variabili d'ambiente`{.action}. Apparirà una tabella con le variabili d’ambiente create sulla tua soluzione. Per aggiungerne una nuova, clicca sul pulsante `Azioni`{.action}, poi su `Aggiungi una variabile d'ambiente`{.action}. Segui dunque le indicazioni in base alla variabile che vuoi creare.
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Cloud Web interessato.
+>>
+>> ![Hosting web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `Variabili d'ambiente`{.action}. Apparirà una tabella con le variabili d'ambiente create sulla tua soluzione.
+>>
+> **Passaggio 3**
+>>
+>> Per aggiungerne una nuova, clicca sul pulsante `Azioni`{.action}, poi su `Aggiungi una variabile d'ambiente`{.action}. Segui dunque le indicazioni in base alla variabile che vuoi creare.
+>>
+>> ![Aggiunta di una variabile d'ambiente su un hosting Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
-
-Se non utilizzi framework di sviluppo che includono variabili d’ambiente o se semplicemente vuoi verificare il corretto funzionamento delle tue variabili, puoi creare uno script per effettuare queste funzioni. Di seguito trovi due esempi che possono esserti d’aiuto nel tuo percorso, ma non sostituiscono l’assistenza di un webmaster.
+Se non utilizzi framework di sviluppo che includono variabili d'ambiente o se semplicemente vuoi verificare il corretto funzionamento delle tue variabili, puoi creare uno script per effettuare queste funzioni. Di seguito trovi due esempi che possono esserti d'aiuto nel tuo percorso, ma non sostituiscono l'assistenza di un webmaster.
 
 - **Per PHP**:
 
@@ -87,121 +124,143 @@ Se non utilizzi framework di sviluppo che includono variabili d’ambiente o se 
 ```sh
 var http = require('http');
 
-http.createServer(function(request, response) {  
-    response.writeHeader(200, {"Content-Type": "text/html"});  
+http.createServer(function(request, response) {
+    response.writeHeader(200, {"Content-Type": "text/html"});
 
     response.write( process.env.DB_DATABASE);
 
-    response.end();  
+    response.end();
 }).listen(80);
 ```
 
-Ricorda di sostituire l’informazione generica presente in questi script “DB_DATABASE” con la tua variabile d’ambiente.
+Ricorda di sostituire l'informazione generica presente in questi script "DB_DATABASE" con la tua variabile d'ambiente.
 
-### Step 4: configura domini aggiuntivi come Multisito (facoltativo)
+### 4 - Configura domini aggiuntivi come Multisito (facoltativo)
 
-Adesso che l’ambiente tecnico del tuo hosting Cloud Web è pronto, puoi configurare domini aggiuntivi come Multisito. Questo ti permette di condividere il tuo spazio al fine di ospitare più siti Internet, ad esempio. Se questo è il tuo caso, sempre dopo aver cliccato sul tuo Cloud Web, clicca sulla scheda `Multisito`{.action}.
+Adesso che l'ambiente tecnico del tuo hosting Cloud Web è pronto, puoi configurare domini aggiuntivi come Multisito. Questo ti permette di condividere il tuo spazio al fine di ospitare più siti Internet. Se questo è il tuo caso, clicca sulle schede seguenti per visualizzare ciascuno dei **3** passaggi.
 
-La tabella che appare contiene quindi tutti domini che hai aggiunto al tuo hosting. Alcuni sono stati creati automaticamente durante l’installazione del tuo hosting. Per aggiungerne un altro, clicca su `Aggiungi un dominio o un sottodominio`{.action} e segui le indicazioni. L’operazione può essere diversa se il dominio è registrato con OVHcloud o meno. 
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Cloud Web interessato.
+>>
+>> ![Hosting web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `Multisito`{.action}. La tabella che appare contiene tutti i domini che hai aggiunto al tuo hosting. Alcuni sono stati creati automaticamente durante l'installazione del tuo hosting.
+>>
+>> Per aggiungerne un altro, clicca su `Aggiungi un dominio o un sottodominio`{.action} e segui le indicazioni. L'operazione può essere diversa se il dominio è registrato con OVHcloud o meno.
+>>
+> **Passaggio 3**
+>>
+>> Ti consigliamo di fare molta attenzione nell'inserire queste informazioni:
+>>
+>> - **Cartella di root**: la cartella in cui il sito inserito verrà ospitato sullo spazio di storage del tuo hosting Cloud Web.
+>>
+>> - **Programma d'esecuzione**: il programma d'esecuzione, preventivamente configurato, che verrà utilizzato dal Multisito che stai impostando.
+>>
+>> > [!warning]
+>> >
+>> > Se hai aggiunto un dominio esterno, è necessario configurare un record TXT denominato **ovhcontrol** sulla configurazione DNS. Questo consente a OVHcloud di assicurarsi che si tratti di un'operazione valida e pertanto, se non viene realizzata, l'aggiunta del dominio viene annullata.
 
-Ti consigliamo di fare molta attenzione nell’inserire queste informazioni:
+Ripeti questa operazione per ciascun dominio che vuoi aggiungere al tuo Cloud Web. Per ottenere maggiori informazioni sull'aggiunta di un dominio come Multisito, consulta la seguente guida: [Ospitare più siti su uno stesso hosting](/pages/web_cloud/web_hosting/multisites_configure_multisite).
 
-- **Cartella di root**: la cartella in cui il sito inserito verrà ospitato sullo spazio di storage del tuo hosting Cloud Web; 
+### 5 - Installa il tuo progetto sull'hosting Cloud Web
 
-- **Programma d'esecuzione**: il programma d’esecuzione, preventivamente configurato, che verrà utilizzato dal Multisito che stai impostando.
+Per realizzare l'installazione del tuo progetto ci sono due possibilità. Ripeti gli step del percorso più appropriato se vuoi mettere online più progetti.
 
-> [!warning]
->
-> Se hai aggiunto un dominio esterno, è necessario configurare un record TXT denominato **ovhcontrol** sulla configurazione DNS, Questo consente a OVHcloud di assicurarsi che si tratti di un’operazione valida e pertanto, se non viene realizzata, l’aggiunta del dominio viene annullata. 
->
+#### 1. Utilizza i nostri moduli in 1 click
 
-Ripeti questa operazione per ciascun dominio che vuoi aggiungere al tuo Cloud Web. Per ottenere maggiori informazioni sull’aggiunta di un dominio come Multisito, consulta la seguente guida (in inglese): [Ospitare più siti su uno stesso hosting](/pages/web_cloud/web_hosting/multisites_configure_multisite).
+Questa soluzione ti permette di usufruire di un CMS pronto all'uso e personalizzabile (tema, contenuti, ecc.). OVHcloud propone 4 moduli in 1 click che permettono di installare un CMS in modo semplice e veloce. Per saperne di più accedi alla pagina [Crea il tuo sito con i moduli in 1 click](/links/web/hosting-website).
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/multisite/add-domain-or-subdomain.png){.thumbnail}
+Se vuoi optare per l'utilizzo di uno dei nostri moduli, clicca sulle schede seguenti per visualizzare ciascuno dei **3** passaggi.
 
-### Step 5: installa il tuo progetto sull’hosting Cloud Web
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting), poi seleziona l'hosting Cloud Web interessato.
+>>
+>> ![Hosting web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Clicca sulla scheda `CMS in 1 click`{.action}, poi su `Aggiungi un modulo`{.action}.
+>>
+> **Passaggio 3**
+>>
+>> A questo punto puoi dare avvio a un'installazione in modalità "semplice" (non personalizzabile) o in modalità "avanzata" (possibilità di personalizzare alcuni elementi).
 
-Per realizzare l’installazione del tuo progetto ci sono due possibilità. Ripeti gli step del percorso più appropriato se vuoi mettere online più progetti.
-
-#### 5.1. Utilizza i nostri moduli in 1 click
-
-Questa soluzione ti permette di usufruire di un CMS pronto all’uso e personalizzabile (tema, contenuti, ecc.). OVHcloud propone 4 moduli in 1 click che permettono di installare un CMS in modo semplice e veloce. Per saperne di più accedi alla pagina [Crea il tuo sito con i moduli in 1 click](/links/web/hosting-website).
-
-Se vuoi optare per l’utilizzo di uno dei nostri moduli, sempre dopo aver selezionato il Cloud Web dallo Spazio Cliente, seleziona la scheda `CMS in 1 click`{.action}, poi su `Aggiungi un modulo`{.action}. A questo punto puoi dare avvio a un’installazione in modalità “semplice” (non personalizzabile) o in modalità “avanzata” (possibilità di personalizzare alcuni elementi).
-
-Per maggiori informazioni sui moduli in 1 click, consulta la nostra guida: [Installare i moduli in 1 click OVHcloud](/pages/web_cloud/web_hosting/cms_install_1_click_modules)
+Per maggiori informazioni sui moduli in 1 click, consulta la nostra guida: [Installare i moduli in 1 click OVHcloud](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 
 > [!primary]
 >
-> Se scegli i moduli in 1 click, è necessario utilizzare il programma d’esecuzione PHP.
->
+> Se scegli i moduli in 1 click, è necessario utilizzare il programma d'esecuzione PHP.
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/1-click-modules/add-a-module.png){.thumbnail}
+#### 2. Installa manualmente il tuo progetto
 
-#### 5.2. Installa manualmente il tuo progetto
+Che si tratti di un nuovo sito Internet o della migrazione di un sito già esistente, l'installazione manuale può rivelarsi più tecnica e dovrà essere effettuata in base alle tue conoscenze. Per questo, ti suggeriamo di rivolgerti a un [professionista](/links/partner) o di contattare l'amministratore del servizio nel caso dovessi avere difficoltà.
 
-Che si tratti di un nuovo sito Internet o della migrazione di un sito già esistente, l’installazione manuale può rivelarsi più tecnica e dovrà essere effettuata in base alle tue conoscenze. Per questo, ti suggeriamo di rivolgerti a un professionista o di contattare l’amministratore del servizio nel caso dovessi avere difficoltà. 
+Se scegli l'installazione manuale, è necessario che tu sia in possesso di tutti i file del sito Internet o dell'applicazione che vuoi installare, così come (se richiesto per un corretto funzionamento) degli identificativi di un database precedentemente creato sul tuo Cloud Web. In caso di migrazione di un sito Internet, procurati un backup completo.
 
-Se scegli l’installazione manuale, è necessario che tu sia in possesso di tutti i file del sito Internet o dell’applicazione che vuoi installare, così come (se richiesto per un corretto funzionamento) degli identificativi di un database precedentemente creato sul tuo Cloud Web. In caso di migrazione di un sito Internet, procurati un backup completo.
+Poiché i progetti possono essere diversi tra loro, non esiste un procedimento universale, ma per ulteriore assistenza sulle operazioni da svolgere puoi consultare le nostre guide: [Pubblicare un sito Web](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) e [Migrare un sito e un servizio di posta in OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh).
 
-Poiché i progetti possono essere diversi tra loro, non esiste un procedimento universale, ma per ulteriore assistenza sulle operazioni da svolgere puoi consultare la nostre guide (in inglese): [Pubblicare un sito Web](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) e [Migrare un sito e un servizio di posta in OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh)
-
-### Step 6: modifica la configurazione del tuo dominio
+### 6 - Modifica la configurazione del tuo dominio
 
 In questa fase è necessario che il tuo progetto sia installato sul Cloud Web OVHcloud e che tu abbia creato i tuoi account email. Se non dovessero ancora funzionare, potrebbe darsi che la configurazione del tuo dominio non sia corretta e, in questo caso, ti consigliamo di seguire questo step.
 
-Ti ricordiamo tuttavia che, se stai effettuando una migrazione dei tuoi servizi a OVHcloud, le operazioni legate ai DNS potrebbero causare un malfunzionamento dei tuoi servizi se non vengono effettuate nel momento giusto. In base ai diversi step descritti nella nostra guida (in inglese) [Migrare un sito e un servizio di posta in OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh), è quindi necessario verificare ed eventualmente correggerne la configurazione alla fine del processo di migrazione.
+Ti ricordiamo tuttavia che, se stai effettuando una migrazione dei tuoi servizi a OVHcloud, le operazioni legate ai DNS potrebbero causare un malfunzionamento dei tuoi servizi se non vengono effettuate nel momento giusto. In base ai diversi step descritti nella nostra guida [Migrare un sito e un servizio di posta in OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh), è quindi necessario verificare ed eventualmente correggerne la configurazione alla fine del processo di migrazione.
 
-#### 6.1. Conoscere i record DNS OVHcloud 
+#### 1. Conoscere i record DNS OVHcloud
 
-Esistono diversi record DNS relativi a OVHcloud. Ci concentreremo in particolare su due di essi, che garantiscono l’accessibilità del sito e la ricezione dei messaggi sui tuoi account email. Segui le indicazioni sottostanti per sapere dove recuperarli:
+Esistono diversi record DNS relativi a OVHcloud. Ci concentreremo in particolare su due di essi, che garantiscono l'accessibilità del sito e la ricezione dei messaggi sui tuoi account email. Segui le indicazioni sottostanti per sapere dove recuperarli:
 
 |Record DNS|Servizio associato|Dove recuperarlo?|
 |---|---|---|
-|A|Per il sito Internet|Nello [Spazio Clienti OVHcloud](/links/manager), clicca su `Hosting`{.action} e seleziona il tuo hosting Cloud Web. L'indirizzo IP viene mostrato in corrispondenza della voce "IPv4" nella scheda `Informazioni generali`{.action}.|
-|MX|Per le email|Nello [Spazio Clienti OVHcloud](/links/manager), clicca su `Email`{.action} e seleziona il tuo dominio. L’informazione viene mostrata in corrispondenza della voce "Record MX" nella scheda `Informazioni generali`{.action}.|
+|A|Per il sito Internet|Consulta la nostra guida [Hosting Web: lista degli indirizzi IP per cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|
+|MX|Per le email|Consulta la nostra guida [Aggiungere un record MX alla configurazione del dominio](/pages/web_cloud/domains/dns_zone_mx).|
 
-#### 6.2. Verificare e modificare i record DNS
+#### 2. Verificare e modificare i record DNS
 
 Adesso che conosci i record DNS relativi al tuo Cloud Web e il tuo servizio di posta OVHcloud, è necessario verificare se la configurazione è stata effettuata correttamente ed eventualmente modificarla. Queste due operazioni devono essere assolutamente eseguite presso il provider che gestisce la zona DNS del tuo dominio.
 
 > [!warning]
 >
-> - Se il tuo dominio non utilizza i DNS di OVHcloud, è necessario effettuare la modifica tramite l’interfaccia del provider che gestisce i nameserver del tuo dominio.
-> 
-> - Se il tuo dominio è registrato presso OVHcloud, puoi verificare se utilizza i nostri DNS accedendo allo [Spazio Clienti OVHcloud](/links/manager) > `Server DNS`{.action} e seleziona il tuo dominio.
+> - Se il tuo dominio non utilizza i DNS di OVHcloud, è necessario effettuare la modifica tramite l'interfaccia del provider che gestisce i nameserver del tuo dominio.
+>
+> - Se il tuo dominio è registrato presso OVHcloud, puoi verificare se utilizza i nostri DNS. Consulta la nostra guida [Modificare i server DNS di un dominio OVHcloud](/pages/web_cloud/domains/dns_server_edit).
 >
 
 Segui le indicazioni sottostanti per sapere dove effettuare le operazioni:
 
 |Configurazione DNS utilizzata|Dove effettuare le operazioni?|
 |---|---|
-|OVHcloud|Dal tuo [Spazio Cliente OVHcloud](/links/manager), accedi alla sezione `Web Cloud`{.action}. Clicca sul menu `Zone DNS`{.action} e seleziona il dominio interessato. Consulta la nostra documentazione "[Modificare una zona DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit)" se necessario.|
-|Altro|Attraverso l’interfaccia del provider che gestisce la configurazione DNS del tuo dominio. Ti suggeriamo inoltre di contattarlo se trovi difficoltà nello svolgere queste operazioni.|
+|OVHcloud|Accedi alla pagina [Zone DNS](/links/control-panel/web-dns-zone) e seleziona il dominio interessato. Consulta la nostra documentazione "[Modificare una zona DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit)" se necessario.|
+|Altro|Attraverso l'interfaccia del provider che gestisce la configurazione DNS del tuo dominio. Ti suggeriamo inoltre di contattarlo se trovi difficoltà nello svolgere queste operazioni.|
 
-Una volta modificata la configurazione DNS del tuo dominio, la propagazione delle modifiche potrebbe richiedere fino a 24 ore. Se hai aggiunto più domini al tuo hosting Cloud Web come Multisito, è necessario ripetere queste due operazioni per ciascun dominio. 
+Una volta modificata la configurazione DNS del tuo dominio, la propagazione delle modifiche potrebbe richiedere fino a 24 ore. Se hai aggiunto più domini al tuo hosting Cloud Web come Multisito, è necessario ripetere queste due operazioni per ciascun dominio.
 
-### Step 7: personalizza il tuo sito
+### 7 - Personalizza il tuo sito
 
 In caso di migrazione di un sito già esistente e quindi già personalizzato, questo step è facoltativo. Se invece il sito è appena stato realizzato, ad esempio utilizzando i nostri moduli, è possibile personalizzarlo modificando il tema e pubblicando i primi contenuti.
 
 Per maggiori informazioni sulle funzionalità disponibili, consulta la documentazione del CMS utilizzato per realizzare il tuo progetto.
 
-### Step 8: utilizza i tuoi indirizzi email
+### 8 - Utilizza i tuoi indirizzi email
 
-A questo punto non ti resta che utilizzare i tuoi account di posta. OVHcloud fornisce un’applicazione online (webmail): RoundCube. Puoi accedere all’App tramite l’indirizzo <https://www.ovh.it/mail/>, inserendo le credenziali associate al tuo account email creato in OVHcloud.
+A questo punto non ti resta che utilizzare i tuoi account di posta. OVHcloud fornisce un'applicazione online (webmail): RoundCube. Puoi accedere all'App tramite l'indirizzo <https://www.ovh.it/mail/>, inserendo le credenziali associate al tuo account email creato in OVHcloud.
 
-Per maggiori informazioni su questo servizio, consulta la nostra guida [Guida all'utilizzo di RoundCube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube) Per configurare l’account email su un client di posta o un dispositivo (ad esempio, smartphone o tablet), fai riferimento alla documentazione disponibile a questa pagina: </products/web-cloud-email-collaborative-solutions-mx-plan>.
+Per maggiori informazioni su questo servizio, consulta la nostra guida [Guida all'utilizzo di RoundCube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube). Per configurare l'account email su un client di posta o un dispositivo (ad esempio, smartphone o tablet), fai riferimento alla documentazione disponibile a questa pagina: </products/web-cloud-email-collaborative-solutions-mx-plan>.
 
 ## Per saperne di più
 
-[Migrare un sito e un servizio di posta in OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh) (in inglese)
+[Migrare un sito e un servizio di posta in OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh)
 
-[Pubblicare un sito Web](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) (in inglese)
+[Pubblicare un sito Web](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online)
 
 [Installare i moduli in 1 click OVHcloud](/pages/web_cloud/web_hosting/cms_install_1_click_modules)
 
-[Ospitare più siti su uno stesso hosting](/pages/web_cloud/web_hosting/multisites_configure_multisite) (in inglese)
+[Ospitare più siti su uno stesso hosting](/pages/web_cloud/web_hosting/multisites_configure_multisite)
 
 Per prestazioni specializzate (referenziamento, sviluppo, ecc.), contatta i [partner OVHcloud](/links/partner).
 

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pl-pl.md
@@ -65,7 +65,7 @@ Aby uzyskać dostęp do frameworków Twojego hostingu [Cloud Web](/links/web/hos
 >>
 >> Kliknij zakładkę `Frameworki`{.action}. Framework jest automatycznie tworzony podczas instalacji hostingu. Oznaczony jest jako `Wybór domyślny` w tabeli, która się wyświetli.
 >>
->> Aby zmodyfikować wcześniej skonfigurowany framework, kliknij przycisk `...`{.action} po jego prawej stronie, a następnie `Modyfikuj`{.action}.
+>> Aby zmodyfikować wcześniej skonfigurowany framework, kliknij przycisk `...`{.action} po jego prawej stronie, a następnie `Zmodyfikuj`{.action}.
 >>
 > **Krok 3**
 >>
@@ -185,7 +185,7 @@ Jeśli decydujesz się na skorzystanie z modułów CMS OVHcloud, kliknij na poni
 >>
 > **Krok 2**
 >>
->> Kliknij zakładkę `Moduły CMS`{.action}, a następnie `Dodaj moduł`{.action}.
+>> Kliknij zakładkę `Moduły CMS`{.action}, a następnie `Dodaj moduł CMS`{.action}.
 >>
 > **Krok 3**
 >>

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Pierwsze kroki z hostingiem Cloud Web"
 excerpt: "Dowiedz się, jak rozpocząć korzystanie z hostingu Cloud Web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Wprowadzenie
@@ -90,7 +90,7 @@ Aby sprawdzić, czy w ramach hostingu Cloud Web dysponujesz 2 vCores, kliknij na
 
 Jeśli chcesz wdrożyć kilka projektów w różnych środowiskach (na przykład: dewelopment, testy lub produkcja), wprowadź zmienne, aby kod mógł odpowiednio działać. W tym celu Cloud Web oferuje możliwość zdefiniowania zmiennych środowiskowych, do których ma dostęp kod Twojej strony WWW lub aplikacji internetowej.
 
-Dzięki temu nie jest na przykład konieczne określanie pliku „.env" we frameworku PHP Laravel, jak wskazuje dokumentacja: <https://laravel.com/docs/master/configuration>.
+Dzięki temu nie jest na przykład konieczne określanie pliku ".env" we frameworku PHP Laravel, jak wskazuje dokumentacja: <https://laravel.com/docs/master/configuration>.
 
 Aby dodać zmienną środowiskową, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
@@ -133,7 +133,7 @@ http.createServer(function(request, response) {
 }).listen(80);
 ```
 
-Pamiętaj, aby zastąpić informację „DB_DATABASE", zapisaną w powyższych skryptach, odpowiednią zmienną środowiskową.
+Pamiętaj, aby zastąpić informację "DB_DATABASE", zapisaną w powyższych skryptach, odpowiednią zmienną środowiskową.
 
 ### 4 - Konfiguracja dodatkowych domen jako MultiSite (opcjonalnie)
 
@@ -172,7 +172,7 @@ Aby zainstalować Twój projekt, masz do dyspozycji dwie możliwości. Powtarzaj
 
 #### 1. Użycie modułów CMS OVHcloud
 
-W tej opcji wybierasz gotowe do użycia rozwiązanie, które dowolnie personalizujesz pod względem struktury strony (szablon, teksty itd.). OVHcloud proponuje cztery moduły CMS, o których możesz dowiedzieć się więcej na stronie [„Twoja strona WWW dzięki modułom CMS"](/links/web/hosting-website).
+W tej opcji wybierasz gotowe do użycia rozwiązanie, które dowolnie personalizujesz pod względem struktury strony (szablon, teksty itd.). OVHcloud proponuje cztery moduły CMS, o których możesz dowiedzieć się więcej na stronie ["Twoja strona WWW dzięki modułom CMS"](/links/web/hosting-website).
 
 Jeśli decydujesz się na skorzystanie z modułów CMS OVHcloud, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
@@ -189,7 +189,7 @@ Jeśli decydujesz się na skorzystanie z modułów CMS OVHcloud, kliknij na poni
 >>
 > **Krok 3**
 >>
->> Będziesz mógł wówczas rozpocząć instalację w trybie „podstawowym" (bez personalizacji) lub „zaawansowanym" (z możliwością personalizacji niektórych elementów).
+>> Będziesz mógł wówczas rozpocząć instalację w trybie "podstawowym" (bez personalizacji) lub "zaawansowanym" (z możliwością personalizacji niektórych elementów).
 
 Jeśli chcesz uzyskać więcej informacji o modułach CMS OVHcloud, zapoznaj się z dokumentacją: [Automatyczna instalacja strony WWW za pomocą modułu CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Pierwsze kroki z hostingiem Cloud Web"
 excerpt: "Dowiedz się, jak rozpocząć korzystanie z hostingu Cloud Web"
-updated: 2025-05-22
+updated: 2026-03-26
 ---
 
 ## Wprowadzenie
@@ -21,7 +21,7 @@ Oferta hostingu Cloud Web łączy w sobie 20 lat doświadczenia OVHcloud w zakre
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -29,19 +29,19 @@ Oferta hostingu Cloud Web łączy w sobie 20 lat doświadczenia OVHcloud w zakre
 
 ## W praktyce
 
-### Etap 1: określenie ram projektu
+### 1 - Określenie ram projektu
 
 Hosting z dyskami SSD, Cloud Web, oferuje więcej możliwości konfiguracji niż klasyczny hosting, aby jak najlepiej dopasować się do Twojego projektu. Bardzo istotne jest, abyś posiadał jasną wizję tego, co chcesz osiągnąć. Dlatego zalecamy, abyś:
 
 - **określił, jaki projekt zamierzasz zainstalować**: chcesz stworzyć blog, sklep internetowy? Chcesz dzielić się pasją czy promować działalność Twojej firmy w Internecie? Zanim przystąpisz do realizacji projektu, jasno go zdefiniuj;
 
-- **pobierz wymagania techniczne niezbędne do instalacji**: istnieje możliwość, że z projektem, który chcesz zainstalować, wiążą się specyficzne wymagania techniczne.  Zapoznaj się z nimi przed instalacją;
+- **pobierz wymagania techniczne niezbędne do instalacji**: istnieje możliwość, że z projektem, który chcesz zainstalować, wiążą się specyficzne wymagania techniczne. Zapoznaj się z nimi przed instalacją;
 
 - **upewnij się, że Twój projekt jest kompatybilny z hostingiem Cloud Web**: potrzebny Ci określony framework lub SQL? Jeśli jeszcze tego nie zrobiłeś, upewnij się, że jest on dostępny wraz z Twoim hostingiem [Cloud Web](/links/web/hosting-cloud-web-offer).
 
 Po wybraniu różnych możliwości i określeniu ram Twojego projektu możesz przystąpić do jego umieszczenia w sieci.
 
-### Etap 2: wybór frameworku
+### 2 - Wybór frameworku
 
 W ramach Cloud Web udostępniamy różne języki programowania do budowy Twojego projektu. Jeśli chcesz użyć innego języka niż ustawione domyślnie PHP, wybierz framework odpowiadający wybranemu przez Ciebie językowi.
 
@@ -52,29 +52,66 @@ Aktualnie dostępne języki to:
 - Python
 - Ruby
 
-Aby uzyskać dostęp do frameworków Twojego hostingu [Cloud Web](/links/web/hosting-cloud-web-offer), zaloguj się do [Panelu klienta OVHcloud](/links/manager). Kliknij `Web Cloud`{.action} na pasku usług po lewej stronie, a następnie `Hosting`{.action}. Wybierz nazwę odpowiedniego hostingu Cloud Web i przejdź do zakładki `Frameworki`{.action}.
+Aby uzyskać dostęp do frameworków Twojego hostingu [Cloud Web](/links/web/hosting-cloud-web-offer), kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
-Framework jest automatycznie tworzony podczas instalacji hostingu. Oznaczony jest jako `Wybór domyślny` w tabeli, która się wyświetli. Aby zmodyfikować wcześniej skonfigurowany framework, kliknij trzy kropki po jego prawej stronie, a następnie `Modyfikuj`{.action}. 
-
-Jeśli dysponujesz pakietem [Cloud Web](/links/web/hosting-cloud-web-offer) z 2 vCores, możesz dodać drugi framework do Twojej oferty (maksymalnie 2 różne frameworki w jednej ofercie), klikając przycisk `Operacje`{.action}, a następnie `Dodaj framework`{.action}.
-
-Aby sprawdzić, czy w ramach hostingu Cloud Web dysponujesz 2 vCores, zaloguj się do [Panelu klienta OVHcloud](/links/manager), kliknij `Hosting`{.action} na pasku usług po lewej stronie, następnie wybierz odpowiedni hosting Cloud Web. Na stronie, która się wyświetla, w ramce **Abonament** i pod napisem `Pakiet` sprawdź, czy jest tam wskazany numer `Cloud Web 3`{.action}.
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiedni hosting Cloud Web.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `Frameworki`{.action}. Framework jest automatycznie tworzony podczas instalacji hostingu. Oznaczony jest jako `Wybór domyślny` w tabeli, która się wyświetli.
+>>
+>> Aby zmodyfikować wcześniej skonfigurowany framework, kliknij przycisk `...`{.action} po jego prawej stronie, a następnie `Modyfikuj`{.action}.
+>>
+> **Krok 3**
+>>
+>> Jeśli dysponujesz pakietem [Cloud Web](/links/web/hosting-cloud-web-offer) z 2 vCores, możesz dodać drugi framework (maksymalnie 2 na ofertę), klikając przycisk `Operacje`{.action}, a następnie `Dodaj framework`{.action}.
 
 Zanim przejdziesz do kolejnych kroków, upewnij się, że posiadasz framework lub frameworki niezbędne do Twojego projektu.
 
-![cloudweb hosting ssd](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/runtime-software-application/edit-runtime.png){.thumbnail}
+Aby sprawdzić, czy w ramach hostingu Cloud Web dysponujesz 2 vCores, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **2** kroków.
 
-### Etap 3: utworzenie zmiennych środowiskowych (opcjonalnie)
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiedni hosting Cloud Web.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> W ramce **Abonament** i pod napisem `Pakiet` sprawdź, czy jest tam wskazany numer `Cloud Web 3`.
 
-Jeśli chcesz wdrożyć kilka projektów kilka w różnych środowiskach (na przykład: dewelopment, testy lub produkcja), wprowadź zmienne, aby kod mógł odpowiednio działać. W tym celu Cloud Web oferuje możliwość zdefiniowania zmiennych środowiskowych, do których ma dostęp kod Twojej strony WWW lub aplikacji internetowej.
+### 3 - Utworzenie zmiennych środowiskowych (opcjonalnie)
 
-Dzięki temu nie jest na przykład konieczne określanie pliku „.env” we frameworku PHP Laravel, jak wskazuje dokumentacja: <https://laravel.com/docs/5.6/configuration>.
+Jeśli chcesz wdrożyć kilka projektów w różnych środowiskach (na przykład: dewelopment, testy lub produkcja), wprowadź zmienne, aby kod mógł odpowiednio działać. W tym celu Cloud Web oferuje możliwość zdefiniowania zmiennych środowiskowych, do których ma dostęp kod Twojej strony WWW lub aplikacji internetowej.
 
-Aby dodać zmienną środowiskową, zaznacz odpowiedni hosting Cloud Web i kliknij zakładkę `Zmienne środowiskowe`{.action}. Zmienne środowiskowe utworzone w ramach Twojej oferty wyświetlają się w tabeli. Aby dodać nową zmienną, kliknij przycisk `Operacje`{.action}, a następnie `Dodaj zmienną środowiskową`{.action}. Następnie postępuj zgodnie ze wskazówkami w zależności od zmiennej, którą chcesz utworzyć.
+Dzięki temu nie jest na przykład konieczne określanie pliku „.env" we frameworku PHP Laravel, jak wskazuje dokumentacja: <https://laravel.com/docs/master/configuration>.
 
-![cloud web hosting ssd](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
+Aby dodać zmienną środowiskową, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
-Jeśli nie używasz środowiska deweloperskiego zawierającej zmienne środowiskowe lub jeśli chcesz sprawdzić, czy zmienne działają poprawnie, możesz utworzyć skrypt, który przeprowadzi weryfikację. Poniżej przykład skryptu, który może być pomocny w przeprowadzanej przez Ciebie operacji, nie zastąpi on jednak pomocy technicznej webmastera.
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiedni hosting Cloud Web.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `Zmienne środowiskowe`{.action}. Zmienne środowiskowe utworzone w ramach Twojej oferty wyświetlają się w tabeli.
+>>
+> **Krok 3**
+>>
+>> Aby dodać nową zmienną, kliknij przycisk `Operacje`{.action}, a następnie `Dodaj zmienną środowiskową`{.action}. Następnie postępuj zgodnie ze wskazówkami w zależności od zmiennej, którą chcesz utworzyć.
+>>
+>> ![Dodawanie zmiennej środowiskowej na hostingu Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
+
+Jeśli nie używasz środowiska deweloperskiego zawierającego zmienne środowiskowe lub jeśli chcesz sprawdzić, czy zmienne działają poprawnie, możesz utworzyć skrypt, który przeprowadzi weryfikację. Poniżej przykład skryptu, który może być pomocny w przeprowadzanej przez Ciebie operacji, nie zastąpi on jednak pomocy technicznej webmastera.
 
 - **W przypadku PHP**:
 
@@ -87,79 +124,101 @@ Jeśli nie używasz środowiska deweloperskiego zawierającej zmienne środowisk
 ```sh
 var http = require('http');
 
-http.createServer(function(request, response) {  
-    response.writeHeader(200, {"Content-Type": "text/html"});  
+http.createServer(function(request, response) {
+    response.writeHeader(200, {"Content-Type": "text/html"});
 
     response.write( process.env.DB_DATABASE);
 
-    response.end();  
+    response.end();
 }).listen(80);
 ```
 
-Pamiętaj, aby zastąpić informację „DB_DATABASE”, zapisaną w powyższych skryptach, odpowiednią zmienną środowiskową.
+Pamiętaj, aby zastąpić informację „DB_DATABASE", zapisaną w powyższych skryptach, odpowiednią zmienną środowiskową.
 
-### Etap 4: konfiguracja dodatkowych domen jako MultiSite (opcjonalnie)
+### 4 - Konfiguracja dodatkowych domen jako MultiSite (opcjonalnie)
 
-Teraz, kiedy środowisko Twojego hostingu Cloud Web jest gotowe, możesz skonfigurować dodatkowe domeny w opcji MultiSite. Dzięki temu będziesz mógł podzielić Twoją przestrzeń i hostować na niej kilka stron WWW.  Jeśli opcja ta jest niezbędna dla Twojego projektu, zaznacz odpowiedni hosting Cloud Web i kliknij zakładkę `MultiSite`{.action}.
+Teraz, kiedy środowisko Twojego hostingu Cloud Web jest gotowe, możesz skonfigurować dodatkowe domeny w opcji MultiSite. Dzięki temu będziesz mógł podzielić Twoją przestrzeń i hostować na niej kilka stron WWW. Jeśli opcja ta jest niezbędna dla Twojego projektu, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
-Tabela, która się wyświetla zawiera wszystkie nazwy domen dodanych do Twojego hostingu. Niektóre z nich zostały utworzone automatycznie podczas instalacji Twojego hostingu. Aby dodać nową domenę, kliknij przycisk `Dodaj domenę lub subdomenę`{.action} i postępuj zgodnie z instrukcjami, które będą się pojawiać. Operacja może przebiegać różnie w zależności od tego, czy domena zarejestrowana jest w OVHcloud czy u innego rejestratora. 
-
-Zalecamy szczególną ostrożność podczas wypełniania następujących danych:
-
-- **katalog główny**: katalog, w którym pliki domena będą przechowywane na przestrzeni dyskowej Twojego hostingu Cloud Web; 
-
-- **Framework**: uprzednio skonfigurowane środowisko wykonawcze, które zostanie użyte przez MultiSite. 
-
-> [!warning]
->
-> Jeśli dodałeś domenę uznawaną jako zewnętrzną, podczas konfiguracji DNS skonfiguruj również pole TXT o nazwie **ovhcontrol**. Dzięki temu OVHcloud ma pewność, że dodanie domeny nastąpiło zgodnie z Twoją wolą. Czynność ta jest zatem niezbędna i jeśli nie zostanie przeprowadzona, dodanie domeny zostanie anulowane. 
->
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiedni hosting Cloud Web.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `MultiSite`{.action}. Tabela, która się wyświetla, zawiera wszystkie nazwy domen dodanych do Twojego hostingu. Niektóre z nich zostały utworzone automatycznie podczas instalacji Twojego hostingu.
+>>
+>> Aby dodać nową domenę, kliknij przycisk `Dodaj domenę lub subdomenę`{.action} i postępuj zgodnie z instrukcjami, które będą się pojawiać. Operacja może przebiegać różnie w zależności od tego, czy domena zarejestrowana jest w OVHcloud czy u innego rejestratora.
+>>
+> **Krok 3**
+>>
+>> Zalecamy szczególną ostrożność podczas wypełniania następujących danych:
+>>
+>> - **katalog główny**: katalog, w którym pliki domeny będą przechowywane na przestrzeni dyskowej Twojego hostingu Cloud Web.
+>>
+>> - **Framework**: uprzednio skonfigurowane środowisko wykonawcze, które zostanie użyte przez MultiSite.
+>>
+>> > [!warning]
+>> >
+>> > Jeśli dodałeś domenę uznawaną jako zewnętrzną, podczas konfiguracji DNS skonfiguruj również pole TXT o nazwie **ovhcontrol**. Dzięki temu OVHcloud ma pewność, że dodanie domeny nastąpiło zgodnie z Twoją wolą. Czynność ta jest niezbędna i jeśli nie zostanie przeprowadzona, dodanie domeny zostanie anulowane.
 
 Powtórz tę operację, jeśli chcesz dodać kilka domen do Twojego hostingu Cloud Web. Aby uzyskać więcej informacji o dodawaniu domeny w opcji MultiSite, zapoznaj się z naszą dokumentacją: [Instalacja kilku stron WWW na jednym hostingu](/pages/web_cloud/web_hosting/multisites_configure_multisite).
 
-![cloud web hosting ssd](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/multisite/add-domain-or-subdomain.png){.thumbnail}
-
-### Etap 5: instalacja Twojego projektu na hostingu Cloud Web
+### 5 - Instalacja Twojego projektu na hostingu Cloud Web
 
 Aby zainstalować Twój projekt, masz do dyspozycji dwie możliwości. Powtarzaj kroki najodpowiedniejszej dla Ciebie metody, jeśli chcesz umieścić w sieci kilka projektów.
 
 #### 1. Użycie modułów CMS OVHcloud
 
-W tej opcji wybierasz gotowe do użycia rozwiązanie, które dowolnie personalizujesz pod względem struktury strony (szablon, teksty itd.). OVHcloud proponuje cztery moduły CMS, o których możesz dowiedzieć się więcej na stronie [„Twoja strona WWW dzięki modułom CMS”](/links/web/hosting-website).
+W tej opcji wybierasz gotowe do użycia rozwiązanie, które dowolnie personalizujesz pod względem struktury strony (szablon, teksty itd.). OVHcloud proponuje cztery moduły CMS, o których możesz dowiedzieć się więcej na stronie [„Twoja strona WWW dzięki modułom CMS"](/links/web/hosting-website).
 
-Jeśli decydujesz się na skorzystanie z modułów CMS OVHcloud, kliknij zakładkę `Moduły CMS`{.action}, a następnie `Dodaj moduł`{.action}.  Będziesz mógł wówczas rozpocząć instalację w trybie „podstawowym” (bez personalizacji) lub „zaawansowanym” (z możliwością personalizacji niektórych elementów).
+Jeśli decydujesz się na skorzystanie z modułów CMS OVHcloud, kliknij na poniższe karty, aby wyświetlić kolejno każdy z **3** kroków.
 
-Jeśli chcesz uzyskać więcej informacji o modułach CMS OVHcloud, zapoznaj się z dokumentacją:  [Automatyczna instalacja strony WWW za pomocą modułu CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiedni hosting Cloud Web.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Kliknij zakładkę `Moduły CMS`{.action}, a następnie `Dodaj moduł`{.action}.
+>>
+> **Krok 3**
+>>
+>> Będziesz mógł wówczas rozpocząć instalację w trybie „podstawowym" (bez personalizacji) lub „zaawansowanym" (z możliwością personalizacji niektórych elementów).
+
+Jeśli chcesz uzyskać więcej informacji o modułach CMS OVHcloud, zapoznaj się z dokumentacją: [Automatyczna instalacja strony WWW za pomocą modułu CMS](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 
 > [!primary]
 >
-> Aby skorzystać z modułu CMS, konieczne jest użycie frameworku PHP. 
->
-
-![cloud web hosting ssd](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/1-click-modules/add-a-module.png){.thumbnail}
+> Aby skorzystać z modułu CMS, konieczne jest użycie frameworku PHP.
 
 #### 2. Ręczna instalacja projektu
 
-W przypadku nowej strony WWW lub migracji strony istniejącej, ręczna instalacja może wymagać odpowiednich kompetencji technicznych. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub kontakt z producentem oprogramowania. 
+W przypadku nowej strony WWW lub migracji strony istniejącej, ręczna instalacja może wymagać odpowiednich kompetencji technicznych. W przypadku trudności zalecamy skorzystanie z pomocy [wyspecjalizowanego usługodawcy](/links/partner) lub kontakt z producentem oprogramowania.
 
 Jeśli decydujesz się na ręczną instalację, powinieneś posiadać wszystkie pliki strony WWW lub aplikacji, które zamierzasz zainstalować, jak również (o ile jest to niezbędne dla jej poprawnego funkcjonowania), dane dostępowe bazy danych utworzonej uprzednio na hostingu Cloud Web. W przypadku migracji strony WWW zadbaj o wykonanie jej pełnej kopii.
 
 Ponieważ projekty różnią się od siebie, nie istnieje jeden uniwersalny sposób postępowania. Podczas wykonywania operacji przydatne mogą być przewodniki [Umieszczenie strony WWW w Internecie](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online) i [Przeniesienie strony WWW do OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh).
 
-### Etap 6: zmiana konfiguracji Twojej domeny
+### 6 - Zmiana konfiguracji Twojej domeny
 
 Na tym etapie Twój projekt powinien być zainstalowany na hostingu Cloud Web, a Twoje konta e-mail utworzone. Jeśli konta jeszcze nie działają, być może konfiguracja Twojej domeny nie jest prawidłowa. W takim przypadku, lub jeśli nie masz co do tego pewności, zalecamy kontynuowanie bieżącego etapu.
 
 Pamiętaj, że jeśli przenosisz usługi do OVHcloud, operacje związane z DNS mogą spowodować niedostępność usług, jeśli operacje przeprowadzane są w nieodpowiednim momencie. Zgodnie z poszczególnymi etapami opisanymi w dokumentacji [Przeniesienie strony WWW do OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh), na zakończenie procesu zmodyfikuj serwery DNS Twojej domeny.
 
-#### 1. Poznaj rodzaje rekordów DNS OVHcloud 
+#### 1. Poznaj rodzaje rekordów DNS OVHcloud
 
-Istnieje kilka rodzajów rekordów DNS w OVHcloud. Będą Cię dotyczyły szczególnie dwa z nich. Zapewniają one dostępność strony WWW i odbiór wiadomości przez Twoje konta e-mail. Postępuj zgodnie z poniższymi wskazówkami, aby dowiedzieć się, gdzie je sprawdzić: 
+Istnieje kilka rodzajów rekordów DNS w OVHcloud. Będą Cię dotyczyły szczególnie dwa z nich. Zapewniają one dostępność strony WWW i odbiór wiadomości przez Twoje konta e-mail. Postępuj zgodnie z poniższymi wskazówkami, aby dowiedzieć się, gdzie je sprawdzić:
 
 |Rekordy DNS|Powiązana usługa|Gdzie sprawdzić rekordy?|
 |---|---|---|
-|A|Dla strony WWW|W [Panelu klienta](/links/manager), w sekcji `Hosting`{.action} zaznacz odpowiedni hosting Cloud Web. Pobierz adres IP, który wyświetla się obok „IPv4” w zakładce `Informacje ogólne`{.action}.|
-|MX|Dla wiadomości e-mail|W [Panelu klienta](/links/manager), w sekcji `E-maile`{.action} zaznacz odpowiednią domenę. Pobierz informacje, które wyświetlają się obok „Pola MX” w zakładce `Informacje ogólne`{.action}.|
+|A|Dla strony WWW|Zapoznaj się z naszym przewodnikiem [Hosting WWW — lista adresów IP klastrów](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|
+|MX|Dla wiadomości e-mail|Zapoznaj się z naszym przewodnikiem [Dodanie rekordu MX do konfiguracji domeny](/pages/web_cloud/domains/dns_zone_mx).|
 
 #### 2. Sprawdź i/lub zmodyfikuj rekordy DNS
 
@@ -168,26 +227,26 @@ Teraz sprawdź, czy rekordy DNS przypisane do Twojego hostingu Cloud Web i kont 
 > [!warning]
 >
 > - Jeśli Twoja domena nie używa konfiguracji DNS OVHcloud, przeprowadź zmianę w interfejsie dostawcy zarządzającego konfiguracją Twojej domeny.
-> 
-> - Jeśli domena jest zarejestrowana w OVHcloud, możesz sprawdzić, czy używa konfiguracji DNS OVHcloud. W tym celu przejdź do [Panelu klienta](/links/manager), zaznacz nazwę odpowiedniej domeny i kliknij zakładkę `Serwery DNS`{.action}.
+>
+> - Jeśli domena jest zarejestrowana w OVHcloud, możesz sprawdzić, czy używa konfiguracji DNS OVHcloud. Zapoznaj się z naszym przewodnikiem [Zmiana serwerów DNS domeny OVHcloud](/pages/web_cloud/domains/dns_server_edit).
 >
 
 Zapoznaj się z poniższymi wskazówkami, aby dowiedzieć się, gdzie przeprowadzić operacje:
 
 |Używana konfiguracja DNS|Gdzie przeprowadzić operacje?|
 |---|---|
-|OVHcloud|W [Panelu klienta OVHcloud](/links/manager) przejdź do sekcji `Web Cloud`{.action}. Kliknij menu `Strefy DNS`{.action}, następnie wybierz odpowiednią domenę. Zapoznaj się z naszą dokumentacją "[Modyfikacja strefy DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit)", jeśli to konieczne.|
+|OVHcloud|Przejdź na stronę [Strefy DNS](/links/control-panel/web-dns-zone) i wybierz odpowiednią domenę. Zapoznaj się z naszą dokumentacją "[Modyfikacja strefy DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit)", jeśli to konieczne.|
 |Inne|W interfejsie dostawcy zarządzającego konfiguracją DNS Twojej domeny. W przypadku trudności w przeprowadzeniu tych operacji zachęcamy do kontaktu z dostawcą zarządzającym konfiguracją DNS Twojej domeny.|
 
-Czas propagacji wprowadzonych w strefie DNS zmian wynosi maksymalnie 24 godziny. Jeśli dodałeś kilka domen do Twojego hostingu Cloud Web w opcji MultiSite, przeprowadź obydwie operacje dla każdej z domen. 
+Czas propagacji wprowadzonych w strefie DNS zmian wynosi maksymalnie 24 godziny. Jeśli dodałeś kilka domen do Twojego hostingu Cloud Web w opcji MultiSite, przeprowadź obydwie operacje dla każdej z domen.
 
-### Etap 7: personalizacja Twojej strony WWW
+### 7 - Personalizacja Twojej strony WWW
 
 Etap ten może być opcjonalny, jeśli przeniosłeś istniejącą wcześniej i spersonalizowaną stronę. W przypadku gdy zainstalowałeś nową stronę WWW na przykład z wykorzystaniem modułów CMS OVHcloud, możesz ją spersonalizować, wprowadzając modyfikacje szablonu i publikując pierwsze treści.
 
-Jeśli chcesz uzyskać wsparcie dotyczące funkcjonalności Twojej strony WWW, zachęcamy do odwiedzenia strony producenta oprogramowanie CMS, na której znajdziesz pomocną dokumentację.
+Jeśli chcesz uzyskać wsparcie dotyczące funkcjonalności Twojej strony WWW, zachęcamy do odwiedzenia strony producenta oprogramowania CMS, na której znajdziesz pomocną dokumentację.
 
-### Etap 8: korzystanie z kont e-mail
+### 8 - Korzystanie z kont e-mail
 
 Zacznij używać Twoich kont e-mail. W tym celu możesz użyć udostępnionej przez OVHcloud aplikacji online - Webmail: RoundCube. Aplikacja dostępna jest pod adresem <https://www.ovh.pl/mail/>. Zaloguj się, wprowadzając dane identyfikacyjne przypisane do Twojego konta e-mail utworzonego w OVHcloud.
 

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Alojamento Cloud Web: primeira utilização"
 excerpt: "Saiba como começar num plano de alojamento Cloud Web"
-updated: 2025-05-22
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -21,7 +21,7 @@ A nossa oferta de alojamento [Cloud Web](/links/web/hosting-cloud-web-offer) com
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -29,7 +29,7 @@ A nossa oferta de alojamento [Cloud Web](/links/web/hosting-cloud-web-offer) com
 
 ## Instruções
 
-### 1 - Tipo de Projeto: Criar ou Transferir um Site.
+### 1 - Tipo de Projeto: Criar ou Transferir um Site
 
 De modo a adequar-se ao máximo ao seu projeto, o alojamento [Cloud Web](/links/web/hosting-cloud-web-offer) oferece mais possibilidades de configuração do que um alojamento web clássico. É importante que tenha uma visão clara do seu objetivo, de forma a levá-lo a cabo o melhor possível. Para isso, aconselhamos o seguinte:
 
@@ -37,7 +37,7 @@ De modo a adequar-se ao máximo ao seu projeto, o alojamento [Cloud Web](/links/
 
 - **reunir os pré-requisitos técnicos necessários à instalação**: é possível que o projeto que deseja instalar exija pré-requisitos técnicos particulares. Certifique-se de os conhecer previamente;
 
-- **certificar-se da compatibilidade técnica do seu projeto com o alojamento Cloud Web**\: precisa de um motor de execução ou de um SQL em particular?  Se ainda não o fez, assegure-se de que este último se encontra disponível com o seu alojamento [Cloud Web](/links/web/hosting-cloud-web-offer).
+- **certificar-se da compatibilidade técnica do seu projeto com o alojamento Cloud Web**: precisa de um motor de execução ou de um SQL em particular? Se ainda não o fez, assegure-se de que este último se encontra disponível com o seu alojamento [Cloud Web](/links/web/hosting-cloud-web-offer).
 
 Depois de ter avaliado as diferentes possibilidades ao seu dispor e de ter delimitado o seu projeto com precisão, já pode começar a pô-lo online.
 
@@ -52,27 +52,64 @@ As linguagens atualmente disponíveis são:
 - Python
 - Ruby
 
-Para aceder aos motores de execução do seu alojamento [Cloud Web](/links/web/hosting-cloud-web-offer), aceda à [Área de Cliente OVHcloud](/links/manager). Clique em `Web Cloud`{.action} na barra à esquerda e, a seguir, em `Alojamentos`{.action}. Escolha o nome do alojamento Cloud Web em causa e aceda ao separador `Motores de execução`{.action}.
+Para aceder aos motores de execução do seu alojamento [Cloud Web](/links/web/hosting-cloud-web-offer), clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
-Será automaticamente criado um motor durante a instalação do alojamento. É indicado como `Escolha padrão` no quadro que se apresenta. Para modificar um motor já parametrizado, clique nos três pontos à direita deste último e, a seguir, em `Modificar`{.action}. 
-
-Se dispõe da oferta [Cloud Web](/links/web/hosting-cloud-web-offer) com 2 vCores, pode adicionar um segundo motor de execução à sua oferta (máximo de 2 motores de execução diferentes por oferta) clicando no botão `Ações`{.action} e, depois em `Adicionar um motor de execução`{.action}.
-
-Para verificar que dispõe de 2 vCores com o seu alojamento Cloud Web, aceda à [Área de Cliente OVHcloud](/links/manager), clique em `Alojamentos`{.action} na barra à esquerda e escolha o nome do alojamento Cloud Web em causa. Na página que vai aparecer, na caixa **Subscrição** e sob a menção `Plano`, verifique se a referência `Cloud Web 3`{.action} está indicada.
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento Cloud Web em causa.
+>>
+>> ![Alojamentos web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Clique no separador `Motores de execução`{.action}. Será automaticamente criado um motor durante a instalação do alojamento. É indicado como `Escolha padrão` no quadro que se apresenta.
+>>
+>> Para modificar um motor já parametrizado, clique no botão `...`{.action} à direita e, a seguir, em `Modificar`{.action}.
+>>
+> **Etapa 3**
+>>
+>> Se dispõe da oferta [Cloud Web](/links/web/hosting-cloud-web-offer) com 2 vCores, pode adicionar um segundo motor de execução (máximo de 2 por oferta) clicando no botão `Ações`{.action} e, depois, em `Adicionar um motor de execução`{.action}.
 
 Assim, antes de prosseguir, certifique-se de que dispõe do ou dos motores de execução necessários ao seu projeto.
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/runtime-software-application/edit-runtime.png){.thumbnail}
+Para verificar que dispõe de 2 vCores com o seu alojamento Cloud Web, clique nos separadores abaixo para visualizar cada uma das **2** etapas.
+
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento Cloud Web em causa.
+>>
+>> ![Alojamentos web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Na caixa **Subscrição** e sob a menção `Plano`, verifique se a referência `Cloud Web 3` está indicada.
 
 ### 3 - Criar variáveis de ambiente (facultativo)
 
 Quando deseja implementar várias vezes o seu projeto em ambientes diferentes (por exemplo: desenvolvimento, teste ou produção), deverá fornecer variáveis de modo que o código reaja em conformidade. Para isso, a [Cloud Web](/links/web/hosting-cloud-web-offer) possibilita a definição de variáveis de ambiente acessíveis pelo código do seu site ou da sua aplicação web.
 
-Por exemplo, desta forma pode deixar de fora um ficheiro «.env» no framework PHP Laravel, como indica a documentação do framework: <https://laravel.com/docs/5.6/configuration>.
+Por exemplo, desta forma pode deixar de fora um ficheiro «.env» no framework PHP Laravel, como indica a documentação do framework: <https://laravel.com/docs/master/configuration>.
 
-Para adicionar uma variável de ambiente, e ainda posicionado no alojamento Cloud Web em causa, clique no separador `Variáveis de ambiente`{.action}. Um quadro exibirá as variáveis de ambiente criadas no seu serviço. Para adicionar uma nova, clique no botão `Ações`{.action} e depois em `Adicionar uma variável de ambiente`{.action}. Então, siga as indicações em função da variável que deseja criar:
+Para adicionar uma variável de ambiente, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento Cloud Web em causa.
+>>
+>> ![Alojamentos web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Clique no separador `Variáveis de ambiente`{.action}. Um quadro exibirá as variáveis de ambiente criadas no seu serviço.
+>>
+> **Etapa 3**
+>>
+>> Para adicionar uma nova, clique no botão `Ações`{.action} e depois em `Adicionar uma variável de ambiente`{.action}. Então, siga as indicações em função da variável que deseja criar.
+>>
+>> ![Adicionar uma variável de ambiente num alojamento Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
 
 Se não utiliza um framework de desenvolvimento que integre as variáveis de ambiente, ou se deseja simplesmente verificar o bom funcionamento das suas variáveis, pode criar um script para efetuar esta verificação. Encontrará abaixo dois exemplos que podem ser-lhe úteis, mas que não substituem a ajuda de um webmaster:
 
@@ -87,12 +124,12 @@ Se não utiliza um framework de desenvolvimento que integre as variáveis de amb
 ```sh
 var http = require('http');
 
-http.createServer(function(request, response) {  
-    response.writeHeader(200, {"Content-Type": "text/html"});  
+http.createServer(function(request, response) {
+    response.writeHeader(200, {"Content-Type": "text/html"});
 
     response.write( process.env.DB_DATABASE);
 
-    response.end();  
+    response.end();
 }).listen(80);
 ```
 
@@ -100,24 +137,34 @@ Tenha o cuidado de substituir a informação genérica presentes nestes scripts 
 
 ### 4 - Configurar domínios adicionais enquanto Multisite (facultativo)
 
-Agora que o ambiente técnico do seu alojamento [Cloud Web](/links/web/hosting-cloud-web-offer) está pronto, pode configurar domínios adicionais enquanto Multisite. Isto permite-lhe partilhar o seu espaço, de forma a alojar nele vários sites, por exemplo. Se isto se adequa ao seu projeto, e ainda posicionado no alojamento Cloud Web em causa, clique no separador `Multisite`{.action}.
+Agora que o ambiente técnico do seu alojamento [Cloud Web](/links/web/hosting-cloud-web-offer) está pronto, pode configurar domínios adicionais enquanto Multisite. Isto permite-lhe partilhar o seu espaço, de forma a alojar nele vários sites, por exemplo. Se isto se adequa ao seu projeto, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
-O quadro que vai aparecer contém os domínios adicionados ao seu alojamento. Alguns de entre eles foram criados automaticamente durante a instalação do alojamento. Para adicionar um novo, clique no botão `Adicionar um domínio ou subdomínio`{.action} e siga as instruções que surgirem. A manipulação pode ser diferente se o domínio em causa estiver registado junto da OVHcloud ou não. 
-
-Por isso, sugerimos que tenha muita atenção durante a introdução das informações seguintes:
-
-- **pasta raiz**: trata-se do repertório onde o domínio indicado deverá ser alojado no espaço de armazenamento do seu serviço de alojamento Cloud Web; 
-
-- **motor de execução**: trata-se do motor de execução, previamente parametrizado, que será utilizado pelo Multisite em vias de ser configurado.
-
-> [!warning]
->
-> Se adicionou um domínio considerado externo, deverá parametrizar um campo TXT chamado **ovhcontrol** na sua configuração DNS. Ele permitirá que a OVHcloud confirme que a operação é legítima. Portanto, é um passo indispensável e, se não for realizado, a operação será anulada. 
->
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento Cloud Web em causa.
+>>
+>> ![Alojamentos web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Clique no separador `Multisite`{.action}. O quadro que vai aparecer contém os domínios adicionados ao seu alojamento. Alguns de entre eles foram criados automaticamente durante a instalação do alojamento.
+>>
+>> Para adicionar um novo, clique no botão `Adicionar um domínio ou subdomínio`{.action} e siga as instruções que surgirem. A manipulação pode ser diferente se o domínio em causa estiver registado junto da OVHcloud ou não.
+>>
+> **Etapa 3**
+>>
+>> Por isso, sugerimos que tenha muita atenção durante a introdução das informações seguintes:
+>>
+>> - **pasta raiz**: trata-se do repertório onde o domínio indicado deverá ser alojado no espaço de armazenamento do seu serviço de alojamento Cloud Web.
+>>
+>> - **motor de execução**: trata-se do motor de execução, previamente parametrizado, que será utilizado pelo Multisite em vias de ser configurado.
+>>
+>> > [!warning]
+>> >
+>> > Se adicionou um domínio considerado externo, deverá parametrizar um campo TXT chamado **ovhcontrol** na sua configuração DNS. Ele permitirá que a OVHcloud confirme que a operação é legítima. Portanto, é um passo indispensável e, se não for realizado, a operação será anulada.
 
 Repita esta manipulação se deseja adicionar vários domínios ao seu alojamento Cloud Web. Para obter mais informação acerca da adição de um domínio enquanto Multisite, consulte o guia: [Partilhar o alojamento entre vários sites](/pages/web_cloud/web_hosting/multisites_configure_multisite).
-
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/multisite/add-domain-or-subdomain.png){.thumbnail}
 
 ### 5 - Instalar o projeto no alojamento Cloud Web
 
@@ -127,20 +174,32 @@ Tem ao dispor duas formas de efetuar a instalação do seu projeto. Repita o pro
 
 Esta solução permite-lhe beneficiar de uma estrutura de site pronta a usar ainda por personalizar (tema, textos, etc.). A OVHcloud disponibiliza quatro com os módulos em 1 clique, a descobrir na página [Criar um site com os módulos em 1 clique](/links/web/hosting-website).
 
-Se optar pela utilização dos nossos módulos em 1 clique, e ainda posicionado no alojamento [Cloud Web](/links/web/hosting-cloud-web-offer) em causa, clique no separador `Módulos em 1 clique`{.action} e, a seguir, em `Adicionar um módulo`{.action}. Então, poderá iniciar uma instalação em modo «simples» (não personalizável) ou em modo «avançado» (com a possibilidade de personalizar certos elementos).
+Se optar pela utilização dos nossos módulos em 1 clique, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
+
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento Cloud Web em causa.
+>>
+>> ![Alojamentos web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Clique no separador `Módulos em 1 clique`{.action} e, a seguir, em `Adicionar um módulo`{.action}.
+>>
+> **Etapa 3**
+>>
+>> Então, poderá iniciar uma instalação em modo «simples» (não personalizável) ou em modo «avançado» (com a possibilidade de personalizar certos elementos).
 
 Para mais informações sobre os módulos, consulte o guia: [Instalar um site com os módulos em 1 clique](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 
 > [!primary]
 >
 > Para utilizar estes últimos, deve imperativamente usar o motor de execução PHP.
->
-
-![cloudweb](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/1-click-modules/add-a-module.png){.thumbnail}
 
 #### 2. Instalar o seu projeto manualmente
 
-Quer se trate de um novo site ou da migração de um site já existente, a instalação manual pode revelar-se mais técnica e deverá ser efetuada em função dos seus próprios conhecimentos. Por isso, recomendamos que recorra a um prestatário especializado e/ou que contacte o editor do serviço se encontrar dificuldades. 
+Quer se trate de um novo site ou da migração de um site já existente, a instalação manual pode revelar-se mais técnica e deverá ser efetuada em função dos seus próprios conhecimentos. Por isso, recomendamos que recorra a um [prestatário especializado](/links/partner) e/ou que contacte o editor do serviço se encontrar dificuldades.
 
 Se optou pela instalação manual, deverá ter na sua posse o conjunto dos ficheiros do site ou da aplicação que deseja instalar, assim como (se for necessário para o seu bom funcionamento) as informações de uma base de dados criada previamente no seu alojamento Cloud Web. No quadro da migração de um site, assegure-se de ter uma cópia integral deste último.
 
@@ -152,34 +211,34 @@ Por esta altura, o seu site está alojado nos serviços da OVHcloud e os endere�
 
 Contudo, repare que, se está a migrar os seus serviços para a OVHcloud, as manipulações ligadas aos DNS podem provocar uma indisponibilidade dos serviços se elas não foram efetuadas num momento adequado. Como tal, deverá seguir as instruções indicadas no guia [Transferir o meu site para a OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh), e modificar os servidores DNS do seu domínio no final do processo.
 
-#### 6.1. Consultar registos DNS do alojamento OVHcloud 
+#### 1. Consultar registos DNS do alojamento OVHcloud
 
 Há vários registos DNS inerentes à OVHcloud. Vamos referir-nos a dois deles em particular: aqueles que permitem garantir a acessibilidade do seu site e a receção de mensagens de e-mail. Siga as indicações abaixo para saber onde os encontrar:
 
 |Registo DNS|Serviço associado|Onde encontrá-lo?|
 |---|---|---|
-|A|Para o site|Na sua [Área de Cliente OVHcloud](/links/manager), posicionado na secção `Alojamentos`{.action}, no alojamento Cloud Web em causa. De seguida, em `Informações gerais`{.action}, tome nota do endereço IP indicado para «IPv4».|
-|MX|Para os e-mails|Na sua [Área de Cliente OVHcloud](/links/manager), posicionado na secção `E-mails`{.action}, no domínio em causa. De seguida, clique em `Informações gerais`{.action} e tome nota das informações indicadas para os «Campos MX».|
+|A|Para o site|Consulte o nosso guia [Alojamento web: lista dos endereços IP por cluster](/pages/web_cloud/web_hosting/clusters_and_shared_hosting_IP).|
+|MX|Para os e-mails|Consulte o nosso guia [Adicionar um registo MX à configuração do domínio](/pages/web_cloud/domains/dns_zone_mx).|
 
-#### 6.2. Verificar e/ou alterar os registos DNS
+#### 2. Verificar e/ou alterar os registos DNS
 
 Agora que conhece os registos DNS inerentes ao seu alojamento [Cloud Web](/links/web/hosting-cloud-web-offer) e ao seu serviço de e-mail OVHcloud, deve verificar se estes últimos estão bem configurados e fazer alterações se necessário. É imperativo que estas duas manipulações sejam feitas junto do prestatário que gere a configuração DNS (a zona DNS) do seu domínio.
 
 > [!warning]
 >
 > - Se o domínio não usar a configuração DNS da OVHcloud, a configuração deverá ser efetuada no sistema do agente responsável pela gestão do seu domínio.
-> 
-> - Se o domínio estiver registado na OVHcloud, pode verificar se este último utiliza a nossa configuração DNS. Para isso, vá à [Área de Cliente](/links/manager), clique no separador`Servidores DNS`{.action} e posicione-se sobre o domínio em questão.
+>
+> - Se o domínio estiver registado na OVHcloud, pode verificar se este último utiliza a nossa configuração DNS. Consulte o nosso guia [Alterar os servidores DNS de um domínio OVHcloud](/pages/web_cloud/domains/dns_server_edit).
 >
 
 Siga as indicações abaixo para saber onde efetuar estas manipulações:
 
 |Configuração DNS utilizada|Onde realizar as manipulações?|
 |---|---|
-|OVHcloud|A partir do seu [Área de Cliente OVHcloud](/links/manager), aceda à parte `Web Cloud`{.action}. Clique no menu `Zonas DNS`{.action} e escolha o domínio em causa. Consulte a nossa documentação "[Editar uma zona DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit)", se necessário.|
+|OVHcloud|Aceda à página [Zonas DNS](/links/control-panel/web-dns-zone) e selecione o domínio em causa. Consulte a nossa documentação "[Editar uma zona DNS OVHcloud](/pages/web_cloud/domains/dns_zone_edit)", se necessário.|
 |Outra|No sistema do agente responsável pela gestão do seu domínio. Sugerimos que o contacte se sentir dificuldades durante as manipulações.|
 
-Uma vez modificada a configuração DNS do domínio, é necessário um tempo máximo de propagação de 24 horas até as alterações serem efetivas. Se adicionou vários domínios ao seu alojamento Cloud Web enquanto Multisite, deverá realizar estas duas manipulações para cada um deles. 
+Uma vez modificada a configuração DNS do domínio, é necessário um tempo máximo de propagação de 24 horas até as alterações serem efetivas. Se adicionou vários domínios ao seu alojamento Cloud Web enquanto Multisite, deverá realizar estas duas manipulações para cada um deles.
 
 ### 7 - Personalizar o site
 
@@ -191,11 +250,11 @@ Caso precise de ajuda relativamente às funcionalidades do seu site, pedimos-lhe
 
 Os seus endereços de e-mail podem ser usados com o Roundcube, um serviço de webmail incluído na oferta de alojamento OVHcloud. Para isso, a OVHcloud disponibiliza uma aplicação online (webmail): RoundCube. Aceda a <https://www.ovh.pt/mail/> e preencha os dados associados ao endereço de e-mail criado através do sistema OVHcloud.
 
-Para saber mais sobre o RoundCube, consulte o guia: [Utilização do RoundCube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube) Se desejar associar o seu endereço de e-mail a um software (cliente) de correio eletrónico no computador, smartphone ou um tablet, consulte a página: </products/web-cloud-email-collaborative-solutions-mx-plan>.
+Para saber mais sobre o RoundCube, consulte o guia: [Utilização do RoundCube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube). Se desejar associar o seu endereço de e-mail a um software (cliente) de correio eletrónico no computador, smartphone ou um tablet, consulte a página: </products/web-cloud-email-collaborative-solutions-mx-plan>.
 
 ## Quer saber mais?
 
-[Transferir o meu site para a OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh) (Versão PT disponível em breve)
+[Transferir o meu site para a OVHcloud](/pages/web_cloud/web_hosting/hosting_migrating_to_ovh)
 
 [Colocar o meu site online](/pages/web_cloud/web_hosting/hosting_how_to_get_my_website_online)
 

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Alojamento Cloud Web: primeira utilização"
 excerpt: "Saiba como começar num plano de alojamento Cloud Web"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/getting_started_cloud_web/guide.pt-pt.md
@@ -65,11 +65,11 @@ Para aceder aos motores de execução do seu alojamento [Cloud Web](/links/web/h
 >>
 >> Clique no separador `Motores de execução`{.action}. Será automaticamente criado um motor durante a instalação do alojamento. É indicado como `Escolha padrão` no quadro que se apresenta.
 >>
->> Para modificar um motor já parametrizado, clique no botão `...`{.action} à direita e, a seguir, em `Modificar`{.action}.
+>> Para modificar um motor já parametrizado, clique no botão `...`{.action} à direita e, a seguir, em `Alterar`{.action}.
 >>
 > **Etapa 3**
 >>
->> Se dispõe da oferta [Cloud Web](/links/web/hosting-cloud-web-offer) com 2 vCores, pode adicionar um segundo motor de execução (máximo de 2 por oferta) clicando no botão `Ações`{.action} e, depois, em `Adicionar um motor de execução`{.action}.
+>> Se dispõe da oferta [Cloud Web](/links/web/hosting-cloud-web-offer) com 2 vCores, pode adicionar um segundo motor de execução (máximo de 2 por oferta) clicando no botão `Ações`{.action} e, depois, em `Adicionar um tempo de execução para o aplicativo de software`{.action}.
 
 Assim, antes de prosseguir, certifique-se de que dispõe do ou dos motores de execução necessários ao seu projeto.
 
@@ -90,7 +90,7 @@ Para verificar que dispõe de 2 vCores com o seu alojamento Cloud Web, clique no
 
 Quando deseja implementar várias vezes o seu projeto em ambientes diferentes (por exemplo: desenvolvimento, teste ou produção), deverá fornecer variáveis de modo que o código reaja em conformidade. Para isso, a [Cloud Web](/links/web/hosting-cloud-web-offer) possibilita a definição de variáveis de ambiente acessíveis pelo código do seu site ou da sua aplicação web.
 
-Por exemplo, desta forma pode deixar de fora um ficheiro «.env» no framework PHP Laravel, como indica a documentação do framework: <https://laravel.com/docs/master/configuration>.
+Por exemplo, desta forma pode deixar de fora um ficheiro ".env" no framework PHP Laravel, como indica a documentação do framework: <https://laravel.com/docs/master/configuration>.
 
 Para adicionar uma variável de ambiente, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
@@ -107,7 +107,7 @@ Para adicionar uma variável de ambiente, clique nos separadores abaixo para vis
 >>
 > **Etapa 3**
 >>
->> Para adicionar uma nova, clique no botão `Ações`{.action} e depois em `Adicionar uma variável de ambiente`{.action}. Então, siga as indicações em função da variável que deseja criar.
+>> Para adicionar uma nova, clique no botão `Ações`{.action} e depois em `Adicionar um ambiente variável`{.action}. Então, siga as indicações em função da variável que deseja criar.
 >>
 >> ![Adicionar uma variável de ambiente num alojamento Cloud Web](/pages/assets/screens/control_panel/product-selection/web-cloud/cloud-web/environment-variables/add-an-environment-variable.png){.thumbnail}
 
@@ -185,11 +185,11 @@ Se optar pela utilização dos nossos módulos em 1 clique, clique nos separador
 >>
 > **Etapa 2**
 >>
->> Clique no separador `Módulos em 1 clique`{.action} e, a seguir, em `Adicionar um módulo`{.action}.
+>> Clique no separador `Módulos "1 clique"`{.action} e, a seguir, em `Adicionar um módulo`{.action}.
 >>
 > **Etapa 3**
 >>
->> Então, poderá iniciar uma instalação em modo «simples» (não personalizável) ou em modo «avançado» (com a possibilidade de personalizar certos elementos).
+>> Então, poderá iniciar uma instalação em modo "simples" (não personalizável) ou em modo "avançado" (com a possibilidade de personalizar certos elementos).
 
 Para mais informações sobre os módulos, consulte o guia: [Instalar um site com os módulos em 1 clique](/pages/web_cloud/web_hosting/cms_install_1_click_modules).
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Webhosting mit Visual Studio Code über SFTP verwalten"
 excerpt: "Eine Website auf einem Webhosting mit Visual Studio Code mithilfe einer SFTP-Erweiterung verwalten"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Ziel
@@ -93,38 +93,79 @@ Diese Datei befindet sich im Ordner .vscode, der sich wiederum im Wurzelverzeich
 
 ### Datei sftp.json konfigurieren
 
-Bevor Sie an Ihrem Projekt arbeiten, laden Sie es in Ihren zuvor erstellten lokalen Ordner herunter. Stellen Sie jedoch zunächst sicher, dass die Datei „sftp.json“ richtig konfiguriert ist. Die relevanten Informationen finden Sie in Ihrem [OVHcloud Kundencenter](/links/manager). Klicken Sie im Bereich `Web Cloud`{.action} auf `Hosting-Pakete`{.action}. Wählen Sie das betreffende Hosting aus und klicken Sie dann auf `FTP - SSH`{.action}.
+Bevor Sie an Ihrem Projekt arbeiten, laden Sie es in Ihren zuvor erstellten lokalen Ordner herunter. Stellen Sie jedoch zunächst sicher, dass die Datei „sftp.json” richtig konfiguriert ist. Lesen Sie unsere Anleitung „[Zugang zum FTP-Speicherplatz Ihres Webhostings](/pages/web_cloud/web_hosting/ftp_connection)”, um die nützlichen Informationen zu finden.
 
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Geben Sie in der Datei „sftp.json” Werte für die folgenden Einträge ein:
 
-Geben Sie in der Datei „sftp.json“ Werte für die folgenden Einträge ein:
+#### name
 
-#### name 
+Klicken Sie auf die Tabs, um die **2** Schritte anzuzeigen.
 
-Markieren Sie ihn an beiden Stellen, die orange hervorgehoben sind.
-
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Markieren Sie ihn an beiden Stellen, die orange hervorgehoben sind.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
-> Der Wert `name` ist personalisierbar, Sie können also einen Wert Ihrer Wahl einstellen. Wenn Sie jedoch mehrere „sftp.json“-Dateien konfigurieren, sollten Sie aus organisatorischen Gründen die oben angezeigten Werte als Referenz verwenden.
->
+> Der Wert `name` ist personalisierbar, Sie können also einen Wert Ihrer Wahl einstellen. Wenn Sie jedoch mehrere „sftp.json”-Dateien konfigurieren, sollten Sie aus organisatorischen Gründen die oben angezeigten Werte als Referenz verwenden.
 
 #### host
 
-Ebenfalls im Tab `FTP-SSH`{.action} ist der Hostname (`host`) unter `FTP- und SFTP-Server`{.action} sichtbar.
+Klicken Sie auf die Tabs, um die **2** Schritte anzuzeigen.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Im Tab `FTP - SSH`{.action} ist der Hostname unter `FTP- und SFTP-Server` sichtbar.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Suchen Sie den Benutzernamen (`username`) in der Spalte `Login`{.action} der Tabelle.
+Klicken Sie auf die Tabs, um die **2** Schritte anzuzeigen.
+
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Im Tab `FTP - SSH`{.action} suchen Sie den Benutzernamen in der Spalte `Login` der Tabelle.
 
 #### remotePath
 
-Den Remote-Pfad (`remotePath`) finden Sie unter `Pfad des home-Verzeichnisses`{.action}. Wenn jedoch mehrere Benutzer konfiguriert sind, kann der angegebene Pfad abweichen. Ersetzen Sie in diesem Fall den nach `home/` angegebenen Benutzernamen durch den Namen Ihrer Wahl aus der Liste `Login`{.action} Ihres Webhostings.
+Klicken Sie auf die Tabs, um die **2** Schritte anzuzeigen.
 
-**Beispiel**: Wenn Ihr Benutzername „john-smith“ lautet, erhalten Sie `home/john-smith`
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting) und wählen Sie das betreffende Webhosting aus.
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Im Tab `FTP - SSH`{.action} finden Sie den Pfad unter `Pfad des home-Verzeichnisses`. Wenn jedoch mehrere Benutzer konfiguriert sind, kann der angegebene Pfad abweichen. Ersetzen Sie in diesem Fall den nach `home/` angegebenen Benutzernamen durch den Namen Ihrer Wahl in der Spalte `Login` der Tabelle.
+>>
+>> **Beispiel**: Wenn Ihr Benutzername „john-smith” lautet, erhalten Sie `home/john-smith`.
 
 Denken Sie außerdem daran, diese Zeile in die Datei „sftp.json“ einzufügen: `"openSsh": true`
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Webhosting mit Visual Studio Code über SFTP verwalten"
 excerpt: "Eine Website auf einem Webhosting mit Visual Studio Code mithilfe einer SFTP-Erweiterung verwalten"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Ziel
@@ -10,7 +10,7 @@ Wenn Sie über ein OVHcloud Webhosting verfügen, können Sie auf einen Speicher
 
 > [!primary]
 >
-> Wenn Sie Ihre Website ohne Visual Studio Code verwalten möchten, können Sie den FileZilla FTP-Client installieren. Weitere Informationen finden Sie in unserer Anleitung „[FileZilla mit Ihrem OVHcloud Hosting verwenden](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide)“. Wenn Sie sich via SSH mit Ihrer Website verbinden möchten, lesen Sie unsere Dokumentation „[SSH-Zugang Ihres Webhostings verwenden](/pages/web_cloud/web_hosting/ssh_on_webhosting)“.
+> Wenn Sie Ihre Website ohne Visual Studio Code verwalten möchten, können Sie den FileZilla FTP-Client installieren. Weitere Informationen finden Sie in unserer Anleitung "[FileZilla mit Ihrem OVHcloud Hosting verwenden](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide)“. Wenn Sie sich via SSH mit Ihrer Website verbinden möchten, lesen Sie unsere Dokumentation "[SSH-Zugang Ihres Webhostings verwenden](/pages/web_cloud/web_hosting/ssh_on_webhosting)“.
 >
 
 **Diese Anleitung erklärt, wie Sie Ihre Website mithilfe von Visual Studio Code verwalten.**
@@ -35,16 +35,16 @@ Wenn Sie über ein OVHcloud Webhosting verfügen, können Sie auf einen Speicher
  
 > [!warning]
 >
-> OVHcloud stellt Ihnen Dienste zur Verfügung, für deren Konfiguration, Verwaltung und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit in Ihrer Verantwortung, sicherzustellen, dass diese ordnungsgemäß funktionieren.
+> OVHcloud stellt Ihnen Dienste zur Verfügung, für deren Konfiguration und Verwaltung Sie die alleinige Verantwortung tragen. Es liegt somit in Ihrer Verantwortung, sicherzustellen, dass diese ordnungsgemäß funktionieren.
 > 
-> Wir stellen Ihnen dieses Tutorial zur Verfügung, um Sie bestmöglich bei gängigen Aufgaben zu begleiten. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Anbieter](/links/partner) oder den Herausgeber von [Visual Studio Code IDE](https://code.visualstudio.com/) zu kontaktieren. Für externe Dienstleistungen bieten wir leider keine Unterstützung. Weitere Informationen finden Sie im Abschnitt [„Weiterführende Informationen“](#go-further) dieser Anleitung.
+> Wir stellen Ihnen dieses Tutorial zur Verfügung, um Sie bestmöglich bei gängigen Aufgaben zu begleiten. Dennoch empfehlen wir Ihnen, falls Sie Hilfe brauchen, einen [spezialisierten Anbieter](/links/partner) oder den Herausgeber von [Visual Studio Code IDE](https://code.visualstudio.com/) zu kontaktieren. Für externe Dienstleistungen bieten wir leider keine Unterstützung. Weitere Informationen finden Sie im Abschnitt ["Weiterführende Informationen“](#go-further) dieser Anleitung.
 >
 
 ### SFTP-Erweiterung für Visual Studio Code installieren
 
 > [!warning]
 >
-> In diesem Tutorial haben wir die Erweiterung „SFTP/FTP sync“ von *Natizyskunk* gewählt. Es steht Ihnen frei, eine andere Wahl zu treffen. Beachten Sie jedoch, dass eine Erweiterung in Visual Studio Code häufig von einem unabhängigen Entwickler erstellt wird, der die Entwicklung jederzeit unterbrechen kann.
+> In diesem Tutorial haben wir die Erweiterung "SFTP/FTP sync“ von *Natizyskunk* gewählt. Es steht Ihnen frei, eine andere Wahl zu treffen. Beachten Sie jedoch, dass eine Erweiterung in Visual Studio Code häufig von einem unabhängigen Entwickler erstellt wird, der die Entwicklung jederzeit unterbrechen kann.
 >
 
 Nachdem Sie Visual Studio Code gestartet haben, klicken Sie oben auf der Benutzeroberfläche im horizontalen Menü auf `View`{.action} und dann auf `Extensions`{.action}.
@@ -56,11 +56,11 @@ Um dieselbe Aktion mit der Tastenkombination durchzuführen, wählen Sie:
 - `Ctrl + Shift + X`, wenn Sie Windows verwenden, 
 - `Maj + Command + X`, wenn Sie auf macOS sind.
 
-Geben Sie oben links im Interface den Namen der Erweiterung „SFTP/FTP sync“ für *Natizyskunk* ein und klicken Sie auf `Install`{.action}.
+Geben Sie oben links im Interface den Namen der Erweiterung "SFTP/FTP sync“ für *Natizyskunk* ein und klicken Sie auf `Install`{.action}.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/extensions.png){.thumbnail}
 
-Es ist auch möglich, [die Erweiterung „SFTP/FTP-Sync“](https://marketplace.visualstudio.com/items?itemName=Natizyskunk.sftp#sftp-sync-extension-for-vs-code)“vom Marketplace in Visual Studio aus zu installieren.
+Es ist auch möglich, [die Erweiterung "SFTP/FTP-Sync“](https://marketplace.visualstudio.com/items?itemName=Natizyskunk.sftp#sftp-sync-extension-for-vs-code)“vom Marketplace in Visual Studio aus zu installieren.
   
 ### Projekt lokal initialisieren
 
@@ -77,7 +77,7 @@ Geben Sie den folgenden Befehl ein: `SFTP: Config`.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/SFTP_config.png){.thumbnail}
 
-Mit diesem Befehl erstellt Visual Studio Code die Konfigurationsdatei „sftp.json“ im Wurzelverzeichnis des zuvor erstellten lokalen Ordners. Da der Speicherort des Projekts in Visual Studio Code jedoch noch nicht lokal bekannt ist, sollte die folgende Meldung angezeigt werden:
+Mit diesem Befehl erstellt Visual Studio Code die Konfigurationsdatei "sftp.json“ im Wurzelverzeichnis des zuvor erstellten lokalen Ordners. Da der Speicherort des Projekts in Visual Studio Code jedoch noch nicht lokal bekannt ist, sollte die folgende Meldung angezeigt werden:
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/SFTP_folder.png){.thumbnail}
 
@@ -85,7 +85,7 @@ Klicken Sie auf `Open Folder`{.action}, navigieren Sie zum gewünschten Speicher
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/select_folder.png){.thumbnail}
 
-Geben Sie in Visual Studio Code den Befehl `SFTP: Config` erneut ein. Eine Konfigurationsdatei mit dem Namen „sftp.json“ wird in Visual Studio Code angezeigt.
+Geben Sie in Visual Studio Code den Befehl `SFTP: Config` erneut ein. Eine Konfigurationsdatei mit dem Namen "sftp.json“ wird in Visual Studio Code angezeigt.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/sftp_json_default.png){.thumbnail}
 
@@ -93,9 +93,9 @@ Diese Datei befindet sich im Ordner .vscode, der sich wiederum im Wurzelverzeich
 
 ### Datei sftp.json konfigurieren
 
-Bevor Sie an Ihrem Projekt arbeiten, laden Sie es in Ihren zuvor erstellten lokalen Ordner herunter. Stellen Sie jedoch zunächst sicher, dass die Datei „sftp.json” richtig konfiguriert ist. Lesen Sie unsere Anleitung „[Zugang zum FTP-Speicherplatz Ihres Webhostings](/pages/web_cloud/web_hosting/ftp_connection)”, um die nützlichen Informationen zu finden.
+Bevor Sie an Ihrem Projekt arbeiten, laden Sie es in Ihren zuvor erstellten lokalen Ordner herunter. Stellen Sie jedoch zunächst sicher, dass die Datei "sftp.json” richtig konfiguriert ist. Lesen Sie unsere Anleitung "[Zugang zum FTP-Speicherplatz Ihres Webhostings](/pages/web_cloud/web_hosting/ftp_connection)”, um die nützlichen Informationen zu finden.
 
-Geben Sie in der Datei „sftp.json” Werte für die folgenden Einträge ein:
+Geben Sie in der Datei "sftp.json” Werte für die folgenden Einträge ein:
 
 #### name
 
@@ -116,7 +116,7 @@ Klicken Sie auf die Tabs, um die **2** Schritte anzuzeigen.
 
 > [!primary]
 >
-> Der Wert `name` ist personalisierbar, Sie können also einen Wert Ihrer Wahl einstellen. Wenn Sie jedoch mehrere „sftp.json”-Dateien konfigurieren, sollten Sie aus organisatorischen Gründen die oben angezeigten Werte als Referenz verwenden.
+> Der Wert `name` ist personalisierbar, Sie können also einen Wert Ihrer Wahl einstellen. Wenn Sie jedoch mehrere "sftp.json”-Dateien konfigurieren, sollten Sie aus organisatorischen Gründen die oben angezeigten Werte als Referenz verwenden.
 
 #### host
 
@@ -165,16 +165,16 @@ Klicken Sie auf die Tabs, um die **2** Schritte anzuzeigen.
 >>
 >> Im Tab `FTP - SSH`{.action} finden Sie den Pfad unter `Pfad des home-Verzeichnisses`. Wenn jedoch mehrere Benutzer konfiguriert sind, kann der angegebene Pfad abweichen. Ersetzen Sie in diesem Fall den nach `home/` angegebenen Benutzernamen durch den Namen Ihrer Wahl in der Spalte `Login` der Tabelle.
 >>
->> **Beispiel**: Wenn Ihr Benutzername „john-smith” lautet, erhalten Sie `home/john-smith`.
+>> **Beispiel**: Wenn Ihr Benutzername "john-smith” lautet, erhalten Sie `home/john-smith`.
 
-Denken Sie außerdem daran, diese Zeile in die Datei „sftp.json“ einzufügen: `"openSsh": true`
+Denken Sie außerdem daran, diese Zeile in die Datei "sftp.json“ einzufügen: `"openSsh": true`
 
 > [!primary]
 >
-> Um nicht nach jedem Befehl in Visual Studio Code das Kennwort eingeben zu müssen, speichern Sie es in der Datei „sftp.json“, indem Sie die Zeile `"password": "<password>"` hinzufügen
+> Um nicht nach jedem Befehl in Visual Studio Code das Kennwort eingeben zu müssen, speichern Sie es in der Datei "sftp.json“, indem Sie die Zeile `"password": "<password>"` hinzufügen
 >
 
-Hier ein Beispiel für eine „sftp.json“-Datei:
+Hier ein Beispiel für eine "sftp.json“-Datei:
 
 ```json
 
@@ -193,32 +193,32 @@ Hier ein Beispiel für eine „sftp.json“-Datei:
 
 ```
 
-Weitere Informationen zu den Optionen in der Datei „sftp.json“ finden Sie in der [Projektdokumentation](https://github.com/Natizyskunk/vscode-sftp/wiki/configuration).
+Weitere Informationen zu den Optionen in der Datei "sftp.json“ finden Sie in der [Projektdokumentation](https://github.com/Natizyskunk/vscode-sftp/wiki/configuration).
 
 ### Projekt lokal herunterladen
 
-Nachdem Sie die Datei „sftp.json“ konfiguriert haben, laden Sie den Inhalt Ihres Projekts herunter, um alle Ordner und Dateien Ihrer Website abzurufen. Rufen Sie dazu Visual Studio Code auf, und geben Sie den folgenden Befehl ein: `SFTP: Download Project`.
+Nachdem Sie die Datei "sftp.json“ konfiguriert haben, laden Sie den Inhalt Ihres Projekts herunter, um alle Ordner und Dateien Ihrer Website abzurufen. Rufen Sie dazu Visual Studio Code auf, und geben Sie den folgenden Befehl ein: `SFTP: Download Project`.
 
-Visual Studio Code fordert Sie auf, den Ordner auszuwählen, den Sie auf Ihr Webhosting hochladen möchten. Geben Sie den zuvor in der Datei „sftp.json“ festgelegten Wert `name` ein.
+Visual Studio Code fordert Sie auf, den Ordner auszuwählen, den Sie auf Ihr Webhosting hochladen möchten. Geben Sie den zuvor in der Datei "sftp.json“ festgelegten Wert `name` ein.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/download_project.png){.thumbnail}
 
-Wenn Sie dazu aufgefordert werden, geben Sie das Passwort für den in der Datei „sftp.json“ angegebenen Benutzer ein und klicken Sie dann auf `enter`. Nach dem Herunterladen werden alle Projektordner und -dateien im Datei-Explorer in der linken Spalte der Visual Studio Code Benutzeroberfläche angezeigt.
+Wenn Sie dazu aufgefordert werden, geben Sie das Passwort für den in der Datei "sftp.json“ angegebenen Benutzer ein und klicken Sie dann auf `enter`. Nach dem Herunterladen werden alle Projektordner und -dateien im Datei-Explorer in der linken Spalte der Visual Studio Code Benutzeroberfläche angezeigt.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/explorer.png){.thumbnail}
 
 > [!primary]
 >
-> Zur Erinnerung: Die richtige Konfiguration der Datei „sftp.json“ ist entscheidend. Wenn Sie vor dem Hochladen Ihres Projekts auf einen Fehler stoßen, wird dies normalerweise durch einen Konfigurationsfehler in der Datei „sftp.json“ verursacht. Weitere Informationen hierzu finden Sie in den [FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
+> Zur Erinnerung: Die richtige Konfiguration der Datei "sftp.json“ ist entscheidend. Wenn Sie vor dem Hochladen Ihres Projekts auf einen Fehler stoßen, wird dies normalerweise durch einen Konfigurationsfehler in der Datei "sftp.json“ verursacht. Weitere Informationen hierzu finden Sie in den [FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
 >
 
 ### Änderungen an Dateien vornehmen
 
 Nun, da das Projekt lokal auf Ihren Computer heruntergeladen wurde, können Sie Dateien in Visual Studio Code auf einfache Weise bearbeiten, hinzufügen oder löschen.
 
-Wenn Sie möchten, dass Ihre lokalen Änderungen bei jedem Speichern einer Datei synchronisiert werden, fügen Sie diese Zeile der Datei „sftp.json“ hinzu: `"uploadOnSave": true`
+Wenn Sie möchten, dass Ihre lokalen Änderungen bei jedem Speichern einer Datei synchronisiert werden, fügen Sie diese Zeile der Datei "sftp.json“ hinzu: `"uploadOnSave": true`
 
-Um diese Funktion zu deaktivieren, aber in der Datei „sftp.json“ zu belassen, ersetzen Sie den Wert `true` durch `false`.
+Um diese Funktion zu deaktivieren, aber in der Datei "sftp.json“ zu belassen, ersetzen Sie den Wert `true` durch `false`.
 
 Bisher haben wir nur die Befehle: `SFTP: Config` und `SFTP: Download Project` erwähnt. Es gibt weitere Befehle, die Sie durch Autovervollständigung beobachten können, indem Sie im Befehlseditor `SFTP:` eingeben.
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -14,7 +14,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 >
 
 **Find out how to manage your website using Visual Studio Code.**
-  
+
 ## Requirements
 
 - a [OVHcloud web hosting plan](/links/web/hosting)
@@ -32,11 +32,11 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 <!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
- 
+
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for configuring, managing and managing. It is therefore up to you to ensure that it works properly.
-> 
+>
 > We offer this tutorial to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the Visual Studio Code IDE](https://code.visualstudio.com/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
 >
 
@@ -44,7 +44,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 
 > [!warning]
 >
-> In this tutorial, we have chosen the “SFTP/FTP sync” extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
+> In this tutorial, we have chosen the "SFTP/FTP sync" extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
 >
 
 After starting Visual Studio Code, go to the horizontal menu at the top of the interface, click `View`{.action} then `Extensions`{.action}.
@@ -53,15 +53,15 @@ After starting Visual Studio Code, go to the horizontal menu at the top of the i
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + X` if you are on Windows, 
+- `Ctrl + Shift + X` if you are on Windows,
 - `Maj + Command + X` if you are on macOS.
 
-In the top left of the interface, enter the name of the *Natizyskunk* “SFTP/FTP sync” extension, and click `Install`{.action}.
+In the top left of the interface, enter the name of the *Natizyskunk* "SFTP/FTP sync" extension, and click `Install`{.action}.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/extensions.png){.thumbnail}
 
 You can also install [the "SFTP/FTP sync" extension](https://marketplace.visualstudio.com/items?itemName=Natizyskunk.sftp#sftp-sync-extension-for-vs-code) from the Visual Studio Marketplace.
-  
+
 ### Initialize project locally
 
 To synchronize your website files on the web hosting plan from Visual Studio Code, enter your project location locally. To do this, create a folder in the location you want.
@@ -70,7 +70,7 @@ Go back to Visual Studio Code in the horizontal menu at the top of the interface
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + P` if you are on Windows, 
+- `Ctrl + Shift + P` if you are on Windows,
 - `Maj + Command + P` if you are on macOS.
 
 Enter the following command: `SFTP: Config`.
@@ -93,47 +93,88 @@ This file is located in the .vscode folder, which is located at the root of your
 
 ### Configure the sftp.json file
 
-Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the “sftp.json” file is correctly configured. Useful information can be found in your [OVHcloud Control Panel](/links/manager). In the `Web Cloud`{.action} section, click `Hosting plans`{.action}. Select the web hosting plan concerned, then click on the `FTP - SSH`{.action} tab.
-
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the "sftp.json" file is correctly configured. Refer to our guide "[Logging in to your Web Hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)" to find the useful information.
 
 In the "sftp.json" file, enter the values for the following entries:
 
 #### name
 
-Locate it at the two locations highlighted in orange.
+To find the name of your web hosting plan, click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate it at the two locations highlighted in orange.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
 > The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
->
 
 #### host
 
-In the `FTP-SSH`{.action} tab, the host name (`host`) is visible under the mention `FTP and SFTP server`{.action}.
+To find the host name (`host`), click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, the host name is visible under the mention `FTP and SFTP server`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Locate the `username` in the `Login`{.action} column of the table.
+To find the username, click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the username in the `Login` column of the table.
 
 #### remotePath
 
-Find the `remotePath` under `Home directory path`{.action}. However, if multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login`{.action} list of your web hosting plan.
+To find the remote path (`remotePath`), click on the tabs below to view each of the **2** steps.
 
-**Example**: If your username is "john-smith" you will get `home/john-smith`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the path under the mention `Home directory path`. If multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login` column of the table.
+>>
+>> **Example**: If your username is "john-smith" you will get `home/john-smith`.
 
-Finally, remember to add this line in the file “sftp.json”: `"openSsh": true`.
+Finally, remember to add this line in the file "sftp.json": `"openSsh": true`.
 
 > [!primary]
 >
-> To avoid entering your password after each command in Visual Studio Code, save it in the file “sftp.json” by adding the line: `"password": "<password>"`
+> To avoid entering your password after each command in Visual Studio Code, save it in the file "sftp.json" by adding the line: `"password": "<password>"`
 >
 
-Here is an example of a file called “sftp.json”:
+Here is an example of a file called "sftp.json":
 
 ```json
 
@@ -156,19 +197,19 @@ For more details on the options in the sftp.json file, see the [project document
 
 ### Download the project locally
 
-Once you have configured the “sftp.json” file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
+Once you have configured the "sftp.json" file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
 
-Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file “sftp.json” .
+Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file "sftp.json" .
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/download_project.png){.thumbnail}
 
-If prompted, enter the user password entered in the “sftp.json” file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
+If prompted, enter the user password entered in the "sftp.json" file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/explorer.png){.thumbnail}
 
 > [!primary]
 >
-> As a reminder, it is important to configure the “sftp.json” file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the “sftp.json” file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
+> As a reminder, it is important to configure the "sftp.json" file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the "sftp.json" file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
 >
 
 ### Make changes to files
@@ -191,7 +232,7 @@ The purpose of this tutorial is to provide an effective introduction to managing
 
 ## Go further <a name="go-further"></a>
 
-[Log in to your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
+[Log in to your web hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
 [Use FileZilla with your OVHcloud hosting plan](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide)
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-asia.md
@@ -116,7 +116,7 @@ To find the name of your web hosting plan, click on the tabs below to view each 
 
 > [!primary]
 >
-> The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
+> The `name` value is customisable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organisational reasons.
 
 #### host
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -14,7 +14,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 >
 
 **Find out how to manage your website using Visual Studio Code.**
-  
+
 ## Requirements
 
 - a [OVHcloud web hosting plan](/links/web/hosting)
@@ -32,11 +32,11 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 <!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
- 
+
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for configuring, managing and managing. It is therefore up to you to ensure that it works properly.
-> 
+>
 > We offer this tutorial to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the Visual Studio Code IDE](https://code.visualstudio.com/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
 >
 
@@ -44,7 +44,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 
 > [!warning]
 >
-> In this tutorial, we have chosen the “SFTP/FTP sync” extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
+> In this tutorial, we have chosen the "SFTP/FTP sync" extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
 >
 
 After starting Visual Studio Code, go to the horizontal menu at the top of the interface, click `View`{.action} then `Extensions`{.action}.
@@ -53,15 +53,15 @@ After starting Visual Studio Code, go to the horizontal menu at the top of the i
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + X` if you are on Windows, 
+- `Ctrl + Shift + X` if you are on Windows,
 - `Maj + Command + X` if you are on macOS.
 
-In the top left of the interface, enter the name of the *Natizyskunk* “SFTP/FTP sync” extension, and click `Install`{.action}.
+In the top left of the interface, enter the name of the *Natizyskunk* "SFTP/FTP sync" extension, and click `Install`{.action}.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/extensions.png){.thumbnail}
 
 You can also install [the "SFTP/FTP sync" extension](https://marketplace.visualstudio.com/items?itemName=Natizyskunk.sftp#sftp-sync-extension-for-vs-code) from the Visual Studio Marketplace.
-  
+
 ### Initialize project locally
 
 To synchronize your website files on the web hosting plan from Visual Studio Code, enter your project location locally. To do this, create a folder in the location you want.
@@ -70,7 +70,7 @@ Go back to Visual Studio Code in the horizontal menu at the top of the interface
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + P` if you are on Windows, 
+- `Ctrl + Shift + P` if you are on Windows,
 - `Maj + Command + P` if you are on macOS.
 
 Enter the following command: `SFTP: Config`.
@@ -93,47 +93,88 @@ This file is located in the .vscode folder, which is located at the root of your
 
 ### Configure the sftp.json file
 
-Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the “sftp.json” file is correctly configured. Useful information can be found in your [OVHcloud Control Panel](/links/manager). In the `Web Cloud`{.action} section, click `Hosting plans`{.action}. Select the web hosting plan concerned, then click on the `FTP - SSH`{.action} tab.
-
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the "sftp.json" file is correctly configured. Refer to our guide "[Logging in to your Web Hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)" to find the useful information.
 
 In the "sftp.json" file, enter the values for the following entries:
 
 #### name
 
-Locate it at the two locations highlighted in orange.
+To find the name of your web hosting plan, click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate it at the two locations highlighted in orange.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
 > The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
->
 
 #### host
 
-In the `FTP-SSH`{.action} tab, the host name (`host`) is visible under the mention `FTP and SFTP server`{.action}.
+To find the host name (`host`), click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, the host name is visible under the mention `FTP and SFTP server`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Locate the `username` in the `Login`{.action} column of the table.
+To find the username, click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the username in the `Login` column of the table.
 
 #### remotePath
 
-Find the `remotePath` under `Home directory path`{.action}. However, if multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login`{.action} list of your web hosting plan.
+To find the remote path (`remotePath`), click on the tabs below to view each of the **2** steps.
 
-**Example**: If your username is "john-smith" you will get `home/john-smith`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the path under the mention `Home directory path`. If multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login` column of the table.
+>>
+>> **Example**: If your username is "john-smith" you will get `home/john-smith`.
 
-Finally, remember to add this line in the file “sftp.json”: `"openSsh": true`.
+Finally, remember to add this line in the file "sftp.json": `"openSsh": true`.
 
 > [!primary]
 >
-> To avoid entering your password after each command in Visual Studio Code, save it in the file “sftp.json” by adding the line: `"password": "<password>"`
+> To avoid entering your password after each command in Visual Studio Code, save it in the file "sftp.json" by adding the line: `"password": "<password>"`
 >
 
-Here is an example of a file called “sftp.json”:
+Here is an example of a file called "sftp.json":
 
 ```json
 
@@ -156,19 +197,19 @@ For more details on the options in the sftp.json file, see the [project document
 
 ### Download the project locally
 
-Once you have configured the “sftp.json” file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
+Once you have configured the "sftp.json" file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
 
-Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file “sftp.json” .
+Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file "sftp.json" .
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/download_project.png){.thumbnail}
 
-If prompted, enter the user password entered in the “sftp.json” file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
+If prompted, enter the user password entered in the "sftp.json" file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/explorer.png){.thumbnail}
 
 > [!primary]
 >
-> As a reminder, it is important to configure the “sftp.json” file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the “sftp.json” file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
+> As a reminder, it is important to configure the "sftp.json" file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the "sftp.json" file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
 >
 
 ### Make changes to files
@@ -191,7 +232,7 @@ The purpose of this tutorial is to provide an effective introduction to managing
 
 ## Go further <a name="go-further"></a>
 
-[Log in to your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
+[Log in to your web hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
 [Use FileZilla with your OVHcloud hosting plan](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide)
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-au.md
@@ -116,7 +116,7 @@ To find the name of your web hosting plan, click on the tabs below to view each 
 
 > [!primary]
 >
-> The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
+> The `name` value is customisable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organisational reasons.
 
 #### host
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -14,7 +14,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 >
 
 **Find out how to manage your website using Visual Studio Code.**
-  
+
 ## Requirements
 
 - a [OVHcloud web hosting plan](/links/web/hosting)
@@ -32,11 +32,11 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 <!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
- 
+
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for configuring, managing and managing. It is therefore up to you to ensure that it works properly.
-> 
+>
 > We offer this tutorial to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the Visual Studio Code IDE](https://code.visualstudio.com/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
 >
 
@@ -44,7 +44,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 
 > [!warning]
 >
-> In this tutorial, we have chosen the “SFTP/FTP sync” extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
+> In this tutorial, we have chosen the "SFTP/FTP sync" extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
 >
 
 After starting Visual Studio Code, go to the horizontal menu at the top of the interface, click `View`{.action} then `Extensions`{.action}.
@@ -53,15 +53,15 @@ After starting Visual Studio Code, go to the horizontal menu at the top of the i
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + X` if you are on Windows, 
+- `Ctrl + Shift + X` if you are on Windows,
 - `Maj + Command + X` if you are on macOS.
 
-In the top left of the interface, enter the name of the *Natizyskunk* “SFTP/FTP sync” extension, and click `Install`{.action}.
+In the top left of the interface, enter the name of the *Natizyskunk* "SFTP/FTP sync" extension, and click `Install`{.action}.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/extensions.png){.thumbnail}
 
 You can also install [the "SFTP/FTP sync" extension](https://marketplace.visualstudio.com/items?itemName=Natizyskunk.sftp#sftp-sync-extension-for-vs-code) from the Visual Studio Marketplace.
-  
+
 ### Initialize project locally
 
 To synchronize your website files on the web hosting plan from Visual Studio Code, enter your project location locally. To do this, create a folder in the location you want.
@@ -70,7 +70,7 @@ Go back to Visual Studio Code in the horizontal menu at the top of the interface
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + P` if you are on Windows, 
+- `Ctrl + Shift + P` if you are on Windows,
 - `Maj + Command + P` if you are on macOS.
 
 Enter the following command: `SFTP: Config`.
@@ -93,47 +93,88 @@ This file is located in the .vscode folder, which is located at the root of your
 
 ### Configure the sftp.json file
 
-Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the “sftp.json” file is correctly configured. Useful information can be found in your [OVHcloud Control Panel](/links/manager). In the `Web Cloud`{.action} section, click `Hosting plans`{.action}. Select the web hosting plan concerned, then click on the `FTP - SSH`{.action} tab.
-
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the "sftp.json" file is correctly configured. Refer to our guide "[Logging in to your Web Hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)" to find the useful information.
 
 In the "sftp.json" file, enter the values for the following entries:
 
 #### name
 
-Locate it at the two locations highlighted in orange.
+To find the name of your web hosting plan, click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate it at the two locations highlighted in orange.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
 > The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
->
 
 #### host
 
-In the `FTP-SSH`{.action} tab, the host name (`host`) is visible under the mention `FTP and SFTP server`{.action}.
+To find the host name (`host`), click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, the host name is visible under the mention `FTP and SFTP server`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Locate the `username` in the `Login`{.action} column of the table.
+To find the username, click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the username in the `Login` column of the table.
 
 #### remotePath
 
-Find the `remotePath` under `Home directory path`{.action}. However, if multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login`{.action} list of your web hosting plan.
+To find the remote path (`remotePath`), click on the tabs below to view each of the **2** steps.
 
-**Example**: If your username is "john-smith" you will get `home/john-smith`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the path under the mention `Home directory path`. If multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login` column of the table.
+>>
+>> **Example**: If your username is "john-smith" you will get `home/john-smith`.
 
-Finally, remember to add this line in the file “sftp.json”: `"openSsh": true`.
+Finally, remember to add this line in the file "sftp.json": `"openSsh": true`.
 
 > [!primary]
 >
-> To avoid entering your password after each command in Visual Studio Code, save it in the file “sftp.json” by adding the line: `"password": "<password>"`
+> To avoid entering your password after each command in Visual Studio Code, save it in the file "sftp.json" by adding the line: `"password": "<password>"`
 >
 
-Here is an example of a file called “sftp.json”:
+Here is an example of a file called "sftp.json":
 
 ```json
 
@@ -156,19 +197,19 @@ For more details on the options in the sftp.json file, see the [project document
 
 ### Download the project locally
 
-Once you have configured the “sftp.json” file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
+Once you have configured the "sftp.json" file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
 
-Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file “sftp.json” .
+Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file "sftp.json" .
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/download_project.png){.thumbnail}
 
-If prompted, enter the user password entered in the “sftp.json” file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
+If prompted, enter the user password entered in the "sftp.json" file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/explorer.png){.thumbnail}
 
 > [!primary]
 >
-> As a reminder, it is important to configure the “sftp.json” file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the “sftp.json” file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
+> As a reminder, it is important to configure the "sftp.json" file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the "sftp.json" file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
 >
 
 ### Make changes to files
@@ -191,7 +232,7 @@ The purpose of this tutorial is to provide an effective introduction to managing
 
 ## Go further <a name="go-further"></a>
 
-[Log in to your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
+[Log in to your web hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
 [Use FileZilla with your OVHcloud hosting plan](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide)
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ca.md
@@ -116,7 +116,7 @@ To find the name of your web hosting plan, click on the tabs below to view each 
 
 > [!primary]
 >
-> The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
+> The `name` value is customisable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organisational reasons.
 
 #### host
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-gb.md
@@ -116,7 +116,7 @@ To find the name of your web hosting plan, click on the tabs below to view each 
 
 > [!primary]
 >
-> The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple “sftp.json” files, it is best to use the values visible above as a reference for organizational reasons.
+> The `name` value is customisable, so you can assign the value of your choice. However, if you are configuring multiple “sftp.json” files, it is best to use the values visible above as a reference for organisational reasons.
 
 #### host
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -93,38 +93,79 @@ This file is located in the .vscode folder, which is located at the root of your
 
 ### Configure the sftp.json file
 
-Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the “sftp.json” file is correctly configured. Useful information can be found in your [OVHcloud Control Panel](/links/manager). In the `Web Cloud`{.action} section, click `Hosting plans`{.action}. Select the web hosting plan concerned, then click on the `FTP - SSH`{.action} tab.
+Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the “sftp.json” file is correctly configured. Refer to our guide “[Logging in to your Web Hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)” to find the useful information.
 
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
-
-In the "sftp.json" file, enter the values for the following entries:
+In the “sftp.json” file, enter the values for the following entries:
 
 #### name
 
-Locate it at the two locations highlighted in orange.
+To find the name of your web hosting plan, click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate it at the two locations highlighted in orange.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
-> The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
->
+> The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple “sftp.json” files, it is best to use the values visible above as a reference for organizational reasons.
 
 #### host
 
-In the `FTP-SSH`{.action} tab, the host name (`host`) is visible under the mention `FTP and SFTP server`{.action}.
+To find the host name (`host`), click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, the host name is visible under the mention `FTP and SFTP server`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Locate the `username` in the `Login`{.action} column of the table.
+To find the username, click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the username in the `Login` column of the table.
 
 #### remotePath
 
-Find the `remotePath` under `Home directory path`{.action}. However, if multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login`{.action} list of your web hosting plan.
+To find the remote path (`remotePath`), click on the tabs below to view each of the **2** steps.
 
-**Example**: If your username is "john-smith" you will get `home/john-smith`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the path under the mention `Home directory path`. If multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login` column of the table.
+>>
+>> **Example**: If your username is “john-smith” you will get `home/john-smith`.
 
 Finally, remember to add this line in the file “sftp.json”: `"openSsh": true`.
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -14,7 +14,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 >
 
 **Find out how to manage your website using Visual Studio Code.**
-  
+
 ## Requirements
 
 - a [OVHcloud web hosting plan](/links/web/hosting)
@@ -32,11 +32,11 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 <!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
- 
+
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for configuring, managing and managing. It is therefore up to you to ensure that it works properly.
-> 
+>
 > We offer this tutorial to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the Visual Studio Code IDE](https://code.visualstudio.com/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
 >
 
@@ -44,7 +44,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 
 > [!warning]
 >
-> In this tutorial, we have chosen the “SFTP/FTP sync” extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
+> In this tutorial, we have chosen the "SFTP/FTP sync" extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
 >
 
 After starting Visual Studio Code, go to the horizontal menu at the top of the interface, click `View`{.action} then `Extensions`{.action}.
@@ -53,15 +53,15 @@ After starting Visual Studio Code, go to the horizontal menu at the top of the i
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + X` if you are on Windows, 
+- `Ctrl + Shift + X` if you are on Windows,
 - `Maj + Command + X` if you are on macOS.
 
-In the top left of the interface, enter the name of the *Natizyskunk* “SFTP/FTP sync” extension, and click `Install`{.action}.
+In the top left of the interface, enter the name of the *Natizyskunk* "SFTP/FTP sync" extension, and click `Install`{.action}.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/extensions.png){.thumbnail}
 
 You can also install [the "SFTP/FTP sync" extension](https://marketplace.visualstudio.com/items?itemName=Natizyskunk.sftp#sftp-sync-extension-for-vs-code) from the Visual Studio Marketplace.
-  
+
 ### Initialize project locally
 
 To synchronize your website files on the web hosting plan from Visual Studio Code, enter your project location locally. To do this, create a folder in the location you want.
@@ -70,7 +70,7 @@ Go back to Visual Studio Code in the horizontal menu at the top of the interface
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + P` if you are on Windows, 
+- `Ctrl + Shift + P` if you are on Windows,
 - `Maj + Command + P` if you are on macOS.
 
 Enter the following command: `SFTP: Config`.
@@ -93,47 +93,88 @@ This file is located in the .vscode folder, which is located at the root of your
 
 ### Configure the sftp.json file
 
-Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the “sftp.json” file is correctly configured. Useful information can be found in your [OVHcloud Control Panel](/links/manager). In the `Web Cloud`{.action} section, click `Hosting plans`{.action}. Select the web hosting plan concerned, then click on the `FTP - SSH`{.action} tab.
-
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the "sftp.json" file is correctly configured. Refer to our guide "[Logging in to your Web Hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)" to find the useful information.
 
 In the "sftp.json" file, enter the values for the following entries:
 
 #### name
 
-Locate it at the two locations highlighted in orange.
+To find the name of your web hosting plan, click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate it at the two locations highlighted in orange.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
 > The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
->
 
 #### host
 
-In the `FTP-SSH`{.action} tab, the host name (`host`) is visible under the mention `FTP and SFTP server`{.action}.
+To find the host name (`host`), click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, the host name is visible under the mention `FTP and SFTP server`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Locate the `username` in the `Login`{.action} column of the table.
+To find the username, click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the username in the `Login` column of the table.
 
 #### remotePath
 
-Find the `remotePath` under `Home directory path`{.action}. However, if multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login`{.action} list of your web hosting plan.
+To find the remote path (`remotePath`), click on the tabs below to view each of the **2** steps.
 
-**Example**: If your username is "john-smith" you will get `home/john-smith`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the path under the mention `Home directory path`. If multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login` column of the table.
+>>
+>> **Example**: If your username is "john-smith" you will get `home/john-smith`.
 
-Finally, remember to add this line in the file “sftp.json”: `"openSsh": true`.
+Finally, remember to add this line in the file "sftp.json": `"openSsh": true`.
 
 > [!primary]
 >
-> To avoid entering your password after each command in Visual Studio Code, save it in the file “sftp.json” by adding the line: `"password": "<password>"`
+> To avoid entering your password after each command in Visual Studio Code, save it in the file "sftp.json" by adding the line: `"password": "<password>"`
 >
 
-Here is an example of a file called “sftp.json”:
+Here is an example of a file called "sftp.json":
 
 ```json
 
@@ -156,19 +197,19 @@ For more details on the options in the sftp.json file, see the [project document
 
 ### Download the project locally
 
-Once you have configured the “sftp.json” file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
+Once you have configured the "sftp.json" file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
 
-Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file “sftp.json” .
+Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file "sftp.json" .
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/download_project.png){.thumbnail}
 
-If prompted, enter the user password entered in the “sftp.json” file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
+If prompted, enter the user password entered in the "sftp.json" file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/explorer.png){.thumbnail}
 
 > [!primary]
 >
-> As a reminder, it is important to configure the “sftp.json” file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the “sftp.json” file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
+> As a reminder, it is important to configure the "sftp.json" file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the "sftp.json" file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
 >
 
 ### Make changes to files
@@ -191,7 +232,7 @@ The purpose of this tutorial is to provide an effective introduction to managing
 
 ## Go further <a name="go-further"></a>
 
-[Log in to your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
+[Log in to your web hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
 [Use FileZilla with your OVHcloud hosting plan](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide)
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-ie.md
@@ -116,7 +116,7 @@ To find the name of your web hosting plan, click on the tabs below to view each 
 
 > [!primary]
 >
-> The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
+> The `name` value is customisable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organisational reasons.
 
 #### host
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -14,7 +14,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 >
 
 **Find out how to manage your website using Visual Studio Code.**
-  
+
 ## Requirements
 
 - a [OVHcloud web hosting plan](/links/web/hosting)
@@ -32,11 +32,11 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 <!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
- 
+
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for configuring, managing and managing. It is therefore up to you to ensure that it works properly.
-> 
+>
 > We offer this tutorial to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the Visual Studio Code IDE](https://code.visualstudio.com/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
 >
 
@@ -44,7 +44,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 
 > [!warning]
 >
-> In this tutorial, we have chosen the “SFTP/FTP sync” extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
+> In this tutorial, we have chosen the "SFTP/FTP sync" extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
 >
 
 After starting Visual Studio Code, go to the horizontal menu at the top of the interface, click `View`{.action} then `Extensions`{.action}.
@@ -53,15 +53,15 @@ After starting Visual Studio Code, go to the horizontal menu at the top of the i
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + X` if you are on Windows, 
+- `Ctrl + Shift + X` if you are on Windows,
 - `Maj + Command + X` if you are on macOS.
 
-In the top left of the interface, enter the name of the *Natizyskunk* “SFTP/FTP sync” extension, and click `Install`{.action}.
+In the top left of the interface, enter the name of the *Natizyskunk* "SFTP/FTP sync" extension, and click `Install`{.action}.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/extensions.png){.thumbnail}
 
 You can also install [the "SFTP/FTP sync" extension](https://marketplace.visualstudio.com/items?itemName=Natizyskunk.sftp#sftp-sync-extension-for-vs-code) from the Visual Studio Marketplace.
-  
+
 ### Initialize project locally
 
 To synchronize your website files on the web hosting plan from Visual Studio Code, enter your project location locally. To do this, create a folder in the location you want.
@@ -70,7 +70,7 @@ Go back to Visual Studio Code in the horizontal menu at the top of the interface
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + P` if you are on Windows, 
+- `Ctrl + Shift + P` if you are on Windows,
 - `Maj + Command + P` if you are on macOS.
 
 Enter the following command: `SFTP: Config`.
@@ -93,47 +93,88 @@ This file is located in the .vscode folder, which is located at the root of your
 
 ### Configure the sftp.json file
 
-Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the “sftp.json” file is correctly configured. Useful information can be found in your [OVHcloud Control Panel](/links/manager). In the `Web Cloud`{.action} section, click `Hosting plans`{.action}. Select the web hosting plan concerned, then click on the `FTP - SSH`{.action} tab.
-
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the "sftp.json" file is correctly configured. Refer to our guide "[Logging in to your Web Hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)" to find the useful information.
 
 In the "sftp.json" file, enter the values for the following entries:
 
 #### name
 
-Locate it at the two locations highlighted in orange.
+To find the name of your web hosting plan, click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate it at the two locations highlighted in orange.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
 > The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
->
 
 #### host
 
-In the `FTP-SSH`{.action} tab, the host name (`host`) is visible under the mention `FTP and SFTP server`{.action}.
+To find the host name (`host`), click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, the host name is visible under the mention `FTP and SFTP server`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Locate the `username` in the `Login`{.action} column of the table.
+To find the username, click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the username in the `Login` column of the table.
 
 #### remotePath
 
-Find the `remotePath` under `Home directory path`{.action}. However, if multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login`{.action} list of your web hosting plan.
+To find the remote path (`remotePath`), click on the tabs below to view each of the **2** steps.
 
-**Example**: If your username is "john-smith" you will get `home/john-smith`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the path under the mention `Home directory path`. If multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login` column of the table.
+>>
+>> **Example**: If your username is "john-smith" you will get `home/john-smith`.
 
-Finally, remember to add this line in the file “sftp.json”: `"openSsh": true`.
+Finally, remember to add this line in the file "sftp.json": `"openSsh": true`.
 
 > [!primary]
 >
-> To avoid entering your password after each command in Visual Studio Code, save it in the file “sftp.json” by adding the line: `"password": "<password>"`
+> To avoid entering your password after each command in Visual Studio Code, save it in the file "sftp.json" by adding the line: `"password": "<password>"`
 >
 
-Here is an example of a file called “sftp.json”:
+Here is an example of a file called "sftp.json":
 
 ```json
 
@@ -156,19 +197,19 @@ For more details on the options in the sftp.json file, see the [project document
 
 ### Download the project locally
 
-Once you have configured the “sftp.json” file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
+Once you have configured the "sftp.json" file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
 
-Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file “sftp.json” .
+Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file "sftp.json" .
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/download_project.png){.thumbnail}
 
-If prompted, enter the user password entered in the “sftp.json” file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
+If prompted, enter the user password entered in the "sftp.json" file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/explorer.png){.thumbnail}
 
 > [!primary]
 >
-> As a reminder, it is important to configure the “sftp.json” file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the “sftp.json” file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
+> As a reminder, it is important to configure the "sftp.json" file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the "sftp.json" file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
 >
 
 ### Make changes to files
@@ -191,7 +232,7 @@ The purpose of this tutorial is to provide an effective introduction to managing
 
 ## Go further <a name="go-further"></a>
 
-[Log in to your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
+[Log in to your web hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
 [Use FileZilla with your OVHcloud hosting plan](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide)
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-sg.md
@@ -116,7 +116,7 @@ To find the name of your web hosting plan, click on the tabs below to view each 
 
 > [!primary]
 >
-> The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
+> The `name` value is customisable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organisational reasons.
 
 #### host
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Managing your web hosting plan with Visual Studio Code via SFTP"
 excerpt: "Administering a website on a web hosting plan with Visual Studio Code using an SFTP extension"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -14,7 +14,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 >
 
 **Find out how to manage your website using Visual Studio Code.**
-  
+
 ## Requirements
 
 - a [OVHcloud web hosting plan](/links/web/hosting)
@@ -32,11 +32,11 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 <!-- CP-NAV-END:web-hosting -->
 
 ## Instructions
- 
+
 > [!warning]
 >
 > OVHcloud provides services that you are responsible for configuring, managing and managing. It is therefore up to you to ensure that it works properly.
-> 
+>
 > We offer this tutorial to help you with common tasks. Nevertheless, we recommend contacting a [specialist provider](/links/partner) or [the publisher of the Visual Studio Code IDE](https://code.visualstudio.com/) if you experience any difficulties. We will not be able to assist you. More information in the ["Go further"](#go-further) section of this tutorial.
 >
 
@@ -44,7 +44,7 @@ If you have an OVHcloud web hosting plan, you can access a storage space that al
 
 > [!warning]
 >
-> In this tutorial, we have chosen the “SFTP/FTP sync” extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
+> In this tutorial, we have chosen the "SFTP/FTP sync" extension of *Natizyskunk*. You are free to choose another one. However, note that an extension on Visual Studio Code is software often created by an independent developer, who can stop its development at any time.
 >
 
 After starting Visual Studio Code, go to the horizontal menu at the top of the interface, click `View`{.action} then `Extensions`{.action}.
@@ -53,15 +53,15 @@ After starting Visual Studio Code, go to the horizontal menu at the top of the i
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + X` if you are on Windows, 
+- `Ctrl + Shift + X` if you are on Windows,
 - `Maj + Command + X` if you are on macOS.
 
-In the top left of the interface, enter the name of the *Natizyskunk* “SFTP/FTP sync” extension, and click `Install`{.action}.
+In the top left of the interface, enter the name of the *Natizyskunk* "SFTP/FTP sync" extension, and click `Install`{.action}.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/extensions.png){.thumbnail}
 
 You can also install [the "SFTP/FTP sync" extension](https://marketplace.visualstudio.com/items?itemName=Natizyskunk.sftp#sftp-sync-extension-for-vs-code) from the Visual Studio Marketplace.
-  
+
 ### Initialize project locally
 
 To synchronize your website files on the web hosting plan from Visual Studio Code, enter your project location locally. To do this, create a folder in the location you want.
@@ -70,7 +70,7 @@ Go back to Visual Studio Code in the horizontal menu at the top of the interface
 
 To do the same with the keyboard shortcut, select:
 
-- `Ctrl + Shift + P` if you are on Windows, 
+- `Ctrl + Shift + P` if you are on Windows,
 - `Maj + Command + P` if you are on macOS.
 
 Enter the following command: `SFTP: Config`.
@@ -93,47 +93,88 @@ This file is located in the .vscode folder, which is located at the root of your
 
 ### Configure the sftp.json file
 
-Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the “sftp.json” file is correctly configured. Useful information can be found in your [OVHcloud Control Panel](/links/manager). In the `Web Cloud`{.action} section, click `Hosting plans`{.action}. Select the web hosting plan concerned, then click on the `FTP - SSH`{.action} tab.
-
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Before you work on your project, upload it to your local folder that you created earlier. However, first, make sure that the "sftp.json" file is correctly configured. Refer to our guide "[Logging in to your Web Hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)" to find the useful information.
 
 In the "sftp.json" file, enter the values for the following entries:
 
 #### name
 
-Locate it at the two locations highlighted in orange.
+To find the name of your web hosting plan, click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> Locate it at the two locations highlighted in orange.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
 > The `name` value is customizable, so you can assign the value of your choice. However, if you are configuring multiple "sftp.json" files, it is best to use the values visible above as a reference for organizational reasons.
->
 
 #### host
 
-In the `FTP-SSH`{.action} tab, the host name (`host`) is visible under the mention `FTP and SFTP server`{.action}.
+To find the host name (`host`), click on the tabs below to view each of the **2** steps.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, the host name is visible under the mention `FTP and SFTP server`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Locate the `username` in the `Login`{.action} column of the table.
+To find the username, click on the tabs below to view each of the **2** steps.
+
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the username in the `Login` column of the table.
 
 #### remotePath
 
-Find the `remotePath` under `Home directory path`{.action}. However, if multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login`{.action} list of your web hosting plan.
+To find the remote path (`remotePath`), click on the tabs below to view each of the **2** steps.
 
-**Example**: If your username is "john-smith" you will get `home/john-smith`.
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page, then select the web hosting plan concerned.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> In the `FTP - SSH`{.action} tab, locate the path under the mention `Home directory path`. If multiple users are configured, the specified path may be different. In this case, replace the username mentioned after `home/` with the one of your choice in the `Login` column of the table.
+>>
+>> **Example**: If your username is "john-smith" you will get `home/john-smith`.
 
-Finally, remember to add this line in the file “sftp.json”: `"openSsh": true`.
+Finally, remember to add this line in the file "sftp.json": `"openSsh": true`.
 
 > [!primary]
 >
-> To avoid entering your password after each command in Visual Studio Code, save it in the file “sftp.json” by adding the line: `"password": "<password>"`
+> To avoid entering your password after each command in Visual Studio Code, save it in the file "sftp.json" by adding the line: `"password": "<password>"`
 >
 
-Here is an example of a file called “sftp.json”:
+Here is an example of a file called "sftp.json":
 
 ```json
 
@@ -156,19 +197,19 @@ For more details on the options in the sftp.json file, see the [project document
 
 ### Download the project locally
 
-Once you have configured the “sftp.json” file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
+Once you have configured the "sftp.json" file, download the contents of your project to retrieve all of the folders and files on your website. To do this, go to Visual Studio Code and enter the following command: `SFTP: Download Project`.
 
-Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file “sftp.json” .
+Visual Studio Code prompts you to select the folder that you want to upload to your Web Hosting plan. Enter the value `name` previously defined in the file "sftp.json" .
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/download_project.png){.thumbnail}
 
-If prompted, enter the user password entered in the “sftp.json” file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
+If prompted, enter the user password entered in the "sftp.json" file, then click `enter`. After downloading, you view all of the folders and files in your project in the File Explorer located in the left column of the Visual Studio Code interface.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/explorer.png){.thumbnail}
 
 > [!primary]
 >
-> As a reminder, it is important to configure the “sftp.json” file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the “sftp.json” file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
+> As a reminder, it is important to configure the "sftp.json" file correctly. If you encounter an error before downloading your project, it is usually caused by a configuration defect in the "sftp.json" file. If you have any questions, please refer to the [Extension FAQ](https://github.com/Natizyskunk/vscode-sftp/blob/HEAD/FAQ.md).
 >
 
 ### Make changes to files
@@ -191,7 +232,7 @@ The purpose of this tutorial is to provide an effective introduction to managing
 
 ## Go further <a name="go-further"></a>
 
-[Log in to your web hosting plan’s FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
+[Log in to your web hosting plan's FTP storage space](/pages/web_cloud/web_hosting/ftp_connection)
 
 [Use FileZilla with your OVHcloud hosting plan](/pages/web_cloud/web_hosting/ftp_filezilla_user_guide)
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Gestionar un alojamiento web con Visual Studio Code a través de SFTP"
 excerpt: "Administrar un sitio web en un alojamiento web con Visual Studio Code gracias a una extensión SFTP"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -25,7 +25,7 @@ Si tiene contratado un plan de hosting de OVHcloud, puede acceder a un espacio d
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -93,38 +93,79 @@ Este archivo se encuentra en la carpeta .vscode, que a su vez se sitúa en la ra
 
 ### Configurar archivo sftp.json
 
-Antes de trabajar en el proyecto, cárguelo en la carpeta local que creó anteriormente. No obstante, en primer lugar, asegúrese de que el archivo "sftp.json" está correctamente configurado. La información útil puede consultarse en el [área de cliente de OVHcloud](/links/manager). En la sección `Web Cloud`{.action}, haga clic en `Alojamientos`{.action}. Seleccione el alojamiento correspondiente y abra la pestaña `FTP - SSH`{.action}.
-
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Antes de trabajar en el proyecto, cárguelo en la carpeta local que creó anteriormente. No obstante, en primer lugar, asegúrese de que el archivo "sftp.json" está correctamente configurado. Consulte nuestra guía "[Conectarse al espacio de almacenamiento FTP de su alojamiento web](/pages/web_cloud/web_hosting/ftp_connection)" para encontrar la información útil.
 
 En el archivo "sftp.json", introduzca los valores para las siguientes entradas:
 
-#### name 
+#### name
 
-Localícelo en las dos ranuras resaltadas en naranja.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Localícelo en las dos ranuras resaltadas en naranja.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
-> El valor `name`(nombre) puede personalizarse, por lo que podrá asignarle el que desee. Sin embargo, si configura varios archivos "sftp.json", es preferible tomar como referencia los valores visibles anteriormente por motivos de organización.
->
+> El valor `name` (nombre) puede personalizarse, por lo que podrá asignarle el que desee. Sin embargo, si configura varios archivos "sftp.json", es preferible tomar como referencia los valores visibles anteriormente por motivos de organización.
 
 #### host
 
-En la pestaña `FTP-SSH`{.action}, el nombre de host (`host`) aparece bajo el epígrafe `Servidor FTP y SFTP`{.action}.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> En la pestaña `FTP - SSH`{.action}, el nombre de host (`host`) aparece bajo el epígrafe `Servidor FTP y SFTP`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Localice el nombre de usuario (`username`) en la columna `Usuario`{.action} de la tabla.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
+
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> En la pestaña `FTP - SSH`{.action}, localice el nombre de usuario en la columna `Usuario` de la tabla.
 
 #### remotePath
 
-Encontrará la ruta remota (`remotePath`) en la entrada `Acceso al directorio de la página principal`{.action}. Sin embargo, si hay varios usuarios configurados, la ruta especificada puede ser diferente. En ese caso, sustituya el nombre de usuario que aparece a continuación de `home/` por el de su elección en la lista `Usuario`{.action} de su alojamiento web.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
-**Ejemplo**: Si su nombre de usuario es "john-smith", obtendrá "home/john-smith"
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> En la pestaña `FTP - SSH`{.action}, encontrará la ruta remota (`remotePath`) en la entrada `Acceso al directorio de la página principal`. Sin embargo, si hay varios usuarios configurados, la ruta especificada puede ser diferente. En ese caso, sustituya el nombre de usuario que aparece a continuación de `home/` por el de su elección en la columna `Usuario` de la tabla.
+>>
+>> **Ejemplo**: Si su nombre de usuario es "john-smith", obtendrá `home/john-smith`.
 
 Por último, no olvide añadir esta línea en el archivo sftp.json : `"openSsh": true`
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Gestionar un alojamiento web con Visual Studio Code a través de SFTP"
 excerpt: "Administrar un sitio web en un alojamiento web con Visual Studio Code gracias a una extensión SFTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Gestionar un alojamiento web con Visual Studio Code a través de SFTP"
 excerpt: "Administrar un sitio web en un alojamiento web con Visual Studio Code gracias a una extensión SFTP"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
  
 
@@ -26,7 +26,7 @@ Si tiene contratado un plan de hosting de OVHcloud, puede acceder a un espacio d
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -94,38 +94,79 @@ Este archivo se encuentra en la carpeta .vscode, que a su vez se sitúa en la ra
 
 ### Configurar archivo sftp.json
 
-Antes de trabajar en el proyecto, cárguelo en la carpeta local que creó anteriormente. No obstante, en primer lugar, asegúrese de que el archivo "sftp.json" está correctamente configurado. La información útil puede consultarse en el [área de cliente de OVHcloud](/links/manager). En la sección `Web Cloud`{.action}, haga clic en `Alojamientos`{.action}. Seleccione el alojamiento correspondiente y abra la pestaña `FTP - SSH`{.action}.
-
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Antes de trabajar en el proyecto, cárguelo en la carpeta local que creó anteriormente. No obstante, en primer lugar, asegúrese de que el archivo "sftp.json" está correctamente configurado. Consulte nuestra guía "[Conectarse al espacio de almacenamiento FTP de su alojamiento web](/pages/web_cloud/web_hosting/ftp_connection)" para encontrar la información útil.
 
 En el archivo "sftp.json", introduzca los valores para las siguientes entradas:
 
-#### name 
+#### name
 
-Localícelo en las dos ranuras resaltadas en naranja.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Localícelo en las dos ranuras resaltadas en naranja.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
-> El valor `name`(nombre) puede personalizarse, por lo que podrá asignarle el que desee. Sin embargo, si configura varios archivos "sftp.json", es preferible tomar como referencia los valores visibles anteriormente por motivos de organización.
->
+> El valor `name` (nombre) puede personalizarse, por lo que podrá asignarle el que desee. Sin embargo, si configura varios archivos "sftp.json", es preferible tomar como referencia los valores visibles anteriormente por motivos de organización.
 
 #### host
 
-En la pestaña `FTP-SSH`{.action}, el nombre de host (`host`) aparece bajo el epígrafe `Servidor FTP y SFTP`{.action}.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> En la pestaña `FTP - SSH`{.action}, el nombre de host (`host`) aparece bajo el epígrafe `Servidor FTP y SFTP`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Localice el nombre de usuario (`username`) en la columna `Usuario`{.action} de la tabla.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
+
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> En la pestaña `FTP - SSH`{.action}, localice el nombre de usuario en la columna `Usuario` de la tabla.
 
 #### remotePath
 
-Encontrará la ruta remota (`remotePath`) en la entrada `Acceso al directorio de la página principal`{.action}. Sin embargo, si hay varios usuarios configurados, la ruta especificada puede ser diferente. En ese caso, sustituya el nombre de usuario que aparece a continuación de `home/` por el de su elección en la lista `Usuario`{.action} de su alojamiento web.
+Haga clic en las fichas siguientes para ver cada una de las **2** etapas.
 
-**Ejemplo**: Si su nombre de usuario es "john-smith", obtendrá "home/john-smith"
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting) y seleccione el alojamiento web correspondiente.
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> En la pestaña `FTP - SSH`{.action}, encontrará la ruta remota (`remotePath`) en la entrada `Acceso al directorio de la página principal`. Sin embargo, si hay varios usuarios configurados, la ruta especificada puede ser diferente. En ese caso, sustituya el nombre de usuario que aparece a continuación de `home/` por el de su elección en la columna `Usuario` de la tabla.
+>>
+>> **Ejemplo**: Si su nombre de usuario es "john-smith", obtendrá `home/john-smith`.
 
 Por último, no olvide añadir esta línea en el archivo sftp.json : `"openSsh": true`
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Gestionar un alojamiento web con Visual Studio Code a través de SFTP"
 excerpt: "Administrar un sitio web en un alojamiento web con Visual Studio Code gracias a una extensión SFTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
  
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Gérer son hébergement web avec Visual Studio Code via SFTP"
 excerpt: "Administrer un site internet sur un hébergement web avec Visual Studio Code grâce à une extension SFTP"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -93,38 +93,79 @@ Ce fichier est présent dans le dossier .vscode, lui-même positionné à la rac
 
 ### Configurer le fichier sftp.json
 
-Avant de travailler sur votre projet, téléchargez-le dans votre dossier local précédemment créé. Cependant, dans un premier temps, assurez-vous que le fichier « sftp.json » est correctement configuré. Les informations utiles sont présentes dans votre [espace client OVHcloud](/links/manager). Dans la partie `Web Cloud`{.action}, cliquez sur `Hébergements`{.action}. Sélectionnez l'hébergement concerné, puis cliquez sur l'onglet `FTP - SSH`{.action}.
+Avant de travailler sur votre projet, téléchargez-le dans votre dossier local précédemment créé. Cependant, dans un premier temps, assurez-vous que le fichier « sftp.json » est correctement configuré. Consultez notre guide « [Se connecter à l’espace de stockage FTP de son hébergement web](/pages/web_cloud/web_hosting/ftp_connection) » pour retrouver les informations utiles.
 
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Dans le fichier « sftp.json », rentrez les valeurs pour les entrées suivantes :
 
-Dans le fichier « sftp.json » , rentrez les valeurs pour les entrées suivantes :
+#### name
 
-#### name 
+Pour retrouver le nom de votre hébergement web, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
-Repérez-le aux deux emplacements surlignés en orange.
-
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l’hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Repérez-le aux deux emplacements surlignés en orange.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
-> La valeur `name`(nom) étant personnalisable, vous pouvez attribuer celle de votre choix. Cependant, si vous configurez plusieurs fichiers « sftp.json » , il est préférable de prendre comme référence les valeurs visibles ci-dessus pour des raisons d'organisation.
->
+> La valeur `name`(nom) étant personnalisable, vous pouvez attribuer celle de votre choix. Cependant, si vous configurez plusieurs fichiers « sftp.json », il est préférable de prendre comme référence les valeurs visibles ci-dessus pour des raisons d’organisation.
 
 #### host
 
-Toujours dans l’onglet `FTP-SSH`{.action}, le nom d'hôte (`host`) est visible sous la mention `Serveur FTP et SFTP`{.action}.
+Pour retrouver le nom d’hôte (`host`), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l’hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l’onglet `FTP - SSH`{.action}, le nom d’hôte est visible sous la mention `Serveur FTP et SFTP`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Repérez le nom d'utilisateur (`username`) dans la colonne `Login`{.action} du tableau.
+Pour retrouver le nom d’utilisateur (`username`), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l’hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l’onglet `FTP - SSH`{.action}, repérez le nom d’utilisateur dans la colonne `Login` du tableau.
 
 #### remotePath
 
-Retrouvez le chemin distant (`remotePath`) sous la mention `chemin du répertoire home`{.action}. Cependant, si plusieurs utilisateurs sont configurés, le chemin indiqué peut être différent. Dans ce cas, remplacez le nom d'utilisateur mentionné après `home/` par celui de votre choix dans liste `Login`{.action} de votre hébergement web.
+Pour retrouver le chemin distant (`remotePath`), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
-**Exemple** : Si votre nom d'utilisateur est « john-smith » vous obtiendrez `home/john-smith`
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l’hébergement web concerné.
+>>
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l’onglet `FTP - SSH`{.action}, repérez le chemin sous la mention `chemin du répertoire home`. Si plusieurs utilisateurs sont configurés, le chemin indiqué peut être différent. Remplacez alors le nom d’utilisateur mentionné après `home/` par celui de votre choix dans la colonne `Login` du tableau.
+>>
+>> **Exemple** : Si votre nom d’utilisateur est « john-smith » vous obtiendrez `home/john-smith`
 
 Enfin, n'oubliez pas d'ajouter cette ligne dans le fichier « sftp.json » : `"openSsh": true`
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Gérer son hébergement web avec Visual Studio Code via SFTP"
 excerpt: "Administrer un site internet sur un hébergement web avec Visual Studio Code grâce à une extension SFTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Gérer son hébergement web avec Visual Studio Code via SFTP"
 excerpt: "Administrer un site internet sur un hébergement web avec Visual Studio Code grâce à une extension SFTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Gérer son hébergement web avec Visual Studio Code via SFTP"
 excerpt: "Administrer un site internet sur un hébergement web avec Visual Studio Code grâce à une extension SFTP"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -93,38 +93,79 @@ Ce fichier est présent dans le dossier .vscode, lui-même positionné à la rac
 
 ### Configurer le fichier sftp.json
 
-Avant de travailler sur votre projet, téléchargez-le dans votre dossier local précédemment créé. Cependant, dans un premier temps, assurez-vous que le fichier « sftp.json » est correctement configuré. Les informations utiles sont présentes dans votre [espace client OVHcloud](/links/manager). Dans la partie `Web Cloud`{.action}, cliquez sur `Hébergements`{.action}. Sélectionnez l'hébergement concerné, puis cliquez sur l'onglet `FTP - SSH`{.action}.
-
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Avant de travailler sur votre projet, téléchargez-le dans votre dossier local précédemment créé. Cependant, dans un premier temps, assurez-vous que le fichier « sftp.json » est correctement configuré. Les informations utiles sont récupérables en consultant notre guide « [Se connecter à l'espace de stockage FTP de son hébergement web](/pages/web_cloud/web_hosting/ftp_connection) ».
 
 Dans le fichier « sftp.json » , rentrez les valeurs pour les entrées suivantes :
 
 #### name 
 
-Repérez-le aux deux emplacements surlignés en orange.
+Pour retrouver le nom de votre hébergement web, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Repérez-le aux deux emplacements surlignés en orange.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
 > La valeur `name`(nom) étant personnalisable, vous pouvez attribuer celle de votre choix. Cependant, si vous configurez plusieurs fichiers « sftp.json » , il est préférable de prendre comme référence les valeurs visibles ci-dessus pour des raisons d'organisation.
->
 
 #### host
 
-Toujours dans l’onglet `FTP-SSH`{.action}, le nom d'hôte (`host`) est visible sous la mention `Serveur FTP et SFTP`{.action}.
+Pour retrouver le nom d’hôte (`host`), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l’hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l’onglet `FTP-SSH`{.action}, le nom d’hôte est visible sous la mention `Serveur FTP et SFTP`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Repérez le nom d'utilisateur (`username`) dans la colonne `Login`{.action} du tableau.
+Pour retrouver le nom d'utilisateur (`username`), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
+
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `FTP-SSH`{.action}, repérez le nom d'utilisateur dans la colonne `Login` du tableau.
 
 #### remotePath
 
-Retrouvez le chemin distant (`remotePath`) sous la mention `chemin du répertoire home`{.action}. Cependant, si plusieurs utilisateurs sont configurés, le chemin indiqué peut être différent. Dans ce cas, remplacez le nom d'utilisateur mentionné après `home/` par celui de votre choix dans liste `Login`{.action} de votre hébergement web.
+Pour retrouver le chemin distant (`remotePath`), cliquez sur les onglets ci-dessous pour afficher successivement chacune des **2** étapes.
 
-**Exemple** : Si votre nom d'utilisateur est « john-smith » vous obtiendrez `home/john-smith`
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> Dans l'onglet `FTP-SSH`{.action}, repérez le chemin sous la mention `chemin du répertoire home`. Si plusieurs utilisateurs sont configurés, le chemin indiqué peut être différent. Dans ce cas, remplacez le nom d'utilisateur mentionné après `home/` par celui de votre choix dans la colonne `Login` du tableau.
+>>
+>> **Exemple** : Si votre nom d'utilisateur est « john-smith » vous obtiendrez `home/john-smith`
 
 Enfin, n'oubliez pas d'ajouter cette ligne dans le fichier « sftp.json » : `"openSsh": true`
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.fr-fr.md
@@ -93,9 +93,9 @@ Ce fichier est présent dans le dossier .vscode, lui-même positionné à la rac
 
 ### Configurer le fichier sftp.json
 
-Avant de travailler sur votre projet, téléchargez-le dans votre dossier local précédemment créé. Cependant, dans un premier temps, assurez-vous que le fichier « sftp.json » est correctement configuré. Les informations utiles sont récupérables en consultant notre guide « [Se connecter à l'espace de stockage FTP de son hébergement web](/pages/web_cloud/web_hosting/ftp_connection) ».
+Avant de travailler sur votre projet, téléchargez-le dans votre dossier local précédemment créé. Cependant, dans un premier temps, assurez-vous que le fichier « sftp.json » est correctement configuré. Consultez notre guide « [Se connecter à l'espace de stockage FTP de son hébergement web](/pages/web_cloud/web_hosting/ftp_connection) » pour retrouver les informations utiles.
 
-Dans le fichier « sftp.json » , rentrez les valeurs pour les entrées suivantes :
+Dans le fichier « sftp.json », rentrez les valeurs pour les entrées suivantes :
 
 #### name 
 
@@ -106,7 +106,7 @@ Pour retrouver le nom de votre hébergement web, cliquez sur les onglets ci-dess
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
@@ -116,7 +116,7 @@ Pour retrouver le nom de votre hébergement web, cliquez sur les onglets ci-dess
 
 > [!primary]
 >
-> La valeur `name`(nom) étant personnalisable, vous pouvez attribuer celle de votre choix. Cependant, si vous configurez plusieurs fichiers « sftp.json » , il est préférable de prendre comme référence les valeurs visibles ci-dessus pour des raisons d'organisation.
+> La valeur `name`(nom) étant personnalisable, vous pouvez attribuer celle de votre choix. Cependant, si vous configurez plusieurs fichiers « sftp.json », il est préférable de prendre comme référence les valeurs visibles ci-dessus pour des raisons d'organisation.
 
 #### host
 
@@ -127,11 +127,11 @@ Pour retrouver le nom d’hôte (`host`), cliquez sur les onglets ci-dessous pou
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l’hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
->> Dans l’onglet `FTP-SSH`{.action}, le nom d’hôte est visible sous la mention `Serveur FTP et SFTP`.
+>> Dans l’onglet `FTP - SSH`{.action}, le nom d’hôte est visible sous la mention `Serveur FTP et SFTP`.
 >>
 >> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
@@ -144,11 +144,11 @@ Pour retrouver le nom d'utilisateur (`username`), cliquez sur les onglets ci-des
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
->> Dans l'onglet `FTP-SSH`{.action}, repérez le nom d'utilisateur dans la colonne `Login` du tableau.
+>> Dans l'onglet `FTP - SSH`{.action}, repérez le nom d'utilisateur dans la colonne `Login` du tableau.
 
 #### remotePath
 
@@ -159,11 +159,11 @@ Pour retrouver le chemin distant (`remotePath`), cliquez sur les onglets ci-dess
 >>
 >> Accédez à la page [Hébergements](/links/control-panel/web-hosting), puis choisissez l'hébergement web concerné.
 >>
->> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>> ![Hébergements web](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
 >>
 > **Étape 2**
 >>
->> Dans l'onglet `FTP-SSH`{.action}, repérez le chemin sous la mention `chemin du répertoire home`. Si plusieurs utilisateurs sont configurés, le chemin indiqué peut être différent. Dans ce cas, remplacez le nom d'utilisateur mentionné après `home/` par celui de votre choix dans la colonne `Login` du tableau.
+>> Dans l'onglet `FTP - SSH`{.action}, repérez le chemin sous la mention `chemin du répertoire home`. Si plusieurs utilisateurs sont configurés, le chemin indiqué peut être différent. Remplacez alors le nom d'utilisateur mentionné après `home/` par celui de votre choix dans la colonne `Login` du tableau.
 >>
 >> **Exemple** : Si votre nom d'utilisateur est « john-smith » vous obtiendrez `home/john-smith`
 
@@ -193,7 +193,7 @@ Voici un exemple de fichier « sftp.json » :
 
 ```
 
-Pour plus de détail concernant les options du fichier « sftp.json » , reportez-vous à la [documentation du projet](https://github.com/Natizyskunk/vscode-sftp/wiki/configuration).
+Pour plus de détail concernant les options du fichier « sftp.json », reportez-vous à la [documentation du projet](https://github.com/Natizyskunk/vscode-sftp/wiki/configuration).
 
 ### Télécharger le projet en local
 
@@ -203,7 +203,7 @@ Visual Studio Code vous demande de sélectionner le dossier que vous souhaitez t
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/download_project.png){.thumbnail}
 
-S'il est demandé, saisissez le mot de passe associé à l’utilisateur renseigné dans le fichier « sftp.json » , puis cliquez sur `enter`. Après le téléchargement, vous visualisez l’ensemble des dossiers et fichiers de votre projet dans l’explorateur de fichiers situé dans la colonne à gauche de l’interface Visual Studio Code.
+S'il est demandé, saisissez le mot de passe associé à l’utilisateur renseigné dans le fichier « sftp.json », puis cliquez sur `enter`. Après le téléchargement, vous visualisez l’ensemble des dossiers et fichiers de votre projet dans l’explorateur de fichiers situé dans la colonne à gauche de l’interface Visual Studio Code.
 
 ![hosting](/pages/assets/screens/other/web-tools/vscode/explorer.png){.thumbnail}
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Gestire un hosting Web con Visual Studio Code via SFTP"
 excerpt: "Gestire un sito Internet su un hosting Web con Visual Studio Code grazie ad un'estensione SFTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Obiettivo

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Gestire un hosting Web con Visual Studio Code via SFTP"
 excerpt: "Gestire un sito Internet su un hosting Web con Visual Studio Code grazie ad un'estensione SFTP"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Obiettivo
@@ -25,7 +25,7 @@ Gli hosting Web OVHcloud mettono a disposizione uno spazio di storage per la ges
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -93,38 +93,79 @@ Il file è presente nella cartella vscode, che si trova nella cartella principal
 
 ### Configura il file sftp.json
 
-Prima di lavorare sul progetto, scaricalo nella cartella locale creata in precedenza. Per prima cosa, assicurati che il file "sftp.json" sia configurato correttamente. Le informazioni utili sono disponibili nello [Spazio Cliente OVHcloud](/links/manager). Nella sezione `Web Cloud`{.action}, clicca su `Hosting`{.action}. Seleziona l’hosting interessato e clicca sulla scheda `FTP - SSH`{.action}.
+Prima di lavorare sul progetto, scaricalo nella cartella locale creata in precedenza. Per prima cosa, assicurati che il file "sftp.json" sia configurato correttamente. Consulta la nostra guida "[Connettersi allo spazio di storage FTP del tuo hosting web](/pages/web_cloud/web_hosting/ftp_connection)" per trovare le informazioni utili.
 
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Nel file "sftp.json", immettere i valori per le voci seguenti:
 
-Nel file sftp.json, immettere i valori per le voci seguenti:
+#### name
 
-#### name 
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
-Individuarlo in entrambe le posizioni evidenziate in arancione.
-
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting) e seleziona l’hosting web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Individuarlo in entrambe le posizioni evidenziate in arancione.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
-> Poiché il valore `name`(nome) è personalizzabile, è possibile assegnare quello desiderato. Tuttavia, se si configura più di un file sftp.json, è preferibile utilizzare come riferimento i valori visualizzati sopra per motivi organizzativi.
->
+> Poiché il valore `name` (nome) è personalizzabile, è possibile assegnare quello desiderato. Tuttavia, se si configura più di un file "sftp.json", è preferibile utilizzare come riferimento i valori visualizzati sopra per motivi organizzativi.
 
 #### host
 
-Sempre nella scheda `FTP-SSH`{.action}, il nome host (`host`) è visibile sotto la dicitura `Server FTP e SFTP`{.action}.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting) e seleziona l’hosting web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Nella scheda `FTP - SSH`{.action}, il nome host (`host`) è visibile sotto la dicitura `Server FTP e SFTP`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Individua il nome utente (`username`) nella colonna `Login`{.action} della tabella.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
+
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting) e seleziona l’hosting web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Nella scheda `FTP - SSH`{.action}, individua il nome utente nella colonna `Login` della tabella.
 
 #### remotePath
 
-Ritrova il percorso remoto (`remotePath`) sotto la voce `Percorso cartella Home`{.action}. Tuttavia, se sono configurati più utenti, il percorso specificato potrebbe essere diverso. In questo caso, sostituisci il nome utente indicato dopo `home/` con quello che preferisci nella lista `Login`{.action} del tuo hosting Web.
+Clicca sulle schede qui sotto per visualizzare in sequenza ciascuno dei **2** passaggi.
 
-**Esempio**: se il tuo nome utente è "john-smith", otterrai `home/john-smith`
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting) e seleziona l’hosting web interessato.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> Nella scheda `FTP - SSH`{.action}, ritrova il percorso remoto (`remotePath`) sotto la voce `Percorso cartella Home`. Tuttavia, se sono configurati più utenti, il percorso specificato potrebbe essere diverso. In questo caso, sostituisci il nome utente indicato dopo `home/` con quello che preferisci nella colonna `Login` della tabella.
+>>
+>> **Esempio**: se il tuo nome utente è "john-smith", otterrai `home/john-smith`.
 
 Infine, ricordati di aggiungere questa riga nel file "sftp.json": `"openSsh": true`
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Zarządzaj hostingiem za pomocą Visual Studio Code przez SFTP"
 excerpt: "Zarządzanie stroną WWW na hostingu za pomocą kodu Visual Studio Code z rozszerzeniem SFTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Wprowadzenie

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Zarządzaj hostingiem za pomocą Visual Studio Code przez SFTP"
 excerpt: "Zarządzanie stroną WWW na hostingu za pomocą kodu Visual Studio Code z rozszerzeniem SFTP"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Wprowadzenie
@@ -25,7 +25,7 @@ Jeśli posiadasz hosting od OVHcloud, zyskasz dostęp do przestrzeni dyskowej um
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -93,38 +93,79 @@ Plik ten znajduje się w folderze .vscode, który jest umieszczony w katalogu g�
 
 ### Konfiguracja pliku sftp.json
 
-Zanim rozpoczniesz pracę nad Twoim projektem, przekaż go do utworzonego wcześniej lokalnego folderu. Najpierw jednak upewnij się, że plik "sftp.json" jest poprawnie skonfigurowany. Przydatne informacje można znaleźć w [Panelu klienta OVHcloud](/links/manager). W sekcji `Web Cloud`{.action} kliknij `Hosting`{.action}. Wybierz odpowiedni hosting, następnie kliknij zakładkę `FTP - SSH`{.action}.
-
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+Zanim rozpoczniesz pracę nad Twoim projektem, przekaż go do utworzonego wcześniej lokalnego folderu. Najpierw jednak upewnij się, że plik "sftp.json" jest poprawnie skonfigurowany. Zapoznaj się z naszym przewodnikiem "[Logowanie do przestrzeni dyskowej FTP hostingu](/pages/web_cloud/web_hosting/ftp_connection)", aby znaleźć potrzebne informacje.
 
 W pliku "sftp.json" wprowadź wartości dla następujących wpisów:
 
-#### name 
+#### name
 
-Odnajdziesz go w dwóch miejscach, które są wyróżnione na pomarańczowo.
+Kliknij poniższe karty, aby wyświetlić kolejne **2** kroki.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> Odnajdziesz go w dwóch miejscach, które są wyróżnione na pomarańczowo.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
-> Możesz ustawić dowolną wartość `name`(nazwa). Jeśli jednak konfigurujesz więcej niż jeden plik "sftp.json", to ze względów organizacyjnych lepiej jest użyć jako odwołania wartości widocznych powyżej.
->
+> Możesz ustawić dowolną wartość `name` (nazwa). Jeśli jednak konfigurujesz więcej niż jeden plik "sftp.json", to ze względów organizacyjnych lepiej jest użyć jako odwołania wartości widocznych powyżej.
 
 #### host
 
-W zakładce `FTP-SSH`{.action} nazwa hosta (`host`) jest widoczna pod napisem `Serwer FTP i SFTP`{.action}.
+Kliknij poniższe karty, aby wyświetlić kolejne **2** kroki.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> W zakładce `FTP - SSH`{.action} nazwa hosta (`host`) jest widoczna pod napisem `Serwer FTP i SFTP`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Odszukaj nazwę użytkownika (`username`) w kolumnie `Login`{.action} tabeli.
+Kliknij poniższe karty, aby wyświetlić kolejne **2** kroki.
+
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> W zakładce `FTP - SSH`{.action} odszukaj nazwę użytkownika w kolumnie `Login` tabeli.
 
 #### remotePath
 
-Znajdź ścieżkę zdalną (`remotePath`) pod nazwą `Ścieżka do katalogu home`{.action}. Jeśli skonfigurowanych jest kilku użytkowników, podana ścieżka może być inna. W takim przypadku zmień nazwę użytkownika wskazaną po `home/` na wybraną przez siebie z listy `Login`{.action} Twojego hostingu.
+Kliknij poniższe karty, aby wyświetlić kolejne **2** kroki.
 
-**Przykład**: Jeśli Twoja nazwa użytkownika to "john-smith", otrzymasz `home/john-smith`
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź na stronę [Hosting](/links/control-panel/web-hosting) i wybierz odpowiedni hosting.
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> W zakładce `FTP - SSH`{.action} znajdź ścieżkę zdalną (`remotePath`) pod nazwą `Ścieżka do katalogu home`. Jeśli skonfigurowanych jest kilku użytkowników, podana ścieżka może być inna. W takim przypadku zmień nazwę użytkownika wskazaną po `home/` na wybraną przez siebie w kolumnie `Login` tabeli.
+>>
+>> **Przykład**: Jeśli Twoja nazwa użytkownika to "john-smith", otrzymasz `home/john-smith`.
 
 Dodaj ten wiersz do pliku "sftp.json": `"openSsh": true`
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Gerir o seu alojamento web com Visual Studio Code via SFTP"
 excerpt: "Administrar um website num alojamento web com Visual Studio Code graças a uma extensão SFTP"
-updated: 2025-10-21
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -25,7 +25,7 @@ Se dispõe de um alojamento web OVHcloud, pode aceder a um espaço de armazename
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -93,38 +93,79 @@ Este ficheiro está presente na pasta .vscode, que por sua vez está posicionado
 
 ### Configurar o ficheiro sftp.json
 
-Antes de trabalhar no seu projeto, transfira-o para a pasta local que criou anteriormente. No entanto, em primeiro lugar, certifique-se de que o ficheiro "sftp.json" está configurado corretamente. As informações úteis estão presentes na sua [Área de Cliente OVHcloud](/links/manager). Na parte `Web Cloud`{.action}, clique em `Alojamentos`{.action}. Selecione o alojamento em causa e depois clique no separador `FTP - SSH`{.action}.
+Antes de trabalhar no seu projeto, transfira-o para a pasta local que criou anteriormente. No entanto, em primeiro lugar, certifique-se de que o ficheiro "sftp.json" está configurado corretamente. Consulte o nosso guia "[Aceder ao espaço de armazenamento FTP do alojamento web](/pages/web_cloud/web_hosting/ftp_connection)" para encontrar as informações úteis.
 
-![FTP - SSH](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh.png){.thumbnail}
+No ficheiro "sftp.json", insira os valores para as seguintes entradas:
 
-ficheiro "sftp.json", insira os valores para as seguintes entradas:
+#### name
 
-#### name 
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
-Localize-o em ambas as localizações realçadas a laranja.
-
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em causa.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> Localize-o em ambas as localizações realçadas a laranja.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hosting_name.png){.thumbnail}
 
 > [!primary]
 >
-> O valor `name`(nome) é personalizável, pelo que pode atribuir um valor à sua escolha. No entanto, se você configurar vários arquivos "sftp.json", é melhor tomar como referência os valores visíveis acima por razões de organização.
->
+> O valor `name` (nome) é personalizável, pelo que pode atribuir um valor à sua escolha. No entanto, se configurar vários ficheiros "sftp.json", é melhor tomar como referência os valores visíveis acima por razões de organização.
 
 #### host
 
-Ainda no separador `FTP-SSH`{.action}, o nome do host (`host`) é visível sob a menção `Servidor FTP e SFTP`{.action}.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
-![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em causa.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> No separador `FTP - SSH`{.action}, o nome do host (`host`) é visível sob a menção `Servidor FTP e SFTP`.
+>>
+>> ![hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/web-hosting/ftp-ssh/hostname.png){.thumbnail}
 
 #### username
 
-Localize o nome de utilizador (`username`) na coluna `Nome de utilizador`{.action} do quadro.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
+
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em causa.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> No separador `FTP - SSH`{.action}, localize o nome de utilizador na coluna `Nome de utilizador` do quadro.
 
 #### remotePath
 
-Encontre o caminho remoto (`remotePath`) na menção `Caminho da pasta home`{.action}. No entanto, se estiver configurado mais do que um utilizador, é possível que o caminho indicado seja diferente. Nesse caso, substitua o nome de utilizador indicado após `home/` por um da sua escolha na lista `Nome de utilizador`{.action} do seu alojamento web.
+Clique nos separadores abaixo para visualizar cada uma das **2** etapas.
 
-**Exemplo**: Se o seu nome de utilizador for "john-smith" receberá `home/john-smith`
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting) e selecione o alojamento web em causa.
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> No separador `FTP - SSH`{.action}, encontre o caminho remoto (`remotePath`) na menção `Caminho da pasta home`. No entanto, se estiver configurado mais do que um utilizador, é possível que o caminho indicado seja diferente. Nesse caso, substitua o nome de utilizador indicado após `home/` por um da sua escolha na coluna `Nome de utilizador` do quadro.
+>>
+>> **Exemplo**: Se o seu nome de utilizador for "john-smith", receberá `home/john-smith`.
 
 Por fim, não se esqueça de adicionar esta linha no ficheiro "sftp.json": `"openSsh": true`
 

--- a/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/handle_sftp_connexion_vscode/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Gerir o seu alojamento web com Visual Studio Code via SFTP"
 excerpt: "Administrar um website num alojamento web com Visual Studio Code graças a uma extensão SFTP"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Migration Ihrer Website und zugehörigen Dienste zu OVHcloud"
 excerpt: "Erfahren Sie hier, wie Sie Ihre Website, Ihren Domainnamen, Ihre Datenbank und E-Mails ohne Dienstunterbrechung zu OVHcloud migrieren"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Ziel
@@ -40,27 +40,27 @@ In dieser Anleitung werden die verschiedenen Aktionen beschrieben, die notwendig
 > Die Anweisungen in dieser Anleitung beziehen sich auf verschiedene Produkte aus dem Web Cloud Universum. Wir empfehlen Ihnen, alle nachstehenden Schritte durchzugehen **bevor** Sie Ihre Dienste migrieren.
 >
 
-Die Migration Ihrer gesamten Website und Ihrer E-Mails zu OVHcloud **ohne Dienstunterbrechung** erfordert ein präzises Verfahren in 10 Schritten:
+Die Migration Ihrer gesamten Website und Ihrer E-Mails zu OVHcloud **ohne Dienstunterbrechung** erfordert ein präzises Verfahren in 10 Teile:
 
-- [Schritt 1: Webhosting und E-Mail-Accounts bei OVHcloud bestellen](#step1)
-- [Schritt 2: Eine DNS-Zone für Ihren Domainnamen bei OVHcloud erstellen und vorkonfigurieren](#step2)
-- [Schritt 3: Vollständiges Backup Ihrer Website erstellen](#step3)
-- [Schritt 4: Backup Ihrer Website in Ihr OVHcloud Hosting importieren](#step4)
-- [Schritt 5: Ihre E-Mail-Accounts bei OVHcloud neu erstellen](#step5)
-- [Schritt 6: OVHcloud E-Mail-Server in der aktiven DNS-Zone Ihres Domainnamens hinterlegen](#step6)
-- [Schritt 7: Transfer des Inhalts Ihrer bestehenden E-Mail-Accounts zu Ihren neuen Accounts bei OVHcloud](#step7)
-- [Schritt 8: Ihre E-Mail-Software rekonfigurieren](#step8)
-- [Schritt 9: Die aktiven DNS-Server Ihres Domainnamens mit OVHcloud DNS-Servern ersetzen](#step9)
-- [Schritt 10: Ihren Domainnamen zu OVHcloud transferieren](#step10)
+- [1 - Webhosting und E-Mail-Accounts bei OVHcloud bestellen](#step1)
+- [2 - Eine DNS-Zone für Ihren Domainnamen bei OVHcloud erstellen und vorkonfigurieren](#step2)
+- [3 - Vollständiges Backup Ihrer Website erstellen](#step3)
+- [4 - Backup Ihrer Website in Ihr OVHcloud Hosting importieren](#step4)
+- [5 - Ihre E-Mail-Accounts bei OVHcloud neu erstellen](#step5)
+- [6 - OVHcloud E-Mail-Server in der aktiven DNS-Zone Ihres Domainnamens hinterlegen](#step6)
+- [7 - Transfer des Inhalts Ihrer bestehenden E-Mail-Accounts zu Ihren neuen Accounts bei OVHcloud](#step7)
+- [8 - Ihre E-Mail-Software rekonfigurieren](#step8)
+- [9 - Die aktiven DNS-Server Ihres Domainnamens mit OVHcloud DNS-Servern ersetzen](#step9)
+- [10 - Ihren Domainnamen zu OVHcloud transferieren](#step10)
 
-Wenn Sie diesen Schritten **der Reihe nach** folgen, werden Sie in der Regel keine Dienstunterbrechung für Ihre Website und den E-Mail-Empfang erfahren.
+Wenn Sie diesen Teilen **der Reihe nach** folgen, werden Sie in der Regel keine Dienstunterbrechung für Ihre Website und den E-Mail-Empfang erfahren.
 
 Abhängig von Ihrem Domain-Registrar, Ihrem Hosting-Anbieter oder Ihrem E-Mail-Anbieter kann es jedoch sein, dass der Zugang zu Ihren Dienstleistungen gesperrt wird, sobald Ihr Domainname nicht mehr über deren Infrastrukturen konfiguriert ist.<br>
 In diesem Fall kann es zu einer Dienstunterbrechung kommen.
 
 Diese Anleitung ist derart gestaltet, die Dauer einer möglichen Unterbrechung zu minimieren.
 
-### Schritt 1: Webhosting und E-Mail-Accounts bei OVHcloud bestellen <a name="step1"></a>
+### 1 - Webhosting und E-Mail-Accounts bei OVHcloud bestellen <a name="step1"></a>
 
 Mehrere [OVHcloud Shared Hosting Angebote](/links/web/hosting) enthalten "[MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)" E-Mail-Dienste. Mit diesem E-Mail-Angebot können E-Mail-Accounts mit jeweils maximal 5 GB Speicherplatz erstellt werden. Wählen Sie aus den unten stehenden Hosting-Angeboten eines aus, das den Anforderungen Ihrer Website an PHP-Version, SQL-Version, Anzahl der benötigten E-Mail-Accounts, sowie der Größe der zu migrierenden Website entspricht:
 
@@ -69,13 +69,24 @@ Mehrere [OVHcloud Shared Hosting Angebote](/links/web/hosting) enthalten "[MX Pl
 - Hosting [Performance](/links/web/hosting-performance-offer) mit **1000 "MX Plan E-Mail-Accounts** (skalierbare dedizierte Ressourcen)
 - Hosting [Cloud Web](/links/web/hosting-cloud-web-offer) mit **200 E-Mail-Accounts** (für Anwendungsentwickler)
 
-Wenn Sie sich für ein passendes Webhosting-Angebot entschieden haben, klicken Sie auf den Button `Bestellen`{.action} auf unserer Webseite. Folgen Sie den Bestellschritten, aber **leiten Sie dabei noch nicht den Transfer Ihres Domainnamens ein**. (Diese Aktion wird in Schritt 10 dieser Anleitung ausgeführt.)
+Wenn Sie sich für ein passendes Webhosting-Angebot entschieden haben, klicken Sie auf den Button `Bestellen`{.action} auf unserer Webseite. Folgen Sie den Bestellschritten, aber **leiten Sie dabei noch nicht den Transfer Ihres Domainnamens ein**. (Diese Aktion wird in Teil 10 dieser Anleitung ausgeführt.)
 
-Wenn Sie bereits Kunde sind, kann die Bestellung auch über Ihr [OVHcloud Kundencenter](/links/manager) ausgeführt werden. Wenn Sie eingeloggt sind, folgen Sie diesen Schritten:
+Sie können die Bestellung auch über Ihr OVHcloud Kundencenter aufgeben. Klicken Sie dazu auf die Tabs, um die **3** Schritte nacheinander anzuzeigen.
 
-- Gehen Sie auf den Tab `Web Cloud`{.action}.
-- Klicken Sie oben links im Interface auf den Button `Bestellen`{.action} und dann auf `Hosting-Pakete`{.action}.
-- Folgen Sie den Bestellschritten **ohne den Transfer Ihrer Domain anzufordern**. (Dies geschieht in Schritt 10 dieser Anleitung.)
+> [!tabs]
+> **Schritt 1**
+>>
+>> Gehen Sie auf die Seite [Hosting-Pakete](/links/control-panel/web-hosting).
+>>
+>> ![Hosting-Pakete](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Schritt 2**
+>>
+>> Klicken Sie oben links im Interface auf den Button `Bestellen`{.action} und dann auf `Hosting-Pakete`{.action}.
+>>
+> **Schritt 3**
+>>
+>> Folgen Sie den Bestellschritten **ohne den Transfer Ihrer Domain anzufordern** (dies geschieht in Teil 10 dieser Anleitung).
 
 Sobald die Zahlung bestätigt wurde, startet die Installation des Hostings. Sie erhalten eine E-Mail an Ihre Kontakt-E-Mail-Adresse, die Zugangsdaten zum FTP-Speicherplatz (File Transfer Protocol) Ihres Webhostings enthält.
 
@@ -84,7 +95,7 @@ Sobald die Zahlung bestätigt wurde, startet die Installation des Hostings. Sie 
 > OVHcloud bietet neben MX Plan weitere E-Mail-Angebote an. Sie können beispielsweise [E-Mail Pro](/links/web/email-pro)-Accounts und/oder [Exchange](/links/web/emails-hosted-exchange)-Accounts mit E-Mail-Accounts kombinieren.
 >
 
-### Schritt 2: Eine DNS-Zone für Ihren Domainnamen bei OVHcloud erstellen und vorkonfigurieren <a name="step2"></a>
+### 2 - Eine DNS-Zone für Ihren Domainnamen bei OVHcloud erstellen und vorkonfigurieren <a name="step2"></a>
 
 Wenn sich Ihr Domainname bei einem anderen Anbieter befindet und Sie ihn zu OVHcloud transferieren möchten, müssen Sie zunächst eine DNS-Zone erstellen und vorkonfigurieren, bevor Sie den Transfer starten, um eine Dienstunterbrechung zu vermeiden.
 
@@ -112,16 +123,16 @@ Die richtige Ziel-IP-Adresse Ihres OVHcloud Hostings finden Sie in unserer Anlei
 
 > [!success]
 >
-> Beachten Sie die beiden Zielwerte für den Eintragstyp NS. Die Werte `dnsXX.ovh.net` und `nsXX.ovh.net` (oder `dns200.anycast.me` und `ns200.anycast.me`) entsprechen den DNS-Servern, die die DNS-Zone für Ihre Domain bereitstellen. Sie werden im [Schritt 9](#step9) dieser Anleitung verwendet.
+> Beachten Sie die beiden Zielwerte für den Eintragstyp NS. Die Werte `dnsXX.ovh.net` und `nsXX.ovh.net` (oder `dns200.anycast.me` und `ns200.anycast.me`) entsprechen den DNS-Servern, die die DNS-Zone für Ihre Domain bereitstellen. Sie werden in [Teil 9](#step9) dieser Anleitung verwendet.
 >
 
-### Schritt 3: Vollständiges Backup Ihrer Website erstellen <a name="step3"></a>
+### 3 - Vollständiges Backup Ihrer Website erstellen <a name="step3"></a>
 
 Kopieren Sie den Inhalt des FTP-Speicherplatzes Ihres aktuellen Hostings, und erstellen Sie ein Backup Ihrer Datenbank, falls Ihre Website eine verwendet.
 
 Diese Aktionen werden ausschließlich bei Ihrem derzeitigen Hosting-Anbieter durchgeführt. Kontaktieren Sie ihn, wenn Sie Schwierigkeiten haben, ein vollständiges Backup Ihrer Website zu erhalten.
 
-### Schritt 4: Backup Ihrer Website in Ihr OVHcloud Hosting importieren <a name="step4"></a>
+### 4 - Backup Ihrer Website in Ihr OVHcloud Hosting importieren <a name="step4"></a>
 
 Um das Backup des FTP-Speicherplatzes Ihrer Website zu importieren, [verbinden Sie sich mit dem FTP-Speicherplatz Ihres OVHcloud Hostings](/pages/web_cloud/web_hosting/ftp_connection) und laden Sie das Backup in den "www"-Wurzelordner hoch (gegebenenfalls in einen anderen Wurzelordner, den Sie zuvor erstellt haben).
 
@@ -141,10 +152,10 @@ Ersetzen Sie hierzu die Verbindungsdaten Ihrer alten Datenbank mit denen Ihrer n
 
 > [!success]
 >
-> Wenn Sie ein Content Management System (CMS) wie WordPress, Joomla!, Drupal oder PrestaShop verwenden, finden Sie die Informationen zur Datenbank in deren Konfigurationsdateien. Sie finden Details hierzu in **Schritt 2** der Anleitung "[Änderung des Passworts einer Datenbank](/pages/web_cloud/web_hosting/sql_change_password)".
+> Wenn Sie ein Content Management System (CMS) wie WordPress, Joomla!, Drupal oder PrestaShop verwenden, finden Sie die Informationen zur Datenbank in deren Konfigurationsdateien. Sie finden Details hierzu in **Teil 2** der Anleitung "[Änderung des Passworts einer Datenbank](/pages/web_cloud/web_hosting/sql_change_password)".
 >
 
-Deklarieren und authorisieren Ihren externen Domainnamen auf Ihrem OVHcloud Webhosting mithilfe der Anleitung „[Mehrere Websites auf einem Webhosting einrichten](/pages/web_cloud/web_hosting/multisites_configure_multisite)“. Geben Sie den Namen des Ordners, den Sie zu Beginn von [Schritt 4](#step4) ausgewählt haben, als Wurzelverzeichnis an. Zur Erinnerung: Es handelt sich um den Ordner im FTP-Speicherplatz, in den Sie Ihre Webseiten-Dateien abgelegt haben.
+Deklarieren und authorisieren Ihren externen Domainnamen auf Ihrem OVHcloud Webhosting mithilfe der Anleitung „[Mehrere Websites auf einem Webhosting einrichten](/pages/web_cloud/web_hosting/multisites_configure_multisite)“. Geben Sie den Namen des Ordners, den Sie zu Beginn von [Teil 4](#step4) ausgewählt haben, als Wurzelverzeichnis an. Zur Erinnerung: Es handelt sich um den Ordner im FTP-Speicherplatz, in den Sie Ihre Webseiten-Dateien abgelegt haben.
 
 > [!warning]
 >
@@ -165,7 +176,7 @@ Deklarieren und authorisieren Ihren externen Domainnamen auf Ihrem OVHcloud Webh
 
 Nach der Propagation der DNS-Konfiguration wird die bei OVHcloud gehostete Website unter Ihrem Domainnamen angezeigt.
 
-### Schritt 5: Ihre E-Mail-Accounts bei OVHcloud neu erstellen <a name="step5"></a>
+### 5 - Ihre E-Mail-Accounts bei OVHcloud neu erstellen <a name="step5"></a>
 
 Erstellen Sie neue E-Mail-Accounts und verwenden Sie dabei die gleichen E-Mail-Adressen, die Sie aktuell bei Ihrem E-Mail-Provider haben. Sie finden mehr Informationen in unserer Anleitung zur [Erstellung von E-Mail-Accounts mit MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
@@ -174,7 +185,7 @@ Wenn Sie sich für eins der E-Mail-Angebote Email Pro oder Exchange entschieden 
 - [Email-Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 - [Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Schritt 6: OVHcloud E-Mail-Server in der aktiven DNS-Zone Ihres Domainnamens hinterlegen <a name="step6"></a>
+### 6 - OVHcloud E-Mail-Server in der aktiven DNS-Zone Ihres Domainnamens hinterlegen <a name="step6"></a>
 
 Bearbeiten Sie die "MX"-Einträge für E-Mail-Server in der aktiven DNS-Zone Ihres Domainnamens.
 Das bewirkt, dass Ihre E-Mails fortan in Ihren neuen E-Mail-Accounts bei OVHcloud ankommen.
@@ -191,7 +202,7 @@ Das bedeutet, dass während der Propagation der DNS-Einstellungen immmer weniger
 Wir empfehlen, die "MX"-Einträge zu ändern, **bevor** Sie den Inhalt Ihrer E-Mail-Accounts migrieren.
 Andernfalls erhalten Sie auch nach der Migration bestehender E-Mails zu den neuen Accounts noch neue E-Mails in den alten Accounts.
 
-### Schritt 7: Transfer des Inhalts Ihrer bestehenden E-Mail-Accounts zu Ihren neuen Accounts bei OVHcloud <a name="step7"></a>
+### 7 - Transfer des Inhalts Ihrer bestehenden E-Mail-Accounts zu Ihren neuen Accounts bei OVHcloud <a name="step7"></a>
 
 Nach der Propagation der DNS-Einstellungen werden Ihre neuen E-Mails nun in Ihren neuen E-Mail-Accounts empfangen. Ihre alten E-Mails befinden sich jedoch weiterhin auf dem zuvor verwendeten E-Mail-Server.
 
@@ -216,7 +227,7 @@ Wiederholen Sie den Vorgang für alle Ihre E-Mail-Accounts.
 
 **Option 2**: Backup des Inhalts Ihrer E-Mail-Accounts mithilfe einer E-Mail-Software (Outlook, Mac Mail, etc.) durchführen, Ihr E-Mail-Programm neu einrichten und das Backup in Ihre neuen OVHcloud E-Mail-Accounts importieren. Weitere Informationen finden Sie in unserer Anleitung „[Ihre E-Mail-Adresse manuell migrieren](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)“.
 
-### Schritt 8: Ihre E-Mail-Software rekonfigurieren <a name="step8"></a>
+### 8 - Ihre E-Mail-Software rekonfigurieren <a name="step8"></a>
 
 Sobald Ihre E-Mail-Accounts bei OVHcloud eingerichtet und bestehende Inhalte migriert sind, konfigurieren Sie Ihre neuen Accounts in Ihrer E-Mail-Software mithilfe unserer Anleitungen zum Thema.
 
@@ -232,9 +243,9 @@ Sobald Ihre E-Mail-Accounts bei OVHcloud eingerichtet und bestehende Inhalte mig
 
 - Sie finden alle unsere Anleitungen zur Konfigurationsunterstützung in den Abschnitten `Konfiguration des Exchange E-Mail-Clients`und `Konfiguration von Exchange auf kompatiblen Smartphones/Tablets` auf der [Seite für Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Schritt 9: Die aktiven DNS-Server Ihres Domainnamens mit OVHcloud DNS-Servern ersetzen <a name="step9"></a>
+### 9 - Die aktiven DNS-Server Ihres Domainnamens mit OVHcloud DNS-Servern ersetzen <a name="step9"></a>
 
-Die in [Schritt 2](#step2) vorkonfigurierte DNS-Zone wird noch nicht auf Ihren Domainnamen angewendet. Ihr Domainname nutzt noch immer die DNS-Server Ihres ursprünglichen Anbieters.
+Die in [Teil 2](#step2) vorkonfigurierte DNS-Zone wird noch nicht auf Ihren Domainnamen angewendet. Ihr Domainname nutzt noch immer die DNS-Server Ihres ursprünglichen Anbieters.
 
 Ersetzen Sie die aktuell aktiven DNS-Server (des bisherigen Registrars) durch die beiden in der OVHcloud DNS-Zone deklarierten DNS-Server (Format `dnsXX.ovh.net` und `nsXX.ovh.net` oder `dns200.anycast.me` und `ns200.anycast.me`). Dieser Vorgang erfolgt über das Verwaltungsinterface des bisherigen Registrars.
 
@@ -243,7 +254,7 @@ Ersetzen Sie die aktuell aktiven DNS-Server (des bisherigen Registrars) durch di
 > Die Änderung der DNS-Server muss beim aktuellen Registrar Ihres Domainnamens durchgeführt werden und **benötigt bis zu 24 bis 48 Stunden**, bis sie voll wirksam ist.
 >
 
-### Schritt 10: Ihren Domainnamen zu OVHcloud transferieren <a name="step10"></a>
+### 10 - Ihren Domainnamen zu OVHcloud transferieren <a name="step10"></a>
 
 Überprüfen Sie nach Abschluss der DNS-Propagierung, ob Ihre gesamte Website funktionsfähig ist. Testen Sie Ihre Website im Browser, um sicherzustellen, dass alle Seiten korrekt angezeigt werden und keine 404-Fehler zurückgegeben werden. Überprüfen Sie auch den Versand und Empfang von E-Mails von Ihren E-Mail-Adressen aus.
 
@@ -255,7 +266,7 @@ Sobald der Transfer Ihrer Daten und Dienstleistungen abgeschlossen ist, können 
 
 ### Fazit
 
-Nachdem Sie die zehn Schritte der Reihe nach ausgeführt haben, wurde Ihre gesamte Website ohne Dienstunterbrechung zu OVHcloud migriert.
+Nachdem Sie die zehn Teile der Reihe nach ausgeführt haben, wurde Ihre gesamte Website ohne Dienstunterbrechung zu OVHcloud migriert.
 
 ## Weiterführende Informationen <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "Migration Ihrer Website und zugehörigen Dienste zu OVHcloud"
 excerpt: "Erfahren Sie hier, wie Sie Ihre Website, Ihren Domainnamen, Ihre Datenbank und E-Mails ohne Dienstunterbrechung zu OVHcloud migrieren"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Ziel
@@ -64,9 +64,9 @@ Diese Anleitung ist derart gestaltet, die Dauer einer möglichen Unterbrechung z
 
 Mehrere [OVHcloud Shared Hosting Angebote](/links/web/hosting) enthalten "[MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)" E-Mail-Dienste. Mit diesem E-Mail-Angebot können E-Mail-Accounts mit jeweils maximal 5 GB Speicherplatz erstellt werden. Wählen Sie aus den unten stehenden Hosting-Angeboten eines aus, das den Anforderungen Ihrer Website an PHP-Version, SQL-Version, Anzahl der benötigten E-Mail-Accounts, sowie der Größe der zu migrierenden Website entspricht:
 
-- Hosting [Basic](/links/web/hosting-personal-offer) mit **10 "MX Plan E-Mail-Accounts**
-- Hosting [Pro](/links/web/hosting-professional-offer) mit **100 "MX Plan E-Mail-Accounts** (für gewerbliche Webseiten)
-- Hosting [Performance](/links/web/hosting-performance-offer) mit **1000 "MX Plan E-Mail-Accounts** (skalierbare dedizierte Ressourcen)
+- Hosting [Basic](/links/web/hosting-personal-offer) mit **10 MX Plan E-Mail-Accounts**
+- Hosting [Pro](/links/web/hosting-professional-offer) mit **100 MX Plan E-Mail-Accounts** (für gewerbliche Webseiten)
+- Hosting [Performance](/links/web/hosting-performance-offer) mit **1000 MX Plan E-Mail-Accounts** (skalierbare dedizierte Ressourcen)
 - Hosting [Cloud Web](/links/web/hosting-cloud-web-offer) mit **200 E-Mail-Accounts** (für Anwendungsentwickler)
 
 Wenn Sie sich für ein passendes Webhosting-Angebot entschieden haben, klicken Sie auf den Button `Bestellen`{.action} auf unserer Webseite. Folgen Sie den Bestellschritten, aber **leiten Sie dabei noch nicht den Transfer Ihres Domainnamens ein**. (Diese Aktion wird in Teil 10 dieser Anleitung ausgeführt.)
@@ -105,7 +105,7 @@ Sobald die DNS-Zone eingerichtet ist, kann sie zur Verwendung mit dem Webhosting
 
 Fügen Sie folgende Einträge hinzu, sofern diese nicht existieren:
 
-**Beispiel** (für die Domain „domain.tld“):
+**Beispiel** (für die Domain "domain.tld“):
 
 |Domain|Datensatztyp|Priorität|Ziel|
 |---|---|---|---|
@@ -155,7 +155,7 @@ Ersetzen Sie hierzu die Verbindungsdaten Ihrer alten Datenbank mit denen Ihrer n
 > Wenn Sie ein Content Management System (CMS) wie WordPress, Joomla!, Drupal oder PrestaShop verwenden, finden Sie die Informationen zur Datenbank in deren Konfigurationsdateien. Sie finden Details hierzu in **Teil 2** der Anleitung "[Änderung des Passworts einer Datenbank](/pages/web_cloud/web_hosting/sql_change_password)".
 >
 
-Deklarieren und authorisieren Ihren externen Domainnamen auf Ihrem OVHcloud Webhosting mithilfe der Anleitung „[Mehrere Websites auf einem Webhosting einrichten](/pages/web_cloud/web_hosting/multisites_configure_multisite)“. Geben Sie den Namen des Ordners, den Sie zu Beginn von [Teil 4](#step4) ausgewählt haben, als Wurzelverzeichnis an. Zur Erinnerung: Es handelt sich um den Ordner im FTP-Speicherplatz, in den Sie Ihre Webseiten-Dateien abgelegt haben.
+Deklarieren und authorisieren Ihren externen Domainnamen auf Ihrem OVHcloud Webhosting mithilfe der Anleitung "[Mehrere Websites auf einem Webhosting einrichten](/pages/web_cloud/web_hosting/multisites_configure_multisite)“. Geben Sie den Namen des Ordners, den Sie zu Beginn von [Teil 4](#step4) ausgewählt haben, als Wurzelverzeichnis an. Zur Erinnerung: Es handelt sich um den Ordner im FTP-Speicherplatz, in den Sie Ihre Webseiten-Dateien abgelegt haben.
 
 > [!warning]
 >
@@ -225,7 +225,7 @@ Wiederholen Sie den Vorgang für alle Ihre E-Mail-Accounts.
 > Wenn Ihre E-Mail-Accounts als "POP" ohne Aufbewahrung von E-Mail-Kopien auf Ihrem E-Mail-Server konfiguriert sind oder wenn Sie E-Mails haben, die nur lokal auf Ihrem Gerät gespeichert sind, kommt nur **Option 2** in Frage.
 >
 
-**Option 2**: Backup des Inhalts Ihrer E-Mail-Accounts mithilfe einer E-Mail-Software (Outlook, Mac Mail, etc.) durchführen, Ihr E-Mail-Programm neu einrichten und das Backup in Ihre neuen OVHcloud E-Mail-Accounts importieren. Weitere Informationen finden Sie in unserer Anleitung „[Ihre E-Mail-Adresse manuell migrieren](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)“.
+**Option 2**: Backup des Inhalts Ihrer E-Mail-Accounts mithilfe einer E-Mail-Software (Outlook, Mac Mail, etc.) durchführen, Ihr E-Mail-Programm neu einrichten und das Backup in Ihre neuen OVHcloud E-Mail-Accounts importieren. Weitere Informationen finden Sie in unserer Anleitung "[Ihre E-Mail-Adresse manuell migrieren](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)“.
 
 ### 8 - Ihre E-Mail-Software rekonfigurieren <a name="step8"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.de-de.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.de-de.md
@@ -40,7 +40,7 @@ In dieser Anleitung werden die verschiedenen Aktionen beschrieben, die notwendig
 > Die Anweisungen in dieser Anleitung beziehen sich auf verschiedene Produkte aus dem Web Cloud Universum. Wir empfehlen Ihnen, alle nachstehenden Schritte durchzugehen **bevor** Sie Ihre Dienste migrieren.
 >
 
-Die Migration Ihrer gesamten Website und Ihrer E-Mails zu OVHcloud **ohne Dienstunterbrechung** erfordert ein präzises Verfahren in 10 Teile:
+Die Migration Ihrer gesamten Website und Ihrer E-Mails zu OVHcloud **ohne Dienstunterbrechung** erfordert ein präzises Verfahren in 10 Teilen:
 
 - [1 - Webhosting und E-Mail-Accounts bei OVHcloud bestellen](#step1)
 - [2 - Eine DNS-Zone für Ihren Domainnamen bei OVHcloud erstellen und vorkonfigurieren](#step2)
@@ -155,7 +155,7 @@ Ersetzen Sie hierzu die Verbindungsdaten Ihrer alten Datenbank mit denen Ihrer n
 > Wenn Sie ein Content Management System (CMS) wie WordPress, Joomla!, Drupal oder PrestaShop verwenden, finden Sie die Informationen zur Datenbank in deren Konfigurationsdateien. Sie finden Details hierzu in **Teil 2** der Anleitung "[Änderung des Passworts einer Datenbank](/pages/web_cloud/web_hosting/sql_change_password)".
 >
 
-Deklarieren und authorisieren Ihren externen Domainnamen auf Ihrem OVHcloud Webhosting mithilfe der Anleitung "[Mehrere Websites auf einem Webhosting einrichten](/pages/web_cloud/web_hosting/multisites_configure_multisite)“. Geben Sie den Namen des Ordners, den Sie zu Beginn von [Teil 4](#step4) ausgewählt haben, als Wurzelverzeichnis an. Zur Erinnerung: Es handelt sich um den Ordner im FTP-Speicherplatz, in den Sie Ihre Webseiten-Dateien abgelegt haben.
+Deklarieren und autorisieren Ihren externen Domainnamen auf Ihrem OVHcloud Webhosting mithilfe der Anleitung “[Mehrere Websites auf einem Webhosting einrichten](/pages/web_cloud/web_hosting/multisites_configure_multisite)”. Geben Sie den Namen des Ordners, den Sie zu Beginn von [Teil 4](#step4) ausgewählt haben, als Wurzelverzeichnis an. Zur Erinnerung: Es handelt sich um den Ordner im FTP-Speicherplatz, in den Sie Ihre Webseiten-Dateien abgelegt haben.
 
 > [!warning]
 >

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-asia.md
@@ -41,7 +41,7 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-part procedure:
 
 - [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
 - [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-asia.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,27 +41,27 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-step procedure:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
 
-- [Step 1: Order the hosting plan and email accounts from OVHcloud](#step1)
-- [Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
-- [Step 3: Retrieve a full backup of your website](#step3)
-- [Step 4: Import your website backup to your OVHcloud hosting plan](#step4)
-- [Step 5: Recreate your email accounts at OVHcloud](#step5)
-- [Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
-- [Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
-- [Step 8: Reconfigure your email software](#step8)
-- [Step 9: Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
-- [Step 10: Transfer your domain name to OVHcloud](#step10)
+- [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
+- [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
+- [3 - Retrieve a full backup of your website](#step3)
+- [4 - Import your website backup to your OVHcloud hosting plan](#step4)
+- [5 - Recreate your email accounts at OVHcloud](#step5)
+- [6 - Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
+- [7 - Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
+- [8 - Reconfigure your email software](#step8)
+- [9 - Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
+- [10 - Transfer your domain name to OVHcloud](#step10)
 
-By following these 10 steps **in order**, you will not experience any downtime when accessing your website or receiving new emails.
+By following these 10 parts **in order**, you will not experience any downtime when accessing your website or receiving new emails.
 
 However, depending on your domain registrar, hosting provider or email service provider, they may cut off access to your old services if they notice that your domain name is no longer configured on their infrastructures.<br>
 In this case, a service interruption may occur.
 
 This guide is designed to minimise the duration of such an interruption.
 
-### Step 1: Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
+### 1 - Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
 
 Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) email solution. With this email offer, you can create email accounts with a maximum storage space of 5 GB each. Choose from the following hosting plans, considering the PHP version, SQL version, number of email accounts you need, and the size of your website to migrate:
 
@@ -69,13 +69,24 @@ Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/p
 - Hosting [Pro](/links/web/hosting-professional-offer) with **100 MX Plan email accounts** (for business)
 - Hosting [Performance](/links/web/hosting-performance-offer) with **1000 MX Plan email accounts** (scalable dedicated resources)
 
-Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in step 10 of this guide.)
+Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in part 10 of this guide.)
 
-You can also place the order from your [OVHcloud Control Panel](/links/manager). Once you have logged in, follow the instructions below:
+You can also place the order from your OVHcloud Control Panel. To do this, click on the tabs below to view each of the **3** steps.
 
-- Go to the `Web Cloud`{.action} tab.
-- In the top left of the interface, click `Order`{.action}, then `Hosting plans`{.action}.
-- Follow the steps in the **order without requesting the transfer of your domain name** (this action will be carried out in step 10 of this guide).
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> At the top left of the interface, click the `Order`{.action} button, then `Hosting plans`{.action}.
+>>
+> **Step 3**
+>>
+>> Follow the steps in the order **without requesting the transfer of your domain name** (this action will be carried out in part 10 of this guide).
 
 Once the payment has been confirmed, the hosting plan installation will begin. An email will be sent to your contact email address. It will contain the credentials for accessing your web hosting plan’s FTP (File Transfer Protocol) storage space.
 
@@ -84,7 +95,7 @@ Once the payment has been confirmed, the hosting plan installation will begin. A
 > OVHcloud offers other email services in addition to the MX Plan solution. For example, you can combine email accounts of the [Exchange offer](/links/web/emails-hosted-exchange) with MX Plan email accounts.
 >
 
-### Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
+### 2 - Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
 
 After your hosting service is installed, log in to your [OVHcloud Control Panel](/links/manager) to create a DNS zone for your domain name. Do not use "**www**" when doing this. You can refer to our guide on [Creating a DNS zone at OVHcloud](/pages/web_cloud/domains/dns_zone_create).
 
@@ -110,16 +121,16 @@ To retrieve the correct target IP address for your OVHcloud hosting plan, please
 
 > [!success]
 >
-> Note the two target values with the record type "NS", `dnsXX.ovh.ca` and `nsXX.ovh.ca`. They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [step 9](#step9) of this guide.
+> Note the two target values with the record type "NS", `dnsXX.ovh.ca` and `nsXX.ovh.ca`. They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [part 9](#step9) of this guide.
 >
 
-### Step 3: Retrieve a full backup of your website <a name="step3"></a>
+### 3 - Retrieve a full backup of your website <a name="step3"></a>
 
 Retrieve the contents of your current web hosting from its FTP storage space. Download a backup of your database as well, if your website uses one.
 
 You can only achieve this with your current hosting provider. Contact them if you are having trouble retrieving a full backup of your website.
 
-### Step 4: Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
+### 4 - Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
 
 To import the backup of your old service provider’s FTP storage space, [log in to the FTP storage space of your OVHcloud hosting](/pages/web_cloud/web_hosting/ftp_connection) and upload the backup to the root folder ‘www’ (or another root folder you have already created).
 
@@ -134,10 +145,10 @@ To do this, replace the login details for your old database with the login detai
 
 > [!success]
 >
-> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **Step 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
+> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **part 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
 >
 
-Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [step 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
+Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [part 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
 
 > [!warning]
 >
@@ -158,13 +169,13 @@ Declare and authorise your external domain name on your OVHcloud web hosting via
 
 After DNS propagation, the website displayed with your domain name will be the one hosted by OVHcloud.
 
-### Step 5: Recreate your email addresses at OVHcloud <a name="step5"></a>
+### 5 - Recreate your email addresses at OVHcloud <a name="step5"></a>
 
 Create new email accounts and name them according to your current email addresses hosted by your email provider. Use our guide on [Creating MX Plan email addresses](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
 If you have opted for an Exchange solution, [please read our documentation on this topic to create your email addresses](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
+### 6 - Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
 
 In this step, you will need to change the "MX" email servers in your domain name’s active DNS zone.
 This will result in you receiving new emails on your new OVHcloud email addresses.
@@ -182,7 +193,7 @@ Once the propagation is complete, all new emails will be received by your OVHclo
 WWe recommend changing the MX records **before** migrating the content of your old email accounts.
 This method avoids you having to redo a migration for the few emails received on your old email accounts during DNS propagation.
 
-### Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
+### 7 - Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
 
 After the DNS propagation, all your new emails are received by your new email accounts. However, your old emails are still stored on your previous email server.
 
@@ -207,7 +218,7 @@ Repeat for all of your email accounts.
 
 **Option 2**: Back up the content of your email accounts using an email client (Outlook, Mac Mail, etc.), reconfigure your email software, then import the backup into your new OVHcloud email accounts. You can find more information in our guide “[Migrating your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)”.
 
-### Step 8: Reconfigure your email software <a name="step8"></a>
+### 8 - Reconfigure your email software <a name="step8"></a>
 
 Once you have migrated your email accounts to OVHcloud, reconfigure your email software using our relevant email guides.
 
@@ -219,9 +230,9 @@ Once you have migrated your email accounts to OVHcloud, reconfigure your email s
 
 - You can find all of our configuration guides in the `Exchange configuration on computer` and `Exchange configuration on smartphone` sections of [our Exchange documentation](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Step 9: Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
+### 9 - Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
 
-The DNS zone preconfigured in [step 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
+The DNS zone preconfigured in [part 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
 
 Replace the current DNS servers (of the original registrar) with the two DNS servers declared in the OVHcloud DNS zone (format `dnsXX.ovh.ca` and `nsXX.ovh.ca`). You can do this in the management interface of the original registrar.
 
@@ -230,7 +241,7 @@ Replace the current DNS servers (of the original registrar) with the two DNS ser
 > The DNS servers must be changed at your domain name’s current registrar, and you will need to allow between **24 and 48 hours** for the changes to propagate fully.
 >
 
-### Step 10: Transfer your domain name to OVHcloud <a name="step10"></a>
+### 10 - Transfer your domain name to OVHcloud <a name="step10"></a>
 
 Once the DNS propagation is complete, check that your entire website is functional. Browse your website to check that all pages are displaying correctly and that no 404 errors are returned. Also check the sending and receiving of emails from your email addresses.
 
@@ -242,7 +253,7 @@ Once you have transferred your data and services, you can cancel your old servic
 
 ### Conclusion
 
-After following the ten steps in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
+After following the ten parts in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
 
 ## Go further <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,27 +41,27 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-step procedure:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
 
-- [Step 1: Order the hosting plan and email accounts from OVHcloud](#step1)
-- [Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
-- [Step 3: Retrieve a full backup of your website](#step3)
-- [Step 4: Import your website backup to your OVHcloud hosting plan](#step4)
-- [Step 5: Recreate your email accounts at OVHcloud](#step5)
-- [Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
-- [Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
-- [Step 8: Reconfigure your email software](#step8)
-- [Step 9: Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
-- [Step 10: Transfer your domain name to OVHcloud](#step10)
+- [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
+- [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
+- [3 - Retrieve a full backup of your website](#step3)
+- [4 - Import your website backup to your OVHcloud hosting plan](#step4)
+- [5 - Recreate your email accounts at OVHcloud](#step5)
+- [6 - Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
+- [7 - Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
+- [8 - Reconfigure your email software](#step8)
+- [9 - Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
+- [10 - Transfer your domain name to OVHcloud](#step10)
 
-By following these 10 steps **in order**, you will not experience any downtime when accessing your website or receiving new emails.
+By following these 10 parts **in order**, you will not experience any downtime when accessing your website or receiving new emails.
 
 However, depending on your domain registrar, hosting provider or email service provider, they may cut off access to your old services if they notice that your domain name is no longer configured on their infrastructures.<br>
 In this case, a service interruption may occur.
 
 This guide is designed to minimise the duration of such an interruption.
 
-### Step 1: Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
+### 1 - Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
 
 Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) email solution. With this email offer, you can create email accounts with a maximum storage space of 5 GB each. Choose from the following hosting plans, considering the PHP version, SQL version, number of email accounts you need, and the size of your website to migrate:
 
@@ -69,13 +69,24 @@ Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/p
 - Hosting [Pro](/links/web/hosting-professional-offer) with **100 MX Plan email accounts** (for business)
 - Hosting [Performance](/links/web/hosting-performance-offer) with **1000 MX Plan email accounts** (scalable dedicated resources)
 
-Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in step 10 of this guide.)
+Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in part 10 of this guide.)
 
-You can also place the order from your [OVHcloud Control Panel](/links/manager). Once you have logged in, follow the instructions below:
+You can also place the order from your OVHcloud Control Panel. To do this, click on the tabs below to view each of the **3** steps.
 
-- Go to the `Web Cloud`{.action} tab.
-- In the top left of the interface, click `Order`{.action}, then `Hosting plans`{.action}.
-- Follow the steps in the **order without requesting the transfer of your domain name** (this action will be carried out in step 10 of this guide).
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> At the top left of the interface, click the `Order`{.action} button, then `Hosting plans`{.action}.
+>>
+> **Step 3**
+>>
+>> Follow the steps in the order **without requesting the transfer of your domain name** (this action will be carried out in part 10 of this guide).
 
 Once the payment has been confirmed, the hosting plan installation will begin. An email will be sent to your contact email address. It will contain the credentials for accessing your web hosting plan’s FTP (File Transfer Protocol) storage space.
 
@@ -84,7 +95,7 @@ Once the payment has been confirmed, the hosting plan installation will begin. A
 > OVHcloud offers other email services in addition to the MX Plan solution. For example, you can combine email accounts of the [Exchange offer](/links/web/emails-hosted-exchange) with MX Plan email accounts.
 >
 
-### Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
+### 2 - Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
 
 If your domain is hosted by another service provider and you would like to transfer it to OVHcloud, you must first create and preconfigure a DNS zone before initiating the transfer, in order to avoid any service interruptions.
 
@@ -112,16 +123,16 @@ To retrieve the correct target IP address for your OVHcloud hosting plan, please
 
 > [!success]
 >
-> Note the two target values with the record type "NS", `dnsXX.ovh.ca` and `nsXX.ovh.ca`. They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [step 9](#step9) of this guide.
+> Note the two target values with the record type "NS", `dnsXX.ovh.ca` and `nsXX.ovh.ca`. They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [part 9](#step9) of this guide.
 >
 
-### Step 3: Retrieve a full backup of your website <a name="step3"></a>
+### 3 - Retrieve a full backup of your website <a name="step3"></a>
 
 Retrieve the contents of your current web hosting from its FTP storage space. Download a backup of your database as well, if your website uses one.
 
 You can only achieve this with your current hosting provider. Contact them if you are having trouble retrieving a full backup of your website.
 
-### Step 4: Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
+### 4 - Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
 
 To import the backup of your old service provider’s FTP storage space, [log in to the FTP storage space of your OVHcloud hosting](/pages/web_cloud/web_hosting/ftp_connection) and upload the backup to the root folder ‘www’ (or another root folder you have already created).
 
@@ -136,10 +147,10 @@ To do this, replace the login details for your old database with the login detai
 
 > [!success]
 >
-> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **Step 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
+> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **part 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
 >
 
-Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [step 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
+Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [part 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
 
 > [!warning]
 >
@@ -160,13 +171,13 @@ Declare and authorise your external domain name on your OVHcloud web hosting via
 
 After DNS propagation, the website displayed with your domain name will be the one hosted by OVHcloud.
 
-### Step 5: Recreate your email addresses at OVHcloud <a name="step5"></a>
+### 5 - Recreate your email addresses at OVHcloud <a name="step5"></a>
 
 Create new email accounts and name them according to your current email addresses hosted by your email provider. Use our guide on [Creating MX Plan email addresses](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
 If you have opted for an Exchange solution, [please read our documentation on this topic to create your email addresses](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
+### 6 - Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
 
 In this step, you will need to change the "MX" email servers in your domain name’s active DNS zone.
 This will result in you receiving new emails on your new OVHcloud email addresses.
@@ -184,7 +195,7 @@ Once the propagation is complete, all new emails will be received by your OVHclo
 WWe recommend changing the MX records **before** migrating the content of your old email accounts.
 This method avoids you having to redo a migration for the few emails received on your old email accounts during DNS propagation.
 
-### Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
+### 7 - Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
 
 After the DNS propagation, all your new emails are received by your new email accounts. However, your old emails are still stored on your previous email server.
 
@@ -209,7 +220,7 @@ Repeat for all of your email accounts.
 
 **Option 2**: Back up the content of your email accounts using an email client (Outlook, Mac Mail, etc.), reconfigure your email software, then import the backup into your new OVHcloud email accounts. You can find more information in our guide “[Migrating your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)”.
 
-### Step 8: Reconfigure your email software <a name="step8"></a>
+### 8 - Reconfigure your email software <a name="step8"></a>
 
 Once you have migrated your email accounts to OVHcloud, reconfigure your email software using our relevant email guides.
 
@@ -221,9 +232,9 @@ Once you have migrated your email accounts to OVHcloud, reconfigure your email s
 
 - You can find all of our configuration guides in the `Exchange configuration on computer` and `Exchange configuration on smartphone` sections of [our Exchange documentation](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Step 9: Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
+### 9 - Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
 
-The DNS zone pre-configured in [step 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
+The DNS zone pre-configured in [part 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
 
 Replace the current DNS servers (of the original registrar) with the two DNS servers declared in the OVHcloud DNS zone (format `dnsXX.ovh.ca` and `nsXX.ovh.ca`). You can do this in the management interface of the original registrar.
 
@@ -232,7 +243,7 @@ Replace the current DNS servers (of the original registrar) with the two DNS ser
 > The DNS servers must be changed at your domain name’s current registrar, and you will need to allow between **24 and 48 hours** for the changes to propagate fully.
 >
 
-### Step 10: Transfer your domain name to OVHcloud <a name="step10"></a>
+### 10 - Transfer your domain name to OVHcloud <a name="step10"></a>
 
 Once the DNS propagation is complete, check that your entire website is functional. Browse your website to check that all pages are displaying correctly and that no 404 errors are returned. Also check the sending and receiving of emails from your email addresses.
 
@@ -244,7 +255,7 @@ Once you have transferred your data and services, you can cancel your old servic
 
 ### Conclusion
 
-After following the ten steps in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
+After following the ten parts in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
 
 ## Go further <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-au.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-au.md
@@ -41,7 +41,7 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-part procedure:
 
 - [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
 - [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,27 +41,27 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-step procedure:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
 
-- [Step 1: Order the hosting plan and email accounts from OVHcloud](#step1)
-- [Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
-- [Step 3: Retrieve a full backup of your website](#step3)
-- [Step 4: Import your website backup to your OVHcloud hosting plan](#step4)
-- [Step 5: Recreate your email accounts at OVHcloud](#step5)
-- [Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
-- [Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
-- [Step 8: Reconfigure your email software](#step8)
-- [Step 9: Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
-- [Step 10: Transfer your domain name to OVHcloud](#step10)
+- [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
+- [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
+- [3 - Retrieve a full backup of your website](#step3)
+- [4 - Import your website backup to your OVHcloud hosting plan](#step4)
+- [5 - Recreate your email accounts at OVHcloud](#step5)
+- [6 - Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
+- [7 - Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
+- [8 - Reconfigure your email software](#step8)
+- [9 - Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
+- [10 - Transfer your domain name to OVHcloud](#step10)
 
-By following these 10 steps **in order**, you will not experience any downtime when accessing your website or receiving new emails.
+By following these 10 parts **in order**, you will not experience any downtime when accessing your website or receiving new emails.
 
 However, depending on your domain registrar, hosting provider or email service provider, they may cut off access to your old services if they notice that your domain name is no longer configured on their infrastructures.<br>
 In this case, a service interruption may occur.
 
 This guide is designed to minimise the duration of such an interruption.
 
-### Step 1: Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
+### 1 - Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
 
 Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) email solution. With this email offer, you can create email accounts with a maximum storage space of 5 GB each. Choose from the following hosting plans, considering the PHP version, SQL version, number of email accounts you need, and the size of your website to migrate:
 
@@ -69,13 +69,24 @@ Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/p
 - Hosting [Pro](/links/web/hosting-professional-offer) with **100 MX Plan email accounts** (for business)
 - Hosting [Performance](/links/web/hosting-performance-offer) with **1000 MX Plan email accounts** (scalable dedicated resources)
 
-Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in step 10 of this guide.)
+Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in part 10 of this guide.)
 
-You can also place the order from your [OVHcloud Control Panel](/links/manager). Once you have logged in, follow the instructions below:
+You can also place the order from your OVHcloud Control Panel. To do this, click on the tabs below to view each of the **3** steps.
 
-- Go to the `Web Cloud`{.action} tab.
-- In the top left of the interface, click `Order`{.action}, then `Hosting plans`{.action}.
-- Follow the steps in the **order without requesting the transfer of your domain name** (this action will be carried out in step 10 of this guide).
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> At the top left of the interface, click the `Order`{.action} button, then `Hosting plans`{.action}.
+>>
+> **Step 3**
+>>
+>> Follow the steps in the order **without requesting the transfer of your domain name** (this action will be carried out in part 10 of this guide).
 
 Once the payment has been confirmed, the hosting plan installation will begin. An email will be sent to your contact email address. It will contain the credentials for accessing your web hosting plan’s FTP (File Transfer Protocol) storage space.
 
@@ -84,7 +95,7 @@ Once the payment has been confirmed, the hosting plan installation will begin. A
 > OVHcloud offers other email services in addition to the MX Plan solution. For example, you can combine email accounts of the [Exchange offer](/links/web/emails-hosted-exchange) with MX Plan email accounts.
 >
 
-### Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
+### 2 - Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
 
 If your domain is hosted by another service provider and you would like to transfer it to OVHcloud, you must first create and preconfigure a DNS zone before initiating the transfer, in order to avoid any service interruptions.
 
@@ -112,16 +123,16 @@ To retrieve the correct target IP address for your OVHcloud hosting plan, please
 
 > [!success]
 >
-> Note the two target values with the record type "NS", `dnsXX.ovh.ca` and `nsXX.ovh.ca`. They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [step 9](#step9) of this guide.
+> Note the two target values with the record type "NS", `dnsXX.ovh.ca` and `nsXX.ovh.ca`. They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [part 9](#step9) of this guide.
 >
 
-### Step 3: Retrieve a full backup of your website <a name="step3"></a>
+### 3 - Retrieve a full backup of your website <a name="step3"></a>
 
 Retrieve the contents of your current web hosting from its FTP storage space. Download a backup of your database as well, if your website uses one.
 
 You can only achieve this with your current hosting provider. Contact them if you are having trouble retrieving a full backup of your website.
 
-### Step 4: Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
+### 4 - Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
 
 To import the backup of your old service provider’s FTP storage space, [log in to the FTP storage space of your OVHcloud hosting](/pages/web_cloud/web_hosting/ftp_connection) and upload the backup to the root folder ‘www’ (or another root folder you have already created).
 
@@ -136,10 +147,10 @@ To do this, replace the login details for your old database with the login detai
 
 > [!success]
 >
-> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **Step 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
+> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **part 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
 >
 
-Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [step 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
+Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [part 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
 
 > [!warning]
 >
@@ -160,13 +171,13 @@ Declare and authorise your external domain name on your OVHcloud web hosting via
 
 After DNS propagation, the website displayed with your domain name will be the one hosted by OVHcloud.
 
-### Step 5: Recreate your email addresses at OVHcloud <a name="step5"></a>
+### 5 - Recreate your email addresses at OVHcloud <a name="step5"></a>
 
 Create new email accounts and name them according to your current email addresses hosted by your email provider. Use our guide on [Creating MX Plan email addresses](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
 If you have opted for an Exchange solution, [please read our documentation on this topic to create your email addresses](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
+### 6 - Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
 
 In this step, you will need to change the "MX" email servers in your domain name’s active DNS zone.
 This will result in you receiving new emails on your new OVHcloud email addresses.
@@ -184,7 +195,7 @@ Once the propagation is complete, all new emails will be received by your OVHclo
 WWe recommend changing the MX records **before** migrating the content of your old email accounts.
 This method avoids you having to redo a migration for the few emails received on your old email accounts during DNS propagation.
 
-### Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
+### 7 - Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
 
 After the DNS propagation, all your new emails are received by your new email accounts. However, your old emails are still stored on your previous email server.
 
@@ -209,7 +220,7 @@ Repeat for all of your email accounts.
 
 **Option 2**: Back up the content of your email accounts using an email client (Outlook, Mac Mail, etc.), reconfigure your email software, then import the backup into your new OVHcloud email accounts. You can find more information in our guide “[Migrating your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)”.
 
-### Step 8: Reconfigure your email software <a name="step8"></a>
+### 8 - Reconfigure your email software <a name="step8"></a>
 
 Once you have migrated your email accounts to OVHcloud, reconfigure your email software using our relevant email guides.
 
@@ -221,9 +232,9 @@ Once you have migrated your email accounts to OVHcloud, reconfigure your email s
 
 - You can find all of our configuration guides in the `Exchange configuration on computer` and `Exchange configuration on smartphone` sections of [our Exchange documentation](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Step 9: Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
+### 9 - Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
 
-The DNS zone pre-configured in [step 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
+The DNS zone pre-configured in [part 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
 
 Replace the current DNS servers (of the original registrar) with the two DNS servers declared in the OVHcloud DNS zone (format `dnsXX.ovh.ca` and `nsXX.ovh.ca`). You can do this in the management interface of the original registrar.
 
@@ -232,7 +243,7 @@ Replace the current DNS servers (of the original registrar) with the two DNS ser
 > The DNS servers must be changed at your domain name’s current registrar, and you will need to allow between **24 and 48 hours** for the changes to propagate fully.
 >
 
-### Step 10: Transfer your domain name to OVHcloud <a name="step10"></a>
+### 10 - Transfer your domain name to OVHcloud <a name="step10"></a>
 
 Once the DNS propagation is complete, check that your entire website is functional. Browse your website to check that all pages are displaying correctly and that no 404 errors are returned. Also check the sending and receiving of emails from your email addresses.
 
@@ -244,7 +255,7 @@ Once you have transferred your data and services, you can cancel your old servic
 
 ### Conclusion
 
-After following the ten steps in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
+After following the ten parts in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
 
 ## Go further <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ca.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ca.md
@@ -41,7 +41,7 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-part procedure:
 
 - [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
 - [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-gb.md
@@ -41,7 +41,7 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-part procedure:
 
 - [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
 - [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-gb.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,27 +41,27 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-step procedure:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
 
-- [Step 1: Order the hosting plan and email accounts from OVHcloud](#step1)
-- [Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
-- [Step 3: Retrieve a full backup of your website](#step3)
-- [Step 4: Import your website backup to your OVHcloud hosting plan](#step4)
-- [Step 5: Recreate your email accounts at OVHcloud](#step5)
-- [Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
-- [Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
-- [Step 8: Reconfigure your email software](#step8)
-- [Step 9: Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
-- [Step 10: Transfer your domain name to OVHcloud](#step10)
+- [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
+- [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
+- [3 - Retrieve a full backup of your website](#step3)
+- [4 - Import your website backup to your OVHcloud hosting plan](#step4)
+- [5 - Recreate your email accounts at OVHcloud](#step5)
+- [6 - Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
+- [7 - Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
+- [8 - Reconfigure your email software](#step8)
+- [9 - Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
+- [10 - Transfer your domain name to OVHcloud](#step10)
 
-By following these 10 steps **in order**, you will not experience any downtime when accessing your website or receiving new emails.
+By following these 10 parts **in order**, you will not experience any downtime when accessing your website or receiving new emails.
 
 However, depending on your domain registrar, hosting provider or email service provider, they may cut off access to your old services if they notice that your domain name is no longer configured on their infrastructures.<br>
 In this case, a service interruption may occur.
 
 This guide is designed to minimise the duration of such an interruption.
 
-### Step 1: Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
+### 1 - Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
 
 Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) email solution. With this email offer, you can create email accounts with a maximum storage space of 5 GB each. Choose from the following hosting plans, considering the PHP version, SQL version, number of email accounts you need, and the size of your website to migrate:
 
@@ -70,13 +70,24 @@ Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/p
 - Hosting [Performance](/links/web/hosting-performance-offer) with **1000 MX Plan email accounts** (scalable dedicated resources)
 - Hosting [Cloud Web](/links/web/hosting-cloud-web-offer) with **200 MX Plan email accounts** (for application developers)
 
-Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in step 10 of this guide.)
+Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in part 10 of this guide.)
 
-You can also place the order from your [OVHcloud Control Panel](/links/manager). Once you have logged in, follow the instructions below:
+You can also place the order from your OVHcloud Control Panel. To do this, click on the tabs below to view each of the **3** steps.
 
-- Go to the `Web Cloud`{.action} tab.
-- In the top left of the interface, click `Order`{.action}, then `Hosting plans`{.action}.
-- Follow the steps in the **order without requesting the transfer of your domain name** (this action will be carried out in step 10 of this guide).
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> At the top left of the interface, click the `Order`{.action} button, then `Hosting plans`{.action}.
+>>
+> **Step 3**
+>>
+>> Follow the steps in the order **without requesting the transfer of your domain name** (this action will be carried out in part 10 of this guide).
 
 Once the payment has been confirmed, the hosting plan installation will begin. An email will be sent to your contact email address. It will contain the credentials for accessing your web hosting plan’s FTP (File Transfer Protocol) storage space.
 
@@ -85,7 +96,7 @@ Once the payment has been confirmed, the hosting plan installation will begin. A
 > OVHcloud offers other email services in addition to the MX Plan solution. For example, you can combine email accounts of the [Email Pro offer](/links/web/email-pro) and the [Exchange offer](/links/web/emails-hosted-exchange) with MX Plan email accounts.
 >
 
-### Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
+### 2 - Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
 
 If your domain is hosted by another service provider and you would like to transfer it to OVHcloud, you must first create and preconfigure a DNS zone before initiating the transfer, in order to avoid any service interruptions.
 
@@ -113,16 +124,16 @@ To retrieve the correct target IP address for your OVHcloud hosting plan, please
 
 > [!success]
 >
-> Note the two target values with the record type "NS", `dnsXX.ovh.net` and `nsXX.ovh.net` (or `dns200.anycast.me` and `ns200.anycast.me`). They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [step 9](#step9) of this guide.
+> Note the two target values with the record type "NS", `dnsXX.ovh.net` and `nsXX.ovh.net` (or `dns200.anycast.me` and `ns200.anycast.me`). They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [part 9](#step9) of this guide.
 >
 
-### Step 3: Retrieve a full backup of your website <a name="step3"></a>
+### 3 - Retrieve a full backup of your website <a name="step3"></a>
 
 Retrieve the contents of your current web hosting from its FTP storage space. Download a backup of your database as well, if your website uses one.
 
 You can only achieve this with your current hosting provider. Contact them if you are having trouble retrieving a full backup of your website.
 
-### Step 4: Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
+### 4 - Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
 
 To import the backup of your old service provider’s FTP storage space, [log in to the FTP storage space of your OVHcloud hosting](/pages/web_cloud/web_hosting/ftp_connection) and upload the backup to the root folder ‘www’ (or another root folder you have already created).
 
@@ -142,10 +153,10 @@ To do this, replace the login details for your old database with the login detai
 
 > [!success]
 >
-> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **Step 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
+> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **part 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
 >
 
-Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [step 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
+Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [part 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
 
 > [!warning]
 >
@@ -166,7 +177,7 @@ Declare and authorise your external domain name on your OVHcloud web hosting via
 
 After DNS propagation, the website displayed with your domain name will be the one hosted by OVHcloud.
 
-### Step 5: Recreate your email addresses at OVHcloud <a name="step5"></a>
+### 5 - Recreate your email addresses at OVHcloud <a name="step5"></a>
 
 Create new email accounts and name them according to your current email addresses hosted by your email provider. Use our guide on [Creating MX Plan email addresses](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
@@ -175,7 +186,7 @@ If you have opted for an Email Pro or Exchange solution, please read our documen
 - [For Email Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 - [For Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
+### 6 - Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
 
 In this step, you will need to change the "MX" email servers in your domain name’s active DNS zone.
 This will result in you receiving new emails on your new OVHcloud email addresses.
@@ -193,7 +204,7 @@ Once the propagation is complete, all new emails will be received by your OVHclo
 We recommend changing the MX records **before** migrating the content of your old email accounts.
 This method avoids you having to redo a migration for the few emails received on your old email accounts during DNS propagation.
 
-### Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
+### 7 - Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
 
 After the DNS propagation, all your new emails are received by your new email accounts. However, your old emails are still stored on your previous email server.
 
@@ -218,7 +229,7 @@ Repeat for all of your email accounts.
 
 **Option 2**: Back up the content of your email accounts using an email client (Outlook, Mac Mail, etc.), reconfigure your email software, then import the backup into your new OVHcloud email accounts. You can find more information in our guide “[Migrating your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)”.
 
-### Step 8: Reconfigure your email software <a name="step8"></a>
+### 8 - Reconfigure your email software <a name="step8"></a>
 
 Once you have migrated your email accounts to OVHcloud, reconfigure your email software using our relevant email guides.
 
@@ -234,9 +245,9 @@ Once you have migrated your email accounts to OVHcloud, reconfigure your email s
 
 - You can find all of our configuration guides in the `Exchange configuration on computer` and `Exchange configuration on smartphone` sections of [our Exchange documentation](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Step 9: Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
+### 9 - Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
 
-The DNS zone preconfigured in [step 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
+The DNS zone preconfigured in [part 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
 
 Replace the current DNS servers (of the original registrar) with the two DNS servers declared in the OVHcloud DNS zone (format `dnsXX.ovh.net` and `nsXX.ovh.net` or `dns200.anycast.me` and `ns200.anycast.me`). You can do this in the management interface of the original registrar.
 
@@ -245,7 +256,7 @@ Replace the current DNS servers (of the original registrar) with the two DNS ser
 > The DNS servers must be changed at your domain name’s current registrar, and you will need to allow between **24 and 48 hours** for the changes to propagate fully.
 >
 
-### Step 10: Transfer your domain name to OVHcloud <a name="step10"></a>
+### 10 - Transfer your domain name to OVHcloud <a name="step10"></a>
 
 Once the DNS propagation is complete, check that your entire website is functional. Browse your website to check that all pages are displaying correctly and that no 404 errors are returned. Also check the sending and receiving of emails from your email addresses.
 
@@ -257,7 +268,7 @@ Once you have transferred your data and services, you can cancel your old servic
 
 ### Conclusion
 
-After following the ten steps in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
+After following the ten parts in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
 
 ## Go further <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,27 +41,27 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-step procedure:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
 
-- [Step 1: Order the hosting plan and email accounts from OVHcloud](#step1)
-- [Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
-- [Step 3: Retrieve a full backup of your website](#step3)
-- [Step 4: Import your website backup to your OVHcloud hosting plan](#step4)
-- [Step 5: Recreate your email accounts at OVHcloud](#step5)
-- [Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
-- [Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
-- [Step 8: Reconfigure your email software](#step8)
-- [Step 9: Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
-- [Step 10: Transfer your domain name to OVHcloud](#step10)
+- [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
+- [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
+- [3 - Retrieve a full backup of your website](#step3)
+- [4 - Import your website backup to your OVHcloud hosting plan](#step4)
+- [5 - Recreate your email accounts at OVHcloud](#step5)
+- [6 - Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
+- [7 - Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
+- [8 - Reconfigure your email software](#step8)
+- [9 - Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
+- [10 - Transfer your domain name to OVHcloud](#step10)
 
-By following these 10 steps **in order**, you will not experience any downtime when accessing your website or receiving new emails.
+By following these 10 parts **in order**, you will not experience any downtime when accessing your website or receiving new emails.
 
 However, depending on your domain registrar, hosting provider or email service provider, they may cut off access to your old services if they notice that your domain name is no longer configured on their infrastructures.<br>
 In this case, a service interruption may occur.
 
 This guide is designed to minimise the duration of such an interruption.
 
-### Step 1: Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
+### 1 - Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
 
 Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) email solution. With this email offer, you can create email accounts with a maximum storage space of 5 GB each. Choose from the following hosting plans, considering the PHP version, SQL version, number of email accounts you need, and the size of your website to migrate:
 
@@ -69,13 +69,24 @@ Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/p
 - Hosting [Pro](/links/web/hosting-professional-offer) with **100 MX Plan email accounts** (for business)
 - Hosting [Performance](/links/web/hosting-performance-offer) with **1000 MX Plan email accounts** (scalable dedicated resources)
 
-Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in step 10 of this guide.)
+Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in part 10 of this guide.)
 
-You can also place the order from your [OVHcloud Control Panel](/links/manager). Once you have logged in, follow the instructions below:
+You can also place the order from your OVHcloud Control Panel. To do this, click on the tabs below to view each of the **3** steps.
 
-- Go to the `Web Cloud`{.action} tab.
-- In the top left of the interface, click `Order`{.action}, then `Hosting plans`{.action}.
-- Follow the steps in the **order without requesting the transfer of your domain name** (this action will be carried out in step 10 of this guide).
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> At the top left of the interface, click the `Order`{.action} button, then `Hosting plans`{.action}.
+>>
+> **Step 3**
+>>
+>> Follow the steps in the order **without requesting the transfer of your domain name** (this action will be carried out in part 10 of this guide).
 
 Once the payment has been confirmed, the hosting plan installation will begin. An email will be sent to your contact email address. It will contain the credentials for accessing your web hosting plan’s FTP (File Transfer Protocol) storage space.
 
@@ -84,7 +95,7 @@ Once the payment has been confirmed, the hosting plan installation will begin. A
 > OVHcloud offers other email services in addition to the MX Plan solution. For example, you can combine email accounts of the [Email Pro offer](/links/web/email-pro) and/or accounts [“Exchange”](/links/web/emails-hosted-exchange) with MX Plan email accounts.
 >
 
-### Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
+### 2 - Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
 
 If your domain is hosted by another service provider and you would like to transfer it to OVHcloud, you must first create and preconfigure a DNS zone before initiating the transfer, in order to avoid any service interruptions.
 
@@ -112,16 +123,16 @@ To retrieve the correct target IP address for your OVHcloud hosting plan, please
 
 > [!success]
 >
-> Note the two target values with the record type "NS", `dnsXX.ovh.net` and `nsXX.ovh.net` (or `dns200.anycast.me` and `ns200.anycast.me`). They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [step 9](#step9) of this guide.
+> Note the two target values with the record type "NS", `dnsXX.ovh.net` and `nsXX.ovh.net` (or `dns200.anycast.me` and `ns200.anycast.me`). They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [part 9](#step9) of this guide.
 >
 
-### Step 3: Retrieve a full backup of your website <a name="step3"></a>
+### 3 - Retrieve a full backup of your website <a name="step3"></a>
 
 Retrieve the contents of your current web hosting from its FTP storage space. Download a backup of your database as well, if your website uses one.
 
 You can only achieve this with your current hosting provider. Contact them if you are having trouble retrieving a full backup of your website.
 
-### Step 4: Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
+### 4 - Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
 
 To import the backup of your old service provider’s FTP storage space, [log in to the FTP storage space of your OVHcloud hosting](/pages/web_cloud/web_hosting/ftp_connection) and upload the backup to the root folder ‘www’ (or another root folder you have already created).
 
@@ -141,10 +152,10 @@ To do this, replace the login details for your old database with the login detai
 
 > [!success]
 >
-> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **Step 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
+> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **part 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
 >
 
-Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [step 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
+Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [part 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
 
 > [!warning]
 >
@@ -165,7 +176,7 @@ Declare and authorise your external domain name on your OVHcloud web hosting via
 
 After DNS propagation, the website displayed with your domain name will be the one hosted by OVHcloud.
 
-### Step 5: Recreate your email addresses at OVHcloud <a name="step5"></a>
+### 5 - Recreate your email addresses at OVHcloud <a name="step5"></a>
 
 Create new email accounts and name them according to your current email addresses hosted by your email provider. Use our guide on [Creating MX Plan email addresses](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
@@ -174,7 +185,7 @@ If you have opted for an Email Pro or Exchange solution, please read our documen
 - For [Email-Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 - For [Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
+### 6 - Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
 
 In this step, you will need to change the "MX" email servers in your domain name’s active DNS zone.
 This will result in you receiving new emails on your new OVHcloud email addresses.
@@ -192,7 +203,7 @@ Once the propagation is complete, all new emails will be received by your OVHclo
 WWe recommend changing the MX records **before** migrating the content of your old email accounts.
 This method avoids you having to redo a migration for the few emails received on your old email accounts during DNS propagation.
 
-### Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
+### 7 - Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
 
 After the DNS propagation, all your new emails are received by your new email accounts. However, your old emails are still stored on your previous email server.
 
@@ -217,7 +228,7 @@ Repeat for all of your email accounts.
 
 **Option 2**: Back up the content of your email accounts using an email client (Outlook, Mac Mail, etc.), reconfigure your email software, then import the backup into your new OVHcloud email accounts. You can find more information in our guide “[Migrating your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)”.
 
-### Step 8: Reconfigure your email software <a name="step8"></a>
+### 8 - Reconfigure your email software <a name="step8"></a>
 
 Once you have migrated your email accounts to OVHcloud, reconfigure your email software using our relevant email guides.
 
@@ -233,9 +244,9 @@ Once you have migrated your email accounts to OVHcloud, reconfigure your email s
 
 - You can find all of our configuration guides in the `Exchange configuration on computer` and `Exchange configuration on smartphone` sections of [our Exchange documentation](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Step 9: Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
+### 9 - Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
 
-The DNS zone pre-configured in [step 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
+The DNS zone pre-configured in [part 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
 
 Replace the current DNS servers (of the original registrar) with the two DNS servers declared in the OVHcloud DNS zone (format `dnsXX.ovh.net` and `nsXX.ovh.net` or `dns200.anycast.me` and `ns200.anycast.me`). You can do this in the management interface of the original registrar.
 
@@ -244,7 +255,7 @@ Replace the current DNS servers (of the original registrar) with the two DNS ser
 > The DNS servers must be changed at your domain name’s current registrar, and you will need to allow between **24 and 48 hours** for the changes to propagate fully.
 >
 
-### Step 10: Transfer your domain name to OVHcloud <a name="step10"></a>
+### 10 - Transfer your domain name to OVHcloud <a name="step10"></a>
 
 Once the DNS propagation is complete, check that your entire website is functional. Browse your website to check that all pages are displaying correctly and that no 404 errors are returned. Also check the sending and receiving of emails from your email addresses.
 
@@ -256,7 +267,7 @@ Once you have transferred your data and services, you can cancel your old servic
 
 ### Conclusion
 
-After following the ten steps in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
+After following the ten parts in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
 
 ## Go further <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ie.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-ie.md
@@ -41,7 +41,7 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-part procedure:
 
 - [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
 - [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,27 +41,27 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-step procedure:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
 
-- [Step 1: Order the hosting plan and email accounts from OVHcloud](#step1)
-- [Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
-- [Step 3: Retrieve a full backup of your website](#step3)
-- [Step 4: Import your website backup to your OVHcloud hosting plan](#step4)
-- [Step 5: Recreate your email accounts at OVHcloud](#step5)
-- [Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
-- [Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
-- [Step 8: Reconfigure your email software](#step8)
-- [Step 9: Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
-- [Step 10: Transfer your domain name to OVHcloud](#step10)
+- [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
+- [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
+- [3 - Retrieve a full backup of your website](#step3)
+- [4 - Import your website backup to your OVHcloud hosting plan](#step4)
+- [5 - Recreate your email accounts at OVHcloud](#step5)
+- [6 - Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
+- [7 - Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
+- [8 - Reconfigure your email software](#step8)
+- [9 - Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
+- [10 - Transfer your domain name to OVHcloud](#step10)
 
-By following these 10 steps **in order**, you will not experience any downtime when accessing your website or receiving new emails.
+By following these 10 parts **in order**, you will not experience any downtime when accessing your website or receiving new emails.
 
 However, depending on your domain registrar, hosting provider or email service provider, they may cut off access to your old services if they notice that your domain name is no longer configured on their infrastructures.<br>
 In this case, a service interruption may occur.
 
 This guide is designed to minimise the duration of such an interruption.
 
-### Step 1: Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
+### 1 - Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
 
 Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) email solution. With this email offer, you can create email accounts with a maximum storage space of 5 GB each. Choose from the following hosting plans, considering the PHP version, SQL version, number of email accounts you need, and the size of your website to migrate:
 
@@ -69,13 +69,24 @@ Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/p
 - Hosting [Pro](/links/web/hosting-professional-offer) with **100 MX Plan email accounts** (for business)
 - Hosting [Performance](/links/web/hosting-performance-offer) with **1000 MX Plan email accounts** (scalable dedicated resources)
 
-Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in step 10 of this guide.)
+Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in part 10 of this guide.)
 
-You can also place the order from your [OVHcloud Control Panel](/links/manager). Once you have logged in, follow the instructions below:
+You can also place the order from your OVHcloud Control Panel. To do this, click on the tabs below to view each of the **3** steps.
 
-- Go to the `Web Cloud`{.action} tab.
-- In the top left of the interface, click `Order`{.action}, then `Hosting plans`{.action}.
-- Follow the steps in the **order without requesting the transfer of your domain name** (this action will be carried out in step 10 of this guide).
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> At the top left of the interface, click the `Order`{.action} button, then `Hosting plans`{.action}.
+>>
+> **Step 3**
+>>
+>> Follow the steps in the order **without requesting the transfer of your domain name** (this action will be carried out in part 10 of this guide).
 
 Once the payment has been confirmed, the hosting plan installation will begin. An email will be sent to your contact email address. It will contain the credentials for accessing your web hosting plan’s FTP (File Transfer Protocol) storage space.
 
@@ -84,7 +95,7 @@ Once the payment has been confirmed, the hosting plan installation will begin. A
 > OVHcloud offers other email services in addition to the MX Plan solution. For example, you can combine email accounts of the [Exchange offer](/links/web/emails-hosted-exchange) with MX Plan email accounts.
 >
 
-### Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
+### 2 - Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
 
 If your domain is hosted by another service provider and you would like to transfer it to OVHcloud, you must first create and preconfigure a DNS zone before initiating the transfer, in order to avoid any service interruptions.
 
@@ -112,16 +123,16 @@ To retrieve the correct target IP address for your OVHcloud hosting plan, please
 
 > [!success]
 >
-> Note the two target values with the record type "NS", `dnsXX.ovh.ca` and `nsXX.ovh.ca`. They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [step 9](#step9) of this guide.
+> Note the two target values with the record type "NS", `dnsXX.ovh.ca` and `nsXX.ovh.ca`. They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [part 9](#step9) of this guide.
 >
 
-### Step 3: Retrieve a full backup of your website <a name="step3"></a>
+### 3 - Retrieve a full backup of your website <a name="step3"></a>
 
 Retrieve the contents of your current web hosting from its FTP storage space. Download a backup of your database as well, if your website uses one.
 
 You can only achieve this with your current hosting provider. Contact them if you are having trouble retrieving a full backup of your website.
 
-### Step 4: Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
+### 4 - Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
 
 To import the backup of your old service provider’s FTP storage space, [log in to the FTP storage space of your OVHcloud hosting](/pages/web_cloud/web_hosting/ftp_connection) and upload the backup to the root folder ‘www’ (or another root folder you have already created).
 
@@ -136,10 +147,10 @@ To do this, replace the login details for your old database with the login detai
 
 > [!success]
 >
-> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **Step 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
+> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **part 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
 >
 
-Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [step 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
+Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [part 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
 
 > [!warning]
 >
@@ -160,13 +171,13 @@ Declare and authorise your external domain name on your OVHcloud web hosting via
 
 After DNS propagation, the website displayed with your domain name will be the one hosted by OVHcloud.
 
-### Step 5: Recreate your email addresses at OVHcloud <a name="step5"></a>
+### 5 - Recreate your email addresses at OVHcloud <a name="step5"></a>
 
 Create new email accounts and name them according to your current email addresses hosted by your email provider. Use our guide on [Creating MX Plan email addresses](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
 If you have opted for an Exchange solution, [please read our documentation on this topic to create your email addresses](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
+### 6 - Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
 
 In this step, you will need to change the "MX" email servers in your domain name’s active DNS zone.
 This will result in you receiving new emails on your new OVHcloud email addresses.
@@ -184,7 +195,7 @@ Once the propagation is complete, all new emails will be received by your OVHclo
 WWe recommend changing the MX records **before** migrating the content of your old email accounts.
 This method avoids you having to redo a migration for the few emails received on your old email accounts during DNS propagation.
 
-### Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
+### 7 - Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
 
 After the DNS propagation, all your new emails are received by your new email accounts. However, your old emails are still stored on your previous email server.
 
@@ -209,7 +220,7 @@ Repeat for all of your email accounts.
 
 **Option 2**: Back up the content of your email accounts using an email client (Outlook, Mac Mail, etc.), reconfigure your email software, then import the backup into your new OVHcloud email accounts. You can find more information in our guide “[Migrating your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)”.
 
-### Step 8: Reconfigure your email software <a name="step8"></a>
+### 8 - Reconfigure your email software <a name="step8"></a>
 
 Once you have migrated your email accounts to OVHcloud, reconfigure your email software using our relevant email guides.
 
@@ -221,9 +232,9 @@ Once you have migrated your email accounts to OVHcloud, reconfigure your email s
 
 - You can find all of our configuration guides in the `Exchange configuration on computer` and `Exchange configuration on smartphone` sections of [our Exchange documentation](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Step 9: Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
+### 9 - Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
 
-The DNS zone pre-configured in [step 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
+The DNS zone pre-configured in [part 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
 
 Replace the current DNS servers (of the original registrar) with the two DNS servers declared in the OVHcloud DNS zone (format `dnsXX.ovh.ca` and `nsXX.ovh.ca`). You can do this in the management interface of the original registrar.
 
@@ -232,7 +243,7 @@ Replace the current DNS servers (of the original registrar) with the two DNS ser
 > The DNS servers must be changed at your domain name’s current registrar, and you will need to allow between **24 and 48 hours** for the changes to propagate fully.
 >
 
-### Step 10: Transfer your domain name to OVHcloud <a name="step10"></a>
+### 10 - Transfer your domain name to OVHcloud <a name="step10"></a>
 
 Once the DNS propagation is complete, check that your entire website is functional. Browse your website to check that all pages are displaying correctly and that no 404 errors are returned. Also check the sending and receiving of emails from your email addresses.
 
@@ -244,7 +255,7 @@ Once you have transferred your data and services, you can cancel your old servic
 
 ### Conclusion
 
-After following the ten steps in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
+After following the ten parts in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
 
 ## Go further <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-sg.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-sg.md
@@ -41,7 +41,7 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-part procedure:
 
 - [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
 - [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objective

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrating your website and associated services to OVHcloud"
 excerpt: "Find out how to migrate your website, domain name, database and emails to OVHcloud without any service interruptions"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objective
@@ -41,27 +41,27 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-step procedure:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
 
-- [Step 1: Order the hosting plan and email accounts from OVHcloud](#step1)
-- [Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
-- [Step 3: Retrieve a full backup of your website](#step3)
-- [Step 4: Import your website backup to your OVHcloud hosting plan](#step4)
-- [Step 5: Recreate your email accounts at OVHcloud](#step5)
-- [Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
-- [Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
-- [Step 8: Reconfigure your email software](#step8)
-- [Step 9: Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
-- [Step 10: Transfer your domain name to OVHcloud](#step10)
+- [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
+- [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)
+- [3 - Retrieve a full backup of your website](#step3)
+- [4 - Import your website backup to your OVHcloud hosting plan](#step4)
+- [5 - Recreate your email accounts at OVHcloud](#step5)
+- [6 - Declare the OVHcloud email servers in your domain name’s active DNS zone](#step6)
+- [7 - Transfer the content of your old email accounts to your new accounts with OVHcloud](#step7)
+- [8 - Reconfigure your email software](#step8)
+- [9 - Replace your domain name’s active DNS servers with those of OVHcloud](#step9)
+- [10 - Transfer your domain name to OVHcloud](#step10)
 
-By following these 10 steps **in order**, you will not experience any downtime when accessing your website or receiving new emails.
+By following these 10 parts **in order**, you will not experience any downtime when accessing your website or receiving new emails.
 
 However, depending on your domain registrar, hosting provider or email service provider, they may cut off access to your old services if they notice that your domain name is no longer configured on their infrastructures.<br>
 In this case, a service interruption may occur.
 
 This guide is designed to minimise the duration of such an interruption.
 
-### Step 1: Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
+### 1 - Order the hosting plan and email addresses from OVHcloud <a name="step1"></a>
 
 Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) email solution. With this email offer, you can create email accounts with a maximum storage space of 5 GB each. Choose from the following hosting plans, considering the PHP version, SQL version, number of email accounts you need, and the size of your website to migrate:
 
@@ -69,13 +69,24 @@ Several [OVHcloud web hosting plans](/links/web/hosting) contain an [MX Plan](/p
 - Hosting [Pro](/links/web/hosting-professional-offer) with **100 MX Plan email accounts** (for business)
 - Hosting [Performance](/links/web/hosting-performance-offer) with **1000 MX Plan email accounts** (scalable dedicated resources)
 
-Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in step 10 of this guide.)
+Once you have chosen your hosting plan, click the `Order`{.action} button on the commercial pages above. Follow the steps for the **order without requesting the transfer of your domain name**. (This action will be performed in part 10 of this guide.)
 
-You can also place the order from your [OVHcloud Control Panel](/links/manager). Once you have logged in, follow the instructions below:
+You can also place the order from your OVHcloud Control Panel. To do this, click on the tabs below to view each of the **3** steps.
 
-- Go to the `Web Cloud`{.action} tab.
-- In the top left of the interface, click `Order`{.action}, then `Hosting plans`{.action}.
-- Follow the steps in the **order without requesting the transfer of your domain name** (this action will be carried out in step 10 of this guide).
+> [!tabs]
+> **Step 1**
+>>
+>> Go to the [Hosting plans](/links/control-panel/web-hosting) page.
+>>
+>> ![Hosting plans](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Step 2**
+>>
+>> At the top left of the interface, click the `Order`{.action} button, then `Hosting plans`{.action}.
+>>
+> **Step 3**
+>>
+>> Follow the steps in the order **without requesting the transfer of your domain name** (this action will be carried out in part 10 of this guide).
 
 Once the payment has been confirmed, the hosting plan installation will begin. An email will be sent to your contact email address. It will contain the credentials for accessing your web hosting plan’s FTP (File Transfer Protocol) storage space.
 
@@ -84,7 +95,7 @@ Once the payment has been confirmed, the hosting plan installation will begin. A
 > OVHcloud offers other email services in addition to the MX Plan solution. For example, you can combine email accounts of the [Exchange offer](/links/web/emails-hosted-exchange) with MX Plan email accounts.
 >
 
-### Step 2: Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
+### 2 - Create and preconfigure a DNS zone for your domain name at OVHcloud <a name="step2"></a>
 
 If your domain is hosted by another service provider and you would like to transfer it to OVHcloud, you must first create and preconfigure a DNS zone before initiating the transfer, in order to avoid any service interruptions.
 
@@ -112,16 +123,16 @@ To retrieve the correct target IP address for your OVHcloud hosting plan, please
 
 > [!success]
 >
-> Note the two target values with the record type "NS", `dnsXX.ovh.ca` and `nsXX.ovh.ca`. They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [step 9](#step9) of this guide.
+> Note the two target values with the record type "NS", `dnsXX.ovh.ca` and `nsXX.ovh.ca`. They correspond to the DNS servers associated with this DNS zone for your domain name. They will be used in [part 9](#step9) of this guide.
 >
 
-### Step 3: Retrieve a full backup of your website <a name="step3"></a>
+### 3 - Retrieve a full backup of your website <a name="step3"></a>
 
 Retrieve the contents of your current web hosting from its FTP storage space. Download a backup of your database as well, if your website uses one.
 
 You can only achieve this with your current hosting provider. Contact them if you are having trouble retrieving a full backup of your website.
 
-### Step 4: Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
+### 4 - Import your website backup to your OVHcloud hosting plan <a name="step4"></a>
 
 To import the backup of your old service provider’s FTP storage space, [log in to the FTP storage space of your OVHcloud hosting](/pages/web_cloud/web_hosting/ftp_connection) and upload the backup to the root folder ‘www’ (or another root folder you have already created).
 
@@ -136,10 +147,10 @@ To do this, replace the login details for your old database with the login detai
 
 > [!success]
 >
-> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **Step 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
+> If you are using a Content Management System (CMS) like WordPress, Joomla!, Drupal or PrestaShop, you can find the information in their configuration files. See **part 2** of the guide “[Changing a database password](/pages/web_cloud/web_hosting/sql_change_password)”.
 >
 
-Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [step 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
+Declare and authorise your external domain name on your OVHcloud web hosting via our guide [Managing multiple websites on an OVHcloud web hosting plan](/pages/web_cloud/web_hosting/multisites_configure_multisite). Enter the name of the folder you chose at the beginning of [part 4](#step4) as the Multisite "Root folder". As a reminder, this is the folder in which you have placed your files in your FTP storage space.
 
 > [!warning]
 >
@@ -160,13 +171,13 @@ Declare and authorise your external domain name on your OVHcloud web hosting via
 
 After DNS propagation, the website displayed with your domain name will be the one hosted by OVHcloud.
 
-### Step 5: Recreate your email addresses at OVHcloud <a name="step5"></a>
+### 5 - Recreate your email addresses at OVHcloud <a name="step5"></a>
 
 Create new email accounts and name them according to your current email addresses hosted by your email provider. Use our guide on [Creating MX Plan email addresses](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
 If you have opted for an Exchange solution, [please read our documentation on this topic to create your email addresses](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Step 6: Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
+### 6 - Declare the OVHcloud email servers in your domain name’s active DNS zone <a name="step6"></a>
 
 In this step, you will need to change the "MX" email servers in your domain name’s active DNS zone.
 This will result in you receiving new emails on your new OVHcloud email addresses.
@@ -184,7 +195,7 @@ Once the propagation is complete, all new emails will be received by your OVHclo
 WWe recommend changing the MX records **before** migrating the content of your old email accounts.
 This method avoids you having to redo a migration for the few emails received on your old email accounts during DNS propagation.
 
-### Step 7: Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
+### 7 - Transfer the content of your old email accounts to your new accounts with OVHcloud <a name="step7"></a>
 
 After the DNS propagation, all your new emails are received by your new email accounts. However, your old emails are still stored on your previous email server.
 
@@ -209,7 +220,7 @@ Repeat for all of your email accounts.
 
 **Option 2**: Back up the content of your email accounts using an email client (Outlook, Mac Mail, etc.), reconfigure your email software, then import the backup into your new OVHcloud email accounts. You can find more information in our guide “[Migrating your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)”.
 
-### Step 8: Reconfigure your email software <a name="step8"></a>
+### 8 - Reconfigure your email software <a name="step8"></a>
 
 Once you have migrated your email accounts to OVHcloud, reconfigure your email software using our relevant email guides.
 
@@ -221,9 +232,9 @@ Once you have migrated your email accounts to OVHcloud, reconfigure your email s
 
 - You can find all of our configuration guides in the `Exchange configuration on computer` and `Exchange configuration on smartphone` sections of [our Exchange documentation](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Step 9: Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
+### 9 - Replace your domain name’s active DNS servers with those of OVHcloud <a name="step9"></a>
 
-The DNS zone pre-configured in [step 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
+The DNS zone pre-configured in [part 2](#step2) has not yet been applied to your domain name. Currently, your domain name still uses your original provider’s DNS servers.
 
 Replace the current DNS servers (of the original registrar) with the two DNS servers declared in the OVHcloud DNS zone (format `dnsXX.ovh.ca` and `nsXX.ovh.ca`). You can do this in the management interface of the original registrar.
 
@@ -232,7 +243,7 @@ Replace the current DNS servers (of the original registrar) with the two DNS ser
 > The DNS servers must be changed at your domain name’s current registrar, and you will need to allow between **24 and 48 hours** for the changes to propagate fully.
 >
 
-### Step 10: Transfer your domain name to OVHcloud <a name="step10"></a>
+### 10 - Transfer your domain name to OVHcloud <a name="step10"></a>
 
 Once the DNS propagation is complete, check that your entire website is functional. Browse your website to check that all pages are displaying correctly and that no 404 errors are returned. Also check the sending and receiving of emails from your email addresses.
 
@@ -244,7 +255,7 @@ Once you have transferred your data and services, you can cancel your old servic
 
 ### Conclusion
 
-After following the ten steps in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
+After following the ten parts in order, your entire website is now migrated to OVHcloud, all without any service interruptions.
 
 ## Go further <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-us.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.en-us.md
@@ -41,7 +41,7 @@ This guide will outline the steps you need to take to migrate your entire websit
 > The instructions in this guide reference several products from the Web Cloud universe. We recommend reading all the steps below **before** you begin migrating your services.
 >
 
-Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise procedure in 10 parts:
+Migrating your entire website and emails to OVHcloud **without any service interruptions** requires a precise 10-part procedure:
 
 - [1 - Order the hosting plan and email accounts from OVHcloud](#step1)
 - [2 - Create and preconfigure a DNS zone for your domain name at OVHcloud](#step2)

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrar un sitio web y los servicios asociados a OVHcloud"
 excerpt: "Descubra cómo migrar un sitio web, un dominio, una base de datos o un correo a OVHcloud sin interrupción del servicio"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-es.md
@@ -53,7 +53,7 @@ Migrar todo su sitio web y el correo a OVHcloud **sin interrupción del servicio
 - [9 - Sustituir los servidores DNS activos de su dominio por los de OVHcloud](#step9)
 - [10 - Transferir su dominio a OVHcloud](#step10)
 
-Siguiendo estas 10 partes **en el orden**, no tendrá interrupción del servicio para el acceso a su sitio web y para la recepción de sus nuevos emails.
+Siguiendo estas 10 partes **en el orden**, no tendrá interrupción del servicio para el acceso a su sitio web y para la recepción de sus nuevos correos electrónicos.
 
 No obstante, en función del agente registrador, del proveedor de alojamiento o del proveedor de servicios de correo, es posible que corten el acceso a sus antiguos servicios si se da cuenta de que el dominio ya no está configurado por sus infraestructuras.<br>
 En ese caso, puede producirse una interrupción del servicio.
@@ -88,7 +88,7 @@ También puede realizar el pedido desde su área de cliente de OVHcloud. Para el
 >>
 >> Siga los pasos del pedido **sin solicitar la transferencia del dominio** (esta acción se realizará en la parte 10 de esta guía).
 
-Una vez validado el pago, se iniciará la instalación del alojamiento. Recibirá un mensaje de correo electrónico en su dirección de correo electrónico de contacto. que contendrá las claves de acceso al espacio de almacenamiento FTP (File Transfer Protocol) de su alojamiento web.
+Una vez validado el pago, se iniciará la instalación del alojamiento. Recibirá un mensaje de correo electrónico en su dirección de correo electrónico de contacto, que contendrá las claves de acceso al espacio de almacenamiento FTP (File Transfer Protocol) de su alojamiento web.
 
 > [!primary]
 >
@@ -157,7 +157,7 @@ Para ello, sustituya los datos de conexión de su antigua base de datos por los 
 > Para asociar una nueva base de datos si utiliza un Content Management System (CMS) como WordPress, Joomla, Drupal o PrestaShop, consulte la información relativa a sus archivos de configuración desde **la parte 2** de la guía "[Modificación de la contraseña de una base de datos](/pages/web_cloud/web_hosting/sql_change_password)".
 >
 
-Declare/autorice su nombre de dominio externo en su alojamiento web OVHcloud siguiendo nuestro tutorial "[gestión de sitios web de un alojamiento web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Introduzca el nombre de la carpeta raíz que haya elegido al comienzo del[parte 4](#step4). Le recordamos que esta es la carpeta en la que ha guardado sus archivos en su espacio de almacenamiento FTP.
+Declare/autorice su nombre de dominio externo en su alojamiento web OVHcloud siguiendo nuestro tutorial "[gestión de sitios web de un alojamiento web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Introduzca el nombre de la carpeta raíz que haya elegido al comienzo del [parte 4](#step4). Le recordamos que esta es la carpeta en la que ha guardado sus archivos en su espacio de almacenamiento FTP.
 
 > [!warning]
 >
@@ -225,7 +225,7 @@ Repita la operación para todas sus cuentas de correo.
 >
 Para ello, es necesario tener las claves de acceso de todas sus antiguas cuentas de correo y el nombre del servidor de correo de su anterior proveedor.
 >
-> Si sus direcciones de correo estuvieran configuradas en POP sin conservar copias de los mensajes en su antiguo servidor de correo, o si tuviera los emails registrados "localmente" en sus dispositivos, solo podrá realizar la **opción 2**.
+> Si sus direcciones de correo estuvieran configuradas en POP sin conservar copias de los mensajes en su antiguo servidor de correo, o si tuviera los correos electrónicos registrados "localmente" en sus dispositivos, solo podrá realizar la **opción 2**.
 >
 
 **Opción 2**: realice una copia de seguridad del contenido de sus direcciones de correo mediante un cliente de correo (Outlook, Mail para Mac...), reconfigure su cliente de correo e importe la copia de seguridad en su nueva dirección de correo de OVHcloud. Para más información, consulte nuestra guía "[Migrar manualmente una dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)".
@@ -259,7 +259,7 @@ Sustituya los servidores DNS actuales (del registrador de origen) por los dos se
 
 ### 10 - Transferir su dominio a OVHcloud <a name="step10"></a>
 
-Una vez completada la propagación DNS, compruebe que todo su sitio web esté operativo. Navegue por su sitio web para comprobar que todas las páginas se muestran correctamente y que no se devuelve ningún error 404. Compruebe también el envío y la recepción de los emails desde sus direcciones de correo.
+Una vez completada la propagación DNS, compruebe que todo su sitio web esté operativo. Navegue por su sitio web para comprobar que todas las páginas se muestran correctamente y que no se devuelve ningún error 404. Compruebe también el envío y la recepción de los correos electrónicos desde sus direcciones de correo.
 
 Si todo está en orden, desbloquee su dominio y recupere su "código de transferencia", "EPP" o "AuthCode" desde su actual agente registrador.
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-es.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrar un sitio web y los servicios asociados a OVHcloud"
 excerpt: "Descubra cómo migrar un sitio web, un dominio, una base de datos o un correo a OVHcloud sin interrupción del servicio"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -27,7 +27,7 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -40,27 +40,27 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 > Las instrucciones de esta guía hacen referencia a varios productos del universo Web Cloud. Le recomendamos que lea todos los pasos que se indican a continuación **antes** para migrar sus servicios.
 >
 
-Migrar todo su sitio web y el correo a OVHcloud **sin interrupción del servicio** requiere un procedimiento específico en 10 pasos:
+Migrar todo su sitio web y el correo a OVHcloud **sin interrupción del servicio** requiere un procedimiento específico en 10 partes:
 
-- [Etapa 1: contratar el alojamiento y las direcciones de correo en OVHcloud](#step1)
-- [Etapa 2: crear y pre-configurar una zona DNS para su dominio en OVHcloud](#step2)
-- [Etapa 3: recuperar una copia de seguridad completa de su sitio web](#step3)
-- [Etapa 4: importar la copia de seguridad de su sitio web en su plan de hosting de OVHcloud](#step4)
-- [Etapa 5: crear sus direcciones de correo de forma idéntica en OVHcloud](#step5)
-- [Etapa 6: Declarar los servidores de correo de OVHcloud en la zona DNS activa de su dominio](#step6)
-- [Etapa 7: transferir el contenido de sus antiguas direcciones de correo a sus nuevas direcciones en OVHcloud](#step7)
-- [Etapa 8: reconfigurar sus aplicaciones de mensajería](#step8)
-- [Etapa 9: sustituir los servidores DNS activos de su dominio por los de OVHcloud](#step9)
-- [Etapa 10: transferir su dominio a OVHcloud](#step10)
+- [1 - Contratar el alojamiento y las direcciones de correo en OVHcloud](#step1)
+- [2 - Crear y pre-configurar una zona DNS para su dominio en OVHcloud](#step2)
+- [3 - Recuperar una copia de seguridad completa de su sitio web](#step3)
+- [4 - Importar la copia de seguridad de su sitio web en su plan de hosting de OVHcloud](#step4)
+- [5 - Crear sus direcciones de correo de forma idéntica en OVHcloud](#step5)
+- [6 - Declarar los servidores de correo de OVHcloud en la zona DNS activa de su dominio](#step6)
+- [7 - Transferir el contenido de sus antiguas direcciones de correo a sus nuevas direcciones en OVHcloud](#step7)
+- [8 - Reconfigurar sus aplicaciones de mensajería](#step8)
+- [9 - Sustituir los servidores DNS activos de su dominio por los de OVHcloud](#step9)
+- [10 - Transferir su dominio a OVHcloud](#step10)
 
-Siguiendo estos 10 Etapas **en el orden**, no tendrá interrupción del servicio para el acceso a su sitio web y para la recepción de sus nuevos emails.
+Siguiendo estas 10 partes **en el orden**, no tendrá interrupción del servicio para el acceso a su sitio web y para la recepción de sus nuevos emails.
 
 No obstante, en función del agente registrador, del proveedor de alojamiento o del proveedor de servicios de correo, es posible que corten el acceso a sus antiguos servicios si se da cuenta de que el dominio ya no está configurado por sus infraestructuras.<br>
 En ese caso, puede producirse una interrupción del servicio.
 
 En caso de que se produzca dicha interrupción, la guía se construirá de forma que se reduzca al mínimo su duración.
 
-### Etapa 1: contratar el alojamiento y las direcciones de correo en OVHcloud <a name="step1"></a>
+### 1 - Contratar el alojamiento y las direcciones de correo en OVHcloud <a name="step1"></a>
 
 Varios [planes de hosting de OVHcloud](/links/web/hosting) contienen una solución de correo electrónico [MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities). Esta solución de correo permite crear direcciones de correo con un espacio de almacenamiento de hasta 5 GB para cada dirección. Elija entre los siguientes planes de hosting en función de la versión PHP, la versión SQL, el número de direcciones de correo que necesite y el tamaño del sitio web que quiere migrar:
 
@@ -69,22 +69,33 @@ Varios [planes de hosting de OVHcloud](/links/web/hosting) contienen una soluci�
 - El alojamiento [Performance](/links/web/hosting-performance-offer) con **1000 direcciones de correo** "MX Plan". Esta oferta se divide en 4 "subproductos".
 - El alojamiento [Cloud Web](/links/web/hosting-cloud-web-offer) con **200 direcciones de correo** "MX Plan". Esta oferta la utilizan los desarrolladores de aplicaciones.
 
-Si todavía no es cliente de OVHcloud, haga clic en el botón `Contratar`{.action} de las páginas comerciales anteriores. Siga los pasos del pedido **sin solicitar la transferencia del dominio** (esta acción se realizará en el paso 10 de esta guía).
+Si todavía no es cliente de OVHcloud, haga clic en el botón `Contratar`{.action} de las páginas comerciales anteriores. Siga los pasos del pedido **sin solicitar la transferencia del dominio** (esta acción se realizará en la parte 10 de esta guía).
 
-También puede realizar el pedido desde su [área de cliente de OVHcloud](/links/manager). Una vez conectado, siga estas instrucciones:
+También puede realizar el pedido desde su área de cliente de OVHcloud. Para ello, haga clic en las pestañas siguientes para visualizar cada una de las **3** etapas.
 
-- Acceda a la pestaña `Web Cloud`{.action}.
-- En la parte superior izquierda de la interfaz, haga clic en el botón `Contratar`{.action} y luego en `Alojamiento`{.action}.
-- Siga los pasos del pedido **sin solicitar la transferencia del dominio** (esta acción se realizará en el paso 10 de esta guía).
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting).
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> En la parte superior izquierda de la interfaz, haga clic en el botón `Contratar`{.action} y luego en `Alojamientos`{.action}.
+>>
+> **Etapa 3**
+>>
+>> Siga los pasos del pedido **sin solicitar la transferencia del dominio** (esta acción se realizará en la parte 10 de esta guía).
 
-Una vez validado el pago, se iniciará la instalación del alojamiento. Recibirá un mensaje de correo electrónico en su dirección de correo electrónico de contacto. que contendrá las claves de acceso al espacio de almacenamiento FTP (File Transfert Protocol) de su alojamiento web.
+Una vez validado el pago, se iniciará la instalación del alojamiento. Recibirá un mensaje de correo electrónico en su dirección de correo electrónico de contacto. que contendrá las claves de acceso al espacio de almacenamiento FTP (File Transfer Protocol) de su alojamiento web.
 
 > [!primary]
 >
 > Además de la solución MX Plan, OVHcloud ofrece otras soluciones de correo. Por ejemplo, puede combinar con direcciones de correo MX Plan direcciones ["Email-Pro"](/links/web/email-pro) y/o cuentas ["Exchange"](/links/web/emails-hosted-exchange).
 >
 
-### Etapa 2: crear y preconfigurar una zona DNS para su dominio en OVHcloud <a name="step2"></a>
+### 2 - Crear y preconfigurar una zona DNS para su dominio en OVHcloud <a name="step2"></a>
 
 Si su dominio está alojado en otro proveedor y desea transferirlo a OVHcloud, deberá crear y preconfigurar previamente una zona DNS antes de iniciar la transferencia para evitar una interrupción del servicio.
 
@@ -114,16 +125,16 @@ Para conocer la dirección IP de destino de su alojamiento de OVHcloud, consulte
 
 > [!success]
 >
-> Observe los dos valores de destino con el tipo de registro "NS". Estos valores, de tipo `dnsXX.ovh.net` y `nsXX.ovh.net` (o `dns200.anycast.me` y `ns200.anycast.me`), corresponden a los servidores DNS asociados a esta zona DNS para su dominio. Se utilizarán en la [etapa 9](#step9) de esta guía.
+> Observe los dos valores de destino con el tipo de registro "NS". Estos valores, de tipo `dnsXX.ovh.net` y `nsXX.ovh.net` (o `dns200.anycast.me` y `ns200.anycast.me`), corresponden a los servidores DNS asociados a esta zona DNS para su dominio. Se utilizarán en la [parte 9](#step9) de esta guía.
 >
 
-### Etapa 3: obtener una copia de seguridad completa del sitio web <a name="step3"></a>
+### 3 - Obtener una copia de seguridad completa del sitio web <a name="step3"></a>
 
 Descargue el contenido del espacio de almacenamiento FTP de su alojamiento actual, así como una copia de seguridad de su base de datos si el sitio web utiliza una.
 
 Estas operaciones se realizan exclusivamente con su proveedor de hosting actual. Contacte con él si tiene dificultades para obtener una copia de seguridad completa de su sitio web.
 
-### Etapa 4: importar la copia de seguridad de su sitio web en su plan de hosting de OVHcloud <a name="step4"></a>
+### 4 - Importar la copia de seguridad de su sitio web en su plan de hosting de OVHcloud <a name="step4"></a>
 
 Para importar la copia de seguridad del espacio de almacenamiento FTP de su anterior proveedor, [conéctese al espacio de almacenamiento FTP de su alojamiento de OVHcloud](/pages/web_cloud/web_hosting/ftp_connection) y envíe la copia de seguridad a la carpeta raíz "www" (o a otra carpeta raíz que haya creado previamente).
 
@@ -143,10 +154,10 @@ Para ello, sustituya los datos de conexión de su antigua base de datos por los 
 
 > [!success]
 >
-> Para asociar una nueva base de datos si utiliza un Content Management System (CMS) como WordPress, Joomla, Drupal o PrestaShop, consulte la información relativa a sus archivos de configuración desde **el etapa 2** de la guía "[Modificación de la contraseña de una base de datos](/pages/web_cloud/web_hosting/sql_change_password)".
+> Para asociar una nueva base de datos si utiliza un Content Management System (CMS) como WordPress, Joomla, Drupal o PrestaShop, consulte la información relativa a sus archivos de configuración desde **la parte 2** de la guía "[Modificación de la contraseña de una base de datos](/pages/web_cloud/web_hosting/sql_change_password)".
 >
 
-Declare/autorice su nombre de dominio externo en su alojamiento web OVHcloud siguiendo nuestro tutorial "[gestión de sitios web de un alojamiento web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Introduzca el nombre de la carpeta raíz que haya elegido al comienzo del[etapa 4](#step4). Le recordamos que esta es la carpeta en la que ha guardado sus archivos en su espacio de almacenamiento FTP.
+Declare/autorice su nombre de dominio externo en su alojamiento web OVHcloud siguiendo nuestro tutorial "[gestión de sitios web de un alojamiento web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Introduzca el nombre de la carpeta raíz que haya elegido al comienzo del[parte 4](#step4). Le recordamos que esta es la carpeta en la que ha guardado sus archivos en su espacio de almacenamiento FTP.
 
 > [!warning]
 >
@@ -167,7 +178,7 @@ Declare/autorice su nombre de dominio externo en su alojamiento web OVHcloud sig
 
 Tras la propagación DNS, el sitio web que se mostrará con su dominio será el alojado en OVHcloud.
 
-### Etapa 5: crear sus direcciones de correo de forma idéntica en OVHcloud <a name="step5"></a>
+### 5 - Crear sus direcciones de correo de forma idéntica en OVHcloud <a name="step5"></a>
 
 Utilice nuestra guía sobre la [creación de direcciones de correo electrónico MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
@@ -176,7 +187,7 @@ Si ha optado por una solución Email Pro o Exchange, consulte nuestra documentac
 - Para [Email-Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 - Para [Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Etapa 6: Declarar los servidores de correo de OVHcloud en la zona DNS activa de su dominio <a name="step6"></a>
+### 6 - Declarar los servidores de correo de OVHcloud en la zona DNS activa de su dominio <a name="step6"></a>
 
 En primer lugar, debe cambiar los servidores de correo MX de la zona DNS activa del dominio.
 Recibirá los nuevos mensajes de correo en las nuevas direcciones de correo de OVHcloud.
@@ -194,7 +205,7 @@ Una vez finalizada la propagación, se le comunicarán todos los nuevos mensajes
 Le recomendamos que realice el cambio de las entradas "MX" **antes** de migrar el contenido de sus antiguas direcciones de correo.
 Este método permite evitar la migración de los pocos mensajes de correo recibidos a sus antiguas direcciones de correo electrónico durante la propagación de DNS.
 
-### Etapa 7: transferir el contenido de sus antiguas direcciones de correo a sus nuevas direcciones en OVHcloud <a name="step7"></a>
+### 7 - Transferir el contenido de sus antiguas direcciones de correo a sus nuevas direcciones en OVHcloud <a name="step7"></a>
 
 Tras la propagación DNS , todos los nuevos mensajes de correo se reciben en las nuevas direcciones de correo. Sin embargo, los mensajes de correo antiguos siempre se guardan en el servidor de correo antiguo.
 
@@ -219,7 +230,7 @@ Para ello, es necesario tener las claves de acceso de todas sus antiguas cuentas
 
 **Opción 2**: realice una copia de seguridad del contenido de sus direcciones de correo mediante un cliente de correo (Outlook, Mail para Mac...), reconfigure su cliente de correo e importe la copia de seguridad en su nueva dirección de correo de OVHcloud. Para más información, consulte nuestra guía "[Migrar manualmente una dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)".
 
-### Etapa 8: reconfigurar su cliente de correo <a name="step8"></a>
+### 8 - Reconfigurar su cliente de correo <a name="step8"></a>
 
 Una vez que haya migrado sus antiguas direcciones de correo a OVHcloud, reconfigure su cliente de correo utilizando todas nuestras guías.
 
@@ -235,9 +246,9 @@ Consulte todas nuestras guías de configuración en `Configuración en el ordena
 
 Consulte todas nuestras guías de ayuda a la configuración en `Configuración Exchange en ordenador` y `Configuración Exchange en smartphone` de [nuestra documentación sobre Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Etapa 9: sustituir los servidores DNS activos de su dominio por los de OVHcloud <a name="step9"></a>
+### 9 - Sustituir los servidores DNS activos de su dominio por los de OVHcloud <a name="step9"></a>
 
-La zona DNS preconfigurada en el [etapa 2](#step2) aún no se aplica a su dominio. Actualmente, su dominio sigue utilizando los servidores DNS de su proveedor de origen.
+La zona DNS preconfigurada en el [parte 2](#step2) aún no se aplica a su dominio. Actualmente, su dominio sigue utilizando los servidores DNS de su proveedor de origen.
 
 Sustituya los servidores DNS actuales (del registrador de origen) por los dos servidores DNS declarados en la zona DNS de OVHcloud (de tipo `dnsXX.ovh.net` y `nsXX.ovh.net` o `dns200.anycast.me` y `ns200.anycast.me`). Esta operación se realiza en la interfaz de gestión del registrador de origen.
 
@@ -246,7 +257,7 @@ Sustituya los servidores DNS actuales (del registrador de origen) por los dos se
 > El cambio de los servidores DNS debe realizarse desde el actual agente registrador del dominio y tarda entre **propagación de 24 a 48 horas**.
 >
 
-### Etapa 10: transferir su dominio a OVHcloud <a name="step10"></a>
+### 10 - Transferir su dominio a OVHcloud <a name="step10"></a>
 
 Una vez completada la propagación DNS, compruebe que todo su sitio web esté operativo. Navegue por su sitio web para comprobar que todas las páginas se muestran correctamente y que no se devuelve ningún error 404. Compruebe también el envío y la recepción de los emails desde sus direcciones de correo.
 
@@ -258,7 +269,7 @@ Una vez que haya realizado la transferencia de los datos y servicios, solo tendr
 
 ### Conclusión
 
-Una vez que haya realizado los diez pasos anteriores, podrá migrar a OVHcloud la totalidad de su sitio web, sin interrupción del servicio.
+Una vez que haya realizado las diez partes anteriores, podrá migrar a OVHcloud la totalidad de su sitio web, sin interrupción del servicio.
 
 ## Más información <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrar un sitio web y los servicios asociados a OVHcloud"
 excerpt: "Descubra cómo migrar un sitio web, un dominio, una base de datos o un correo a OVHcloud sin interrupción del servicio"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrar un sitio web y los servicios asociados a OVHcloud"
 excerpt: "Descubra cómo migrar un sitio web, un dominio, una base de datos o un correo a OVHcloud sin interrupción del servicio"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -27,7 +27,7 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 
 ### Acceso al área de cliente de OVHcloud
 
-- **Enlace directo:** [Hosting plans](/links/control-panel/web-hosting)
+- **Enlace directo:** [Alojamientos](/links/control-panel/web-hosting)
 - **Ruta de navegación:** `Web Cloud`{.action} > `Alojamientos`{.action} > Seleccione su alojamiento web
 
 ---
@@ -40,27 +40,27 @@ La configuración, la gestión y la responsabilidad de los servicios que OVHclou
 > Las instrucciones de esta guía hacen referencia a varios productos del universo Web Cloud. Le recomendamos que lea todos los pasos que se indican a continuación **antes** para migrar sus servicios.
 >
 
-Migrar todo su sitio web y el correo a OVHcloud **sin interrupción del servicio** requiere un procedimiento específico en 10 pasos:
+Migrar todo su sitio web y el correo a OVHcloud **sin interrupción del servicio** requiere un procedimiento específico en 10 partes:
 
-- [Etapa 1: contratar el alojamiento y las direcciones de correo en OVHcloud](#step1)
-- [Etapa 2: crear y pre-configurar una zona DNS para su dominio en OVHcloud](#step2)
-- [Etapa 3: recuperar una copia de seguridad completa de su sitio web](#step3)
-- [Etapa 4: importar la copia de seguridad de su sitio web en su plan de hosting de OVHcloud](#step4)
-- [Etapa 5: crear sus direcciones de correo de forma idéntica en OVHcloud](#step5)
-- [Etapa 6: Declarar los servidores de correo de OVHcloud en la zona DNS activa de su dominio](#step6)
-- [Etapa 7: transferir el contenido de sus antiguas direcciones de correo a sus nuevas direcciones en OVHcloud](#step7)
-- [Etapa 8: reconfigurar sus aplicaciones de mensajería](#step8)
-- [Etapa 9: sustituir los servidores DNS activos de su dominio por los de OVHcloud](#step9)
-- [Etapa 10: transferir su dominio a OVHcloud](#step10)
+- [1 - Contratar el alojamiento y las direcciones de correo en OVHcloud](#step1)
+- [2 - Crear y pre-configurar una zona DNS para su dominio en OVHcloud](#step2)
+- [3 - Recuperar una copia de seguridad completa de su sitio web](#step3)
+- [4 - Importar la copia de seguridad de su sitio web en su plan de hosting de OVHcloud](#step4)
+- [5 - Crear sus direcciones de correo de forma idéntica en OVHcloud](#step5)
+- [6 - Declarar los servidores de correo de OVHcloud en la zona DNS activa de su dominio](#step6)
+- [7 - Transferir el contenido de sus antiguas direcciones de correo a sus nuevas direcciones en OVHcloud](#step7)
+- [8 - Reconfigurar sus aplicaciones de mensajería](#step8)
+- [9 - Sustituir los servidores DNS activos de su dominio por los de OVHcloud](#step9)
+- [10 - Transferir su dominio a OVHcloud](#step10)
 
-Siguiendo estos 10 Etapas **en el orden**, no tendrá interrupción del servicio para el acceso a su sitio web y para la recepción de sus nuevos emails.
+Siguiendo estas 10 partes **en el orden**, no tendrá interrupción del servicio para el acceso a su sitio web y para la recepción de sus nuevos emails.
 
 No obstante, en función del agente registrador, del proveedor de alojamiento o del proveedor de servicios de correo, es posible que corten el acceso a sus antiguos servicios si se da cuenta de que el dominio ya no está configurado por sus infraestructuras.<br>
 En ese caso, puede producirse una interrupción del servicio.
 
 En caso de que se produzca dicha interrupción, la guía se construirá de forma que se reduzca al mínimo su duración.
 
-### Etapa 1: contratar el alojamiento y las direcciones de correo en OVHcloud <a name="step1"></a>
+### 1 - Contratar el alojamiento y las direcciones de correo en OVHcloud <a name="step1"></a>
 
 Varios [planes de hosting de OVHcloud](/links/web/hosting) contienen una solución de correo electrónico [MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities). Esta solución de correo permite crear direcciones de correo con un espacio de almacenamiento de hasta 5 GB para cada dirección. Elija entre los siguientes planes de hosting en función de la versión PHP, la versión SQL, el número de direcciones de correo que necesite y el tamaño del sitio web que quiere migrar:
 
@@ -68,22 +68,33 @@ Varios [planes de hosting de OVHcloud](/links/web/hosting) contienen una soluci�
 - El alojamiento [Pro](/links/web/hosting-professional-offer) con **100 direcciones de correo** "MX Plan"
 - El alojamiento [Performance](/links/web/hosting-performance-offer) con **1000 direcciones de correo** "MX Plan". Esta oferta se divide en 4 "subproductos".
 
-Si todavía no es cliente de OVHcloud, haga clic en el botón `Contratar`{.action} de las páginas comerciales anteriores. Siga los pasos del pedido **sin solicitar la transferencia del dominio** (esta acción se realizará en el paso 10 de esta guía).
+Si todavía no es cliente de OVHcloud, haga clic en el botón `Contratar`{.action} de las páginas comerciales anteriores. Siga los pasos del pedido **sin solicitar la transferencia del dominio** (esta acción se realizará en la parte 10 de esta guía).
 
-También puede realizar el pedido desde su [área de cliente de OVHcloud](/links/manager). Una vez conectado, siga estas instrucciones:
+También puede realizar el pedido desde su área de cliente de OVHcloud. Para ello, haga clic en las pestañas siguientes para visualizar cada una de las **3** etapas.
 
-- Acceda a la pestaña `Web Cloud`{.action}.
-- En la parte superior izquierda de la interfaz, haga clic en el botón `Contratar`{.action} y luego en `Alojamiento`{.action}.
-- Siga los pasos del pedido **sin solicitar la transferencia del dominio** (esta acción se realizará en el paso 10 de esta guía).
+> [!tabs]
+> **Etapa 1**
+>>
+>> Acceda a la página [Alojamientos](/links/control-panel/web-hosting).
+>>
+>> ![Alojamientos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> En la parte superior izquierda de la interfaz, haga clic en el botón `Contratar`{.action} y luego en `Alojamientos`{.action}.
+>>
+> **Etapa 3**
+>>
+>> Siga los pasos del pedido **sin solicitar la transferencia del dominio** (esta acción se realizará en la parte 10 de esta guía).
 
-Una vez validado el pago, se iniciará la instalación del alojamiento. Recibirá un mensaje de correo electrónico en su dirección de correo electrónico de contacto. que contendrá las claves de acceso al espacio de almacenamiento FTP (File Transfert Protocol) de su alojamiento web.
+Una vez validado el pago, se iniciará la instalación del alojamiento. Recibirá un mensaje de correo electrónico en su dirección de correo electrónico de contacto. que contendrá las claves de acceso al espacio de almacenamiento FTP (File Transfer Protocol) de su alojamiento web.
 
 > [!primary]
 >
 > Además de la solución MX Plan, OVHcloud ofrece otras soluciones de correo. Por ejemplo, puede combinar con direcciones de correo MX Plan direcciones cuentas ["Exchange"](/links/web/emails-hosted-exchange).
 >
 
-### Etapa 2: crear y preconfigurar una zona DNS para su dominio en OVHcloud <a name="step2"></a>
+### 2 - Crear y preconfigurar una zona DNS para su dominio en OVHcloud <a name="step2"></a>
 
 Una vez creado el alojamiento, conéctese a su [área de cliente de OVHcloud](/links/manager) y cree una zona DNS para su dominio **sin los "www"**. Si lo necesita, consulte nuestra guía sobre la [creación de una zona DNS en OVHcloud](/pages/web_cloud/domains/dns_zone_create).
 
@@ -109,16 +120,16 @@ Para conocer la dirección IP de destino de su alojamiento de OVHcloud, consulte
 
 > [!success]
 >
-> Observe los dos valores de destino con el tipo de registro "NS". Estos valores, de tipo `dnsXX.ovh.ca` y `nsXX.ovh.ca`, corresponden a los servidores DNS asociados a esta zona DNS para su dominio. Se utilizarán en la [etapa 9](#step9) de esta guía.
+> Observe los dos valores de destino con el tipo de registro "NS". Estos valores, de tipo `dnsXX.ovh.ca` y `nsXX.ovh.ca`, corresponden a los servidores DNS asociados a esta zona DNS para su dominio. Se utilizarán en la [parte 9](#step9) de esta guía.
 >
 
-### Etapa 3: obtener una copia de seguridad completa del sitio web <a name="step3"></a>
+### 3 - Obtener una copia de seguridad completa del sitio web <a name="step3"></a>
 
 Descargue el contenido del espacio de almacenamiento FTP de su alojamiento actual, así como una copia de seguridad de su base de datos si el sitio web utiliza una.
 
 Estas operaciones se realizan exclusivamente con su proveedor de hosting actual. Contacte con él si tiene dificultades para obtener una copia de seguridad completa de su sitio web.
 
-### Etapa 4: importar la copia de seguridad de su sitio web en su plan de hosting de OVHcloud <a name="step4"></a>
+### 4 - Importar la copia de seguridad de su sitio web en su plan de hosting de OVHcloud <a name="step4"></a>
 
 Para importar la copia de seguridad del espacio de almacenamiento FTP de su anterior proveedor, [conéctese al espacio de almacenamiento FTP de su alojamiento de OVHcloud](/pages/web_cloud/web_hosting/ftp_connection) y envíe la copia de seguridad a la carpeta raíz "www" (o a otra carpeta raíz que haya creado previamente).
 
@@ -133,10 +144,10 @@ Para ello, sustituya los datos de conexión de su antigua base de datos por los 
 
 > [!success]
 >
-> Para asociar una nueva base de datos si utiliza un Content Management System (CMS) como WordPress, Joomla, Drupal o PrestaShop, consulte la información relativa a sus archivos de configuración desde **el etapa 2** de la guía "[Modificación de la contraseña de una base de datos](/pages/web_cloud/web_hosting/sql_change_password)".
+> Para asociar una nueva base de datos si utiliza un Content Management System (CMS) como WordPress, Joomla, Drupal o PrestaShop, consulte la información relativa a sus archivos de configuración desde **la parte 2** de la guía "[Modificación de la contraseña de una base de datos](/pages/web_cloud/web_hosting/sql_change_password)".
 >
 
-Declare/autorice su nombre de dominio externo en su alojamiento web OVHcloud siguiendo nuestro tutorial "[gestión de sitios web de un alojamiento web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Introduzca el nombre de la carpeta raíz que haya elegido al comienzo del[etapa 4](#step4). Le recordamos que esta es la carpeta en la que ha guardado sus archivos en su espacio de almacenamiento FTP.
+Declare/autorice su nombre de dominio externo en su alojamiento web OVHcloud siguiendo nuestro tutorial "[gestión de sitios web de un alojamiento web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Introduzca el nombre de la carpeta raíz que haya elegido al comienzo del[parte 4](#step4). Le recordamos que esta es la carpeta en la que ha guardado sus archivos en su espacio de almacenamiento FTP.
 
 > [!warning]
 >
@@ -157,13 +168,13 @@ Declare/autorice su nombre de dominio externo en su alojamiento web OVHcloud sig
 
 Tras la propagación DNS, el sitio web que se mostrará con su dominio será el alojado en OVHcloud.
 
-### Etapa 5: crear sus direcciones de correo de forma idéntica en OVHcloud <a name="step5"></a>
+### 5 - Crear sus direcciones de correo de forma idéntica en OVHcloud <a name="step5"></a>
 
 Utilice nuestra guía sobre la [creación de direcciones de correo electrónico MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
 Si ha optado por una solución Exchange, [consulte nuestra documentación sobre el asunto para crear sus direcciones de correo](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Etapa 6: Declarar los servidores de correo de OVHcloud en la zona DNS activa de su dominio <a name="step6"></a>
+### 6 - Declarar los servidores de correo de OVHcloud en la zona DNS activa de su dominio <a name="step6"></a>
 
 En primer lugar, debe cambiar los servidores de correo MX de la zona DNS activa del dominio.
 Recibirá los nuevos mensajes de correo en las nuevas direcciones de correo de OVHcloud.
@@ -181,7 +192,7 @@ Una vez finalizada la propagación, se le comunicarán todos los nuevos mensajes
 Le recomendamos que realice el cambio de las entradas "MX" **antes** de migrar el contenido de sus antiguas direcciones de correo.
 Este método permite evitar la migración de los pocos mensajes de correo recibidos a sus antiguas direcciones de correo electrónico durante la propagación de DNS.
 
-### Etapa 7: transferir el contenido de sus antiguas direcciones de correo a sus nuevas direcciones en OVHcloud <a name="step7"></a>
+### 7 - Transferir el contenido de sus antiguas direcciones de correo a sus nuevas direcciones en OVHcloud <a name="step7"></a>
 
 Tras la propagación DNS , todos los nuevos mensajes de correo se reciben en las nuevas direcciones de correo. Sin embargo, los mensajes de correo antiguos siempre se guardan en el servidor de correo antiguo.
 
@@ -206,7 +217,7 @@ Para ello, es necesario tener las claves de acceso de todas sus antiguas cuentas
 
 **Opción 2**: realice una copia de seguridad del contenido de sus direcciones de correo mediante un cliente de correo (Outlook, Mail para Mac...), reconfigure su cliente de correo e importe la copia de seguridad en su nueva dirección de correo de OVHcloud. Para más información, consulte nuestra guía "[Migrar manualmente una dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)".
 
-### Etapa 8: reconfigurar su cliente de correo <a name="step8"></a>
+### 8 - Reconfigurar su cliente de correo <a name="step8"></a>
 
 Una vez que haya migrado sus antiguas direcciones de correo a OVHcloud, reconfigure su cliente de correo utilizando todas nuestras guías.
 
@@ -218,9 +229,9 @@ Todos los parámetros de configuración se encuentran en la guía "[Información
 
 Consulte todas nuestras guías de ayuda a la configuración en `Configuración Exchange en ordenador` y `Configuración Exchange en smartphone` de [nuestra documentación sobre Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Etapa 9: sustituir los servidores DNS activos de su dominio por los de OVHcloud <a name="step9"></a>
+### 9 - Sustituir los servidores DNS activos de su dominio por los de OVHcloud <a name="step9"></a>
 
-La zona DNS preconfigurada en el [etapa 2](#step2) aún no se aplica a su dominio. Actualmente, su dominio sigue utilizando los servidores DNS de su proveedor de origen.
+La zona DNS preconfigurada en el [parte 2](#step2) aún no se aplica a su dominio. Actualmente, su dominio sigue utilizando los servidores DNS de su proveedor de origen.
 
 Sustituya los servidores DNS actuales (del registrador de origen) por los dos servidores DNS declarados en la zona DNS de OVHcloud (de tipo `dnsXX.ovh.ca` y `nsXX.ovh.ca`). Esta operación se realiza en la interfaz de gestión del registrador de origen.
 
@@ -229,7 +240,7 @@ Sustituya los servidores DNS actuales (del registrador de origen) por los dos se
 > El cambio de los servidores DNS debe realizarse desde el actual agente registrador del dominio y tarda entre **propagación de 24 a 48 horas***.
 >
 
-### Etapa 10: transferir su dominio a OVHcloud <a name="step10"></a>
+### 10 - Transferir su dominio a OVHcloud <a name="step10"></a>
 
 Una vez completada la propagación DNS, compruebe que todo su sitio web esté operativo. Navegue por su sitio web para comprobar que todas las páginas se muestran correctamente y que no se devuelve ningún error 404. Compruebe también el envío y la recepción de los emails desde sus direcciones de correo.
 
@@ -241,7 +252,7 @@ Una vez que haya realizado la transferencia de los datos y servicios, solo tendr
 
 ### Conclusión
 
-Una vez que haya realizado los diez pasos anteriores, podrá migrar a OVHcloud la totalidad de su sitio web, sin interrupción del servicio.
+Una vez que haya realizado las diez partes anteriores, podrá migrar a OVHcloud la totalidad de su sitio web, sin interrupción del servicio.
 
 ## Más información <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-us.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.es-us.md
@@ -53,7 +53,7 @@ Migrar todo su sitio web y el correo a OVHcloud **sin interrupción del servicio
 - [9 - Sustituir los servidores DNS activos de su dominio por los de OVHcloud](#step9)
 - [10 - Transferir su dominio a OVHcloud](#step10)
 
-Siguiendo estas 10 partes **en el orden**, no tendrá interrupción del servicio para el acceso a su sitio web y para la recepción de sus nuevos emails.
+Siguiendo estas 10 partes **en el orden**, no tendrá interrupción del servicio para el acceso a su sitio web y para la recepción de sus nuevos correos electrónicos.
 
 No obstante, en función del agente registrador, del proveedor de alojamiento o del proveedor de servicios de correo, es posible que corten el acceso a sus antiguos servicios si se da cuenta de que el dominio ya no está configurado por sus infraestructuras.<br>
 En ese caso, puede producirse una interrupción del servicio.
@@ -87,7 +87,7 @@ También puede realizar el pedido desde su área de cliente de OVHcloud. Para el
 >>
 >> Siga los pasos del pedido **sin solicitar la transferencia del dominio** (esta acción se realizará en la parte 10 de esta guía).
 
-Una vez validado el pago, se iniciará la instalación del alojamiento. Recibirá un mensaje de correo electrónico en su dirección de correo electrónico de contacto. que contendrá las claves de acceso al espacio de almacenamiento FTP (File Transfer Protocol) de su alojamiento web.
+Una vez validado el pago, se iniciará la instalación del alojamiento. Recibirá un mensaje de correo electrónico en su dirección de correo electrónico de contacto, que contendrá las claves de acceso al espacio de almacenamiento FTP (File Transfer Protocol) de su alojamiento web.
 
 > [!primary]
 >
@@ -147,7 +147,7 @@ Para ello, sustituya los datos de conexión de su antigua base de datos por los 
 > Para asociar una nueva base de datos si utiliza un Content Management System (CMS) como WordPress, Joomla, Drupal o PrestaShop, consulte la información relativa a sus archivos de configuración desde **la parte 2** de la guía "[Modificación de la contraseña de una base de datos](/pages/web_cloud/web_hosting/sql_change_password)".
 >
 
-Declare/autorice su nombre de dominio externo en su alojamiento web OVHcloud siguiendo nuestro tutorial "[gestión de sitios web de un alojamiento web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Introduzca el nombre de la carpeta raíz que haya elegido al comienzo del[parte 4](#step4). Le recordamos que esta es la carpeta en la que ha guardado sus archivos en su espacio de almacenamiento FTP.
+Declare/autorice su nombre de dominio externo en su alojamiento web OVHcloud siguiendo nuestro tutorial "[gestión de sitios web de un alojamiento web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Introduzca el nombre de la carpeta raíz que haya elegido al comienzo del [parte 4](#step4). Le recordamos que esta es la carpeta en la que ha guardado sus archivos en su espacio de almacenamiento FTP.
 
 > [!warning]
 >
@@ -212,7 +212,7 @@ Repita la operación para todas sus cuentas de correo.
 >
 Para ello, es necesario tener las claves de acceso de todas sus antiguas cuentas de correo y el nombre del servidor de correo de su anterior proveedor.
 >
-> Si sus direcciones de correo estuvieran configuradas en POP sin conservar copias de los mensajes en su antiguo servidor de correo, o si tuviera los emails registrados "localmente" en sus dispositivos, solo podrá realizar la **opción 2**.
+> Si sus direcciones de correo estuvieran configuradas en POP sin conservar copias de los mensajes en su antiguo servidor de correo, o si tuviera los correos electrónicos registrados "localmente" en sus dispositivos, solo podrá realizar la **opción 2**.
 >
 
 **Opción 2**: realice una copia de seguridad del contenido de sus direcciones de correo mediante un cliente de correo (Outlook, Mail para Mac...), reconfigure su cliente de correo e importe la copia de seguridad en su nueva dirección de correo de OVHcloud. Para más información, consulte nuestra guía "[Migrar manualmente una dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)".
@@ -242,7 +242,7 @@ Sustituya los servidores DNS actuales (del registrador de origen) por los dos se
 
 ### 10 - Transferir su dominio a OVHcloud <a name="step10"></a>
 
-Una vez completada la propagación DNS, compruebe que todo su sitio web esté operativo. Navegue por su sitio web para comprobar que todas las páginas se muestran correctamente y que no se devuelve ningún error 404. Compruebe también el envío y la recepción de los emails desde sus direcciones de correo.
+Una vez completada la propagación DNS, compruebe que todo su sitio web esté operativo. Navegue por su sitio web para comprobar que todas las páginas se muestran correctamente y que no se devuelve ningún error 404. Compruebe también el envío y la recepción de los correos electrónicos desde sus direcciones de correo.
 
 Si todo está en orden, desbloquee su dominio y recupere su "código de transferencia", "EPP" o "AuthCode" desde su actual agente registrador.
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrer son site web et ses services associés vers OVHcloud"
 excerpt: "Découvrez comment migrer votre site web, votre nom de domaine, votre base de données et vos e-mails chez OVHcloud sans interruption de services"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -40,27 +40,27 @@ Ce guide vous présente les différentes actions à réaliser pour migrer l'ense
 > Les instructions de ce guide référencent plusieurs produits de l'univers Web Cloud, nous vous recommandons de lire toutes les étapes ci-dessous **avant** de vous lancer dans la migration de vos services.
 >
 
-Migrer l'intégralité de votre site internet et vos e-mails vers OVHcloud **sans interruption de service** nécessite d'appliquer une procédure précise en 10 étapes :
+Migrer l'intégralité de votre site internet et vos e-mails vers OVHcloud **sans interruption de service** nécessite d'appliquer une procédure précise en 10 parties :
 
-- [Etape 1 : commander l'hébergement et les adresses e-mail chez OVHcloud](#step1)
-- [Etape 2 : créer et pré-configurer une zone DNS pour votre nom de domaine chez OVHcloud](#step2)
-- [Etape 3 : récupérer une sauvegarde complète de votre site web](#step3)
-- [Etape 4 : importer la sauvegarde de votre site web sur votre offre d'hébergement OVHcloud](#step4)
-- [Etape 5 : recréer vos adresses e-mail à l'identique chez OVHcloud](#step5)
-- [Etape 6 : déclarer les serveurs e-mail OVHcloud dans la zone DNS active de votre nom de domaine](#step6)
-- [Etape 7 : transférer le contenu de vos anciennes adresses e-mail dans vos nouvelles adresses chez OVHcloud](#step7)
-- [Etape 8 : reconfigurer vos logiciels de messagerie](#step8)
-- [Etape 9 : remplacer les serveurs DNS actifs de votre nom de domaine par ceux d'OVHcloud](#step9)
-- [Etape 10 : transférer votre nom de domaine chez OVHcloud](#step10)
+- [1 - Commander l'hébergement et les adresses e-mail chez OVHcloud](#step1)
+- [2 - Créer et pré-configurer une zone DNS pour votre nom de domaine chez OVHcloud](#step2)
+- [3 - Récupérer une sauvegarde complète de votre site web](#step3)
+- [4 - Importer la sauvegarde de votre site web sur votre offre d'hébergement OVHcloud](#step4)
+- [5 - Recréer vos adresses e-mail à l'identique chez OVHcloud](#step5)
+- [6 - Déclarer les serveurs e-mail OVHcloud dans la zone DNS active de votre nom de domaine](#step6)
+- [7 - Transférer le contenu de vos anciennes adresses e-mail dans vos nouvelles adresses chez OVHcloud](#step7)
+- [8 - Reconfigurer vos logiciels de messagerie](#step8)
+- [9 - Remplacer les serveurs DNS actifs de votre nom de domaine par ceux d'OVHcloud](#step9)
+- [10 - Transférer votre nom de domaine chez OVHcloud](#step10)
 
-En suivant ces 10 étapes **dans l'ordre**, vous n'aurez pas d'interruption de service pour l'accès à votre site web et pour la réception de vos nouveaux e-mails.
+En suivant ces 10 parties **dans l'ordre**, vous n'aurez pas d'interruption de service pour l'accès à votre site web et pour la réception de vos nouveaux e-mails.
 
 Cependant, en fonction de votre bureau d'enregistrement, de votre fournisseur d'hébergement ou de votre fournisseur de services e-mail, il est possible que ces derniers coupent l'accès à vos anciens services s'ils constatent que votre nom de domaine n'est plus configuré par le biais de leurs infrastructures.<br>
 Dans ce cas, une interruption de service peut survenir.
 
 Si une telle interruption devait avoir lieu, ce guide est construit de telle sorte à en minimiser la durée.
 
-### Etape 1 : commander l'hébergement et les adresses e-mail chez OVHcloud <a name="step1"></a>
+### 1 - Commander l'hébergement et les adresses e-mail chez OVHcloud <a name="step1"></a>
 
 Plusieurs [offres d'hébergement mutualisé OVHcloud](/links/web/hosting) contiennent une offre e-mail « [MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) ». Cette offre e-mail permet de créer des adresses e-mail avec un espace de stockage de 5 Go maximum pour chaque adresse. Choisissez parmi les offres d'hébergement ci-dessous en fonction de la version PHP, de la version SQL, du nombre d'adresses e-mail dont vous avez besoin et de la taille de votre site web à migrer :
 
@@ -68,22 +68,33 @@ Plusieurs [offres d'hébergement mutualisé OVHcloud](/links/web/hosting) contie
 - L'hébergement [Pro](/links/web/hosting-professional-offer) avec **100 adresses e-mail** « MX Plan »
 - L'hébergement [Performance](/links/web/hosting-performance-offer) avec **1000 adresses e-mail** « MX Plan ». Cette offre est déclinée en 4 « sous-offres ».
 
-Une fois votre offre d'hébergement choisie, si vous n'êtes pas encore client OVHcloud, cliquez sur le bouton `Commander`{.action} présent sur les pages commerciales ci-dessus. Suivez les étapes de la commande **sans demander le transfert de votre nom de domaine** (cette action sera effectuée à l'étape 10 de ce guide).
+Une fois votre offre d'hébergement choisie, si vous n'êtes pas encore client OVHcloud, cliquez sur le bouton `Commander`{.action} présent sur les pages commerciales ci-dessus. Suivez les étapes de la commande **sans demander le transfert de votre nom de domaine** (cette action sera effectuée à la partie 10 de ce guide).
 
-Vous pouvez aussi effectuer la commande depuis votre [espace client OVHcloud](/links/manager). Une fois connecté, suivez les instructions suivantes :
+Vous pouvez aussi effectuer la commande depuis votre espace client OVHcloud. Pour cela, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-- Rendez-vous sur l'onglet `Web Cloud`{.action}.
-- En haut à gauche de l'interface, cliquez sur le bouton `Commander`{.action} puis sur `Hébergements`{.action}.
-- Poursuivez les étapes de la commande **sans demander le transfert de votre nom de domaine** (cette action sera effectuée à l'étape 10 de ce guide).
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting).
+>>
+>> ![Hébergements](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> En haut à gauche de l'interface, cliquez sur le bouton `Commander`{.action} puis sur `Hébergements`{.action}.
+>>
+> **Étape 3**
+>>
+>> Poursuivez les étapes de la commande **sans demander le transfert de votre nom de domaine** (cette action sera effectuée à la partie 10 de ce guide).
 
-Une fois le paiement validé, l'installation de l'hébergement va démarrer. Un e-mail sera envoyé sur votre adresse e-mail de contact. Celui-ci contiendra les identifiants d'accès à l'espace de stockage FTP (File Transfert Protocol) de votre hébergement Web.
+Une fois le paiement validé, l'installation de l'hébergement va démarrer. Un e-mail sera envoyé sur votre adresse e-mail de contact. Celui-ci contiendra les identifiants d'accès à l'espace de stockage FTP (File Transfer Protocol) de votre hébergement Web.
 
 > [!primary]
 >
 > OVHcloud propose d'autres offres e-mail en plus de l'offre « MX Plan ». Vous pouvez, par exemple, combiner à des adresses e-mail « MX Plan » des comptes [« Exchange »](/links/web/emails-hosted-exchange).
 >
 
-### Etape 2 : créer et préconfigurer une zone DNS pour votre nom de domaine chez OVHcloud <a name="step2"></a>
+### 2 - Créer et préconfigurer une zone DNS pour votre nom de domaine chez OVHcloud <a name="step2"></a>
 
 Si votre domaine se trouve chez un autre prestataire et que vous souhaitez le transférer chez OVHcloud, vous devez dans un premier temps créer et pré-configurer une zone DNS avant d'initier le transfert, afin d'éviter une interruption de services.
 
@@ -111,16 +122,16 @@ Pour récupérer la bonne adresse IP cible de votre hébergement OVHcloud, consu
 
 > [!success]
 >
-> Notez les deux valeurs cibles ayant pour type d'enregistrement « NS ». Ces valeurs, de type `dnsXX.ovh.ca` et `nsXX.ovh.ca`, correspondent aux serveurs DNS associés à cette zone DNS pour votre nom de domaine. Elles serviront lors de l'[étape 9](#step9) de ce guide.
+> Notez les deux valeurs cibles ayant pour type d'enregistrement « NS ». Ces valeurs, de type `dnsXX.ovh.ca` et `nsXX.ovh.ca`, correspondent aux serveurs DNS associés à cette zone DNS pour votre nom de domaine. Elles serviront lors de la [partie 9](#step9) de ce guide.
 >
 
-### Etape 3 : récupérer une sauvegarde complète de votre site web <a name="step3"></a>
+### 3 - Récupérer une sauvegarde complète de votre site web <a name="step3"></a>
 
 Récupérez le contenu de l'espace de stockage FTP de votre hébergement actuel, ainsi qu'une sauvegarde de votre base de données si votre site web en utilise une.
 
 Ces opérations se font exclusivement auprès de votre hébergeur actuel. Contactez-le si vous éprouvez des difficultés à récupérer une sauvegarde complète de votre site web.
 
-### Etape 4 : importer la sauvegarde de votre site web sur votre offre d'hébergement OVHcloud <a name="step4"></a>
+### 4 - Importer la sauvegarde de votre site web sur votre offre d'hébergement OVHcloud <a name="step4"></a>
 
 Pour importer la sauvegarde de l'espace de stockage FTP de votre ancien prestataire, [connectez-vous à l'espace de stockage FTP de votre hébergement OVHcloud](/pages/web_cloud/web_hosting/ftp_connection) et téléversez la sauvegarde dans le dossier racine « www » (ou dans un autre dossier racine que vous aurez préalablement créé).
 
@@ -140,10 +151,10 @@ Pour cela, remplacez les informations de connexion de votre ancienne base de don
 
 > [!success]
 >
-> Pour lier votre nouvelle base de données si vous utilisez un Content Management System (CMS) comme WordPress, Joomla!, Drupal ou PrestaShop, retrouvez les informations sur leurs fichiers de configuration depuis **l'étape 2** du guide « [modification du mot de passe d'une base de données](/pages/web_cloud/web_hosting/sql_change_password) ».
+> Pour lier votre nouvelle base de données si vous utilisez un Content Management System (CMS) comme WordPress, Joomla!, Drupal ou PrestaShop, retrouvez les informations sur leurs fichiers de configuration depuis **la partie 2** du guide « [modification du mot de passe d'une base de données](/pages/web_cloud/web_hosting/sql_change_password) ».
 >
 
-Déclarez/autorisez votre nom de domaine externe sur votre hébergement web OVHcloud via notre guide « [gestion des sites web d'un hébergement web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite) ». Déclarez bien le « nom » du dossier racine que vous avez choisi au début de l'[étape 4](#step4). Pour rappel, il s'agit du dossier dans lequel vous avez placé vos fichiers dans votre espace de stockage FTP.
+Déclarez/autorisez votre nom de domaine externe sur votre hébergement web OVHcloud via notre guide « [gestion des sites web d'un hébergement web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite) ». Déclarez bien le « nom » du dossier racine que vous avez choisi au début de la [partie 4](#step4). Pour rappel, il s'agit du dossier dans lequel vous avez placé vos fichiers dans votre espace de stockage FTP.
 
 > [!warning]
 >
@@ -164,13 +175,13 @@ Déclarez/autorisez votre nom de domaine externe sur votre hébergement web OVHc
 
 Après la propagation DNS, le site web qui s'affichera avec votre nom de domaine sera celui hébergé chez OVHcloud.
 
-### Etape 5 : recréer vos adresses e-mail à l'identique chez OVHcloud <a name="step5"></a>
+### 5 - Recréer vos adresses e-mail à l'identique chez OVHcloud <a name="step5"></a>
 
 Recréez à l'identique les adresses e-mail présentes chez votre fournisseur e-mail à l'aide de notre guide sur la [création d'adresses e-mail « MX Plan »](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
 Si vous avez opté pour une solution « Exchange », [consultez notre documentation sur le sujet pour créer vos adresses e-mail](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Etape 6 : déclarer les serveurs e-mail OVHcloud dans la zone DNS active de votre nom de domaine <a name="step6"></a>
+### 6 - Déclarer les serveurs e-mail OVHcloud dans la zone DNS active de votre nom de domaine <a name="step6"></a>
 
 Cette étape consiste à effectuer le changement des serveurs e-mail « MX » dans la zone DNS active de votre nom de domaine.
 Cela aura pour effet de réceptionner vos nouveaux e-mails sur vos nouvelles adresses e-mail OVHcloud.
@@ -188,7 +199,7 @@ Une fois la propagation terminée, tous les nouveaux e-mails reçus seront réce
 Nous vous conseillons de faire le changement des entrées « MX » **avant** d'effectuer la migration du contenu de vos anciennes adresses e-mail.
 En effet, cette méthode vous évite de refaire une migration pour les quelques e-mails reçus sur vos anciennes adresses e-mail pendant la propagation DNS.
 
-### Etape 7 : transférer le contenu de vos anciennes adresses e-mail dans vos nouvelles adresses chez OVHcloud <a name="step7"></a>
+### 7 - Transférer le contenu de vos anciennes adresses e-mail dans vos nouvelles adresses chez OVHcloud <a name="step7"></a>
 
 Après la propagation DNS, vos nouveaux e-mails sont désormais tous reçus sur vos nouvelles adresses e-mail. Mais vos anciens e-mails sont toujours enregistrés sur votre ancien serveur e-mail.
 
@@ -213,7 +224,7 @@ Réitérez l'opération pour l'ensemble de vos comptes e-mail.
 
 **Option 2** : effectuez une sauvegarde du contenu de vos anciennes adresses e-mail à l'aide d'un logiciel de messagerie (Outlook, Mail pour macOS, etc.). Reconfigurez votre logiciel de messagerie puis importez la sauvegarde dans votre nouvelle adresse e-mail OVHcloud. Retrouvez plus d'informations dans notre guide « [Migrer manuellement votre adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration) ».
 
-### Etape 8 : reconfigurer vos logiciels de messagerie <a name="step8"></a>
+### 8 - Reconfigurer vos logiciels de messagerie <a name="step8"></a>
 
 Une fois vos anciennes adresses e-mail migrées chez OVHcloud, reconfigurez vos logiciels de messagerie à l'aide de l'ensemble de nos guides sur le sujet.
 
@@ -225,9 +236,9 @@ Une fois vos anciennes adresses e-mail migrées chez OVHcloud, reconfigurez vos 
 
 - Retrouvez l'ensemble de nos guides d'aide à la configuration dans les sections `Configuration Exchange sur ordinateur` et `Configuration Exchange sur smartphone` de [notre documentation sur l'offre Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Etape 9 : remplacer les serveurs DNS actifs de votre nom de domaine par ceux d'OVHcloud <a name="step9"></a>
+### 9 - Remplacer les serveurs DNS actifs de votre nom de domaine par ceux d'OVHcloud <a name="step9"></a>
 
-La zone DNS pré-configurée lors de l'[étape 2](#step2) n'est pas encore appliquée à votre nom de domaine. Actuellement, votre nom de domaine utilise toujours les serveurs DNS de votre fournisseur d'origine.
+La zone DNS pré-configurée lors de la [partie 2](#step2) n'est pas encore appliquée à votre nom de domaine. Actuellement, votre nom de domaine utilise toujours les serveurs DNS de votre fournisseur d'origine.
 
 Remplacez les serveurs DNS actuels (du registrar d'origine) par les deux serveurs DNS déclarés dans la zone DNS OVHcloud (de type `dnsXX.ovh.ca` et `nsXX.ovh.ca`). Cette manipulation se fait dans l'interface de gestion du registrar d'origine.
 
@@ -236,7 +247,7 @@ Remplacez les serveurs DNS actuels (du registrar d'origine) par les deux serveur
 > Le changement des serveurs DNS doit être effectué depuis le bureau d'enregistrement actuel de votre nom de domaine et nécessite un temps de **propagation de 24 à 48 heures** maximum avant d’être pleinement effectif.
 >
 
-### Etape 10 : transférer votre nom de domaine chez OVHcloud <a name="step10"></a>
+### 10 - Transférer votre nom de domaine chez OVHcloud <a name="step10"></a>
 
 Une fois la propagation DNS terminée, vérifiez que l'ensemble de votre site web est fonctionnel. Naviguez sur votre site internet pour vérifier que toutes les pages s'affichent correctement et qu'aucune erreur 404 n'est renvoyée. Vérifiez également l'envoi et la réception des e-mails depuis vos adresses e-mail.
 
@@ -248,7 +259,7 @@ Une fois le transfert de vos données et services terminé, il ne vous reste plu
 
 ### Conclusion
 
-Après avoir suivi les dix étapes dans l'ordre, l'intégralité de votre site web est maintenant migrée chez OVHcloud, tout cela sans interruption de service.
+Après avoir suivi les dix parties dans l'ordre, l'intégralité de votre site web est maintenant migrée chez OVHcloud, tout cela sans interruption de service.
 
 ## Aller plus loin
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.fr-ca.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrer son site web et ses services associés vers OVHcloud"
 excerpt: "Découvrez comment migrer votre site web, votre nom de domaine, votre base de données et vos e-mails chez OVHcloud sans interruption de services"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrer son site web et ses services associés vers OVHcloud"
 excerpt: "Découvrez comment migrer votre site web, votre nom de domaine, votre base de données et vos e-mails chez OVHcloud sans interruption de services"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objectif
@@ -60,7 +60,7 @@ Dans ce cas, une interruption de service peut survenir.
 
 Si une telle interruption devait avoir lieu, ce guide est construit de telle sorte à en minimiser la durée.
 
-### Etape 1 : commander l'hébergement et les adresses e-mail chez OVHcloud <a name="step1"></a>
+### 1 - Commander l'hébergement et les adresses e-mail chez OVHcloud <a name="step1"></a>
 
 Plusieurs [offres d'hébergement mutualisé OVHcloud](/links/web/hosting) contiennent une offre e-mail « [MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) ». Cette offre e-mail permet de créer des adresses e-mail avec un espace de stockage de 5 Go maximum pour chaque adresse. Choisissez parmi les offres d'hébergement ci-dessous en fonction de la version PHP, de la version SQL, du nombre d'adresses e-mail dont vous avez besoin et de la taille de votre site web à migrer :
 
@@ -71,20 +71,31 @@ Plusieurs [offres d'hébergement mutualisé OVHcloud](/links/web/hosting) contie
 
 Une fois votre offre d'hébergement choisie, si vous n'êtes pas encore client OVHcloud, cliquez sur le bouton `Commander`{.action} présent sur les pages commerciales ci-dessus. Suivez les étapes de la commande **sans demander le transfert de votre nom de domaine** (cette action sera effectuée à l'étape 10 de ce guide).
 
-Vous pouvez aussi effectuer la commande depuis votre [espace client OVHcloud](/links/manager). Une fois connecté, suivez les instructions suivantes :
+Vous pouvez aussi effectuer la commande depuis votre espace client OVHcloud. Pour cela, cliquez sur les onglets ci-dessous pour afficher successivement chacune des **3** étapes.
 
-- Rendez-vous sur l'onglet `Web Cloud`{.action}.
-- En haut à gauche de l'interface, cliquez sur le bouton `Commander`{.action} puis sur `Hébergements`{.action}.
-- Poursuivez les étapes de la commande **sans demander le transfert de votre nom de domaine** (cette action sera effectuée à l'étape 10 de ce guide).
+> [!tabs]
+> **Étape 1**
+>>
+>> Accédez à la page [Hébergements](/links/control-panel/web-hosting).
+>>
+>> ![Web Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Étape 2**
+>>
+>> En haut à gauche de l'interface, cliquez sur le bouton `Commander`{.action} puis sur `Hébergements`{.action}.
+>>
+> **Étape 3**
+>>
+>> Poursuivez les étapes de la commande **sans demander le transfert de votre nom de domaine** (cette action sera effectuée à l'étape 10 de ce guide).
 
-Une fois le paiement validé, l'installation de l'hébergement va démarrer. Un e-mail sera envoyé sur votre adresse e-mail de contact. Celui-ci contiendra les identifiants d'accès à l'espace de stockage FTP (File Transfert Protocol) de votre hébergement Web.
+Une fois le paiement validé, l'installation de l'hébergement va démarrer. Un e-mail sera envoyé sur votre adresse e-mail de contact. Celui-ci contiendra les identifiants d'accès à l'espace de stockage FTP (File Transfert Protocol) de votre hébergement web.
 
 > [!primary]
 >
 > OVHcloud propose d'autres offres e-mail en plus de l'offre « MX Plan ». Vous pouvez, par exemple, combiner à des adresses e-mail « MX Plan » des adresses [« Email-Pro »](/links/web/email-pro) et/ou des comptes [« Exchange »](/links/web/emails-hosted-exchange).
 >
 
-### Etape 2 : créer et préconfigurer une zone DNS pour votre nom de domaine chez OVHcloud <a name="step2"></a>
+### 2 - Créer et préconfigurer une zone DNS pour votre nom de domaine chez OVHcloud <a name="step2"></a>
 
 Si votre domaine se trouve chez un autre prestataire et que vous souhaitez le transférer chez OVHcloud, vous devez dans un premier temps créer et pré-configurer une zone DNS avant d'initier le transfert, afin d'éviter une interruption de services.
 
@@ -112,16 +123,16 @@ Pour récupérer la bonne adresse IP cible de votre hébergement OVHcloud, consu
 
 > [!success]
 >
-> Notez les deux valeurs cibles ayant pour type d'enregistrement « NS ». Ces valeurs, de type `dnsXX.ovh.net` et `nsXX.ovh.net` (ou `dns200.anycast.me` et `ns200.anycast.me`), correspondent aux serveurs DNS associés à cette zone DNS pour votre nom de domaine. Elles serviront lors de l'[étape 9](#step9) de ce guide.
+> Notez les deux valeurs cibles ayant pour type d'enregistrement « NS ». Ces valeurs, de type `dnsXX.ovh.net` et `nsXX.ovh.net` (ou `dns200.anycast.me` et `ns200.anycast.me`), correspondent aux serveurs DNS associés à cette zone DNS pour votre nom de domaine. Elles serviront lors de la [partie 9](#step9) de ce guide.
 >
 
-### Etape 3 : récupérer une sauvegarde complète de votre site web <a name="step3"></a>
+### 3 - Récupérer une sauvegarde complète de votre site web <a name="step3"></a>
 
 Récupérez le contenu de l'espace de stockage FTP de votre hébergement actuel, ainsi qu'une sauvegarde de votre base de données si votre site web en utilise une.
 
 Ces opérations se font exclusivement auprès de votre hébergeur actuel. Contactez-le si vous éprouvez des difficultés à récupérer une sauvegarde complète de votre site web.
 
-### Etape 4 : importer la sauvegarde de votre site web sur votre offre d'hébergement OVHcloud <a name="step4"></a>
+### 4 - Importer la sauvegarde de votre site web sur votre offre d'hébergement OVHcloud <a name="step4"></a>
 
 Pour importer la sauvegarde de l'espace de stockage FTP de votre ancien prestataire, [connectez-vous à l'espace de stockage FTP de votre hébergement OVHcloud](/pages/web_cloud/web_hosting/ftp_connection) et téléversez la sauvegarde dans le dossier racine « www » (ou dans un autre dossier racine que vous aurez préalablement créé).
 
@@ -141,10 +152,10 @@ Pour cela, remplacez les informations de connexion de votre ancienne base de don
 
 > [!success]
 >
-> Pour lier votre nouvelle base de données si vous utilisez un Content Management System (CMS) comme WordPress, Joomla!, Drupal ou PrestaShop, retrouvez les informations sur leurs fichiers de configuration depuis **l'étape 2** du guide « [modification du mot de passe d'une base de données](/pages/web_cloud/web_hosting/sql_change_password) ».
+> Pour lier votre nouvelle base de données si vous utilisez un Content Management System (CMS) comme WordPress, Joomla!, Drupal ou PrestaShop, retrouvez les informations sur leurs fichiers de configuration depuis la **partie 2** du guide « [modification du mot de passe d'une base de données](/pages/web_cloud/web_hosting/sql_change_password) ».
 >
 
-Déclarez/autorisez votre nom de domaine externe sur votre hébergement web OVHcloud via notre guide « [gestion des sites web d'un hébergement web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite) ». Déclarez bien le « nom » du dossier racine que vous avez choisi au début de l'[étape 4](#step4). Pour rappel, il s'agit du dossier dans lequel vous avez placé vos fichiers dans votre espace de stockage FTP.
+Déclarez/autorisez votre nom de domaine externe sur votre hébergement web OVHcloud via notre guide « [gestion des sites web d'un hébergement web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite) ». Déclarez bien le « nom » du dossier racine que vous avez choisi au début de la [partie 4](#step4). Pour rappel, il s'agit du dossier dans lequel vous avez placé vos fichiers dans votre espace de stockage FTP.
 
 > [!warning]
 >
@@ -165,7 +176,7 @@ Déclarez/autorisez votre nom de domaine externe sur votre hébergement web OVHc
 
 Après la propagation DNS, le site web qui s'affichera avec votre nom de domaine sera celui hébergé chez OVHcloud.
 
-### Etape 5 : recréer vos adresses e-mail à l'identique chez OVHcloud <a name="step5"></a>
+### 5 - Recréer vos adresses e-mail à l'identique chez OVHcloud <a name="step5"></a>
 
 Recréez à l'identique les adresses e-mail présentes chez votre fournisseur e-mail à l'aide de notre guide sur la [création d'adresses e-mail « MX Plan »](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
@@ -174,7 +185,7 @@ Si vous avez opté pour une solution « Email Pro » ou « Exchange », consulte
 - Pour [Email-Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 - Pour [Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Etape 6 : déclarer les serveurs e-mail OVHcloud dans la zone DNS active de votre nom de domaine <a name="step6"></a>
+### 6 - Déclarer les serveurs e-mail OVHcloud dans la zone DNS active de votre nom de domaine <a name="step6"></a>
 
 Cette étape consiste à effectuer le changement des serveurs e-mail « MX » dans la zone DNS active de votre nom de domaine.
 Cela aura pour effet de réceptionner vos nouveaux e-mails sur vos nouvelles adresses e-mail OVHcloud.
@@ -192,7 +203,7 @@ Une fois la propagation terminée, tous les nouveaux e-mails reçus seront réce
 Nous vous conseillons de faire le changement des entrées « MX » **avant** d'effectuer la migration du contenu de vos anciennes adresses e-mail.
 En effet, cette méthode vous évite de refaire une migration pour les quelques e-mails reçus sur vos anciennes adresses e-mail pendant la propagation DNS.
 
-### Etape 7 : transférer le contenu de vos anciennes adresses e-mail dans vos nouvelles adresses chez OVHcloud <a name="step7"></a>
+### 7 - Transférer le contenu de vos anciennes adresses e-mail dans vos nouvelles adresses chez OVHcloud <a name="step7"></a>
 
 Après la propagation DNS, vos nouveaux e-mails sont désormais tous reçus sur vos nouvelles adresses e-mail. Mais vos anciens e-mails sont toujours enregistrés sur votre ancien serveur e-mail.
 
@@ -217,7 +228,7 @@ Réitérez l'opération pour l'ensemble de vos comptes e-mail.
 
 **Option 2** : effectuez une sauvegarde du contenu de vos anciennes adresses e-mail à l'aide d'un logiciel de messagerie (Outlook, Mail pour macOS, etc.). Reconfigurez votre logiciel de messagerie puis importez la sauvegarde dans votre nouvelle adresse e-mail OVHcloud. Retrouvez plus d'informations dans notre guide « [Migrer manuellement votre adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration) ».
 
-### Etape 8 : reconfigurer vos logiciels de messagerie <a name="step8"></a>
+### 8 - Reconfigurer vos logiciels de messagerie <a name="step8"></a>
 
 Une fois vos anciennes adresses e-mail migrées chez OVHcloud, reconfigurez vos logiciels de messagerie à l'aide de l'ensemble de nos guides sur le sujet.
 
@@ -233,9 +244,9 @@ Une fois vos anciennes adresses e-mail migrées chez OVHcloud, reconfigurez vos 
 
 - Retrouvez l'ensemble de nos guides d'aide à la configuration dans les sections `Configuration Exchange sur ordinateur` et `Configuration Exchange sur smartphone` de [notre documentation sur l'offre Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Etape 9 : remplacer les serveurs DNS actifs de votre nom de domaine par ceux d'OVHcloud <a name="step9"></a>
+### 9 - Remplacer les serveurs DNS actifs de votre nom de domaine par ceux d'OVHcloud <a name="step9"></a>
 
-La zone DNS pré-configurée lors de l'[étape 2](#step2) n'est pas encore appliquée à votre nom de domaine. Actuellement, votre nom de domaine utilise toujours les serveurs DNS de votre fournisseur d'origine.
+La zone DNS pré-configurée lors de la [partie 2](#step2) n'est pas encore appliquée à votre nom de domaine. Actuellement, votre nom de domaine utilise toujours les serveurs DNS de votre fournisseur d'origine.
 
 Remplacez les serveurs DNS actuels (du registrar d'origine) par les deux serveurs DNS déclarés dans la zone DNS OVHcloud (de type `dnsXX.ovh.net` et `nsXX.ovh.net` ou `dns200.anycast.me` et `ns200.anycast.me`). Cette manipulation se fait dans l'interface de gestion du registrar d'origine.
 
@@ -244,7 +255,7 @@ Remplacez les serveurs DNS actuels (du registrar d'origine) par les deux serveur
 > Le changement des serveurs DNS doit être effectué depuis le bureau d'enregistrement actuel de votre nom de domaine et nécessite un temps de **propagation de 24 à 48 heures** maximum avant d’être pleinement effectif.
 >
 
-### Etape 10 : transférer votre nom de domaine chez OVHcloud <a name="step10"></a>
+### 10 - Transférer votre nom de domaine chez OVHcloud <a name="step10"></a>
 
 Une fois la propagation DNS terminée, vérifiez que l'ensemble de votre site web est fonctionnel. Naviguez sur votre site internet pour vérifier que toutes les pages s'affichent correctement et qu'aucune erreur 404 n'est renvoyée. Vérifiez également l'envoi et la réception des e-mails depuis vos adresses e-mail.
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrer son site web et ses services associés vers OVHcloud"
 excerpt: "Découvrez comment migrer votre site web, votre nom de domaine, votre base de données et vos e-mails chez OVHcloud sans interruption de services"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objectif

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.fr-fr.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.fr-fr.md
@@ -40,20 +40,20 @@ Ce guide vous présente les différentes actions à réaliser pour migrer l'ense
 > Les instructions de ce guide référencent plusieurs produits de l'univers Web Cloud, nous vous recommandons de lire toutes les étapes ci-dessous **avant** de vous lancer dans la migration de vos services.
 >
 
-Migrer l'intégralité de votre site internet et vos e-mails vers OVHcloud **sans interruption de service** nécessite d'appliquer une procédure précise en 10 étapes :
+Migrer l'intégralité de votre site internet et vos e-mails vers OVHcloud **sans interruption de service** nécessite d'appliquer une procédure précise en 10 parties :
 
-- [Etape 1 : commander l'hébergement et les adresses e-mail chez OVHcloud](#step1)
-- [Etape 2 : créer et pré-configurer une zone DNS pour votre nom de domaine chez OVHcloud](#step2)
-- [Etape 3 : récupérer une sauvegarde complète de votre site web](#step3)
-- [Etape 4 : importer la sauvegarde de votre site web sur votre offre d'hébergement OVHcloud](#step4)
-- [Etape 5 : recréer vos adresses e-mail à l'identique chez OVHcloud](#step5)
-- [Etape 6 : déclarer les serveurs e-mail OVHcloud dans la zone DNS active de votre nom de domaine](#step6)
-- [Etape 7 : transférer le contenu de vos anciennes adresses e-mail dans vos nouvelles adresses chez OVHcloud](#step7)
-- [Etape 8 : reconfigurer vos logiciels de messagerie](#step8)
-- [Etape 9 : remplacer les serveurs DNS actifs de votre nom de domaine par ceux d'OVHcloud](#step9)
-- [Etape 10 : transférer votre nom de domaine chez OVHcloud](#step10)
+- [1 - Commander l'hébergement et les adresses e-mail chez OVHcloud](#step1)
+- [2 - Créer et préconfigurer une zone DNS pour votre nom de domaine chez OVHcloud](#step2)
+- [3 - Récupérer une sauvegarde complète de votre site web](#step3)
+- [4 - Importer la sauvegarde de votre site web sur votre offre d'hébergement OVHcloud](#step4)
+- [5 - Recréer vos adresses e-mail à l'identique chez OVHcloud](#step5)
+- [6 - Déclarer les serveurs e-mail OVHcloud dans la zone DNS active de votre nom de domaine](#step6)
+- [7 - Transférer le contenu de vos anciennes adresses e-mail dans vos nouvelles adresses chez OVHcloud](#step7)
+- [8 - Reconfigurer vos logiciels de messagerie](#step8)
+- [9 - Remplacer les serveurs DNS actifs de votre nom de domaine par ceux d'OVHcloud](#step9)
+- [10 - Transférer votre nom de domaine chez OVHcloud](#step10)
 
-En suivant ces 10 étapes **dans l'ordre**, vous n'aurez pas d'interruption de service pour l'accès à votre site web et pour la réception de vos nouveaux e-mails.
+En suivant ces 10 parties **dans l'ordre**, vous n'aurez pas d'interruption de service pour l'accès à votre site web et pour la réception de vos nouveaux e-mails.
 
 Cependant, en fonction de votre bureau d'enregistrement, de votre fournisseur d'hébergement ou de votre fournisseur de services e-mail, il est possible que ces derniers coupent l'accès à vos anciens services s'ils constatent que votre nom de domaine n'est plus configuré par le biais de leurs infrastructures.<br>
 Dans ce cas, une interruption de service peut survenir.
@@ -88,7 +88,7 @@ Vous pouvez aussi effectuer la commande depuis votre espace client OVHcloud. Pou
 >>
 >> Poursuivez les étapes de la commande **sans demander le transfert de votre nom de domaine** (cette action sera effectuée à l'étape 10 de ce guide).
 
-Une fois le paiement validé, l'installation de l'hébergement va démarrer. Un e-mail sera envoyé sur votre adresse e-mail de contact. Celui-ci contiendra les identifiants d'accès à l'espace de stockage FTP (File Transfert Protocol) de votre hébergement web.
+Une fois le paiement validé, l'installation de l'hébergement va démarrer. Un e-mail sera envoyé à votre adresse e-mail de contact. Celui-ci contiendra les identifiants d'accès à l'espace de stockage FTP (File Transfer Protocol) de votre hébergement web.
 
 > [!primary]
 >
@@ -97,7 +97,7 @@ Une fois le paiement validé, l'installation de l'hébergement va démarrer. Un 
 
 ### 2 - Créer et préconfigurer une zone DNS pour votre nom de domaine chez OVHcloud <a name="step2"></a>
 
-Si votre domaine se trouve chez un autre prestataire et que vous souhaitez le transférer chez OVHcloud, vous devez dans un premier temps créer et pré-configurer une zone DNS avant d'initier le transfert, afin d'éviter une interruption de services.
+Si votre domaine se trouve chez un autre prestataire et que vous souhaitez le transférer chez OVHcloud, vous devez dans un premier temps créer et préconfigurer une zone DNS avant d'initier le transfert, afin d'éviter une interruption de services.
 
 Lorsque votre hébergement est créé, connectez-vous à votre [espace client OVHcloud](/links/manager) puis créez une zone DNS pour votre nom de domaine **sans les « www »**. Vous pouvez vous aider de notre guide sur la [création d'une zone DNS chez OVHcloud](/pages/web_cloud/domains/dns_zone_create).
 
@@ -123,7 +123,7 @@ Pour récupérer la bonne adresse IP cible de votre hébergement OVHcloud, consu
 
 > [!success]
 >
-> Notez les deux valeurs cibles ayant pour type d'enregistrement « NS ». Ces valeurs, de type `dnsXX.ovh.net` et `nsXX.ovh.net` (ou `dns200.anycast.me` et `ns200.anycast.me`), correspondent aux serveurs DNS associés à cette zone DNS pour votre nom de domaine. Elles serviront lors de la [partie 9](#step9) de ce guide.
+> Notez les deux valeurs cibles ayant pour type d'enregistrement « NS ». Ces valeurs, de type `dnsXX.ovh.net` et `nsXX.ovh.net` (ou `dns200.anycast.me` et `ns200.anycast.me`), correspondent aux serveurs DNS associés à cette zone DNS pour votre nom de domaine. Elles serviront à la [partie 9](#step9) de ce guide.
 >
 
 ### 3 - Récupérer une sauvegarde complète de votre site web <a name="step3"></a>

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrare un sito Web e i servizi associati a OVHcloud"
 excerpt: "Scopri come migrare il tuo sito Web, il tuo dominio, il tuo database e le tue email in OVHcloud senza interruzione di servizi"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Obiettivo
@@ -27,7 +27,7 @@ Questa guida ti mostra le operazioni da effettuare per migrare in OVHcloud siti 
 
 ### Accesso allo Spazio Cliente OVHcloud
 
-- **Link diretto:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link diretto:** [Hosting](/links/control-panel/web-hosting)
 - **Percorso di navigazione:** `Web Cloud`{.action} > `Hosting`{.action} > Seleziona il tuo hosting web
 
 ---
@@ -40,27 +40,27 @@ Questa guida ti mostra le operazioni da effettuare per migrare in OVHcloud siti 
 > Le istruzioni di questa guida per utilizzare diversi prodotti dell'universo Web Cloud, ti consigliamo di seguire gli step riportati di seguito **prima** per effettuare la migrazione dei tuoi servizi.
 >
 
-Per migrare l’intero sito Web e le email in OVHcloud **senza interruzione del servizio** è necessario seguire una procedura precisa in 10 step:
+Per migrare l’intero sito Web e le email in OVHcloud **senza interruzione del servizio** è necessario seguire una procedura precisa in 10 parti:
 
-- [Step 1: ordina l'hosting e gli indirizzi email in OVHcloud](#step1)
-- [Step 2: creare e preconfigurare una zona DNS per il tuo dominio in OVHcloud](#step2)
-- [Step 3: recuperare un backup completo del tuo sito Web](#step3)
-- [Step 4: importare il backup del tuo sito Web sulla tua offerta di hosting OVHcloud](#step4)
-- [Step 5: creare i tuoi indirizzi email identici in OVHcloud](#step5)
-- [Step 6: dichiarare i server di posta OVHcloud nella zona DNS attiva del dominio](#step6)
-- [Step 7: trasferire il contenuto dei tuoi vecchi indirizzi email nei tuoi nuovi indirizzi presso OVHcloud](#step7)
-- [Step 8: riconfigurare i tuoi software di messaggeria](#step8)
-- [Step 9: sostituire i server DNS attivi del tuo dominio con quelli di OVHcloud](#step9)
-- [Step 10: trasferire il tuo dominio in OVHcloud](#step10)
+- [1 - Ordina l’hosting e gli indirizzi email in OVHcloud](#step1)
+- [2 - Creare e preconfigurare una zona DNS per il tuo dominio in OVHcloud](#step2)
+- [3 - Recuperare un backup completo del tuo sito Web](#step3)
+- [4 - Importare il backup del tuo sito Web sulla tua offerta di hosting OVHcloud](#step4)
+- [5 - Creare i tuoi indirizzi email identici in OVHcloud](#step5)
+- [6 - Dichiarare i server di posta OVHcloud nella zona DNS attiva del dominio](#step6)
+- [7 - Trasferire il contenuto dei tuoi vecchi indirizzi email nei tuoi nuovi indirizzi presso OVHcloud](#step7)
+- [8 - Riconfigurare i tuoi software di messaggeria](#step8)
+- [9 - Sostituire i server DNS attivi del tuo dominio con quelli di OVHcloud](#step9)
+- [10 - Trasferire il tuo dominio in OVHcloud](#step10)
 
-Seguendo questi 10 step **nell'ordine**, non avrai interruzioni di servizio per l'accesso al tuo sito Web e per la ricezione delle tue nuove email.
+Seguendo queste 10 parti **nell’ordine**, non avrai interruzioni di servizio per l'accesso al tuo sito Web e per la ricezione delle tue nuove email.
 
 Tuttavia, in base al tuo Registrar, provider di hosting o provider di servizi email, è possibile che questi ultimi impediscano l'accesso ai tuoi servizi precedenti nel caso in cui si accorgano che il tuo dominio non è più configurato tramite le loro infrastrutture.<br>
 In questo caso, potrebbe verificarsi un'interruzione del servizio.
 
 Se tale interruzione dovesse verificarsi, la guida deve essere costruita in modo da ridurne al minimo la durata.
 
-### Step 1: ordina l'hosting e gli indirizzi email in OVHcloud <a name="step1"></a>
+### 1 - Ordina l'hosting e gli indirizzi email in OVHcloud <a name="step1"></a>
 
 Diverse [offerte di hosting condiviso OVHcloud](/links/web/hosting) contengono un'offerta email "[MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)". Questa offerta email permette di creare indirizzi email con uno spazio di storage massimo di 5 GB per ogni indirizzo. Scegli tra le offerte di hosting qui sotto in base alla versione PHP, alla versione SQL, al numero di indirizzi email di cui hai bisogno e alla dimensione del tuo sito da migrare:
 
@@ -69,22 +69,33 @@ Diverse [offerte di hosting condiviso OVHcloud](/links/web/hosting) contengono u
 - Hosting [Performance](/links/web/hosting-performance-offer) con **1000 indirizzi email** "MX Plan". Questa offerta è disponibile in 4 "sottolivello".
 - L'hosting [Cloud Web](/links/web/hosting-cloud-web-offer) con **200 indirizzi email** "MX Plan". Questa offerta è utilizzata dagli sviluppatori di applicazioni.
 
-Una volta scelta la soluzione di hosting, se non sei ancora cliente OVHcloud, clicca su `Ordine`{.action} nelle precedenti pagine commerciali. Segui gli step dell'ordine **senza richiedere il trasferimento del tuo dominio** (questa operazione verrà eseguita nello step 10 di questa guida).
+Una volta scelta la soluzione di hosting, se non sei ancora cliente OVHcloud, clicca su `Ordine`{.action} nelle precedenti pagine commerciali. Segui gli step dell'ordine **senza richiedere il trasferimento del tuo dominio** (questa operazione verrà eseguita nella parte 10 di questa guida).
 
-oppure accedi allo [Spazio Cliente OVHcloud](/links/manager). Una volta effettuato l’accesso, segui queste istruzioni:
+Puoi anche effettuare l’ordine dallo Spazio Cliente OVHcloud. Per farlo, clicca sulle schede seguenti per visualizzare ciascuno dei **3** passaggi.
 
-- Accedi alla scheda `Web Cloud`{.action}.
-- In alto a sinistra dell’interfaccia, clicca sul pulsante `Ordinare`{.action} e poi su `Hosting`{.action}.
-- Prosegui con l’ordine **senza richiedere il trasferimento del tuo dominio** (operazione che verrà eseguita allo Step 10 di questa guida).
+> [!tabs]
+> **Passaggio 1**
+>>
+>> Accedi alla pagina [Hosting](/links/control-panel/web-hosting).
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Passaggio 2**
+>>
+>> In alto a sinistra dell’interfaccia, clicca sul pulsante `Ordina`{.action} e poi su `Hosting`{.action}.
+>>
+> **Passaggio 3**
+>>
+>> Prosegui con l’ordine **senza richiedere il trasferimento del tuo dominio** (operazione che verrà eseguita nella parte 10 di questa guida).
 
-Una volta confermato il pagamento, l'installazione dell'hosting verrà avviata. Riceverai un'email al tuo indirizzo email di contatto. che contiene le credenziali di accesso allo spazio di storage FTP (File Transfert Protocol) del tuo hosting Web.
+Una volta confermato il pagamento, l'installazione dell'hosting verrà avviata. Riceverai un'email al tuo indirizzo email di contatto. che contiene le credenziali di accesso allo spazio di storage FTP (File Transfer Protocol) del tuo hosting Web.
 
 > [!primary]
 >
 > OVHcloud propone altre offerte email in aggiunta al servizio "MX Plan". È possibile, ad esempio, combinare a degli indirizzi email "MX Plan" degli indirizzi ["Email-Pro"](/links/web/email-pro) e/o degli account ["Exchange"](/links/web/emails-hosted-exchange).
 >
 
-### Step 2: creare e preconfigurare una zona DNS per il tuo dominio presso OVHcloud <a name="step2"></a>
+### 2 - Creare e preconfigurare una zona DNS per il tuo dominio presso OVHcloud <a name="step2"></a>
 
 Se il dominio si trova presso un altro provider e vuoi trasferirlo in OVHcloud, è necessario creare e preconfigurare una zona DNS prima di avviare il trasferimento, per evitare un’interruzione del servizio.
 
@@ -112,16 +123,16 @@ Per recuperare l’indirizzo IP di destinazione corretto per il tuo hosting OVHc
 
 > [!success]
 >
-> Prendere nota dei due valori di destinazione con tipo di record "NS". Questi valori, di tipo `dnsXX.ovh.net` e `nsXX.ovh.net` (o `dns200.anycast.me` e `ns200.anycast.me`), corrispondono ai server DNS associati a questa zona DNS per il tuo dominio. e saranno utilizzati nello [step 9](#step9) di questa guida.
+> Prendere nota dei due valori di destinazione con tipo di record "NS". Questi valori, di tipo `dnsXX.ovh.net` e `nsXX.ovh.net` (o `dns200.anycast.me` e `ns200.anycast.me`), corrispondono ai server DNS associati a questa zona DNS per il tuo dominio. e saranno utilizzati nella [parte 9](#step9) di questa guida.
 >
 
-### Step 3: recuperare un backup completo del tuo sito Web <a name="step3"></a>
+### 3 - Recuperare un backup completo del tuo sito Web <a name="step3"></a>
 
 Recupera il contenuto dello spazio di storage FTP del tuo hosting corrente e un backup del tuo database se ne utilizza uno.
 
 Queste operazioni vengono eseguite esclusivamente presso il tuo hosting provider attuale. Contattaci se hai difficoltà a recuperare un backup completo del tuo sito Web.
 
-### Step 4: importare il backup del tuo sito Web sulla tua offerta di hosting OVHcloud <a name="step4"></a>
+### 4 - Importare il backup del tuo sito Web sulla tua offerta di hosting OVHcloud <a name="step4"></a>
 
 Per importare il backup dello spazio di storage FTP del tuo precedente provider, [accedi allo spazio di storage FTP del tuo hosting OVHcloud](/pages/web_cloud/web_hosting/ftp_connection) e trasferisci il backup nella cartella root "www" (o in un'altra cartella root creata precedentemente).
 
@@ -141,10 +152,10 @@ Sostituisci le informazioni di connessione del tuo database precedente con quell
 
 > [!success]
 >
-> Per collegare il tuo nuovo database se utilizzi un Content Management System (CMS) come WordPress, Joomla!, Drupal o PrestaShop, consulta le informazioni sui file di configurazione nello **Step 2** della guida ["Modificare la password di un database"](/pages/web_cloud/web_hosting/sql_change_password).
+> Per collegare il tuo nuovo database se utilizzi un Content Management System (CMS) come WordPress, Joomla!, Drupal o PrestaShop, consulta le informazioni sui file di configurazione nella **parte 2** della guida ["Modificare la password di un database"](/pages/web_cloud/web_hosting/sql_change_password).
 >
 
-Dichiarate/autorizzate il vostro nome di dominio esterno sull'ospedaggio web OVHcloud tramite la nostra guida "[gestione dei siti web di un ospedaggio web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Dichiarare correttamente il "nome" della cartella di root scelta all'inizio dello [step 4](#step4). Ti ricordiamo che questa è la cartella in cui hai inserito i tuoi file nel tuo spazio di storage FTP.
+Dichiarate/autorizzate il vostro nome di dominio esterno sull'ospedaggio web OVHcloud tramite la nostra guida "[gestione dei siti web di un ospedaggio web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Dichiarare correttamente il "nome" della cartella di root scelta all'inizio della [parte 4](#step4). Ti ricordiamo che questa è la cartella in cui hai inserito i tuoi file nel tuo spazio di storage FTP.
 
 > [!warning]
 >
@@ -165,7 +176,7 @@ Dichiarate/autorizzate il vostro nome di dominio esterno sull'ospedaggio web OVH
 
 Dopo la propagazione DNS, il sito che comparirà con il dominio sarà quello ospitato in OVHcloud.
 
-### Step 5: creare i tuoi indirizzi email allo stesso modo in OVHcloud <a name="step5"></a>
+### 5 - Creare i tuoi indirizzi email allo stesso modo in OVHcloud <a name="step5"></a>
 
 Ricevi allo stesso modo gli indirizzi email presenti presso il tuo provider tramite la nostra guida sulla [creazione di indirizzi email "MX Plan"](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
@@ -174,7 +185,7 @@ Se hai scelto una soluzione Email Pro o Exchange, consulta la nostra documentazi
 - Per [Email-Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 - Per [Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Step 6: dichiarare i server di posta OVHcloud nella zona DNS attiva del dominio <a name="step6"></a>
+### 6 - Dichiarare i server di posta OVHcloud nella zona DNS attiva del dominio <a name="step6"></a>
 
 Questo step consiste nel modificare i server di posta "MX" nella zona DNS attiva del tuo dominio.
 in modo da ricevere le nuove email sui nuovi indirizzi email OVHcloud.
@@ -192,7 +203,7 @@ Una volta terminata la propagazione, tutte le nuove email ricevute saranno ricev
 Ti consigliamo di modificare il record "MX" **prima** di effettuare la migrazione del contenuto dei tuoi vecchi indirizzi email.
 Questo metodo ti evita di effettuare una migrazione per le poche email ricevute sui tuoi vecchi indirizzi email durante la propagazione DNS.
 
-### Step 7: trasferire il contenuto dei tuoi vecchi indirizzi email nei tuoi nuovi indirizzi presso OVHcloud <a name="step7"></a>
+### 7 - Trasferire il contenuto dei tuoi vecchi indirizzi email nei tuoi nuovi indirizzi presso OVHcloud <a name="step7"></a>
 
 Dopo la propagazione DNS, tutte le nuove email vengono ricevute sui nuovi indirizzi email. Ma le tue email precedenti sono ancora salvate sul tuo server di posta precedente.
 
@@ -217,7 +228,7 @@ Effettua l'operazione su tutti i tuoi account email.
 
 **Opzione 2**: effettua un backup del contenuto dei tuoi indirizzi email con un client di posta (Outlook, Mail per Mac, ecc...), riconfigura il tuo client di posta e importa il backup nel tuo nuovo indirizzo email OVHcloud. Per maggiori informazioni consulta la nostra guida "[Migra manualmente il tuo indirizzo email](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)".
 
-### Step 8: riconfigurare il tuo client di posta <a name="step8"></a>
+### 8 - Riconfigurare il tuo client di posta <a name="step8"></a>
 
 Una volta migrati i vecchi indirizzi email in OVHcloud, è possibile riconfigurare i client di posta utilizzando tutte le nostre guide disponibili online.
 
@@ -233,9 +244,9 @@ Una volta migrati i vecchi indirizzi email in OVHcloud, è possibile riconfigura
 
 - Tutte le nostre guide all'aiuto alla configurazione sono disponibili nelle sezioni `Configurazione di Exchange sul computer` e `Configurazione di Exchange su smartphone` di [la nostra guida sull'offerta Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Step 9: sostituire i server DNS attivi del tuo dominio con quelli di OVHcloud <a name="step9"></a>
+### 9 - Sostituire i server DNS attivi del tuo dominio con quelli di OVHcloud <a name="step9"></a>
 
-La zona DNS preconfigurata nello [step 2](#step2) non è ancora stata applicata al dominio. Al momento il dominio utilizza ancora i server DNS del provider di origine.
+La zona DNS preconfigurata nella [parte 2](#step2) non è ancora stata applicata al dominio. Al momento il dominio utilizza ancora i server DNS del provider di origine.
 
 Sostituisci i server DNS correnti (del registrar di origine) con i due server DNS dichiarati nella zona DNS OVHcloud (di tipo `dnsXX.ovh.net` e `nsXX.ovh.net` o `dns200.anycast.me` e `ns200.anycast.me`). Questa operazione viene effettuata nell’interfaccia di gestione del registrar di origine.
 
@@ -244,7 +255,7 @@ Sostituisci i server DNS correnti (del registrar di origine) con i due server DN
 > La modifica dei server DNS deve essere effettuata dall'attuale Registrar del tuo dominio e richiede un tempo di **propagazione massimo da 24 a 48 ore** prima di essere pienamente efficace.
 >
 
-### Step 10: trasferire il tuo dominio in OVHcloud <a name="step10"></a>
+### 10 - Trasferire il tuo dominio in OVHcloud <a name="step10"></a>
 
 Una volta completata la propagazione DNS, verifica che l’intero sito Web sia operativo. Accedere al sito Web per verificare che tutte le pagine siano visualizzate correttamente e che non venga restituito alcun errore 404. Verifica anche l’invio e la ricezione delle email dai tuoi indirizzi email.
 
@@ -256,7 +267,7 @@ Una volta terminato il trasferimento dei tuoi dati e servizi, non ti resta che d
 
 ### Conclusione
 
-Dopo aver completato tutti e dieci gli step nell’ordine indicato, l’intero sito Web viene migrato in OVHcloud, senza interruzione del servizio.
+Dopo aver completato tutte le dieci parti nell’ordine indicato, l’intero sito Web viene migrato in OVHcloud, senza interruzione del servizio.
 
 ## Per saperne di più <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.it-it.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrare un sito Web e i servizi associati a OVHcloud"
 excerpt: "Scopri come migrare il tuo sito Web, il tuo dominio, il tuo database e le tue email in OVHcloud senza interruzione di servizi"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Obiettivo

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Przeniesienie strony WWW i powiązanych z nią usług do OVHcloud"
 excerpt: "Dowiedz się, jak migrować stronę WWW, nazwę domeny, bazę danych oraz konta e-mail do OVHcloud bez przerwy w dostępności usług"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Wprowadzenie

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.pl-pl.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Przeniesienie strony WWW i powiązanych z nią usług do OVHcloud"
 excerpt: "Dowiedz się, jak migrować stronę WWW, nazwę domeny, bazę danych oraz konta e-mail do OVHcloud bez przerwy w dostępności usług"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Wprowadzenie
@@ -27,7 +27,7 @@ Niniejszy przewodnik prezentuje różne działania, jakie należy przeprowadzić
 
 ### Dostęp do Panelu klienta OVHcloud
 
-- **Link bezpośredni:** [Hosting plans](/links/control-panel/web-hosting)
+- **Link bezpośredni:** [Hosting](/links/control-panel/web-hosting)
 - **Ścieżka nawigacji:** `Web Cloud`{.action} > `Hosting`{.action} > Wybierz hosting WWW
 
 ---
@@ -40,27 +40,27 @@ Niniejszy przewodnik prezentuje różne działania, jakie należy przeprowadzić
 > Instrukcje zawarte w tym przewodniku odnoszą się do kilku produktów z usług WWW Cloud. Zalecamy zapoznanie się z poniższymi krokami **przed**, aby rozpocząć migrację Twoich usług.
 >
 
-Przeniesienie całej strony WWW i kont e-mail do OVHcloud **bez przerwy w dostępie do usługi** wymaga zastosowania 10 konkretnych procedur:
+Przeniesienie całej strony WWW i kont e-mail do OVHcloud **bez przerwy w dostępie do usługi** wymaga zastosowania procedury w 10 części:
 
-- [Etap 1: zamów hosting i konta e-mail w OVHcloud](#step1)
-- [Etap 2: utworzyć i wstępnie skonfigurować strefę DNS dla Twojej domeny w OVHcloud](#step2)
-- [Etap 3: pobrać pełną kopię zapasową Twojej strony WWW](#step3)
-- [Etap 4: importować kopię zapasową Twojej strony WWW do Twojego hostingu OVHcloud](#step4)
-- [Etap 5: stwórz konta e-mail w serwisie OVHcloud](#step5)
-- [Etap 6: zadeklarować serwery e-mail OVHcloud w strefie DNS domeny](#step6)
-- [Etap 7: przeniesienie zawartości poprzednich kont e-mail na nowe konta OVHcloud](#step7)
-- [Etap 8: ponownie skonfiguruj oprogramowanie poczty elektronicznej](#step8)
-- [Etap 9: zastąpienie aktywnych serwerów DNS Twojej domeny serwerami OVHcloud](#step9)
-- [Etap 10: przenieść domenę do OVHcloud](#step10)
+- [1 - Zamów hosting i konta e-mail w OVHcloud](#step1)
+- [2 - Utworzyć i wstępnie skonfigurować strefę DNS dla Twojej domeny w OVHcloud](#step2)
+- [3 - Pobrać pełną kopię zapasową Twojej strony WWW](#step3)
+- [4 - Importować kopię zapasową Twojej strony WWW do Twojego hostingu OVHcloud](#step4)
+- [5 - Stwórz konta e-mail w serwisie OVHcloud](#step5)
+- [6 - Zadeklarować serwery e-mail OVHcloud w strefie DNS domeny](#step6)
+- [7 - Przeniesienie zawartości poprzednich kont e-mail na nowe konta OVHcloud](#step7)
+- [8 - Ponownie skonfiguruj oprogramowanie poczty elektronicznej](#step8)
+- [9 - Zastąpienie aktywnych serwerów DNS Twojej domeny serwerami OVHcloud](#step9)
+- [10 - Przenieść domenę do OVHcloud](#step10)
 
-Zgodnie z tymi 10 krokami **w kolejności**, nie będziesz miał przerwy w dostępie do Twojej strony WWW ani do otrzymywania nowych wiadomości e-mail.
+Zgodnie z tymi 10 częściami **w kolejności**, nie będziesz miał przerwy w dostępie do Twojej strony WWW ani do otrzymywania nowych wiadomości e-mail.
 
 W zależności od operatora, dostawcy hostingu lub dostawcy usług e-mail, możliwe jest jednak, że odcinają oni dostęp do Twoich starych usług, jeśli stwierdzą, że Twoja domena nie jest już skonfigurowana w ramach infrastruktury.<br>
 W takim przypadku może wystąpić przerwa w działaniu usługi.
 
 W przypadku wystąpienia takiej przerwy przewodnik ten jest tak skonstruowany, aby zminimalizować czas jej trwania.
 
-### Etap 1: zamów hosting i konta e-mail w OVHcloud <a name="step1"></a>
+### 1 - Zamów hosting i konta e-mail w OVHcloud <a name="step1"></a>
 
 Kilka [ofert hostingu OVHcloud](/links/web/hosting) zawiera ofertę e-mail "[MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)". Ta oferta e-mail pozwala na tworzenie kont e-mail z przestrzenią dyskową do 5 GB dla każdego konta. Wybierz spośród poniższych pakietów hostingowych w zależności od wersji PHP, wersji SQL, liczby kont e-mail, których potrzebujesz oraz rozmiaru Twojej strony, którą chcesz przenieść:
 
@@ -69,22 +69,33 @@ Kilka [ofert hostingu OVHcloud](/links/web/hosting) zawiera ofertę e-mail "[MX 
 - Hosting [Performance](/links/web/hosting-performance-offer) z **1000 adresów e-mail** "MX Plan". Oferta jest podzielona na 4 "podoferty".
 - Hosting [Cloud Web](/links/web/hosting-cloud-web-offer) z **200 adresów e-mail** "MX Plan". Ta oferta jest używana przez programistów aplikacji.
 
-Po wybraniu oferty hostingu, jeśli nie jesteś jeszcze klientem OVHcloud, kliknij przycisk `Zamów`{.action} na powyższych stronach handlowych. Postępuj zgodnie z kolejnymi poleceniami **bez konieczności przenoszenia domeny** (Operacja ta zostanie wykonana na etapie 10 niniejszego przewodnika).
+Po wybraniu oferty hostingu, jeśli nie jesteś jeszcze klientem OVHcloud, kliknij przycisk `Zamów`{.action} na powyższych stronach handlowych. Postępuj zgodnie z kolejnymi poleceniami **bez konieczności przenoszenia domeny** (Operacja ta zostanie wykonana w części 10 niniejszego przewodnika).
 
-Zamówienie możesz również złożyć w [Panelu klienta OVHcloud](/links/manager). Po zalogowaniu wykonaj następujące instrukcje:
+Zamówienie możesz również złożyć w Panelu klienta OVHcloud. W tym celu kliknij kolejno poniższe karty, aby wyświetlić każdy z **3** kroków.
 
-- Przejdź do zakładki `Web Cloud`{.action}.
-- W lewym górnym rogu interfejsu kliknij przycisk `Zamów`{.action}, a następnie `Hosting`{.action}.
-- Wykonaj kolejne kroki zamówienia **bez żądania transferu domeny** (operacja ta zostanie wykonana na etapie 10 niniejszego przewodnika).
+> [!tabs]
+> **Krok 1**
+>>
+>> Przejdź do strony [Hosting](/links/control-panel/web-hosting).
+>>
+>> ![Hosting](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Krok 2**
+>>
+>> W lewym górnym rogu interfejsu kliknij przycisk `Zamów`{.action}, a następnie `Hosting`{.action}.
+>>
+> **Krok 3**
+>>
+>> Wykonaj kolejne kroki zamówienia **bez żądania transferu domeny** (operacja ta zostanie wykonana w części 10 niniejszego przewodnika).
 
-Po zatwierdzeniu płatności rozpocznie się instalacja hostingu. Na adres e-mail do kontaktu zostanie wysłana wiadomość. Identyfikatory dostępu do przestrzeni dyskowej FTP (File Transfert Protocol) Twojego hostingu WWW.
+Po zatwierdzeniu płatności rozpocznie się instalacja hostingu. Na adres e-mail do kontaktu zostanie wysłana wiadomość. Identyfikatory dostępu do przestrzeni dyskowej FTP (File Transfer Protocol) Twojego hostingu WWW.
 
 > [!primary]
 >
 > OVHcloud poza ofertą "MX Plan" proponuje również inne usługi e-mail. Możesz na przykład połączyć konta e-mail "MX Plan" z adresami ["Email-Pro"](/links/web/email-pro) i/lub kontami ["Exchange"](/links/web/emails-hosted-exchange).
 >
 
-### Etap 2: utworzyć i wstępnie skonfigurować strefę DNS dla Twojej domeny w OVHcloud <a name="step2"></a>
+### 2 - Utworzyć i wstępnie skonfigurować strefę DNS dla Twojej domeny w OVHcloud <a name="step2"></a>
 
 Jeśli Twoja domena jest zarejestrowana u innego dostawcy i chcesz ją przenieść do OVHcloud, utwórz i skonfiguruj wstępnie strefę DNS przed rozpoczęciem transferu, aby uniknąć przerwy w dostępie do usług.
 
@@ -112,16 +123,16 @@ Aby dowiedzieć się, jaki adres IP jest odpowiedni dla Twojego hostingu OVHclou
 
 > [!success]
 >
-> Zanotuj dwie wartości docelowe z typem rekordu "NS". Wartości te, typu `dnsXX.ovh.net` i `nsXX.ovh.net` (lub `dns200.anycast.me` i `ns200.anycast.me`), odpowiadają serwerom DNS przypisanym do tej strefy DNS dla Twojej domeny. Zostaną one użyte w [etapie 9](#step9) niniejszego przewodnika.
+> Zanotuj dwie wartości docelowe z typem rekordu "NS". Wartości te, typu `dnsXX.ovh.net` i `nsXX.ovh.net` (lub `dns200.anycast.me` i `ns200.anycast.me`), odpowiadają serwerom DNS przypisanym do tej strefy DNS dla Twojej domeny. Zostaną one użyte w [części 9](#step9) niniejszego przewodnika.
 >
 
-### Etap 3: pobrać pełną kopię zapasową Twojej strony WWW <a name="step3"></a>
+### 3 - Pobrać pełną kopię zapasową Twojej strony WWW <a name="step3"></a>
 
 Pobierz zawartość przestrzeni dyskowej FTP Twojego aktualnego hostingu, a także kopię zapasową bazy danych, jeśli Twoja strona WWW używa bazy.
 
 Operacje te wykonywane są wyłącznie na dotychczasowym hostingu. Skontaktuj się z nim, jeśli masz trudności z pobraniem pełnej kopii zapasowej Twojej strony WWW.
 
-### Etap 4: zaimportować kopię zapasową Twojej strony WWW do hostingu OVHcloud <a name="step4"></a>
+### 4 - Zaimportować kopię zapasową Twojej strony WWW do hostingu OVHcloud <a name="step4"></a>
 
 Aby zaimportować kopię zapasową przestrzeni dyskowej FTP poprzedniego dostawcy, [zaloguj się do przestrzeni FTP Twojego hostingu OVHcloud](/pages/web_cloud/web_hosting/ftp_connection) i przesłać kopię zapasową do katalogu głównego "www" (lub innego katalogu głównego, który wcześniej utworzyłeś).
 
@@ -141,10 +152,10 @@ W tym celu zastąp dane do logowania do starej bazy danych informacjami pochodz�
 
 > [!success]
 >
-> Aby połączyć nową bazę danych, jeśli korzystasz z Content Management System (CMS), takiego jak WordPress, Joomla!, Drupal lub PrestaShop, znajdziesz informacje dotyczące plików konfiguracyjnych w pliku konfiguracyjnym w **etap 4** w przewodniku ["zmiana hasła do bazy danych"](/pages/web_cloud/web_hosting/sql_change_password).
+> Aby połączyć nową bazę danych, jeśli korzystasz z Content Management System (CMS), takiego jak WordPress, Joomla!, Drupal lub PrestaShop, znajdziesz informacje dotyczące plików konfiguracyjnych w pliku konfiguracyjnym w **część 4** w przewodniku ["zmiana hasła do bazy danych"](/pages/web_cloud/web_hosting/sql_change_password).
 >
 
-Deklaruj/autoryzuj swoje zewnętrzne nazwy domeny na swoim OVHcloud Hosting Web za pomocą naszego przewodnika "[konfiguracja wielu witryn na OVHcloud Hosting Web](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Proszę podać nazwę katalogu głównego wybranego na początku [etap 4](#step4). Przypominamy, że jest to folder, w którym umieściłeś pliki na przestrzeni FTP.
+Deklaruj/autoryzuj swoje zewnętrzne nazwy domeny na swoim OVHcloud Hosting Web za pomocą naszego przewodnika "[konfiguracja wielu witryn na OVHcloud Hosting Web](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Proszę podać nazwę katalogu głównego wybranego na początku [część 4](#step4). Przypominamy, że jest to folder, w którym umieściłeś pliki na przestrzeni FTP.
 
 > [!warning]
 >
@@ -165,7 +176,7 @@ Deklaruj/autoryzuj swoje zewnętrzne nazwy domeny na swoim OVHcloud Hosting Web 
 
 Po propagacji DNS stroną, która będzie się wyświetlać z Twoją domeną, będzie strona zainstalowana w OVHcloud.
 
-### Etap 5: stwórz konta e-mail w identyczny sposób w OVHcloud <a name="step5"></a>
+### 5 - Stwórz konta e-mail w identyczny sposób w OVHcloud <a name="step5"></a>
 
 Skorzystaj z naszego przewodnika dotyczącego [tworzenia kont e-mail "MX Plan"](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation) i przypisz do konta e-mail hostowane u Twojego dostawcy.
 
@@ -174,7 +185,7 @@ Jeśli wybrałeś rozwiązanie "Email Pro" lub "Exchange", zapoznaj się z nasz�
 - Dla [Email-Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 - W przypadku [Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Etap 6: zadeklarować serwery e-mail OVHcloud w strefie DNS domeny <a name="step6"></a>
+### 6 - Zadeklarować serwery e-mail OVHcloud w strefie DNS domeny <a name="step6"></a>
 
 Etap ten polega na zmianie serwerów e-mail "MX" w strefie DNS domeny.
 W rezultacie otrzymasz nowe e-maile z nowych adresów e-mail OVHcloud.
@@ -192,7 +203,7 @@ Po zakończeniu propagacji wszystkie nowe e-maile zostaną odebrane na Twoje kon
 Rekomendujemy zmianę wpisów "MX" **przed** rozpoczęciem migracji zawartości Twoich starych adresów e-mail.
 Dzięki tej metodzie unikasz ponownej migracji niektórych e-maili otrzymanych na poprzednich kontach e-mail podczas propagacji DNS.
 
-### Etap 7: przenieść zawartość poprzednich kont e-mail do nowych adresów e-mail OVHcloud <a name="step7"></a>
+### 7 - Przenieść zawartość poprzednich kont e-mail do nowych adresów e-mail OVHcloud <a name="step7"></a>
 
 Po propagacji DNS nowe e-maile są odtąd odbierane na nowe adresy e-mail. Ale Twoje stare e-maile są nadal przechowywane na starym serwerze e-mail.
 
@@ -217,7 +228,7 @@ Powtórz operację dla wszystkich Twoich kont e-mail.
 
 **Wariant 2**: wykonaj kopię zapasową zawartości Twoich kont e-mail przy użyciu programu pocztowego (Outlook, Mail dla Mac,...), ponownie skonfiguruj program pocztowy i zaimportuj kopię zapasową na nowy adres e-mail OVHcloud. Więcej informacji znajdziesz w naszym przewodniku "[Ręczna migracja Twojego konta e-mail](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)".
 
-### Etap 8: konfiguruj ponownie programy pocztowe <a name="step8"></a>
+### 8 - Konfiguruj ponownie programy pocztowe <a name="step8"></a>
 
 Po zakończeniu migracji Twoich poprzednich kont e-mail do OVHcloud możesz ponownie skonfigurować Twoje oprogramowanie poczty elektronicznej, korzystając ze wszystkich naszych przewodników.
 
@@ -233,9 +244,9 @@ Po zakończeniu migracji Twoich poprzednich kont e-mail do OVHcloud możesz pono
 
 - Wszystkie nasze przewodniki dotyczące konfiguracji znajdują się w sekcjach `Konfiguracja Exchange na komputerze` oraz `Konfiguracja Exchange na smartphonie` [dokumentacja dotycząca oferty Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Etap 9: zastąpienie aktywnych serwerów DNS Twojej domeny serwerami OVHcloud <a name="step9"></a>
+### 9 - Zastąpienie aktywnych serwerów DNS Twojej domeny serwerami OVHcloud <a name="step9"></a>
 
-Strefa DNS wstępnie skonfigurowana w trakcie [etapu 2](#step2) nie jest jeszcze zastosowana dla Twojej domeny. Aktualnie Twoja domena nadal używa serwerów DNS Twojego operatora.
+Strefa DNS wstępnie skonfigurowana w trakcie [części 2](#step2) nie jest jeszcze zastosowana dla Twojej domeny. Aktualnie Twoja domena nadal używa serwerów DNS Twojego operatora.
 
 Zastąp aktualne serwery DNS (operatora) dwoma serwerami DNS zadeklarowanymi w strefie DNS OVHcloud (typu `dnsXX.ovh.net` i `nsXX.ovh.net` lub `dns200.anycast.me` i `ns200.anycast.me`). Operacja ta jest wykonywana w interfejsie zarządzania rejestratora.
 
@@ -244,7 +255,7 @@ Zastąp aktualne serwery DNS (operatora) dwoma serwerami DNS zadeklarowanymi w s
 > Zmiana serwerów DNS musi zostać wykonana z aktualnego operatora domeny. Czas **propagacji wynosi od 24 do 48 godzin**, zanim zostanie w pełni wykonana.
 >
 
-### Etap 10: przenieść domenę do OVHcloud <a name="step10"></a>
+### 10 - Przenieść domenę do OVHcloud <a name="step10"></a>
 
 Po zakończeniu propagacji DNS sprawdź, czy cała Twoja strona WWW działa poprawnie. Przeglądaj swoją stronę internetową, aby upewnić się, że wszystkie strony wyświetlają się poprawnie i nie są zwracane błędy 404. Sprawdź również, czy wysyłasz i odbierasz wiadomości e-mail z Twoich adresów e-mail.
 
@@ -256,7 +267,7 @@ Po zakończeniu transferu danych i usług zrezygnuj ze starych usług u poprzedn
 
 ### Zakończenie
 
-Po wykonaniu 10 kroków w tej kolejności cała Twoja strona WWW zostanie przeniesiona do OVHcloud, bez przerwy w dostępie do usług.
+Po wykonaniu 10 części w tej kolejności cała Twoja strona WWW zostanie przeniesiona do OVHcloud, bez przerwy w dostępie do usług.
 
 ## Sprawdź również <a name="go-further"></a>
 

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrar o seu website e os seus serviços associados para a OVHcloud"
 excerpt: "Descubra como migrar o seu website, o seu nome de domínio, a sua base de dados e os seus e-mails para a OVHcloud sem interrupção de serviços"
-updated: 2026-03-26
+updated: 2026-03-31
 ---
 
 ## Objetivo

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.pt-pt.md
@@ -152,7 +152,7 @@ Para isso, substitua as informações de ligação da sua antiga base de dados p
 
 > [!success]
 >
-> Para ligar a sua nova base de dados se utiliza um Content Management System (CMS) como WordPress, Joomla!, Drupal ou PrestaShop, encontre as informações sobre os seus ficheiros de configuração a partir do **parte 2** do guia "[modificação da palavra-passe de uma base de dados](/pages/web_cloud/web_hosting/sql_change_password)".
+> Para ligar a sua nova base de dados se utiliza um Content Management System (CMS) como WordPress, Joomla!, Drupal ou PrestaShop, encontre as informações sobre os seus ficheiros de configuração a partir da **parte 2** do guia "[modificação da palavra-passe de uma base de dados](/pages/web_cloud/web_hosting/sql_change_password)".
 >
 
 Declare/autorize o seu nome de domínio externo no seu alojamento web OVHcloud através do nosso guia "[gestão dos websites de um alojamento web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Declare o "nome" da pasta raiz que escolheu no início da [parte 4](#step4). Relembramos que esta é a pasta na qual colocou os seus ficheiros no seu espaço de armazenamento FTP.

--- a/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.pt-pt.md
+++ b/pages/web_cloud/web_hosting/hosting_migrating_to_ovh/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Migrar o seu website e os seus serviços associados para a OVHcloud"
 excerpt: "Descubra como migrar o seu website, o seu nome de domínio, a sua base de dados e os seus e-mails para a OVHcloud sem interrupção de serviços"
-updated: 2025-10-28
+updated: 2026-03-26
 ---
 
 ## Objetivo
@@ -27,7 +27,7 @@ Este guia apresenta-lhe as diferentes ações a realizar para migrar o conjunto 
 
 ### Acesso à Área de Cliente OVHcloud
 
-- **Ligação direta:** [Hosting plans](/links/control-panel/web-hosting)
+- **Ligação direta:** [Alojamentos](/links/control-panel/web-hosting)
 - **Caminho de navegação:** `Web Cloud`{.action} > `Alojamentos`{.action} > Selecione o seu alojamento web
 
 ---
@@ -40,27 +40,27 @@ Este guia apresenta-lhe as diferentes ações a realizar para migrar o conjunto 
 > As instruções deste guia referem-se a vários produtos do universo Web Cloud, recomendamos que leia todos os passos em baixo **antes** de começar a migração dos seus serviços.
 >
 
-A migração do site e dos e-mails para a OVHcloud **sem interrupção do serviço** requer um procedimento preciso em 10 etapas:
+A migração do site e dos e-mails para a OVHcloud **sem interrupção do serviço** requer um procedimento preciso em 10 partes:
 
-- [Etapa 1: encomendar o alojamento e os endereços de e-mail na OVHcloud](#step1)
-- [Etapa 2: criar e pré-configurar uma zona DNS para o seu domínio na OVHcloud](#step2)
-- [Etapa 3: recuperar um backup completo do seu website](#step3)
-- [Etapa 4: importar o backup do seu website para a sua oferta de alojamento OVHcloud](#step4)
-- [Etapa 5: recriar os seus endereços de e-mail para a OVHcloud](#step5)
-- [Etapa 6: declarar os servidores de e-mail OVHcloud na zona DNS ativa do seu domínio](#step6)
-- [Etapa 7: transferir o conteúdo dos endereços de e-mail antigos para os novos endereços na OVHcloud](#step7)
-- [Etapa 8: reconfigurar o software de e-mail](#step8)
-- [Etapa 9: substituir os servidores DNS ativos do seu domínio pelos da OVHcloud](#step9)
-- [Etapa 10: transferir o domínio para a OVHcloud](#step10)
+- [1 - Encomendar o alojamento e os endereços de e-mail na OVHcloud](#step1)
+- [2 - Criar e pré-configurar uma zona DNS para o seu domínio na OVHcloud](#step2)
+- [3 - Recuperar um backup completo do seu website](#step3)
+- [4 - Importar o backup do seu website para a sua oferta de alojamento OVHcloud](#step4)
+- [5 - Recriar os seus endereços de e-mail para a OVHcloud](#step5)
+- [6 - Declarar os servidores de e-mail OVHcloud na zona DNS ativa do seu domínio](#step6)
+- [7 - Transferir o conteúdo dos endereços de e-mail antigos para os novos endereços na OVHcloud](#step7)
+- [8 - Reconfigurar o software de e-mail](#step8)
+- [9 - Substituir os servidores DNS ativos do seu domínio pelos da OVHcloud](#step9)
+- [10 - Transferir o domínio para a OVHcloud](#step10)
 
-Ao seguir estes 10 Etapas **por ordem**, não terá nenhuma interrupção do serviço para aceder ao seu website e receber os seus novos e-mails.
+Ao seguir estas 10 partes **por ordem**, não terá nenhuma interrupção do serviço para aceder ao seu website e receber os seus novos e-mails.
 
 No entanto, dependendo do seu agente de registo, do seu fornecedor de alojamento ou do seu prestador de serviços de e-mail, é possível que estes últimos cortem o acesso aos seus antigos serviços se verificarem que o seu nome de domínio já não está configurado através das suas infraestruturas.<br>
 Neste caso, pode ocorrer uma interrupção do serviço.
 
 Se tal interrupção ocorrer, este guia será construído de forma a minimizar a sua duração.
 
-### Etapa 1: encomendar o alojamento e os endereços de e-mail na OVHcloud <a name="step1"></a>
+### 1 - Encomendar o alojamento e os endereços de e-mail na OVHcloud <a name="step1"></a>
 
 Várias ofertas de [alojamento partilhado OVHcloud](/links/web/hosting) incluem uma oferta de e-mail "[MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)". Esta oferta de e-mail permite criar endereços de e-mail com um espaço de armazenamento de 5 GB no máximo para cada endereço. Escolha a seguir as ofertas de alojamento em função da versão PHP, da versão SQL, do número de endereços de e-mail que precisa e do tamanho do seu site a migrar:
 
@@ -69,13 +69,24 @@ Várias ofertas de [alojamento partilhado OVHcloud](/links/web/hosting) incluem 
 - O alojamento [Performance](/links/web/hosting-performance-offer) com **1000 endereços de e-mail** "MX Plan". Esta oferta é indicada em 4 "subofertas".
 - O alojamento [Cloud Web](/links/web/hosting-cloud-web-offer) com **200 endereços de e-mail** "MX Plan". Esta oferta é utilizada pelos programadores de aplicações.
 
-Depois de escolher a oferta de alojamento, se ainda não é cliente da OVHcloud, clique no botão `Encomendar`{.action} presente nas páginas comerciais acima. Siga os passos da encomenda **sem solicitar a transferência do seu nome de domínio** (esta ação será realizada na etapa 10 deste manual).
+Depois de escolher a oferta de alojamento, se ainda não é cliente da OVHcloud, clique no botão `Encomendar`{.action} presente nas páginas comerciais acima. Siga os passos da encomenda **sem solicitar a transferência do seu nome de domínio** (esta ação será realizada na parte 10 deste manual).
 
-Também pode efetuar a encomenda a partir da sua [Área de Cliente OVHcloud](/links/manager). Uma vez ligado, siga as instruções seguintes:
+Também pode efetuar a encomenda a partir da sua Área de Cliente OVHcloud. Para isso, clique nos separadores abaixo para visualizar cada uma das **3** etapas.
 
-- Aceda ao separador `Web Cloud`{.action}.
-- No canto superior esquerdo da interface, clique no botão `Encomendar`{.action} e, a seguir, em `Alojamento`{.action}.
-- Prossiga com a encomenda **sem solicitar a transferência do domínio** (a transferência será efetuada na etapa 10 deste manual).
+> [!tabs]
+> **Etapa 1**
+>>
+>> Aceda à página [Alojamentos](/links/control-panel/web-hosting).
+>>
+>> ![Alojamentos](/pages/assets/screens/control_panel/product-selection/web-cloud/hosting-plans.png){.thumbnail}
+>>
+> **Etapa 2**
+>>
+>> No canto superior esquerdo da interface, clique no botão `Encomendar`{.action} e, a seguir, em `Alojamentos`{.action}.
+>>
+> **Etapa 3**
+>>
+>> Prossiga com a encomenda **sem solicitar a transferência do domínio** (a transferência será efetuada na parte 10 deste manual).
 
 Depois de validar o pagamento, a instalação do alojamento vai iniciar. Um e-mail será enviado para o seu endereço de e-mail de contacto. Este último conterá as credenciais de acesso ao espaço de armazenamento FTP (File Transfer Protocol) do seu alojamento Web.
 
@@ -84,7 +95,7 @@ Depois de validar o pagamento, a instalação do alojamento vai iniciar. Um e-ma
 > A OVHcloud oferece outras ofertas de e-mail para além da oferta "MX Plan". Por exemplo, pode combinar endereços de e-mail "MX Plan" de endereços ["Email-Pro"](/links/web/email-pro) e/ou contas ["Exchange"](/links/web/emails-hosted-exchange).
 >
 
-### Etapa 2 : criar e pré-configurar uma zona DNS para o seu domínio na OVHcloud <a name="step2"></a>
+### 2 - Criar e pré-configurar uma zona DNS para o seu domínio na OVHcloud <a name="step2"></a>
 
 Se o seu domínio se encontrar noutro prestador e pretender transferi-lo para a OVHcloud, deve num primeiro tempo criar e pré-configurar uma zona DNS antes de iniciar a transferência, a fim de evitar uma interrupção de serviços.
 
@@ -112,16 +123,16 @@ Para obter o endereço IP certo de destino do seu alojamento OVHcloud, consulte 
 
 > [!success]
 >
-> Anote os dois valores alvo que têm como tipo de registo "NS". Estes valores, do tipo `dnsXX.ovh.net` e `nsXX.ovh.net` (ou `dns200.anycast.me` e `ns200.anycast.me`), correspondem aos servidores DNS associados a esta zona DNS para o seu domínio. Estas instruções serão utilizadas na [etapa 9](#step9) deste manual.
+> Anote os dois valores alvo que têm como tipo de registo "NS". Estes valores, do tipo `dnsXX.ovh.net` e `nsXX.ovh.net` (ou `dns200.anycast.me` e `ns200.anycast.me`), correspondem aos servidores DNS associados a esta zona DNS para o seu domínio. Estas instruções serão utilizadas na [parte 9](#step9) deste manual.
 >
 
-### Etapa 3 : recuperar um backup completo do seu website <a name="step3"></a>
+### 3 - Recuperar um backup completo do seu website <a name="step3"></a>
 
 Obtenha o conteúdo do espaço de armazenamento FTP do seu alojamento atual, assim como um backup da sua base de dados caso o seu site utilize um.
 
 Estas operações são realizadas exclusivamente junto do seu alojador atual. Contacte-o se tiver dificuldades em recuperar um backup completo do seu website.
 
-#### Etapa 4 : importar o backup do seu website para a sua oferta de alojamento OVHcloud <a name="step4"></a>
+### 4 - Importar o backup do seu website para a sua oferta de alojamento OVHcloud <a name="step4"></a>
 
 Para importar o backup do espaço de armazenamento FTP do antigo fornecedor, [aceda ao espaço de armazenamento FTP do seu alojamento OVHcloud](/pages/web_cloud/web_hosting/ftp_connection) e elimine o backup da pasta raiz "www" (ou de outra pasta raiz que tenha criado).
 
@@ -141,10 +152,10 @@ Para isso, substitua as informações de ligação da sua antiga base de dados p
 
 > [!success]
 >
-> Para ligar a sua nova base de dados se utiliza um Content Management System (CMS) como WordPress, Joomla!, Drupal ou PrestaShop, encontre as informações sobre os seus ficheiros de configuração a partir do **etapa 2** do guia "[modificação da palavra-passe de uma base de dados](/pages/web_cloud/web_hosting/sql_change_password)".
+> Para ligar a sua nova base de dados se utiliza um Content Management System (CMS) como WordPress, Joomla!, Drupal ou PrestaShop, encontre as informações sobre os seus ficheiros de configuração a partir do **parte 2** do guia "[modificação da palavra-passe de uma base de dados](/pages/web_cloud/web_hosting/sql_change_password)".
 >
 
-Declare/autorize o seu nome de domínio externo no seu alojamento web OVHcloud através do nosso guia "[gestão dos websites de um alojamento web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Declare o "nome" da pasta raiz que escolheu no início da [etapa 4](#step4). Relembramos que esta é a pasta na qual colocou os seus ficheiros no seu espaço de armazenamento FTP.
+Declare/autorize o seu nome de domínio externo no seu alojamento web OVHcloud através do nosso guia "[gestão dos websites de um alojamento web OVHcloud](/pages/web_cloud/web_hosting/multisites_configure_multisite)". Declare o "nome" da pasta raiz que escolheu no início da [parte 4](#step4). Relembramos que esta é a pasta na qual colocou os seus ficheiros no seu espaço de armazenamento FTP.
 
 > [!warning]
 >
@@ -165,7 +176,7 @@ Declare/autorize o seu nome de domínio externo no seu alojamento web OVHcloud a
 
 Após a propagação DNS, o site que irá aparecer com o seu domínio será o alojado na OVHcloud.
 
-### Etapa 5 : recriar os seus endereços de e-mail para os mesmos na OVHcloud <a name="step5"></a>
+### 5 - Recriar os seus endereços de e-mail para os mesmos na OVHcloud <a name="step5"></a>
 
 Recrie de forma idêntica os endereços de e-mail presentes no seu fornecedor de e-mail através do nosso guia sobre a [criação de endereços de e-mail "MX Plan"](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_creation).
 
@@ -174,7 +185,7 @@ Se optou por uma solução "Email Pro" ou "Exchange", consulte o nosso manual pa
 - Para [Email-Pro](/pages/web_cloud/email_and_collaborative_solutions/email_pro/first_config)
 - Para [Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted)
 
-### Etapa 6 : declarar os servidores de e-mail OVHcloud na zona DNS ativa do seu nome de domínio <a name="step6"></a>
+### 6 - Declarar os servidores de e-mail OVHcloud na zona DNS ativa do seu nome de domínio <a name="step6"></a>
 
 Esta etapa consiste em efetuar a alteração dos servidores de e-mail "MX" na zona DNS ativa do seu domínio.
 Isto irá permitir que receba novos e-mails nos novos endereços de e-mail da OVHcloud.
@@ -192,7 +203,7 @@ Depois de finalizar a propagação, todos os novos e-mails recebidos serão rece
 Recomendamos que altere as entradas "MX" **antes** de efetuar a migração do conteúdo dos seus antigos endereços de e-mail.
 Este método permite evitar uma migração adicional para os poucos e-mails recebidos nos endereços de e-mail antigos durante a propagação do DNS.
 
-### Etapa 7 : transferir o conteúdo dos endereços de e-mail antigos para os novos endereços OVHcloud <a name="step7"></a>
+### 7 - Transferir o conteúdo dos endereços de e-mail antigos para os novos endereços OVHcloud <a name="step7"></a>
 
 Após a propagação DNS, os seus novos e-mails são agora todos recebidos nos seus novos endereços de e-mail. Mas os e-mails antigos ainda estão a ser guardados no servidor de e-mail antigo.
 
@@ -217,7 +228,7 @@ Repita a operação para o conjunto das suas contas de e-mail.
 
 **Opção 2**: faça um backup do conteúdo dos seus endereços de e-mail com a ajuda de um software de mensagens (Outlook, Mail para Mac,...), reconfigure o seu software de e-mail e depois importe o backup para o seu novo endereço de e-mail OVHcloud. Para mais informações, consulte o nosso guia "[Migrar manualmente o seu endereço de e-mail](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)".
 
-### Etapa 8 : reconfigurar os seus softwares de e-mail <a name="step8"></a>
+### 8 - Reconfigurar os seus softwares de e-mail <a name="step8"></a>
 
 Depois de migrar os seus antigos endereços de e-mail para a OVHcloud, reconfigure os seus softwares de e-mail com a ajuda de todos os nossos guias sobre o assumpto.
 
@@ -233,9 +244,9 @@ Depois de migrar os seus antigos endereços de e-mail para a OVHcloud, reconfigu
 
 - Encontre os nossos guias de ajuda à configuração nas secções `Configuration Exchange no computador` e `Configuration Exchange no smartphone` de [a nossa documentação sobre a oferta Exchange](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
 
-### Etapa 9: substituir os servidores DNS ativos do seu domínio pelos da OVHcloud <a name="step9"></a>
+### 9 - Substituir os servidores DNS ativos do seu domínio pelos da OVHcloud <a name="step9"></a>
 
-A zona DNS pré-configurada durante a [etapa 2](#step2) não é ainda aplicada ao seu domínio. Atualmente, o seu domínio utiliza sempre os servidores DNS do seu fornecedor de origem.
+A zona DNS pré-configurada durante a [parte 2](#step2) não é ainda aplicada ao seu domínio. Atualmente, o seu domínio utiliza sempre os servidores DNS do seu fornecedor de origem.
 
 Substitua os servidores DNS atuais (do registar de origem) pelos dois servidores DNS declarados na zona DNS da OVHcloud (de tipo `dnsXX.ovh.net` e `nsXX.ovh.net` ou `dns200.anycast.me` e `ns200.anycast.me`). Esta operação faz-se na interface de gestão do registar de origem.
 
@@ -244,7 +255,7 @@ Substitua os servidores DNS atuais (do registar de origem) pelos dois servidores
 > A alteração dos servidores DNS deve ser efetuada a partir do agente de registo atual do seu nome de domínio e requer um tempo de **propagação de 24 a 48 horas**, no máximo, antes de ficar totalmente efetivo.
 >
 
-### Etapa 10 : transferir o domínio para a OVHcloud <a name="step10"></a>
+### 10 - Transferir o domínio para a OVHcloud <a name="step10"></a>
 
 Uma vez a propagação DNS terminada, verifique que o conjunto do seu website está funcional. Navegue no seu site para verificar se todas as páginas são apresentadas corretamente e se não foi reenviado nenhum erro 404. Verifique também o envio e a receção dos e-mails a partir dos seus endereços de e-mail.
 
@@ -256,7 +267,7 @@ Uma vez concluída a transferência dos seus dados e serviços, só precisa de r
 
 ### Conclusão
 
-Após ter seguido as dez etapas em ordem, todo o seu website é agora migrado para a OVHcloud, tudo sem interrupção de serviço.
+Após ter seguido as dez partes em ordem, todo o seu website é agora migrado para a OVHcloud, tudo sem interrupção de serviço.
 
 ## Quer saber mais? <a name="go-further"></a>
 


### PR DESCRIPTION
Need proof by @benchbzh for FRFR

Etat des lieux pour FRFR (inclue des guides non modifiés car déjà conformes aux attentes): 

| # | Guide | Action | Détail |
|---|-------|--------|--------|
| 1 | activate-email-hosting | ✅ Conforme | — |
| 2 | activate_start10m | ✅ Conforme | — |
| 3 | backup_ftp_cloud_web | Modifié | Parcours CP → tabs 5 étapes, `<br>` supprimé |
| 4 | cdn_statistics_and_logs | ✅ Conforme | — |
| 5 | clusters_and_shared_hosting_IP | ✅ Conforme | — |
| 6 | cms-update-password-admin | Modifié | Parcours phpMyAdmin → tabs 4 étapes |
| 7 | cms_manual_installation | CP-NAV supprimé | Headings renommés, parcours → renvoi guide, pas de parcours CP |
| 8 | configure_ipv6 | ✅ Conforme | — |
| 9 | copy_database | Modifié | Fusion 2 sections → 2 `/// details` × 6 étapes, 4 `/// details` cas d'usage, `<style>` |
| 10 | cron_tasks | Modifié | Parcours CP → tabs 5 étapes, headings renommés, 2023→2026 |
| 11 | diagnosis_database_errors | Modifié | 4 `/// details` infos CP, 6 tabs, `<style>`, proofread fixes |
| 12 | diagnostic-not-secured | Modifié | Tabs 2 étapes, tableau → 6 `/// details`, `<style>`, headings |
| 13 | diagnostic-website-not-accessible | Modifié | Tabs billing 3 étapes, lien domains, scénarios DNS → 3 `/// details` + tabs 4 étapes, `<style>`, headings |
| 14 | diagnostic_403_forbidden | CP-NAV supprimé | Headings renommés, pas de parcours CP |
| 15 | diagnostic_fix_500_internal_server_error | CP-NAV supprimé | Pas de parcours CP |
| 16 | diagnostic_slownesses | CP-NAV supprimé | Pas de parcours CP |
| 17 | enable_sftp | ✅ Conforme | — |
| 18 | ftp_change_password | Modifié | Tabs dans 2 `/// details` (Perso/Pro) × 3 étapes, `<style>` |
| 19 | ftp_connection | Modifié | Step 4 ajoutée (infos FTP/SSH) |
| 20 | ftp_filezilla_user_guide | Modifié | Parcours CP → tabs 3 étapes, SFTP → renvoi guide |
| 21 | ftp_manage_users | ✅ Conforme | — |
| 22 | ftp_recurring_ftp_problems | Modifié | Parcours SFTP → renvoi guide |
| 23 | getting_started_cloud_web | Modifié | 10 headings, 4 tabs (moteurs, vCores, variables, multisite, modules), DNS → lien |
| 24 | handle_sftp_connexion_vscode | Modifié | Parcours → renvoi guide FTP, 4 tabs (name, host, username, remotePath) |
| 25 | hosting_migrating_to_ovh | Modifié | 10 headings, parcours commande → tabs 3 étapes, `l'étape` → `la partie` |
