### PR TITLE
[Audit] - WEB - Emails - all offers - update wave 2 

### DIFF
--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: 'E-Mail Alias und Weiterleitung verwenden'
 excerpt: 'Erfahren Sie hier, wie Sie E-Mail Aliase und Weiterleitungen verwalten'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: 'Using email aliases and redirections'
 excerpt: 'Find out how to manage aliases and email redirections'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>
@@ -90,52 +90,12 @@ Click on the tabs below for an illustrated explanation of how aliases and redire
 **Contents**
 
 - [Create a redirection](#redirect)
-    - [Via the Control Panel](#redirect-manager)
     - [Via webmail](#redirect-webmail)
 - [Delete a redirection](#redirect-delete)
 - [Create an alias](#alias)
 - [Delete an alias](#alias-delete)
 
 ### Creating a redirection <a name="redirect"></a>
-
-#### Via the OVH Control Panel <a name="redirect-manager"></a>
-
-Currently, only the **MX Plan** and **Redirect** plans have a redirection management interface via the OVHcloud Control Panel.
-
-##### MX Plan / redirect <a name="redirect-manager-mxplan"></a>
-
-From your MX Plan service, select the domain concerned.
-
-In our example, this is a **redirection with a local copy** (see [diagram 2](#diagram) at the beginning of this guide). If this is what you need, follow the steps below:
-
-By default, you are in the `General information`{.action} tab of your MX Plan. Click on the `Emails`{.action} tab, then on the right-hand side on the `Manage redirections`{.action} button.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-The table of redirections that are already active appears. On the right, click `Add a redirection`{.action}.
-
-![emails](images/mxplan-legacy-2.png){.thumbnail .w-640}
-
-In the form `Create a redirection`, enter the following information:
-
-- **From address**: Enter the email address you would like to redirect.
-- **To the address**: Enter the destination address for your redirection here. This can be one of your OVHcloud email addresses, or an external email address.
-- **Choose a copy mode**: Choose if you want to:
-     - **Keep a copy of the email with OVHcloud**: Receive the email on your main address as well as the redirection address (see [diagram 2](#diagram) at the beginning of this guide).
-     - **Do not store a copy of the email**: Send directly to the redirection address without the primary address receiving it (see [diagram 1](#diagram) at the beginning of this guide).
-
-Then click `Confirm`{.action} to confirm the addition of this redirection.
-
-![emails](images/mxplan-legacy-3.png){.thumbnail .w-640}
-
-> [!primary]
->
-> To modify the destination address or delete a redirection, click `...`{.action}, to the right of the redirection concerned.
-
-> [!primary]
->
-> When you choose the "**Keep a copy of the email with OVHcloud**" copy mode, a redirection from the email address to itself is created automatically in the redirections list, and it materializes this local copy.
->
 
 #### Via webmail <a name="redirect-webmail"></a>
 
@@ -199,21 +159,6 @@ Browse the tabs below to set up your redirection via Outlook Web App:
 >
 
 #### Delete a redirection <a name="redirect-delete"></a>
-
-##### MX Plan via the OVHcloud Control Panel <a name="redirect-delete-mxplan"></a>
-
-From your MX Plan service, select the domain concerned.
-
-Follow the steps below to delete a redirection:
-
-- By default, you are in the `General information`{.action} tab of your MX Plan.
-- Click the `Emails`{.action} tab, then on the right-hand side the `Manage redirections`{.action} button.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-- Click `...`{.action}, to the right of the redirection concerned, then `Delete redirection`{.action}.
-
-![emails](images/mxplan-redirect-delete01.png){.thumbnail .w-640}
 
 ##### Outlook Web App (OWA) <a name="redirect-delete-owa"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: 'Using email aliases and redirections'
 excerpt: 'Find out how to manage aliases and email redirections'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>
@@ -90,52 +90,12 @@ Click on the tabs below for an illustrated explanation of how aliases and redire
 **Contents**
 
 - [Create a redirection](#redirect)
-    - [Via the Control Panel](#redirect-manager)
     - [Via webmail](#redirect-webmail)
 - [Delete a redirection](#redirect-delete)
 - [Create an alias](#alias)
 - [Delete an alias](#alias-delete)
 
 ### Creating a redirection <a name="redirect"></a>
-
-#### Via the OVH Control Panel <a name="redirect-manager"></a>
-
-Currently, only the **MX Plan** and **Redirect** plans have a redirection management interface via the OVHcloud Control Panel.
-
-##### MX Plan / redirect <a name="redirect-manager-mxplan"></a>
-
-From your MX Plan service, select the domain concerned.
-
-In our example, this is a **redirection with a local copy** (see [diagram 2](#diagram) at the beginning of this guide). If this is what you need, follow the steps below:
-
-By default, you are in the `General information`{.action} tab of your MX Plan. Click on the `Emails`{.action} tab, then on the right-hand side on the `Manage redirections`{.action} button.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-The table of redirections that are already active appears. On the right, click `Add a redirection`{.action}.
-
-![emails](images/mxplan-legacy-2.png){.thumbnail .w-640}
-
-In the form `Create a redirection`, enter the following information:
-
-- **From address**: Enter the email address you would like to redirect.
-- **To the address**: Enter the destination address for your redirection here. This can be one of your OVHcloud email addresses, or an external email address.
-- **Choose a copy mode**: Choose if you want to:
-     - **Keep a copy of the email with OVHcloud**: Receive the email on your main address as well as the redirection address (see [diagram 2](#diagram) at the beginning of this guide).
-     - **Do not store a copy of the email**: Send directly to the redirection address without the primary address receiving it (see [diagram 1](#diagram) at the beginning of this guide).
-
-Then click `Confirm`{.action} to confirm the addition of this redirection.
-
-![emails](images/mxplan-legacy-3.png){.thumbnail .w-640}
-
-> [!primary]
->
-> To modify the destination address or delete a redirection, click `...`{.action}, to the right of the redirection concerned.
-
-> [!primary]
->
-> When you choose the "**Keep a copy of the email with OVHcloud**" copy mode, a redirection from the email address to itself is created automatically in the redirections list, and it materializes this local copy.
->
 
 #### Via webmail <a name="redirect-webmail"></a>
 
@@ -199,21 +159,6 @@ Browse the tabs below to set up your redirection via Outlook Web App:
 >
 
 #### Delete a redirection <a name="redirect-delete"></a>
-
-##### MX Plan via the OVHcloud Control Panel <a name="redirect-delete-mxplan"></a>
-
-From your MX Plan service, select the domain concerned.
-
-Follow the steps below to delete a redirection:
-
-- By default, you are in the `General information`{.action} tab of your MX Plan.
-- Click the `Emails`{.action} tab, then on the right-hand side the `Manage redirections`{.action} button.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-- Click `...`{.action}, to the right of the redirection concerned, then `Delete redirection`{.action}.
-
-![emails](images/mxplan-redirect-delete01.png){.thumbnail .w-640}
 
 ##### Outlook Web App (OWA) <a name="redirect-delete-owa"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: 'Using email aliases and redirections'
 excerpt: 'Find out how to manage aliases and email redirections'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>
@@ -101,52 +101,12 @@ Click on the tabs below for an illustrated explanation of how aliases and redire
 **Contents**
 
 - [Create a redirection](#redirect)
-    - [Via the Control Panel](#redirect-manager)
     - [Via webmail](#redirect-webmail)
 - [Delete a redirection](#redirect-delete)
 - [Create an alias](#alias)
 - [Delete an alias](#alias-delete)
 
 ### Creating a redirection <a name="redirect"></a>
-
-#### Via the OVH Control Panel <a name="redirect-manager"></a>
-
-Currently, only the **MX Plan** and **Redirect** plans have a redirection management interface via the OVHcloud Control Panel.
-
-##### MX Plan / redirect <a name="redirect-manager-mxplan"></a>
-
-From your MX Plan service, select the domain concerned.
-
-In our example, this is a **redirection with a local copy** (see [diagram 2](#diagram) at the beginning of this guide). If this is what you need, follow the steps below:
-
-By default, you are in the `General information`{.action} tab of your MX Plan. Click on the `Emails`{.action} tab, then on the right-hand side on the `Manage redirections`{.action} button.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-The table of redirections that are already active appears. On the right, click `Add a redirection`{.action}.
-
-![emails](images/mxplan-legacy-2.png){.thumbnail .w-640}
-
-In the form `Create a redirection`, enter the following information:
-
-- **From address**: Enter the email address you would like to redirect.
-- **To the address**: Enter the destination address for your redirection here. This can be one of your OVHcloud email addresses, or an external email address.
-- **Choose a copy mode**: Choose if you want to:
-     - **Keep a copy of the email with OVHcloud**: Receive the email on your main address as well as the redirection address (see [diagram 2](#diagram) at the beginning of this guide).
-     - **Do not store a copy of the email**: Send directly to the redirection address without the primary address receiving it (see [diagram 1](#diagram) at the beginning of this guide).
-
-Then click `Confirm`{.action} to confirm the addition of this redirection.
-
-![emails](images/mxplan-legacy-3.png){.thumbnail .w-640}
-
-> [!primary]
->
-> To modify the destination address or delete a redirection, click `...`{.action}, to the right of the redirection concerned.
-
-> [!primary]
->
-> When you choose the "**Keep a copy of the email with OVHcloud**" copy mode, a redirection from the email address to itself is created automatically in the redirections list, and it materializes this local copy.
->
 
 #### Via webmail <a name="redirect-webmail"></a>
 
@@ -210,21 +170,6 @@ Browse the tabs below to set up your redirection via Outlook Web App:
 >
 
 #### Delete a redirection <a name="redirect-delete"></a>
-
-##### MX Plan via the OVHcloud Control Panel <a name="redirect-delete-mxplan"></a>
-
-From your MX Plan service, select the domain concerned.
-
-Follow the steps below to delete a redirection:
-
-- By default, you are in the `General information`{.action} tab of your MX Plan.
-- Click the `Emails`{.action} tab, then on the right-hand side the `Manage redirections`{.action} button.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-- Click `...`{.action}, to the right of the redirection concerned, then `Delete redirection`{.action}.
-
-![emails](images/mxplan-redirect-delete01.png){.thumbnail .w-640}
 
 ##### Outlook Web App (OWA) <a name="redirect-delete-owa"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: 'Using email aliases and redirections'
 excerpt: 'Find out how to manage aliases and email redirections'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: 'Using email aliases and redirections'
 excerpt: 'Find out how to manage aliases and email redirections'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: 'Using email aliases and redirections'
 excerpt: 'Find out how to manage aliases and email redirections'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>
@@ -90,52 +90,12 @@ Click on the tabs below for an illustrated explanation of how aliases and redire
 **Contents**
 
 - [Create a redirection](#redirect)
-    - [Via the Control Panel](#redirect-manager)
     - [Via webmail](#redirect-webmail)
 - [Delete a redirection](#redirect-delete)
 - [Create an alias](#alias)
 - [Delete an alias](#alias-delete)
 
 ### Creating a redirection <a name="redirect"></a>
-
-#### Via the OVH Control Panel <a name="redirect-manager"></a>
-
-Currently, only the **MX Plan** and **Redirect** plans have a redirection management interface via the OVHcloud Control Panel.
-
-##### MX Plan / redirect <a name="redirect-manager-mxplan"></a>
-
-From your MX Plan service, select the domain concerned.
-
-In our example, this is a **redirection with a local copy** (see [diagram 2](#diagram) at the beginning of this guide). If this is what you need, follow the steps below:
-
-By default, you are in the `General information`{.action} tab of your MX Plan. Click on the `Emails`{.action} tab, then on the right-hand side on the `Manage redirections`{.action} button.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-The table of redirections that are already active appears. On the right, click `Add a redirection`{.action}.
-
-![emails](images/mxplan-legacy-2.png){.thumbnail .w-640}
-
-In the form `Create a redirection`, enter the following information:
-
-- **From address**: Enter the email address you would like to redirect.
-- **To the address**: Enter the destination address for your redirection here. This can be one of your OVHcloud email addresses, or an external email address.
-- **Choose a copy mode**: Choose if you want to:
-     - **Keep a copy of the email with OVHcloud**: Receive the email on your main address as well as the redirection address (see [diagram 2](#diagram) at the beginning of this guide).
-     - **Do not store a copy of the email**: Send directly to the redirection address without the primary address receiving it (see [diagram 1](#diagram) at the beginning of this guide).
-
-Then click `Confirm`{.action} to confirm the addition of this redirection.
-
-![emails](images/mxplan-legacy-3.png){.thumbnail .w-640}
-
-> [!primary]
->
-> To modify the destination address or delete a redirection, click `...`{.action}, to the right of the redirection concerned.
-
-> [!primary]
->
-> When you choose the "**Keep a copy of the email with OVHcloud**" copy mode, a redirection from the email address to itself is created automatically in the redirections list, and it materializes this local copy.
->
 
 #### Via webmail <a name="redirect-webmail"></a>
 
@@ -199,21 +159,6 @@ Browse the tabs below to set up your redirection via Outlook Web App:
 >
 
 #### Delete a redirection <a name="redirect-delete"></a>
-
-##### MX Plan via the OVHcloud Control Panel <a name="redirect-delete-mxplan"></a>
-
-From your MX Plan service, select the domain concerned.
-
-Follow the steps below to delete a redirection:
-
-- By default, you are in the `General information`{.action} tab of your MX Plan.
-- Click the `Emails`{.action} tab, then on the right-hand side the `Manage redirections`{.action} button.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-- Click `...`{.action}, to the right of the redirection concerned, then `Delete redirection`{.action}.
-
-![emails](images/mxplan-redirect-delete01.png){.thumbnail .w-640}
 
 ##### Outlook Web App (OWA) <a name="redirect-delete-owa"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: 'Using email aliases and redirections'
 excerpt: 'Find out how to manage aliases and email redirections'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>
@@ -101,52 +101,12 @@ Click on the tabs below for an illustrated explanation of how aliases and redire
 **Contents**
 
 - [Create a redirection](#redirect)
-    - [Via the Control Panel](#redirect-manager)
     - [Via webmail](#redirect-webmail)
 - [Delete a redirection](#redirect-delete)
 - [Create an alias](#alias)
 - [Delete an alias](#alias-delete)
 
 ### Creating a redirection <a name="redirect"></a>
-
-#### Via the OVH Control Panel <a name="redirect-manager"></a>
-
-Currently, only the **MX Plan** and **Redirect** plans have a redirection management interface via the OVHcloud Control Panel.
-
-##### MX Plan / redirect <a name="redirect-manager-mxplan"></a>
-
-From your MX Plan service, select the domain concerned.
-
-In our example, this is a **redirection with a local copy** (see [diagram 2](#diagram) at the beginning of this guide). If this is what you need, follow the steps below:
-
-By default, you are in the `General information`{.action} tab of your MX Plan. Click on the `Emails`{.action} tab, then on the right-hand side on the `Manage redirections`{.action} button.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-The table of redirections that are already active appears. On the right, click `Add a redirection`{.action}.
-
-![emails](images/mxplan-legacy-2.png){.thumbnail .w-640}
-
-In the form `Create a redirection`, enter the following information:
-
-- **From address**: Enter the email address you would like to redirect.
-- **To the address**: Enter the destination address for your redirection here. This can be one of your OVHcloud email addresses, or an external email address.
-- **Choose a copy mode**: Choose if you want to:
-     - **Keep a copy of the email with OVHcloud**: Receive the email on your main address as well as the redirection address (see [diagram 2](#diagram) at the beginning of this guide).
-     - **Do not store a copy of the email**: Send directly to the redirection address without the primary address receiving it (see [diagram 1](#diagram) at the beginning of this guide).
-
-Then click `Confirm`{.action} to confirm the addition of this redirection.
-
-![emails](images/mxplan-legacy-3.png){.thumbnail .w-640}
-
-> [!primary]
->
-> To modify the destination address or delete a redirection, click `...`{.action}, to the right of the redirection concerned.
-
-> [!primary]
->
-> When you choose the "**Keep a copy of the email with OVHcloud**" copy mode, a redirection from the email address to itself is created automatically in the redirections list, and it materializes this local copy.
->
 
 #### Via webmail <a name="redirect-webmail"></a>
 
@@ -210,21 +170,6 @@ Browse the tabs below to set up your redirection via Outlook Web App:
 >
 
 #### Delete a redirection <a name="redirect-delete"></a>
-
-##### MX Plan via the OVHcloud Control Panel <a name="redirect-delete-mxplan"></a>
-
-From your MX Plan service, select the domain concerned.
-
-Follow the steps below to delete a redirection:
-
-- By default, you are in the `General information`{.action} tab of your MX Plan.
-- Click the `Emails`{.action} tab, then on the right-hand side the `Manage redirections`{.action} button.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-- Click `...`{.action}, to the right of the redirection concerned, then `Delete redirection`{.action}.
-
-![emails](images/mxplan-redirect-delete01.png){.thumbnail .w-640}
 
 ##### Outlook Web App (OWA) <a name="redirect-delete-owa"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: 'Utilizar los alias y redirecciones de correo'
 excerpt: 'Cómo gestionar los alias y redirecciones de correo'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: 'Utilizar los alias y redirecciones de correo'
 excerpt: 'Cómo gestionar los alias y redirecciones de correo'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>
@@ -101,52 +101,12 @@ Haga clic en las fichas siguientes para obtener una explicación ilustrada del f
 **Contenido**
 
 - [Crear una redirección](#redirect)
-    - [Desde el área de cliente](#redirect-manager)
     - [Desde el webmail](#redirect-webmail)
 - [Eliminar una redirección](#redirect-delete)
 - [Crear alias](#alias)
 - [Eliminar alias](#alias-delete)
 
 ### Crear una redirección <a name="redirect"></a>
-
-#### Desde el área de cliente <a name="redirect-manager"></a>
-
-Actualmente, solo los planes **MX plan** y **Redirect** disponen de una interfaz de gestión de las redirecciones a través del área de cliente de OVHcloud.
-
-##### MX Plan / redirect <a name="redirect-manager-mxplan"></a>
-
-Desde su servicio MX Plan, seleccione el dominio en cuestión.
-
-En nuestro ejemplo, se trata de una **redirección con copia local** (consulte el [esquema 2](#diagram) al principio de esta guía). Si lo necesita, siga los pasos que se indican a continuación:
-
-Por defecto, se encuentra en la pestaña `Información general`{.action} de su MX Plan. Haga clic en la pestaña `Correo electrónico`{.action} y seleccione el botón `Gestionar las redirecciones`{.action} en el lado derecho.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-Se mostrará una tabla con las redirecciones activas. A la derecha, haga clic en el botón `Crear una redirección`{.action}.
-
-![emails](images/mxplan-legacy-2.png){.thumbnail .w-640}
-
-En el formulario `Crear una redirección`, complete los siguientes elementos:
-
-- **De la dirección**: Introduzca aquí la dirección de correo electrónico que quiera redirigir.
-- **A la dirección**: Introduzca aquí la dirección de destino de su redirección. Puede ser una de sus direcciones de correo electrónico de OVHcloud o una dirección de correo electrónico externa.
-- **Seleccione un modo de copia**: Elija si desea:
-     - **Conservar una copia del correo en OVHcloud**: Recibir el correo en su dirección principal y la dirección de redirección (ver el [esquema 2](#diagram) al principio de esta guía).
-     - **No conservar copia del correo**: Reenviar directamente a la dirección de redirección sin que la dirección principal lo reciba (ver el [esquema 1](#diagram) al principio de esta guía).
-
-Haga clic en `Aceptar`{.action} para confirmar la redirección.
-
-![emails](images/mxplan-legacy-3.png){.thumbnail .w-640}
-
-> [!primary]
->
-> Para modificar la dirección de destino o eliminar una redirección, haga clic en `...`{.action}, a la derecha de la redirección correspondiente.
-
-> [!primary]
->
-> Al elegir el modo de copia "**Conservar una copia del correo en OVHcloud**", se crea automáticamente una redirección de la dirección de correo hacia ella misma en la lista de redirecciones, materializando esta copia local.
->
 
 #### Desde el webmail <a name="redirect-webmail"></a>
 
@@ -210,21 +170,6 @@ Desplácese por las fichas siguientes para configurar la redirección a través 
 >
 
 #### Eliminar una redirección <a name="redirect-delete"></a>
-
-##### MX Plan desde el área de cliente <a name="redirect-delete-mxplan"></a>
-
-Desde su servicio MX Plan, seleccione el dominio en cuestión.
-
-Siga los pasos que se indican a continuación para eliminar una redirección:
-
-- Por defecto, se encuentra en la pestaña `Información general`{.action} de su MX Plan.
-- Haga clic en la pestaña `Correo electrónico`{.action} y seleccione el botón `Gestiónar las redirecciones`{.action}.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-- Haga clic en `...`{.action}, a la derecha de la redirección correspondiente y luego en `Eliminar la redirección`{.action}.
-
-![emails](images/mxplan-redirect-delete01.png){.thumbnail .w-640}
 
 ##### Outlook Web App (OWA) <a name="redirect-delete-owa"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Utiliser les alias et redirections e-mail"
 excerpt: "Découvrez comment gérer vos alias et redirections e-mail"
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>
@@ -101,52 +101,12 @@ Cliquez sur les onglets suivants pour des explications illustrées sur le foncti
 **Sommaire**
 
 - [Créer une redirection](#redirect)
-    - [Depuis l'espace client](#redirect-manager)
     - [Depuis le webmail](#redirect-webmail)
 - [Supprimer une redirection](#redirect-delete)
 - [Créer un alias](#alias)
 - [Supprimer un alias](#alias-delete)
 
 ### Créer une redirection <a name="redirect"></a>
-
-#### Depuis l'espace client <a name="redirect-manager"></a>
-
-Actuellement, seules les offres **MX plan** et **Redirect** disposent d'une interface de gestion des redirections via l'espace client OVHcloud.
-
-##### MX Plan / redirect <a name="redirect-manager-mxplan"></a>
-
-Depuis votre service MX Plan, sélectionnez le domaine concerné.
-
-Dans notre exemple, il s'agit d'une **redirection avec copie locale** (voir le [schéma 2](#diagram) au début de ce guide). Si cela correspond à votre besoin, suivez les étapes ci-dessous.
-
-Par défaut, vous êtes dans l'onglet `Informations générales`{.action} de votre MX Plan. Cliquez sur l'onglet `Emails`{.action} puis à droite sur le bouton `Gestion des redirections`{.action}.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-Le tableau des redirections déjà actives s'affiche. À droite, cliquez sur le bouton `Ajouter une redirection`{.action}.
-
-![emails](images/mxplan-legacy-2.png){.thumbnail .w-640}
-
-Dans le formulaire `Créer une redirection`, complétez les éléments suivants :
-
-- **De l'adresse** : Renseignez ici l'adresse e-mail que vous souhaitez rediriger.
-- **Vers l'adresse** : Renseignez ici l'adresse de destination de votre redirection. Il peut s'agir de l'une de vos adresses e-mail OVHcloud, ou d'une adresse e-mail externe.
-- **Choisissez un mode de copie** : Choisissez si vous souhaitez :
-      - **Conserver une copie du mail chez OVHcloud** : Recevoir l'e-mail sur votre adresse principale ainsi que l'adresse de redirection (voir le [schéma 2](#diagram) au début de ce guide).
-      - **Ne pas conserver de copie du mail** : Renvoyer directement vers l'adresse de redirection sans que l'adresse principale ne le reçoive (voir le [schéma 1](#diagram) au début de ce guide).
-
-Cliquez ensuite sur `Valider`{.action} pour confirmer l'ajout de cette redirection.
-
-![emails](images/mxplan-legacy-3.png){.thumbnail .w-640}
-
-> [!primary]
->
-> Pour modifier l'adresse de destination ou supprimer une redirection, cliquez sur `...`{.action}, à droite de la redirection concernée.
-
-> [!primary]
->
-> Lorsque vous choisissez le mode de copie « **Conserver une copie du mail chez OVHcloud** », une redirection de l'adresse e-mail vers elle-même est créée automatiquement dans la liste des redirections, elle matérialise cette copie locale.
->
 
 #### Depuis le webmail <a name="redirect-webmail"></a>
 
@@ -210,21 +170,6 @@ Parcourez les onglets ci-dessous pour mettre en place votre redirection via Outl
 >
 
 #### Supprimer une redirection <a name="redirect-delete"></a>
-
-##### MX Plan via espace client <a name="redirect-delete-mxplan"></a>
-
-Depuis votre service MX Plan, sélectionnez le domaine concerné.
-
-Suivez les étapes ci-dessous pour supprimer une redirection :
-
-- Par défaut, vous êtes dans l'onglet `Informations générales`{.action} de votre MX Plan.
-- Cliquez sur l'onglet `Emails`{.action} puis à droite sur le bouton `Gestion des redirections`{.action}.
-
-![emails](images/mxplan-legacy-1.png){.thumbnail .w-640}
-
-- Cliquez sur `...`{.action}, à droite de la redirection concernée puis sur `Supprimer la redirection`{.action}.
-
-![emails](images/mxplan-redirect-delete01.png){.thumbnail .w-640}
 
 ##### Outlook Web App (OWA) <a name="redirect-delete-owa"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Utiliser les alias et redirections e-mail"
 excerpt: "Découvrez comment gérer vos alias et redirections e-mail"
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: 'Utilizzare gli alias e i reindirizzamenti email'
 excerpt: 'Come gestire gli alias e i reindirizzamenti email'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Korzystanie z aliasów i przekierowań e-mail"
 excerpt: "Dowiedz się, jak zarządzać aliasami i przekierowaniami e-mail"
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: 'Utilizar os alias e reencaminhamentos de e-mail'
 excerpt: 'Saiba como gerir os seus alias e reencaminhamentos de e-mail'
-updated: 2025-06-03
+updated: 2026-03-31
 ---
 
 <style>

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_dns_cname/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_dns_cname/guide.en-us.md
@@ -1,0 +1,123 @@
+---
+title: Creating a CNAME record to validate your domain name on your email solution
+excerpt: Find out how to validate your domain name for your email service by adding a CNAME record
+updated: 2023-08-29
+---
+
+## Objective
+
+When you add a domain name to your email service, you may be asked to configure a CNAME record in the DNS zone. The purpose of this procedure is to ensure that the domain name concerned is legitimate for use on the email service.
+
+> [!primary]
+>
+> If the domain name, i.e. its DNS zone, is managed in the same customer account as the email service, configuring the CNAME record is not necessary.
+
+**Find out how to validate your domain name for your email service by adding a CNAME record.**
+
+## Requirements
+
+- An [Exchange](/links/web/emails-exchange) solution
+- A domain name linked to your email service, see [Adding a domain name to an email service](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain)
+- Administrative rights to [configure the DNS zone](/pages/web_cloud/domains/dns_zone_edit) for the domain name concerned (in the OVHcloud Control Panel or an external management interface)
+
+<!-- CP-NAV-START:web-exchange -->
+---
+
+### OVHcloud Control Panel Access
+
+- **Direct link:** [Exchange](/links/control-panel/web-exchange)
+- **Navigation path:** `Web Cloud`{.action} > `Exchange`{.action} > Select your platform
+
+---
+<!-- CP-NAV-END:web-exchange -->
+
+## Instructions
+
+### Why create a CNAME record?
+
+The CNAME record is used here as an alias, it points to a target that itself points to an IP address. This record is not mapped to an email service.
+
+The CNAME record is used as a validation code (token) for our [**Hosted Exchange**](/links/web/emails-hosted-exchange) solution. It is added to the DNS zone of the domain name you want to validate for use with your emails. The purpose is to check that the user of the email service is authorised to use the domain name they are adding.
+
+In the diagram below, the email service ([Exchange](/links/web/emails-exchange)) is represented by the contents of the green frame.<br>
+You have created accounts (**contact**, **john.smith** and **mary.johnson** in this example) that will have email addresses associated with them.<br>
+The domain name **mydomain.ovh** has been added to the email service (please refer to the guide on [Adding a domain name to your email service](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain)).<br>
+The email service generates a unique validation code ("**abcd1-check**" in our example).<br>
+If the DNS zone for the domain name **mydomain.ovh** is not managed in the same OVHcloud customer account, or is managed from an external interface, this code must then be added as a CNAME record. This record is represented by the blue box in the example.<br>
+The email service automatically checks the DNS records of the domain name **mydomain.ovh** for the validation code.
+
+![email](images/email-dns-conf-cname01.png){.thumbnail}
+
+As soon as the email service reads the validation code in the DNS zone of the domain name **mydomain.ovh**, it becomes possible to use the addresses **contact@mydomain.ovh**, **john.smith@mydomain.ovh** and **mary.johnson@mydomain.ovh**.
+
+### Step 1 - Understand the OVHcloud CNAME diagnostic <a name="step1"></a>
+
+The **CNAME** diagnostic box will appear in the `Associated domains`{.action} tab of your email service after you have added your domain name.
+
+![cnamedomainemail](images/cname_exchange_diagnostic.png){.thumbnail}
+
+In the example above, the box is red. Here are the possible reasons for this state:
+
+- **The domain name declared is not managed in the same OVHcloud customer account as your email service**. Access the Control Panel of the OVHcloud account in which the domain name's DNS zone is managed and follow [step 3](#step3) of this guide.
+- **The domain name declared uses DNS servers not provided by OVHcloud**. The domain name is registered with OVHcloud, but it uses custom DNS servers. To check this, select the domain name in the `Domain names`{.action} section on the left-hand column. In the `General information`{.action} tab, check the status below "DNS servers". If it says `Custom`{.action}, you have declared external servers in the `DNS servers`{.action} tab. Log in to the management interface of your DNS provider in order to edit the CNAME record.
+
+![email](images/email-dns-conf-cname02.png){.thumbnail}
+
+- **The domain name declared is not registered with OVHcloud and does not use OVHcloud DNS servers**. Your domain name is registered at another registrar. You will need to contact your domain name provider to verify how to access the DNS zone configuration.
+
+### Step 2 - Retrieve the validation code <a name="step2"></a>
+
+Go to the `Associated domains`{.action} tab, and click on the red `CNAME` box in the "diagnostic" column to retrieve the information required.
+
+The CNAME record is displayed in the dialog box that appears.
+
+![cnamedomainemail](images/cname_exchange_informations.png){.thumbnail}
+
+The middle line consists of the verification code and the target (`a1bcd-check.mydomain.ovh to ovh.com.` in the example above) for the CNAME record.
+
+### Step 3 - Create the CNAME record <a name="step3"></a>
+
+Select the tab that corresponds to the interface you are using:
+
+> [!tabs]
+> **In the OVHcloud Control Panel**
+>> In the `Web Cloud`{.action} section, click `Domain names`{.action}, then select the domain name concerned. Switch to the `DNS zone`{.action} tab.<br>
+>> Your DNS zone configuration will appear. To add a CNAME record, click on the button `Add Entry`{.action} on the right.<br>
+>> In the new window, you can select the type of DNS record to add. Click `CNAME`{.action} and fill in the fields according to the information retrieved in [step 2](#step2) of this guide.<br>
+>> For example, if the validation code is "**a1bcd-check**", this must be entered into the "Sub-domain" field. Enter "**ovh.com.**" as the "target" and make sure to keep the trailing "**.**".
+>>
+>> ![cnamedomainemail](images/cname_add_entry_dns_zone.png){.thumbnail}
+>>
+>> Once you have entered this information, click `Next`{.action}. Verify that the information displayed is correct, then click `Confirm`{.action}.<br>
+>>
+>> > [!warning]
+>> >
+>> > The modification is usually applied within a few minutes but might require a propagation time up to 24 hours.
+>>
+> **From an interface external to OVHcloud**
+>>
+>> Log in to the interface that manages the domain name's DNS zone and add a CNAME record to it, with the following settings:
+>>
+>> - **Sub-domain**: Enter the value in the form "**xxxxx-check**", replacing "**xxxxx**" with the unique code listed in [step 2](#step2) of this guide.
+>> - **Target**: Enter the value "**ovh.com.**", keeping in mind the trailing "**.**" (if your input interface has not added it automatically).
+>>
+>> Confirm this change in your DNS zone.
+>>
+>> > [!warning]
+>> >
+>> > The modification is usually applied within a few minutes but might require a propagation time up to 24 hours.
+>> >
+>>
+>> Here is an example of a DNS response after adding a validation CNAME record:
+>>
+>> ```text
+>> ab1cd-check.mydomain.ovh. 3600	IN	CNAME	ovh.com.
+>> ```
+
+To check that the CNAME record configuration has been successfully queried by your OVHcloud email service, open it in the Control Panel and go to the tab `Associated domains`{.action}. If the `CNAME` box is no longer present in the "diagnostic" column, the domain name was associated with your service. If not, then your configuration changes may not have propagated fully.
+
+![cnamedomainemail](images/cname_exchange_diagnostic_green.png){.thumbnail}
+
+## Go further
+
+Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_dns_cname/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_dns_cname/guide.es-us.md
@@ -1,0 +1,123 @@
+---
+title: 'Crear un registro CNAME para asociar un dominio'
+excerpt: 'Cómo y por qué añadir un registro CNAME a un dominio'
+updated: 2023-08-29
+---
+
+## Objetivo
+
+Al añadir un dominio a su plataforma de correo, es posible que se le pida que configure un registro CNAME en la zona DNS. El objetivo de esta operación es garantizar que el dominio en cuestión es legítimo para su uso en la plataforma de correo.
+
+> [!primary]
+>
+> Si el dominio añadido se gestiona en la misma cuenta de cliente que la plataforma de correo, y más concretamente en su zona DNS, no es necesario configurar ningún registro CNAME.
+
+**Esta guía explica cómo validar un dominio en una plataforma de correo añadiendo un registro CNAME.**
+
+## Requisitos
+
+- Disponer de una solución [Exchange](/links/web/emails-exchange).
+- Haber añadido un dominio a su plataforma de correo. Si lo necesita, puede consultar la guía [Añadir un dominio a una plataforma de correo](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain).
+- Estar en condiciones de [configurar la zona DNS](/pages/web_cloud/domains/dns_zone_edit) del dominio en cuestión, desde el área de cliente de OVHcloud o desde la interfaz de gestión en la que esté registrado.
+
+<!-- CP-NAV-START:web-exchange -->
+---
+
+### Acceso al área de cliente de OVHcloud
+
+- **Enlace directo:** [Exchange](/links/control-panel/web-exchange)
+- **Ruta de navegación:** `Web Cloud`{.action} > `Exchange`{.action} > Seleccione su plataforma
+
+---
+<!-- CP-NAV-END:web-exchange -->
+
+## Procedimiento
+
+### ¿Por qué crear un registro CNAME?
+
+Aquí se utiliza el registro CNAME como alias, que apunta a un destino que, a su vez, apunta a una dirección IP. Por lo tanto, no se trata de un registro vinculado a un servicio de correo.
+
+En el marco de nuestra oferta [**Hosted Exchange**](/links/web/emails-hosted-exchange), este registro CNAME se utiliza como código de validación (token) que será visible en la zona DNS del dominio que se quiera validar. El objetivo es comprobar que el usuario de la plataforma de correo es el gestor del dominio que añade.
+
+En el diagrama siguiente, la plataforma de correo electrónico ([Exchange](/links/web/emails-exchange)) se representa mediante el marco verde.<br>
+Para formar las direcciones de correo electrónico, añada cuentas (representadas en este caso por "**contacto**", "**john.smith**" y "**mary.johnson**").<br>
+El dominio **mydomain.ovh** se ha añadido a la plataforma de correo (consultar la guía "[Añadir un dominio a una plataforma de correo](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain) ").<br>
+La plataforma genera un código de validación (en nuestro ejemplo, "**abcd1-check**").<br>
+Si la zona DNS del dominio **mydomain.ovh** no está gestionada en la misma cuenta de cliente de OVHcloud o se gestiona desde un panel de control externo, deberá añadir el código en forma de registro CNAME. Este registro se representa mediante el marco azul del ejemplo.<br>
+La plataforma de correo puede observar los registros DNS del dominio **mydomain.ovh** para comprobar la presencia del código de validación.
+
+![Correo electrónico](images/email-dns-conf-cname01.png){.thumbnail}
+
+Una vez que la plataforma de correo haya podido leer el código de validación en la zona DNS del dominio **mydomain.ovh**, es posible formar las direcciones **contact@mydomain.ovh**, **john.smith@mydomain.ovh** y **mary.johnson@mydomain.ovh**.
+
+### Paso 1 - Entender el diagnóstico CNAME de OVHcloud <a name="step1"></a>
+
+La etiqueta de diagnóstico **CNAME** aparece en la pestaña `Dominios asociados`{.action} de su plataforma de correo tras añadir su dominio.
+
+![CNAME](images/cname_exchange_diagnostic.png){.thumbnail}
+
+En el ejemplo anterior, la etiqueta es roja. Estas son las posibles razones de este diagnóstico:
+
+- **El dominio declarado no se gestiona con la misma cuenta de cliente de OVHcloud que su plataforma de correo**. Realice [el paso 3](#step3) de esta guía desde el área de cliente de la cuenta de OVHcloud que gestiona la zona DNS del dominio.
+- **El dominio declarado utiliza servidores DNS externos a OVHcloud**: el dominio está registrado en OVHcloud, pero utiliza servidores DNS "personalizados". Para comprobarlo, en la columna izquierda, haga clic en `Dominios`{.action} y seleccione el dominio. En la pestaña `Información general`{.action}, consulte "Servidores DNS". Si especifica `Personalizados`{.action}, deberá conectarse a la interfaz de gestión de los servidores DNS registrados en la pestaña `Servidores DNS`{.action}
+
+![Correo electrónico](images/email-dns-conf-cname02.png){.thumbnail}
+
+- **El dominio no está registrado en OVHcloud y no utiliza servidores DNS de OVHcloud**: el dominio está registrado en otro agente registrador. Compruebe que la zona DNS se haya configurado correctamente desde el panel que le ofrezca el agente registrador del dominio.
+
+### Paso 2 - Obtener el código de validación <a name="step2"></a>
+
+Abra la pestaña `Dominios asociados`{.action} y haga clic en la etiqueta roja `CNAME` en la columna "Diagnóstico" para obtener la información necesaria.
+
+El registro CNAME se describe en el cuadro de diálogo que aparece.
+
+![CNAME](images/cname_exchange_informations.png){.thumbnail}
+
+Introduzca el código único que aparece en la línea central (`a1bcd-check.mydomain.ovh to ovh.com.` en el ejemplo anterior).
+
+### Paso 3 - Crear el registro CNAME <a name="step3"></a>
+
+Seleccione la pestaña correspondiente a su situación:
+
+> [!tabs]
+> **Desde el área de cliente de OVHcloud**
+>> En la sección `Web Cloud`{.action}, haga clic en `Dominios`{.action} y seleccione el dominio correspondiente. A continuación, abra la pestaña `Zona DNS`{.action}.<br>
+>> Aparecerá la configuración de la zona DNS. Para añadir un registro CNAME, haga clic en el botón `Añadir un registro`{.action} a la derecha.<br>
+>> En la nueva ventana, podrá ver varios registros DNS. Haga clic en `CNAME`{.action} y complete los campos según la información obtenida en [el paso 2](#step2) de esta guía.<br>
+>> Por ejemplo, si el código de validación es "**a1bcd-check**", debe introducirse en la casilla "subdominio". Por último, introduzca "**ovh.com.**" en el apartado "Destino", recordando el apartado **.**" final.
+>>
+>> ![CNAME](images/cname_add_entry_dns_zone.png){.thumbnail}
+>>
+>> Una vez introducidos los datos, haga clic en el botón `Siguiente`{.action}. Asegúrese de que la información mostrada es correcta y haga clic en `Confirmar`{.action}.<br>
+>>
+>> > [!warning]
+>> >
+>> > El cambio tarda un tiempo de propagación que normalmente se aplica en unos minutos. Sin embargo, puede llegar hasta las 24 horas.
+>>
+> **Desde una interfaz externa a OVHcloud**
+>>
+>> Conéctese a la interfaz que gestiona la zona DNS del dominio y añada un registro de tipo CNAME a la misma, con los siguientes parámetros:
+>>
+>> - **Subdominio**: Introduzca el valor como "**xxxxx-check**", sustituyendo las "**x**" por el código único que aparece en [el paso 2](#step2) de esta guía.
+>> - **Destino**: Introduzca el valor "**ovh.com.**" recordando el "**.**" final si su interfaz de entrada no lo hace automáticamente.
+>>
+>> Confirme este cambio en su zona DNS.
+>>
+>> > [!warning]
+>> >
+>> > Este cambio requiere un tiempo de propagación, que suele aplicarse en cuestión de minutos. Sin embargo, puede llegar hasta las 24 horas.
+>> >
+>>
+>> A continuación ofrecemos un ejemplo de respuesta DNS tras añadir un registro CNAME de validación:
+>>
+>> ```bash
+>> ab1cd-check.mydomain.ovh. 3600	IN	CNAME	ovh.com.
+>> ```
+
+Para comprobar que la plataforma de correo ha leído la configuración del registro CNAME, vuelva a esta y abra la pestaña `Dominios asociados`{.action}. Si la etiqueta `CNAME` ya no aparece en la columna "Diagnóstico", el dominio se añadirá correctamente. Si sigue estando roja, es posible que la propagación todavía no haya finalizado.
+
+![CNAME](images/cname_exchange_diagnostic_green.png){.thumbnail}
+
+## Más información
+
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-ca.md
@@ -196,7 +196,7 @@ Example of migration tracking:
 
 [Manually migrate your email address](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)
 
-[Migrating an MX Plan email account to an Email Pro or Exchange account](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel)
+[Migrating an MX Plan email address to an Exchange account](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.en-us.md
@@ -196,7 +196,7 @@ Example of migration tracking:
 
 [Manually migrate your email address](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)
 
-[Migrating an MX Plan email account to an Email Pro or Exchange account](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel)
+[Migrating an MX Plan email address to an Exchange account](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel)
 
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.es-us.md
@@ -196,7 +196,7 @@ Ejemplo de seguimiento de migración:
 
 [Migrar manualmente su dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)
 
-[Migrar una dirección de correo electrónico MX Plan a una cuenta Email Pro o Exchange](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel)
+[Migrar una cuenta MX Plan a una cuenta Exchange](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel)
 
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con los [partners de OVHcloud](/links/partner).
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm/guide.fr-ca.md
@@ -196,7 +196,7 @@ Exemple de suivi de migration :
 
 [Migrer manuellement votre adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration)
 
-[Migrer une adresse e-mail MX Plan vers un compte Email Pro ou Exchange](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel)
+[Migrer une adresse e-mail MX Plan vers un compte Exchange](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel)
 
 Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
 


### PR DESCRIPTION
## What type of Pull Request is this?

- Fix
- Optimization

## Description

Wave 2 — Regional audit corrections (emails)

1. migration_omm (4 files) — Removed "Email Pro" from "Go further" link text in CA/US locales, aligning with the actual target guide titles (Exchange only).
2. exchange_dns_cname (2 files created) — Created missing en-us and es-us guides (duplicated from en-ca / adapted from es-es without Email Pro refs), fixing broken links in exchange_adding_domain.
3. feature_redirections (7 files) — Removed "Via the Control Panel" sections (create + delete) from all non-EU locales (en-ca, en-us, fr-ca, es-us, en-au, en-sg, en-asia). CP redirections rely on the /email/domain API which is EU-only; only the webmail/OWA method (working in all regions) is kept.
4. feature_redirections (15 files) — Updated updated frontmatter date to 2026-03-31 across all locales.
