### PR TITLE
Bare Metal Cloud - lacp-netplan: drop main-private MAC heuristic

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "So konfigurieren Sie Link-Aggregation mit LACP in Debian 12 oder Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: "So konfigurieren Sie Link-Aggregation mit LACP in Debian 12 oder Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "How to configure Link Aggregation with LACP in Debian 12 or Ubuntu 24.04"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Cómo configurar la agregación de enlaces con LACP en Debian 12 o Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: "Cómo configurar la agregación de enlaces con LACP en Debian 12 o Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Cómo configurar la agregación de enlaces con LACP en Debian 12 o Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Cómo configurar la agregación de enlaces con LACP en Debian 12 o Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Comment configurer l'agrégation de liens avec LACP dans Debian 12 ou Ubuntu 24.04"
 excerpt: "Activez l'agrégation de liens dans votre serveur Debian 12 ou Ubuntu 24.04 (Netplan) pour augmenter la disponibilité de votre serveur et augmenter l'efficacité de vos connexions réseau"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Comment configurer l'agrégation de liens avec LACP dans Debian 12 ou Ubuntu 24.04"
 excerpt: "Activez l'agrégation de liens dans votre serveur Debian 12 ou Ubuntu 24.04 (Netplan) pour augmenter la disponibilité de votre serveur et augmenter l'efficacité de vos connexions réseau"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Cliquez sur l'onglet `Interfaces réseau`{.action} et prenez note des adresses M
 
 > [!primary]
 > Veuillez noter que l'adresse MAC de l'interface **publique principale** est celle qui reçoit les offres DHCP à la fois dans le système d'exploitation du serveur et en mode rescue. Cette interface gère la connectivité publique dans la configuration par défaut.
->
-> Quant à l'adresse MAC de l'interface **privée principale**, il s'agit de celle dont la valeur est la plus faible. Dans l'image exemple ci-dessus, il s'agit de l'adresse `a1:b2:c3:d4:e5:d6`.
 >
 
 Maintenant que vous savez quelles adresses MAC sont associées à chaque type (public/privé) d'interface, vous devez récupérer les noms des interfaces.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Comment configurer l'agrégation de liens avec LACP dans Debian 12 ou Ubuntu 24.04"
 excerpt: "Activez l'agrégation de liens dans votre serveur Debian 12 ou Ubuntu 24.04 (Netplan) pour augmenter la disponibilité de votre serveur et augmenter l'efficacité de vos connexions réseau"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Comment configurer l'agrégation de liens avec LACP dans Debian 12 ou Ubuntu 24.04"
 excerpt: "Activez l'agrégation de liens dans votre serveur Debian 12 ou Ubuntu 24.04 (Netplan) pour augmenter la disponibilité de votre serveur et augmenter l'efficacité de vos connexions réseau"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Cliquez sur l'onglet `Interfaces réseau`{.action} et prenez note des adresses M
 
 > [!primary]
 > Veuillez noter que l'adresse MAC de l'interface **publique principale** est celle qui reçoit les offres DHCP à la fois dans le système d'exploitation du serveur et en mode rescue. Cette interface gère la connectivité publique dans la configuration par défaut.
->
-> Quant à l'adresse MAC de l'interface **privée principale**, il s'agit de celle dont la valeur est la plus faible. Dans l'image exemple ci-dessus, il s'agit de l'adresse `a1:b2:c3:d4:e5:d6`.
 >
 
 Maintenant que vous savez quelles adresses MAC sont associées à chaque type (public/privé) d'interface, vous devez récupérer les noms des interfaces.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Come configurare l'aggregazione di link con LACP in Debian 12 o Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: "Come configurare l'aggregazione di link con LACP in Debian 12 o Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Jak skonfigurować agregację łączy za pomocą protokołu LACP w Debianie 12 lub Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: "Jak skonfigurować agregację łączy za pomocą protokołu LACP w Debianie 12 lub Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Como configurar a agregação de links com LACP em Debian 12 ou Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-04-13
+updated: 2026-04-14
 ---
 
 <style>

--- a/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/lacp-enable-netplan/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: "Como configurar a agregação de links com LACP em Debian 12 ou Ubuntu 24.04 (EN)"
 excerpt: "Enable Link Aggregation in your Debian 12 or Ubuntu 24.04 server (Netplan) to increase your server’s availability and boost the efficiency of your network connections"
-updated: 2026-01-09
+updated: 2026-04-13
 ---
 
 <style>
@@ -60,8 +60,6 @@ Switch to the tab `Network Interfaces`{.action} and take note of the MAC address
 
 > [!primary]
 > Please note that the MAC address of the **main public** interface is the one receiving DHCP offers, both in the server's operating system and in rescue mode. This interface handles public connectivity in the default configuration.
->
-> Additionally, the MAC address of the **main private** interface is the one with the lowest value. In the example image above, this is the address `a1:b2:c3:d4:e5:d6`.
 >
 
 Now that you know which MAC addresses are associated to each type (public/private) of interface, you need to retrieve the interfaces names.


### PR DESCRIPTION


<!--
Hello 👋
Thank you for submitting a Pull Request.

For Work In Progress Pull Requests, please use the Draft PR feature, see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details. As long as your Pull Request is a draft, the OVHcloud Guides Team will not start proofreading it.

For a timely review/response, please avoid force-pushing additional commits if your PR already received reviews or comments.

DO NOT USE a fork if you are an OVHcloud employee. Instead, please contact the OVHcloud Guides Team so to be granted /write access to this repository.

Feel free to apply labels on your Pull Request, selecting them from the list to your right.

Before submitting a Pull Request, please ensure you have:

- 📖 Read the OVHcloud Documentation readme: https://github.com/ovh/docs/blob/develop/readme.md
- 🇬🇧 Edited (at least) the en-gb version of a guide.
- 🇫🇷 Edited also the fr-fr version if you are a French speaker.
- 🌐 Edited all the files if you're doing a fix or a minor update (this is not mandatory but recommended).
- 👷‍♀️ Created a small PR, if applicable.
- ✅ Tested every step you're documenting.
- 📝 Used descriptive commit messages.
- 📐 Resized images which width exceeds 1400px.
- 📝 Edited or blurred any sensitive/private information from your text and images (IPs, user IDs, private URLs, etc.).
-->

## What type of Pull Request is this?

<!-- Delete the lines which don't apply: -->

- Update of existing guide(s)
- Fix

## Description

The note suggesting that the main private interface could be identified as the one with the lowest MAC address value is no longer accurate and should not be relied upon. In the future, the fallback/main private interface will be exposed directly via the API.

This partially reverts c88844644c (ovh/docs#8833).

Ref: PUBM-52371

## Mandatory information

The translations in this Pull Request have been done using:

- [x] This Pull Request didn't require any translation.

<!-- Delete the line which doesn't apply: -->
- This Pull Request can be merged as soon as possible.


<!-- If you know about the following, please mention it. If you don't know, delete the line.-->
- This Pull Request content should be replicated for the US OVHcloud documentation : YES