### PR TITLE
[Audit] - WEB - Emails - all offers - update wave 3

### DIFF
--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted/guide.en-us.md
@@ -60,10 +60,10 @@ Choose one of your domain names from the list, or select the check box `My domai
 
 #### Are you going to only use the OVHcloud Exchange solution with this domain name?
 
-The question "**Are you going to use OVHcloud Exchange only with this domain?**" will determine the type of configuration for your domain name. 
+The question "**Are you going to use OVHcloud Exchange only with this domain?**" will determine the type of configuration for your domain name.
 
 - If you use an Exchange offer alone or with other **OVHcloud email offers**, the configuration can be done automatically, or manually using only OVHcloud email servers.
-- If you are using your Exchange solution as a complement to an **external email service to the OVHcloud email offers**, you will be asked to enter the URL of your external email service’s incoming server under the heading `(SMTP) server`.
+- If you are using your Exchange solution as a complement to an **external email service to the OVHcloud email offers**, you will be asked to enter the URL of your external email service's incoming server under the heading `(SMTP) server`.
 
 ![email](images/exchange-wizard02.png){.thumbnail}
 
@@ -84,7 +84,7 @@ Determine the name of your Exchange email addresses, and add additional informat
 
 - If you configure your Exchange platform with a domain name that is not managed on the same control panel as this platform, or with another domain name provider, you will see the following window:<br>
 ![email](images/exchange-wizard05.png){.thumbnail .w-640}<br>
-This window will prompt you to add a **CNAME record** to the domain name’s DNS zone. The purpose of this entry is to check that you are actually managing this domain name.<br>
+This window will prompt you to add a **CNAME record** to the domain name's DNS zone. The purpose of this entry is to check that you are actually managing this domain name.<br>
 
 > [!warning]
 > Without this validation by CNAME record, you cannot use the platform with this domain name.
@@ -93,7 +93,7 @@ This window will prompt you to add a **CNAME record** to the domain name’s DNS
 ![email](images/exchange-wizard06.png){.thumbnail .w-640}<br>
 Here, you will find the values to enter into your DNS zone. The **MX records** correspond to the receiving servers of your emails. The **SRV field** corresponds to the automatic configuration of your email addresses.
 
-You can find the DNS zone configuration details for your email service on our [Add an MX record to your domain name’s configuration](/pages/web_cloud/domains/dns_zone_mx) page.
+You can find the DNS zone configuration details for your email service on our [Add an MX record to your domain name's configuration](/pages/web_cloud/domains/dns_zone_mx) page.
 
 ### Add additional domain names (optional)
 
@@ -110,7 +110,7 @@ To find out more, please refer to this guide on [Adding a domain name to an Exch
 
 > [!primary]
 >
-> If a domain name requires a specific action for its configuration, a red box will appear in the `Diagnostic`{.action} column of the table. By clicking on it, you will see the modifications that need to be made. If this domain name does not use OVHcloud configuration (its DNS servers), you will need to carry out the modifications in the interface you use to manage your domain name’s configuration. 
+> If a domain name requires a specific action for its configuration, a red box will appear in the `Diagnostic`{.action} column of the table. By clicking on it, you will see the modifications that need to be made. If this domain name does not use OVHcloud configuration (its DNS servers), you will need to carry out the modifications in the interface you use to manage your domain name's configuration.
 >
 
 ![Add a domain](images/first-steps-hosted-exchange-add-domain.png){.thumbnail}
@@ -121,7 +121,7 @@ You can configure additional accounts if you have not already done so via the wi
 
 To do this, click on the Hosted Exchange service concerned in your [OVHcloud Control Panel](/links/manager), then on `Email accounts`{.action}. You will see a table showing all of the accounts currently configured, or about to be configured on your service.
 
-The accounts that have not yet been configured configuration will appear in the table as “*@configureme.me*”. To configure them, click on the pencil icon, then follow the steps.
+The accounts that have not yet been configured configuration will appear in the table as "*@configureme.me*". To configure them, click on the pencil icon, then follow the steps.
 
 > [!primary]
 >
@@ -156,7 +156,7 @@ To subscribe, go to our page on [Getting an Outlook licence for Exchange](/pages
 
 ### Set up collaborative features (optional)
 
-Now that your Hosted Exchange service is configured and functional, you can set up the service’s collaborative features in your [OVHcloud Control Panel](/links/manager). You can use these features to create resources (meeting rooms, equipment, etc.), groups, and more.
+Now that your Hosted Exchange service is configured and functional, you can set up the service's collaborative features in your [OVHcloud Control Panel](/links/manager). You can use these features to create resources (meeting rooms, equipment, etc.), groups, and more.
 
 To enable these features, select the Hosted Exchange service concerned in your [OVHcloud Control Panel](/links/manager), then choose which action to perform from the tabs that appear.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted/guide.es-us.md
@@ -1,0 +1,184 @@
+---
+title: 'Primeros pasos con el servicio Hosted Exchange'
+excerpt: 'Cómo configurar por primera vez el servicio Hosted Exchange'
+updated: 2025-04-28
+---
+
+<style>
+.w-640 {
+  max-width:640px !important;
+}
+</style>
+
+## Objetivo
+
+El servicio Hosted Exchange le permite disfrutar de direcciones de correo electrónico profesionales que facilitan el trabajo colaborativo gracias a funciones como la sincronización del calendario o de los contactos.
+
+**Esta guía explica cómo configurar por primera vez el servicio Hosted Exchange.**
+
+## Requisitos
+
+- Tener contratado un plan [Hosted Exchange](/links/web/emails-hosted-exchange).
+- Haber recibido el email de confirmación de la instalación de la solución Hosted Exchange.
+- Tener un dominio.
+
+<!-- CP-NAV-START:web-exchange -->
+---
+
+### Acceso al área de cliente de OVHcloud
+
+- **Enlace directo:** [Exchange](/links/control-panel/web-exchange)
+- **Ruta de navegación:** `Web Cloud`{.action} > `Exchange`{.action} > Seleccione su plataforma
+
+---
+<!-- CP-NAV-END:web-exchange -->
+
+## Procedimiento
+
+### Acceder a la gestión del servicio
+
+Una vez que el servicio Hosted Exchange haya sido creado y esté disponible :
+
+> [!primary]
+>
+> El nombre de los servicios Hosted Exchange comienza por «**hosted-**», contiene una parte del ID de cliente y termina por una cifra (1 para el primer servicio Hosted Exchange instalado, 2 para el segundo y así sucesivamente).
+>
+
+### Configuración del servicio por primera vez
+
+Si todavía no ha utilizado el servicio, deberá configurarlo por primera vez. que le permitirá acceder a las nuevas direcciones de correo Exchange.
+
+Para ello, la primera vez que acceda al panel de gestión de su servicio Hosted Exchange, aparecerá un asistente de configuración. Haga clic en `Empezar`{.action} para configurar el servicio.
+
+Este asistente de configuración le permitirá realizar diversas acciones. En función de su situación:
+
+#### Elegir un dominio
+
+Seleccione uno de sus dominios de la lista o marque la casilla `Mi dominio no aparece en la lista de abajo` para introducir un dominio que no esté gestionado en su área de cliente **pero que pueda configurar**.
+
+![Correo electrónico](images/exchange-wizard01.png){.thumbnail}
+
+#### ¿Solo va a utilizar el servicio Exchange de OVHcloud con este dominio?
+
+La pregunta "¿**Va a utilizar únicamente la solución Exchange de OVHcloud con este dominio?** " determinará el tipo de configuración del dominio.
+
+- Si utiliza un servicio Exchange solo o con otros servicios de **correo de OVHcloud**, podrá configurarlo automáticamente o manualmente solo utilizando los servidores de correo de OVHcloud.
+- Si utiliza su servicio Exchange como complemento de un servicio de correo **externo a los productos de correo de OVHcloud**, deberá introducir, bajo la mención `Servidor de relay (SMTP)`, la URL del servidor de recepción de su servicio de correo externo.
+
+![Correo electrónico](images/exchange-wizard02.png){.thumbnail}
+
+#### ¿Cómo quiere configurar su zona DNS?
+
+- **Configuración automática**: Si el dominio está gestionado por OVHcloud y es el mismo ID de cliente que el servicio Exchange, se configurará automáticamente en la zona DNS del dominio.
+- **Configuración manual**: El dominio no se gestiona en el mismo área de cliente que su plataforma, sino que se gestiona con otro proveedor de dominios, o usted mismo quiere realizar la configuración.<br> Una vez finalizado el proceso de configuración, podrá consultar los valores que deberá introducir, o bien en la sección `Dominios asociados`{.action} de su plataforma.
+
+![Correo electrónico](images/exchange-wizard03.png){.thumbnail}
+
+#### **Configuración de las cuentas Exchange**
+
+Asigne un nombre a sus direcciones de correo Exchange y añada información adicional.
+
+![Correo electrónico](images/exchange-wizard04.png){.thumbnail}
+
+#### **Caso particular**
+
+- Si configura su plataforma Exchange con un dominio no gestionado en el mismo área de cliente que esta plataforma, o con otro proveedor de dominio, tendrá la siguiente ventana :
+
+![Correo electrónico](images/exchange-wizard05.png){.thumbnail .w-640}
+
+Esta ventana le invita a añadir un **registro CNAME** en la zona DNS del dominio. Este registro permite comprobar que usted gestiona el dominio.
+
+> [!warning]
+>
+> Sin esta validación por registro CNAME, no es posible utilizar la plataforma con este nombre de dominio.
+
+- Si configura su plataforma Exchange con un dominio no gestionado en el mismo área de cliente que esta plataforma, gestionada con otro proveedor de dominio, o si ha optado por configurar manualmente su nombre de dominio, se mostrará la siguiente ventana :
+
+![Correo electrónico](images/exchange-wizard06.png){.thumbnail .w-640}
+
+Aquí encontrará los valores que deberá introducir en su zona DNS. Los **registros MX** corresponden a la recepción del correo. El **registro SRV** se corresponde con la configuración automática de las direcciones de correo.
+
+Consulte la configuración de su zona DNS relativa a su servicio de correo en nuestra página "[Añadir un registro MX a la configuración del dominio](/pages/web_cloud/domains/dns_zone_mx)".
+
+### Añadir dominios adicionales (opcional)
+
+Una vez que haya configurado por primera vez el dominio, también puede configurar, a través del asistente, dominios adicionales si así lo desea y si todavía no lo ha hecho.
+
+> [!warning]
+>
+> Todas las direcciones creadas en el servicio Exchange se mostrarán en el directorio de las direcciones del servicio, incluidas aquellas que posean un dominio diferente. Si desea crear directorios separados, deberá contratar un nuevo servicio Hosted Exchange para el o los dominios en cuestión.
+>
+
+Para añadir un nuevo dominio, seleccione el servicio Hosted Exchange correspondiente en el [área de cliente de OVHcloud](/links/manager) y abra la pestaña `Dominios asociados`{.action}. Se mostrará una tabla con los dominios ya configurados o que estén siendo configurados en el servicio. Haga clic en el botón `Añadir un dominio`{.action} y siga los pasos que se le indican para añadir el dominio.
+
+Para más información, consulte la guía [Añadir un dominio a un servicio Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_adding_domain).
+
+> [!primary]
+>
+> Si es necesario realizar alguna acción concreta para configurar el dominio, se mostrará una etiqueta roja en la columna `Diagnóstico`{.action}. Al hacer clic, se mostrarán las operaciones necesarias. Si el dominio no utiliza la configuración de OVHcloud (es decir, si no utiliza los servidores DNS de OVHcloud), deberá realizar los cambios necesarios desde el panel que le ofrezca su proveedor para gestionar sus servidores DNS.
+>
+
+![Añadir un dominio](images/first-steps-hosted-exchange-add-domain.png){.thumbnail}
+
+### Configurar cuentas Exchange adicionales (opcional)
+
+Puede configurar cuentas adicionales si lo desea y si no lo ha hecho ya a través del asistente.
+
+Para ello, haga clic en el servicio Hosted Exchange correspondiente en su [área de cliente de OVHcloud](/links/manager) y luego en la pestaña `Cuentas de correo`{.action}. La tabla mostrará las cuentas actualmente configuradas o pendientes de configuración en su servicio.
+
+Las cuentas pendientes de configurar con el formato *@configureme.me*. Para configurarlas, haga clic en el icono con forma de lápiz y siga los pasos que se le indican.
+
+> [!primary]
+>
+> Repita esta operación para cada cuenta que tenga. Puede contratar nuevas contrataciones haciendo clic en el botón `Acciones`{.action} y seleccionando `Contratar cuentas`{.action}.
+>
+
+![Añadir una cuenta de correo](images/first-steps-hosted-exchange-add-account.png){.thumbnail}
+
+### Utilizar las direcciones de correo
+
+Una vez que haya configurado las cuentas, ¡ya puede utilizarlas! Para ello, OVHcloud pone a su disposición el webmail **Outlook Web App** (OWA). Puede acceder a ella en la dirección [Webmail](/links/web/email). Para acceder, introduzca las claves de su dirección de correo electrónico. Para más información, consulte las guías de OVHcloud sobre las [Soluciones colaborativas Microsoft](/products/web-cloud-email-collaborative-solutions-microsoft-exchange), en el apartado relativo a Outlook Web App (OWA).
+
+Si es la primera vez que inicia sesión en OWA con esta dirección de correo electrónico, se le pedirá que especifique el idioma de la interfaz y la zona horaria. Haga clic en `Guardar`{.action} para continuar.
+
+> [!primary]
+>
+> Las zonas horarias se enumeran según [el estándar UTC (hora universal coordinada)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), no por orden alfabético de ciudades.
+>
+> **Ejemplo** : Para Europa Occidental, se trata de UTC +1 (Bruselas, Copenhague, Madrid, París).
+
+Si desea configurar su cuenta de correo electrónico en un cliente de correo o un dispositivo externo (smartphone o tablet), consulte las guías de OVHcloud sobre las [soluciones colaborativas Microsoft](/products/web-cloud-email-collaborative-solutions-microsoft-exchange). Para un uso óptimo de su cuenta Exchange en un cliente de correo de escritorio, asegúrese de que este sea compatible con el servicio.
+
+OVHcloud ofrece, desde el [área de cliente de OVHcloud](/links/manager), licencias Outlook opcionales con su cuenta de correo Exchange.
+
+Para suscribirse, consulte nuestra página "[Obtener una licencia Outlook para Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license)".
+
+> [!primary]
+>
+> Tanto si utiliza un cliente de correo web como uno de escritorio compatible, Exchange sincroniza todos los parámetros de configuración (filtros, firmas, carpetas...).
+> Así pues, si utiliza Exchange en tres dispositivos y a través de tres modos de conexión distintos (webmail, distintos clientes de correo compatibles), toda su información estará disponible simultáneamente.
+>
+
+### Configuración de las funciones colaborativas (opcional)
+
+Una vez que el servicio Hosted Exchange haya sido configurado y esté operativo, ya puede activar las funcionalidades de colaboración en el [área de cliente de OVHcloud](/links/manager). Estas funciones permiten crear recursos (salas de reuniones, equipamiento...) y grupos, entre otros.
+
+Para activar las distintas funciones, seleccione el servicio Hosted Exchange correspondiente en el [área de cliente de OVHcloud](/links/manager) y abra la pestaña correspondiente a la acción que quiera realizar.
+
+Para más información sobre estas funciones, consulte las guías de OVHcloud sobre las [soluciones colaborativas Microsoft](/products/web-cloud-email-collaborative-solutions-microsoft-exchange).
+
+## Más información <a name="go-further"></a>
+
+[Crear un grupo de contactos](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
+
+[Crear y utilizar una cuenta compartida](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_shared_account)
+
+[Crear y utilizar cuentas de recursos](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_resources)
+
+[Establecer permisos sobre una cuenta de correo](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_delegation)
+
+[Compartir una carpeta desde la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+
+[Gestionar la facturación de las cuentas Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/manage_billing_exchange)
+
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/exchange_starting_hosted/guide.fr-ca.md
@@ -152,8 +152,6 @@ OVHcloud propose, depuis l'[espace client OVHcloud](/links/manager), des licence
 
 Pour y souscrire, consultez notre page « [Obtenir une licence Outlook pour Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license) ».
 
-Vous pouvez également obtenir des [licences Office 365 sur notre site](/links/web/ms365). Nous vous recommandons l'une de ces solutions si vous souhaitez bénéficier du logiciel de messagerie Outlook ou de plus de logiciels de la suite Office, selon vos besoins.
-
 > [!primary]
 >
 > Exchange permet une synchronisation complète de vos paramètres (filtres, signatures, dossiers, etc.), que vous utilisiez une application web ou un logiciel de messagerie compatible.

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license/guide.en-ca.md
@@ -1,0 +1,76 @@
+---
+title: How to obtain an Outlook licence for Exchange
+excerpt: Find out how to subscribe to an Outlook licence from your OVHcloud Exchange platform and how to activate it
+updated: 2025-04-28
+---
+
+## Objective
+
+With an Outlook licence you can use the Outlook email client to view and manage the emails in your Exchange account.
+
+OVHcloud offers the Outlook licence for a monthly cost of €2 ex VAT. It will be linked to an OVHcloud Exchange account that you manage.
+
+After subscribing, you can download the Outlook client as one of the following 3 versions:
+
+- Outlook for Windows 32 bit
+- Outlook for Windows 64 bit
+- Outlook for MAC 64 bit
+
+**This guide explains how to order an Outlook licence from your OVHcloud Exchange platform and how to activate it.**
+
+<!-- CP-NAV-START:web-exchange -->
+---
+
+### OVHcloud Control Panel Access
+
+- **Direct link:** [Exchange](/links/control-panel/web-exchange)
+- **Navigation path:** `Web Cloud`{.action} > `Exchange`{.action} > Select your platform
+
+---
+<!-- CP-NAV-END:web-exchange -->
+
+## Instructions
+
+### Ordering an Outlook licence
+
+#### For a Hosted Exchange account
+
+Click on the `...`{.action} icon to the right of the account concerned, then on `Order an Outlook`{.action} licence.
+
+![Outlook](images/order-outlook01.png){.thumbnail}
+
+Set the renewal frequency for your Outlook licence, and confirm the conditions. Then click `Next`{.action}.
+
+![Outlook](images/order-outlook02.png){.thumbnail}
+
+Once you have verified your order summary, use the `Pay`{.action} button to generate the purchase order. You will be redirected to a new page where you can pay for your order using the payment methods available to you.
+
+You will need to wait a few moments for your Outlook licence to become available in the OVHcloud Control Panel.
+
+### Downloading and installing Outlook
+
+You now need to download the appropriate Outlook installation file for your device.
+
+In the management interface for your Exchange platform, click on the `...`{.action} icon to the right of the account concerned, then on `Use Outlook licence`{.action}.
+
+Choose the version from the drop-down menu based on your operating system and language, then click `Next`{.action}.
+
+![Outlook](images/order-outlook05.png){.thumbnail}
+
+After a few moments, a download link is generated, along with a licence key needed to activate your Outlook installation.
+
+![Outlook](images/order-outlook06.png){.thumbnail}
+
+The downloaded file is in the .ISO format, i.e. a disk image. Start the installation and enter the licence key when prompted.
+
+### Deleting the Outlook licence from your account
+
+Click on the `...`{.action} icon to the right of the account concerned, then on `Delete Outlook licence`{.action}.
+
+![Outlook](images/order-outlook07.png){.thumbnail}
+
+Once you have confirmed, you are reminded that the licence will be permanently deleted on its expiry date.
+
+## Go further <a name="go-further"></a>
+
+Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license/guide.en-us.md
@@ -1,0 +1,76 @@
+---
+title: How to obtain an Outlook licence for Exchange
+excerpt: Find out how to subscribe to an Outlook licence from your OVHcloud Exchange platform and how to activate it
+updated: 2025-04-28
+---
+
+## Objective
+
+With an Outlook licence you can use the Outlook email client to view and manage the emails in your Exchange account.
+
+OVHcloud offers the Outlook licence for a monthly cost of €2 ex VAT. It will be linked to an OVHcloud Exchange account that you manage.
+
+After subscribing, you can download the Outlook client as one of the following 3 versions:
+
+- Outlook for Windows 32 bit
+- Outlook for Windows 64 bit
+- Outlook for MAC 64 bit
+
+**This guide explains how to order an Outlook licence from your OVHcloud Exchange platform and how to activate it.**
+
+<!-- CP-NAV-START:web-exchange -->
+---
+
+### OVHcloud Control Panel Access
+
+- **Direct link:** [Exchange](/links/control-panel/web-exchange)
+- **Navigation path:** `Web Cloud`{.action} > `Exchange`{.action} > Select your platform
+
+---
+<!-- CP-NAV-END:web-exchange -->
+
+## Instructions
+
+### Ordering an Outlook licence
+
+#### For a Hosted Exchange account
+
+Click on the `...`{.action} icon to the right of the account concerned, then on `Order an Outlook`{.action} licence.
+
+![Outlook](images/order-outlook01.png){.thumbnail}
+
+Set the renewal frequency for your Outlook licence, and confirm the conditions. Then click `Next`{.action}.
+
+![Outlook](images/order-outlook02.png){.thumbnail}
+
+Once you have verified your order summary, use the `Pay`{.action} button to generate the purchase order. You will be redirected to a new page where you can pay for your order using the payment methods available to you.
+
+You will need to wait a few moments for your Outlook licence to become available in the OVHcloud Control Panel.
+
+### Downloading and installing Outlook
+
+You now need to download the appropriate Outlook installation file for your device.
+
+In the management interface for your Exchange platform, click on the `...`{.action} icon to the right of the account concerned, then on `Use Outlook licence`{.action}.
+
+Choose the version from the drop-down menu based on your operating system and language, then click `Next`{.action}.
+
+![Outlook](images/order-outlook05.png){.thumbnail}
+
+After a few moments, a download link is generated, along with a licence key needed to activate your Outlook installation.
+
+![Outlook](images/order-outlook06.png){.thumbnail}
+
+The downloaded file is in the .ISO format, i.e. a disk image. Start the installation and enter the licence key when prompted.
+
+### Deleting the Outlook licence from your account
+
+Click on the `...`{.action} icon to the right of the account concerned, then on `Delete Outlook licence`{.action}.
+
+![Outlook](images/order-outlook07.png){.thumbnail}
+
+Once you have confirmed, you are reminded that the licence will be permanently deleted on its expiry date.
+
+## Go further <a name="go-further"></a>
+
+Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license/guide.es-us.md
@@ -1,0 +1,72 @@
+---
+title: Obtener una licencia Outlook para Exchange
+excerpt: Cómo contratar una licencia Outlook desde una plataforma Exchange de OVHcloud e instalarla
+updated: 2025-04-28
+---
+
+## Objetivo
+
+Desea disfrutar de una licencia Outlook para consultar y gestionar sus emails en su cuenta Exchange.
+
+OVHcloud le ofrece el cliente de correo Outlook al precio de 2 euros (+IVA) al mes. Estará asociado a una cuenta Exchange de OVHcloud de la que usted es responsable.
+
+Una vez contratada, puede descargar Outlook de una de las 3 versiones siguientes:
+
+- Outlook para Windows 32 bits.
+- Outlook para Windows 64 bits.
+- Outlook para MAC 64 bits.
+
+**Esta guía explica cómo contratar e instalar una licencia Outlook desde una plataforma Exchange de OVHcloud.**
+
+<!-- CP-NAV-START:web-exchange -->
+---
+
+### Acceso al área de cliente de OVHcloud
+
+- **Enlace directo:** [Exchange](/links/control-panel/web-exchange)
+- **Ruta de navegación:** `Web Cloud`{.action} > `Exchange`{.action} > Seleccione su plataforma
+
+---
+<!-- CP-NAV-END:web-exchange -->
+
+## Procedimiento
+
+### Contratar una licencia Outlook
+
+#### Para una cuenta Hosted Exchange
+
+![Outlook](images/order-outlook01.png){.thumbnail}
+
+Indique la frecuencia de renovación de la licencia Outlook y acepte las condiciones. Haga clic en `Siguiente`{.action} para continuar.
+
+![Outlook](images/order-outlook02.png){.thumbnail}
+
+Una vez hecho el resumen del pedido, utilice el botón `Abonar`{.action} para generar la orden de pedido. Será redirigido a una nueva página en la que podrá abonar el pedido utilizando las formas de pago que tenga a su disposición.
+
+Espere a que se ponga a su disposición la licencia Outlook en el área de cliente.
+
+### Descargar e instalar Outlook
+
+Ya puede descargar el archivo de instalación de Outlook para su máquina.
+
+Desde la interfaz de gestión de su plataforma Exchange, haga clic en el icono `...`{.action} a la derecha de la cuenta correspondiente y, seguidamente, en `Utilizar la licencia Outlook`{.action}.
+
+Seleccione la versión en el menú desplegable, en función de su sistema operativo y del idioma, y haga clic en `Siguiente`{.action}.
+
+![Outlook](images/order-outlook05.png){.thumbnail}
+
+Al cabo de unos minutos, se generará un enlace de descarga y una clave de licencia para instalar en la máquina.
+
+![Outlook](images/order-outlook06.png){.thumbnail}
+
+El archivo descargado tiene el formato .ISO, es decir, una imagen de disco. Ejecute la instalación e introduzca la clave de licencia cuando se le pida.
+
+### Eliminar la licencia Outlook de su cuenta
+
+![Outlook](images/order-outlook07.png){.thumbnail}
+
+Tras la validación, le recordamos que la licencia se eliminará definitivamente en su fecha de expiración.
+
+## Más información <a name="go-further"></a>
+
+Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/office_outlook_license/guide.fr-ca.md
@@ -1,0 +1,76 @@
+---
+title: Obtenir une licence Outlook pour Exchange
+excerpt: Découvrez comment souscrire une licence Outlook depuis votre plateforme Exchange OVHcloud et l'installer
+updated: 2025-04-28
+---
+
+## Objectif
+
+Vous souhaitez bénéficier d'une licence Outlook pour consulter et gérer vos e-mails sur votre compte Exchange.
+
+OVHcloud vous propose le client de messagerie Outlook au tarif de 2 euros HT par mois. Il sera associé à un compte Exchange OVHcloud dont vous avez la gestion.
+
+Après votre souscription, vous pouvez télécharger Outlook parmi l'une des 3 versions suivantes :
+
+- Outlook pour Windows 32 bits.
+- Outlook pour Windows 64 bits.
+- Outlook pour MAC 64 bits.
+
+**Découvrez comment souscrire une licence Outlook depuis votre plateforme Exchange OVHcloud et l'installer.**
+
+<!-- CP-NAV-START:web-exchange -->
+---
+
+### Accès à l'espace client OVHcloud
+
+- **Lien direct :** [Exchange](/links/control-panel/web-exchange)
+- **Pour accéder à vos services :** `Web Cloud`{.action} > `Exchange`{.action} > Sélectionnez votre plateforme
+
+---
+<!-- CP-NAV-END:web-exchange -->
+
+## En pratique
+
+### Commander une licence Outlook
+
+#### Pour un compte Hosted Exchange
+
+Cliquez sur l'icône `...`{.action} à droite du compte concerné, puis sur `Commander une licence Outlook`{.action}.
+
+![Outlook](images/order-outlook01.png){.thumbnail}
+
+Définissez la fréquence de renouvellement de votre licence Outlook et validez les conditions. Cliquez ensuite sur `Suivant`{.action}.
+
+![Outlook](images/order-outlook02.png){.thumbnail}
+
+Après le récapitulatif de votre commande, utilisez le bouton `Régler`{.action} afin de générer le bon de commande. Vous serez redirigé vers une nouvelle page qui vous permettra de régler votre commande via les moyens de paiement à votre disposition.
+
+Patientez quelques instants le temps de la mise à disposition de votre licence Outlook dans votre espace client.
+
+### Télécharger et installer Outlook
+
+Il vous faut maintenant télécharger le fichier d'installation d'Outlook pour votre machine.
+
+Depuis l'interface de gestion de votre plateforme Exchange, cliquez sur l'icône `...`{.action} à droite du compte concerné, puis sur `Utiliser la licence Outlook`{.action}.
+
+Choisissez la version dans le menu déroulant en fonction de votre système d'exploitation et la langue, puis cliquez sur `Suivant`{.action}.
+
+![Outlook](images/order-outlook05.png){.thumbnail}
+
+Après quelques instants, un lien de téléchargement est généré, ainsi qu'une clé de licence à utiliser lors de l'installation sur votre machine.
+
+![Outlook](images/order-outlook06.png){.thumbnail}
+
+Le fichier téléchargé est au format .ISO, c'est-à-dire une image disque. Lancez l'installation et saisissez la clé de licence lorsqu'elle vous sera demandée.
+
+### Supprimer la licence Outlook de votre compte
+
+Cliquez sur l'icône `...`{.action} à droite du compte concerné, puis sur `Supprimer la licence Outlook`{.action}.
+
+![Outlook](images/order-outlook07.png){.thumbnail}
+
+Après validation, il vous est rappelé que la licence sera définitivement supprimée à sa date d'expiration.
+
+## Aller plus loin <a name="go-further"></a>
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
@@ -79,9 +79,8 @@ Avant de débuter votre migration, il vous faudra identifier la version du MX Pl
 
 > [!warning]
 >
-> Cette partie concerne l'ensemble des services MX Plan utilisant la technologie webmail Roundcube ou OWA.
+> Cette partie concerne l'ensemble des services MX Plan utilisant la technologie webmail OWA.
 >
-> Néanmoins, si vous souhaitez migrer un service MX Plan utilisant le webmail Roundcube vers une plateforme Exchange OVHcloud, suivez la partie « [Migration automatique d'une offre MX Plan Roundcube vers Exchange](#roundcube-mxplan) » de ce guide.
 
 > [!warning]
 >
@@ -126,58 +125,6 @@ Après la migration, vérifiez que vous retrouvez vos éléments en vous connect
 Vous pouvez conserver ou supprimer le compte d'origine avec le nom provisoire après cette migration.
 
 Si vous souhaitez le supprimer, dirigez-vous dans l'onglet `Comptes e-mail`{.action} de votre MX Plan, cliquez sur le bouton `...`{.action} puis sur `Réinitialiser ce compte`{.action}.
-
-#### 3.2 Migration automatique d'une offre MX Plan Roundcube vers Exchange <a name="roundcube-mxplan"></a>
-
-> [!warning]
->
-> Cette partie concerne uniquement les services MX Plan utilisant la technologie webmail Roundcube.
-
-> [!primary]
->
-> Votre compte OVHcloud doit préalablement être contact administrateur **et** contact technique du service MX plan à migrer, **ainsi que** du service Exchange vers lequel vous migrez.
->
-> Pour plus d'information sur les changements de contacts, consultez notre guide pour [gérer les contacts de ses services](/pages/account_and_service_management/account_information/managing_contacts).
->
-
-La migration peut être effectuée depuis deux interfaces :<br>
-
-- **celle de l'assistant de configuration Hosted Exchange**, uniquement si vous venez de commander un service Hosted Exchange et que vous n'avez encore rien paramétré sur ce dernier ;
-- **celle du MX Plan**, dès que vous êtes en possession d'un service Exchange (déjà configuré ou non) et d'une adresse MX Plan que vous souhaitez migrer.
-
-> Pour rappel, avant de débuter la migration, assurez-vous qu'aucune **redirection** ou qu'aucun **répondeur** ne soient paramétrés sur votre MX Plan.
->
-> ![email](images/mxplan-legacy-redirect.png){.thumbnail .w-640}
-
-Une fois que vous êtes prêt, poursuivez la lecture de cette documentation selon l'interface sélectionnée. Nous vous rappelons que le délai de migration dépend de la quantité de contenu à migrer vers votre nouveau compte. Celui-ci peut varier de quelques minutes à plusieurs heures.
-
-> [!warning]
->
-> Une fois la migration confirmée, vous ne pourrez plus accéder à votre ancienne adresse e-mail MX Plan ni annuler le processus de migration. Nous vous conseillons vivement de réaliser cette opération à un horaire propice.
->
-> Même si vous ne pourrez plus accéder à votre adresse e-mail actuelle, les messages déjà réceptionnés ainsi que ceux reçus ne seront pas perdus. Tous seront immédiatement accessibles depuis votre nouveau compte.
->
-
-##### **Migration depuis l'assistant de configuration Exchange**
-
-L'assistant s'affiche pour vous aider à configurer votre nouveau service Exchange. Durant ce processus, vous pouvez sélectionner les comptes e-mail MX Plan à migrer.
-
-Si l'assistant de configuration ne s'affiche pas, les informations générales du service Exchange apparaîtront à la place. Dans ce cas, vous devrez réaliser la migration de vos comptes via l'interface MX Plan.
-
-##### **Migration depuis l'interface MX Plan**
-
-Pour réaliser la migration depuis cette interface, rendez-vous dans la section [MX Plan](/links/control-panel/web-mx-plan) de votre espace client OVHcloud et sélectionnez le domaine concerné. Dans l'onglet `Emails`{.action}, cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source), puis sur `Migrer le compte`{.action}.
-
-![exchange](images/access_the_migration_tool.png){.thumbnail .w-640}
-
-Dans la fenêtre qui s'affiche, sélectionnez le service de destination (celui vers lequel vous souhaitez migrer l'adresse) puis cliquez sur `Suivant`{.action}. S'il possède au minimum un compte « libre » (c'est-à-dire encore non paramétré), la migration s'effectuera vers l'un de ces comptes. Dès lors, prenez connaissance des informations qui s'affichent, validez-les, puis cliquez sur `Suivant`{.action} pour poursuivre l'opération.
-
-Si vous ne possédez pas de compte « libre », un bouton `Commander des comptes`{.action} apparaîtra. Suivez les étapes, puis patientez le temps que les comptes soient installés pour effectuer de nouveau la manipulation.
-
-Confirmez enfin le mot de passe de l'adresse e-mail source (celle que vous voulez migrer), puis cliquez sur `Migrer`{.action}. Cette manipulation sera à répéter autant de fois que nécessaire pour la migration d'autres comptes.
-
-![exchange](images/account_migration_steps.png){.thumbnail .w-640}
-
 
 ### Étape 4 : Vérifier ou modifier la configuration de votre domaine
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-asia.md
@@ -189,8 +189,6 @@ You can set up an automatic reply directly by logging in to your email account v
 
 [Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 
-[MX Plan - Create an automatic response on an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)
-
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-au.md
@@ -189,8 +189,6 @@ You can set up an automatic reply directly by logging in to your email account v
 
 [Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 
-[MX Plan - Create an automatic response on an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)
-
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-ca.md
@@ -189,8 +189,6 @@ You can set up an automatic reply directly by logging in to your email account v
 
 [Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 
-[MX Plan - Create an automatic response on an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)
-
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-sg.md
@@ -189,8 +189,6 @@ You can set up an automatic reply directly by logging in to your email account v
 
 [Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 
-[MX Plan - Create an automatic response on an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)
-
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.en-us.md
@@ -189,8 +189,6 @@ You can set up an automatic reply directly by logging in to your email account v
 
 [Use email redirections](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 
-[MX Plan - Create an automatic response on an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)
-
 For specialised services (SEO, development, etc.), contact [OVHcloud partners](/links/partner).
 
 If you would like assistance using and configuring your OVHcloud solutions, please refer to our [support offers](/links/support).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.es-us.md
@@ -190,8 +190,6 @@ La puesta en marcha de una respuesta automática se realiza directamente conect�
 
 [Utilizar las redirecciones de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 
-[MX Plan - Crear una respuesta automática en una dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)
-
 Para servicios especializados (posicionamiento, desarrollo, etc.), contacte con [partners de OVHcloud](/links/partner).
 
 Si quiere disfrutar de ayuda para utilizar y configurar sus soluciones de OVHcloud, puede consultar nuestras distintas soluciones [pestañas de soporte](/links/support).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities/guide.fr-ca.md
@@ -189,8 +189,6 @@ La mise en place d'une réponse automatique se réalise directement en se connec
 
 [Utiliser les redirections e-mail](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 
-[MX Plan - Créer une réponse automatique sur une adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)
-
 Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-asia.md
@@ -144,8 +144,6 @@ With [webmail](/links/web/email), you can access your email at any time, from an
 
 All of your email addresses are managed via the [OVHcloud Control Panel](/links/manager). To do this, log in and access the product concerned. You can change the passwords for your email addresses, check how much space they have left, create new email addresses, or delete existing ones.
 
-**Tips and Tricks**: With MX Plan email solutions, you can delegate management of an email account to another OVHcloud account, while keeping control of it yourself. Simply configure a delegation in your [OVHcloud Control Panel](/links/manager). You can use [our documentation](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_delegation).
-
 ///
 
 /// details | What should I know before I create an email address?
@@ -202,15 +200,7 @@ If you have signed up to [one of our OVHcloud email solutions](/links/web/emails
 
 Want to change your [email solution](/links/web/emails) to get more space and features, but want to keep the content of your existing email address? To do this, please follow the migration guide that corresponds to your needs:
 
-- [Migrate your email addresses from one OVHcloud email platform to another](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrate your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration).
-- [Migrate email accounts via the OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).
-
-///
-
-/// details | Does the Office 365 Pro Plus offer include a Skype license?
-
-Office 365 Pro Plus does not contain a Skype license. Only Skype for Business software is included.
 
 ///
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-au.md
@@ -144,8 +144,6 @@ With [webmail](/links/web/email), you can access your email at any time, from an
 
 All of your email addresses are managed via the [OVHcloud Control Panel](/links/manager). To do this, log in and access the product concerned. You can change the passwords for your email addresses, check how much space they have left, create new email addresses, or delete existing ones.
 
-**Tips and Tricks**: With MX Plan email solutions, you can delegate management of an email account to another OVHcloud account, while keeping control of it yourself. Simply configure a delegation in your [OVHcloud Control Panel](/links/manager). You can use [our documentation](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_delegation).
-
 ///
 
 /// details | What should I know before I create an email address?
@@ -202,15 +200,7 @@ If you have signed up to [one of our OVHcloud email solutions](/links/web/emails
 
 Want to change your [email solution](/links/web/emails) to get more space and features, but want to keep the content of your existing email address? To do this, please follow the migration guide that corresponds to your needs:
 
-- [Migrate your email addresses from one OVHcloud email platform to another](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrate your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration).
-- [Migrate email accounts via the OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).
-
-///
-
-/// details | Does the Office 365 Pro Plus offer include a Skype license?
-
-Office 365 Pro Plus does not contain a Skype license. Only Skype for Business software is included.
 
 ///
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-ca.md
@@ -184,8 +184,6 @@ With [webmail](/links/web/email), you can access your email at any time, from an
 
 All of your email addresses are managed via the [OVHcloud Control Panel](/links/manager). To do this, log in and access the product concerned. You can change the passwords for your email addresses, check how much space they have left, create new email addresses, or delete existing ones.
 
-**Tips and Tricks**: With MX Plan email solutions, you can delegate management of an email account to another OVHcloud account, while keeping control of it yourself. Simply configure a delegation in your [OVHcloud Control Panel](/links/manager). You can use [our documentation](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_delegation).
-
 ///
 
 /// details | What should I know before I create an email address?
@@ -246,12 +244,6 @@ Want to change your [email solution](/links/web/emails) to get more space and fe
 - [Migrate your email addresses from one OVHcloud email platform to another](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrate your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration).
 - [Migrate email accounts via the OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).
-
-///
-
-/// details | Does the Office 365 Pro Plus offer include a Skype license?
-
-Office 365 Pro Plus does not contain a Skype license. Only Skype for Business software is included.
 
 ///
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-sg.md
@@ -144,8 +144,6 @@ With [webmail](/links/web/email), you can access your email at any time, from an
 
 All of your email addresses are managed via the [OVHcloud Control Panel](/links/manager). To do this, log in and access the product concerned. You can change the passwords for your email addresses, check how much space they have left, create new email addresses, or delete existing ones.
 
-**Tips and Tricks**: With MX Plan email solutions, you can delegate management of an email account to another OVHcloud account, while keeping control of it yourself. Simply configure a delegation in your [OVHcloud Control Panel](/links/manager). You can use [our documentation](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_delegation).
-
 ///
 
 /// details | What should I know before I create an email address?
@@ -202,15 +200,7 @@ If you have signed up to [one of our OVHcloud email solutions](/links/web/emails
 
 Want to change your [email solution](/links/web/emails) to get more space and features, but want to keep the content of your existing email address? To do this, please follow the migration guide that corresponds to your needs:
 
-- [Migrate your email addresses from one OVHcloud email platform to another](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrate your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration).
-- [Migrate email accounts via the OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).
-
-///
-
-/// details | Does the Office 365 Pro Plus offer include a Skype license?
-
-Office 365 Pro Plus does not contain a Skype license. Only Skype for Business software is included.
 
 ///
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.en-us.md
@@ -184,8 +184,6 @@ With [webmail](/links/web/email), you can access your email at any time, from an
 
 All of your email addresses are managed via the [OVHcloud Control Panel](/links/manager). To do this, log in and access the product concerned. You can change the passwords for your email addresses, check how much space they have left, create new email addresses, or delete existing ones.
 
-**Tips and Tricks**: With MX Plan email solutions, you can delegate management of an email account to another OVHcloud account, while keeping control of it yourself. Simply configure a delegation in your [OVHcloud Control Panel](/links/manager). You can use [our documentation](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_delegation).
-
 ///
 
 /// details | What should I know before I create an email address?
@@ -246,12 +244,6 @@ Want to change your [email solution](/links/web/emails) to get more space and fe
 - [Migrate your email addresses from one OVHcloud email platform to another](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrate your email address manually](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration).
 - [Migrate email accounts via the OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).
-
-///
-
-/// details | Does the Office 365 Pro Plus offer include a Skype license?
-
-Office 365 Pro Plus does not contain a Skype license. Only Skype for Business software is included.
 
 ///
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.es-us.md
@@ -184,8 +184,6 @@ Gracias al [webmail](/links/web/email), podrá acceder a su correo en cualquier 
 
 Todas sus direcciones de correo se gestionan desde el [área de cliente de OVHcloud](/links/manager). Para ello, una vez que se haya conectado, acceda al producto correspondiente. Puede de esta manera modificar la contraseña de sus direcciones de correo, verificar su índice de llenado, crear nuevas direcciones o eliminar direcciones existentes.
 
-**Trucos y consejos**: En los servicios MX Plan, puede delegar la gestión de una cuenta de correo en otra cuenta de OVHcloud, pero usted mismo podrá controlarla. Para ello, solo tiene que configurar una delegación desde su [área de cliente de OVHcloud](/links/manager). Puede basarse en [nuestra documentación](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_delegation).
-
 ///
 
 /// details | ¿Qué hay que saber antes de crear una dirección de correo electrónico?
@@ -246,12 +244,6 @@ Si ha contratado [una de nuestras soluciones de correo de OVHcloud](/links/web/e
 - [Migrar las direcciones de correo electrónico de una plataforma de correo de OVHcloud a otra](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrar manualmente una dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration).
 - [Migrar cuentas de correo electrónico mediante OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm).
-
-///
-
-/// details | ¿La solución Office 365 Pro Plus incluye licencia Skype?
-
-La solución Office 365 Pro Plus no incluye licencia Skype. Solo se incluye Skype for Business.
 
 ///
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-emails/guide.fr-ca.md
@@ -186,8 +186,6 @@ Grâce au [webmail](/links/web/email), vous pouvez accéder à tout moment à vo
 
 L'ensemble de vos adresses e-mail se gère depuis votre [espace client OVHcloud](/links/manager). Pour cela, une fois connecté, accédez au produit concerné. Vous pouvez ainsi modifier le mot de passe de vos adresses e-mail, vérifier leur taux de remplissage, créer de nouvelles adresses ou supprimer des adresses existantes.
 
-**Trucs et Astuces** : Sur les offres e-mail MX Plan, vous pouvez déléguer la gestion d'un compte e-mail à un autre compte OVHcloud tout en gardant vous-même la main sur celui-ci. Pour cela, il vous suffit de configurer une délégation, depuis votre [espace client OVHcloud](/links/manager). Vous pouvez vous appuyer sur [notre documentation](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_delegation).
-
 ///
 
 /// details | Que faut-il savoir avant de créer une adresse e-mail ?
@@ -248,12 +246,6 @@ Vous souhaitez changer d'[offre e-mail](/links/web/emails) pour bénéficier de 
 - [Migrer vos adresses e-mail d'une plateforme e-mail OVHcloud vers une autre](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel).
 - [Migrer manuellement votre adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/migrating/manual_email_migration).
 - [Migrer des comptes e-mail via OVHcloud Mail Migrator](/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_omm)..
-
-///
-
-/// details | L'offre Office 365 Pro Plus comprend-elle une licence Skype ?
-
-L’offre Office 365 Pro Plus ne contient pas de licence Skype. Seul le logiciel Skype for Business y est inclus.
 
 ///
 


### PR DESCRIPTION

## What type of Pull Request is this?

- Fix
- Optimization

## Description

Wave 3 — Regional consistency fixes for non-EU email guides

Removed references to EU-only products and features from CA, US, and APAC locale guides:

1. exchange_starting_hosted (CA/US): removed Office 365 license line; added missing en-us and es-us locale files
2. office_outlook_license (CA/US): created en-ca, en-us, fr-ca, es-us locale files without the Private Exchange section
3. migration_control_panel (fr-ca): removed Roundcube-to-Exchange auto-migration section
4. email_generalities (CA/US/APAC): removed link to feature_auto_responses, which is EU-only
5. faq-emails (CA/US): removed feature_delegation tip and Office 365 Pro Plus/Skype FAQ block
6. faq-emails (APAC): same removals, plus removed link to migration_control_panel (Exchange not available in APAC)
