### PR TITLE
OPCP - Add Landing Zone Manager guide and clarify CloudStore L3 delegation

### DIFF
--- a/pages/hosted_private_cloud/opcp/cloudstore-getting-started/guide.en-gb.md
+++ b/pages/hosted_private_cloud/opcp/cloudstore-getting-started/guide.en-gb.md
@@ -54,14 +54,14 @@ Before using the CloudStore, it is important to understand its main concepts.
 The CloudStore distinguishes between two audiences:
 
 - **Cloud providers** (IT admins, Service admins): OVHcloud customers who operate the platform. They provision infrastructure, deploy services, and manage accounts.
-- **Cloud users** (End users): Customers of cloud providers who consume the services deployed for them through the **Landing Zone**.
+- **Cloud users** (Landing Zone Manager users): Customers of cloud providers who consume the services deployed for them through the **Landing Zone**.
 
 | Persona | Responsibilities |
 |---------|-----------------|
 | IT admin | Create accounts, activate services, deploy apps |
 | Service admin | Manage a specific service, deploy its controller and apps |
 | Account admin | Manage the configuration of their account |
-| End user | Access apps through the Landing Zone |
+| Landing Zone Manager user | Access apps through the Landing Zone |
 
 #### The controller/app pattern
 
@@ -91,7 +91,7 @@ The platform automatically:
 - Create a dedicated Keycloak realm named `account-{name}`.
 - Create an admin user with the `account-admin` role.
 - Set up a temporary password (the account admin will be prompted to change it on first login).
-- Configure a `landing-zone` client for end-user access.
+- Configure a `landing-zone` client for Landing Zone Manager user access.
 
 ### Deploying a service
 
@@ -151,10 +151,15 @@ CloudStore uses a layered Keycloak federation model that mirrors the platform ar
 |-------|-------------------|-------|---------|
 | L1 | OPCP Core Keycloak | DC operators, Super admins | Infrastructure-level identity |
 | L2 | CloudStore Keycloak | IT admins, Service admins | Platform management |
-| L3 | Per-account Keycloak realms | End users | Application access |
+| L3 | Per-account Keycloak realms | Landing Zone Manager users | Application access |
 
 - **Keycloak L2** is federated with **L1** (OPCP Core). This means rights granted on OpenStack projects at L1 are carried through to L2.
 - **Keycloak L3** is an independent instance managed by the CloudStore API. Each account gets its own isolated realm.
+
+> [!info]
+>
+> The **L3 layer** is provided by the [Landing Zone Manager](/pages/hosted_private_cloud/opcp/landing-zone-manager), a separate OPCP product responsible for Landing Zone Manager user account management. Its Keycloak stack is **not federated** with the L1 (OPCP Core) and L2 (CloudStore) Keycloak instances.
+>
 
 #### Managing IAM on CloudStore Keycloak (L2)
 
@@ -170,9 +175,9 @@ Once this role is assigned, the user will have the necessary permissions to admi
 
 ### The Landing Zone
 
-The **Landing Zone** is the interface for end users (cloud users). It provides a simplified view of the apps deployed for their account.
+The **Landing Zone** is the interface for Landing Zone Manager users (cloud users). It provides a simplified view of the apps deployed for their account.
 
-End users authenticate through their account-specific Keycloak realm (L3) and can only access apps deployed for their account. The Landing Zone retrieves the list of accessible apps and filters them based on user permissions.
+Landing Zone Manager users authenticate through their account-specific Keycloak realm (L3) and can only access apps deployed for their account. The Landing Zone retrieves the list of accessible apps and filters them based on user permissions.
 
 ## Go further
 

--- a/pages/hosted_private_cloud/opcp/cloudstore-getting-started/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/opcp/cloudstore-getting-started/guide.fr-fr.md
@@ -54,14 +54,14 @@ Avant d'utiliser le CloudStore, il est important de comprendre ses principaux co
 Le CloudStore distingue deux types d'utilisateurs :
 
 - **Fournisseurs cloud** (IT admins, Service admins) : Clients OVHcloud qui exploitent la plateforme. Ils provisionnent l'infrastructure, déploient les services et gèrent les comptes.
-- **Utilisateurs cloud** (End users) : Clients des fournisseurs cloud qui consomment les services déployés pour eux via la **Landing Zone**.
+- **Utilisateurs cloud** (Landing Zone Manager users) : Clients des fournisseurs cloud qui consomment les services déployés pour eux via la **Landing Zone**.
 
 | Persona | Responsabilités |
 |---------|-----------------|
 | IT admin | Créer des comptes, activer des services, déployer des apps |
 | Service admin | Gérer un service spécifique, déployer son contrôleur et ses apps |
 | Account admin | Gérer la configuration de son compte |
-| End user | Accéder aux apps via la Landing Zone |
+| Landing Zone Manager user | Accéder aux apps via la Landing Zone |
 
 #### Le modèle contrôleur/app
 
@@ -91,7 +91,7 @@ La plateforme effectue automatiquement les actions suivantes :
 - Création d'un realm Keycloak dédié nommé `account-{name}`.
 - Création d'un utilisateur administrateur avec le rôle `account-admin`.
 - Configuration d'un mot de passe temporaire (l'administrateur du compte sera invité à le modifier lors de sa première connexion).
-- Configuration d'un client `landing-zone` pour l'accès des utilisateurs finaux.
+- Configuration d'un client `landing-zone` pour l'accès des utilisateurs Landing Zone Manager.
 
 ### Déploiement d'un service
 
@@ -151,10 +151,15 @@ Le CloudStore utilise un modèle de fédération Keycloak en couches qui reflèt
 |--------|-------------------|--------------|------|
 | L1 | OPCP Core Keycloak | DC operators, Super admins | Identité au niveau infrastructure |
 | L2 | CloudStore Keycloak | IT admins, Service admins | Gestion de la plateforme |
-| L3 | Realms Keycloak par compte | End users | Accès aux applications |
+| L3 | Realms Keycloak par compte | Landing Zone Manager users | Accès aux applications |
 
 - **Keycloak L2** est fédéré avec **L1** (OPCP Core). Les droits accordés sur les projets OpenStack au niveau L1 sont ainsi propagés au niveau L2.
 - **Keycloak L3** est une instance indépendante gérée par l'API CloudStore. Chaque compte dispose de son propre realm isolé.
+
+> [!info]
+>
+> La **couche L3** est fournie par le [Landing Zone Manager](/pages/hosted_private_cloud/opcp/landing-zone-manager), un produit OPCP distinct en charge de la gestion des comptes utilisateurs Landing Zone Manager. Sa stack Keycloak **n'est pas fédérée** avec les instances Keycloak L1 (OPCP Core) et L2 (CloudStore).
+>
 
 #### Gestion de l'IAM sur le Keycloak CloudStore (L2)
 
@@ -170,9 +175,9 @@ Une fois ce rôle attribué, l'utilisateur disposera des permissions nécessaire
 
 ### La Landing Zone
 
-La **Landing Zone** est l'interface destinée aux utilisateurs finaux (utilisateurs cloud). Elle offre une vue simplifiée des apps déployées pour leur compte.
+La **Landing Zone** est l'interface destinée aux utilisateurs Landing Zone Manager (utilisateurs cloud). Elle offre une vue simplifiée des apps déployées pour leur compte.
 
-Les utilisateurs finaux s'authentifient via le realm Keycloak spécifique à leur compte (L3) et ne peuvent accéder qu'aux apps déployées pour leur compte. La Landing Zone récupère la liste des apps accessibles et les filtre en fonction des permissions de l'utilisateur.
+Les utilisateurs Landing Zone Manager s'authentifient via le realm Keycloak spécifique à leur compte (L3) et ne peuvent accéder qu'aux apps déployées pour leur compte. La Landing Zone récupère la liste des apps accessibles et les filtre en fonction des permissions de l'utilisateur.
 
 ## Aller plus loin
 

--- a/pages/hosted_private_cloud/opcp/landing-zone-manager/guide.en-gb.md
+++ b/pages/hosted_private_cloud/opcp/landing-zone-manager/guide.en-gb.md
@@ -1,0 +1,91 @@
+---
+title: "Landing Zone Manager - Creating and using an account"
+excerpt: "Find out how to create a new user account in the Landing Zone Manager and log in for the first time"
+updated: 2026-04-21
+---
+
+## Objective
+
+The Landing Zone Manager provides self-service account management that lets administrators provision new users and grant them access to the platform. Each account created in the Landing Zone Manager is backed by a dedicated realm in the underlying Keycloak instance.
+
+**This guide explains how to create a new account in the Landing Zone Manager and how to log in with it for the first time.**
+
+## Requirements
+
+- access to the Landing Zone Manager with administrator privileges allowing account management
+- the first-login default password defined during your Landing Zone Manager deployment
+- the URL of the Landing Zone Manager (previously communicated by your administrator)
+- valid user information to provision (full name and email address)
+
+## Instructions
+
+### Step 1: Access the account management section
+
+Log in to the Landing Zone Manager with an account that has administrator privileges. From the main navigation, open the `Account management`{.action} section.
+
+### Step 2: Create a new account
+
+Click the `+ Create New account`{.action} button to open the account creation form.
+
+Fill in the following required fields:
+
+|Field|Description|
+|---|---|
+|Name|The display name of the account|
+|Email|The user's email address. This value will also be used as the **login** identifier|
+|First name|The user's first name|
+|Last name|The user's last name|
+
+Once all fields are filled in, confirm the creation of the account.
+
+> [!primary]
+>
+> The email address provided is used as the login identifier for the new account. Make sure it is correct before validating, as users will authenticate with this value.
+>
+
+### Step 3: Share the first-login credentials
+
+After the account is successfully created, the user can log in for the first time using:
+
+- **Login**: the email address entered during creation
+- **Password**: the first-login default password defined during the Landing Zone Manager deployment
+
+> [!warning]
+>
+> The default password is shared across first logins and is defined at deployment time. For security reasons, users should change this password immediately after their first successful login.
+>
+
+### Step 4: First connection to the Landing Zone Manager
+
+Once the account has been provisioned, the user can connect to the Landing Zone Manager using the URL previously communicated.
+
+From the login page:
+
+1. Enter the email address used when creating the account as the login.
+2. Enter the first-login default password.
+3. Validate to access the Landing Zone Manager.
+
+On first login, the user may be prompted to update their password and complete any additional authentication setup required by the platform.
+
+## How accounts are mapped in Keycloak
+
+> [!info]
+>
+> The Landing Zone Manager runs on its **own dedicated Keycloak stack**, independent from the OPCP Core Keycloak and from any CloudStore Keycloak. It is not federated with these instances: identities, realms and credentials managed in the Landing Zone Manager are fully isolated from the rest of the OPCP identity layers.
+>
+
+Every account created in the Landing Zone Manager automatically generates a dedicated **realm in Keycloak**. This design ensures:
+
+- independent configuration of authentication flows per account
+- separate user bases and role mappings per realm
+
+> [!primary]
+>
+> Because each account corresponds to a distinct Keycloak realm, any identity-related operation (adding users, configuring federation, defining roles) must be performed within the realm associated with the target account.
+>
+
+## Go further
+
+If you need training or technical assistance for the implementation of our solutions, contact your sales representative or click [this link](/links/professional-services) to request a quote and have your project analyzed by our Professional Services team experts.
+
+Join our [community of users](/links/community).

--- a/pages/hosted_private_cloud/opcp/landing-zone-manager/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/opcp/landing-zone-manager/guide.fr-fr.md
@@ -1,0 +1,91 @@
+---
+title: "Landing Zone Manager - Créer et utiliser un compte"
+excerpt: "Découvrez comment créer un nouveau compte utilisateur dans le Landing Zone Manager et s'y connecter pour la première fois"
+updated: 2026-04-21
+---
+
+## Objectif
+
+Le Landing Zone Manager propose une gestion de comptes en self-service qui permet aux administrateurs de provisionner de nouveaux utilisateurs et de leur donner accès à la plateforme. Chaque compte créé dans le Landing Zone Manager s'appuie sur un realm dédié dans l'instance Keycloak sous-jacente.
+
+**Ce guide explique comment créer un nouveau compte dans le Landing Zone Manager et comment s'y connecter pour la première fois.**
+
+## Prérequis
+
+- disposer d'un accès au Landing Zone Manager avec les privilèges d'administrateur permettant la gestion des comptes
+- connaître le mot de passe par défaut de première connexion défini lors du déploiement de votre Landing Zone Manager
+- disposer de l'URL du Landing Zone Manager (communiquée au préalable par votre administrateur)
+- disposer des informations utilisateur à provisionner (nom complet et adresse email)
+
+## En pratique
+
+### Étape 1 : Accéder à la section de gestion des comptes
+
+Connectez-vous au Landing Zone Manager avec un compte disposant des privilèges d'administrateur. Depuis la navigation principale, ouvrez la section `Account management`{.action}.
+
+### Étape 2 : Créer un nouveau compte
+
+Cliquez sur le bouton `+ Create New account`{.action} pour ouvrir le formulaire de création de compte.
+
+Renseignez les champs obligatoires suivants :
+
+|Champ|Description|
+|---|---|
+|Name|Le nom d'affichage du compte|
+|Email|L'adresse email de l'utilisateur. Cette valeur sera également utilisée comme identifiant de **connexion**|
+|First name|Le prénom de l'utilisateur|
+|Last name|Le nom de famille de l'utilisateur|
+
+Une fois tous les champs remplis, confirmez la création du compte.
+
+> [!primary]
+>
+> L'adresse email fournie est utilisée comme identifiant de connexion du nouveau compte. Assurez-vous qu'elle est correcte avant de valider, car les utilisateurs s'authentifieront avec cette valeur.
+>
+
+### Étape 3 : Communiquer les identifiants de première connexion
+
+Une fois le compte créé avec succès, l'utilisateur peut se connecter pour la première fois en utilisant :
+
+- **Login** : l'adresse email saisie lors de la création
+- **Mot de passe** : le mot de passe par défaut de première connexion défini lors du déploiement du Landing Zone Manager
+
+> [!warning]
+>
+> Le mot de passe par défaut est partagé entre toutes les premières connexions et est défini au moment du déploiement. Pour des raisons de sécurité, les utilisateurs doivent le changer immédiatement après leur première connexion réussie.
+>
+
+### Étape 4 : Première connexion au Landing Zone Manager
+
+Une fois le compte provisionné, l'utilisateur peut se connecter au Landing Zone Manager en utilisant l'URL communiquée précédemment.
+
+Depuis la page de connexion :
+
+1. Saisissez l'adresse email utilisée lors de la création du compte comme identifiant.
+2. Saisissez le mot de passe par défaut de première connexion.
+3. Validez pour accéder au Landing Zone Manager.
+
+Lors de la première connexion, l'utilisateur peut être invité à mettre à jour son mot de passe et à compléter les étapes d'authentification supplémentaires requises par la plateforme.
+
+## Correspondance des comptes dans Keycloak
+
+> [!info]
+>
+> Le Landing Zone Manager repose sur sa **propre stack Keycloak dédiée**, indépendante du Keycloak OPCP Core et de tout Keycloak CloudStore. Il n'est pas fédéré avec ces instances : les identités, realms et identifiants gérés dans le Landing Zone Manager sont totalement isolés des autres couches d'identité OPCP.
+>
+
+Chaque compte créé dans le Landing Zone Manager génère automatiquement un **realm dédié dans Keycloak**. Cette conception garantit :
+
+- une configuration indépendante des flux d'authentification par compte
+- des bases d'utilisateurs et des mappings de rôles séparés par realm
+
+> [!primary]
+>
+> Comme chaque compte correspond à un realm Keycloak distinct, toute opération liée à l'identité (ajout d'utilisateurs, configuration de la fédération, définition de rôles) doit être effectuée au sein du realm associé au compte cible.
+>
+
+## Aller plus loin
+
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en oeuvre de nos solutions, contactez votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse personnalisée de votre projet à nos experts de l'équipe Professional Services.
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/opcp/landing-zone-manager/meta.yaml
+++ b/pages/hosted_private_cloud/opcp/landing-zone-manager/meta.yaml
@@ -1,0 +1,2 @@
+id: df72f7c9-0fef-4bdc-825f-105720c4997d
+full_slug: opcp-landing-zone-manager

--- a/pages/index.md
+++ b/pages/index.md
@@ -600,6 +600,8 @@
             + [OPCP - How to see node inventory](hosted_private_cloud/opcp/how-to-see-node-inventory)
         + [CloudStore](hosted-private-cloud-hosted-private-cloud-opcp-cloudstore)
             + [Getting started with your CloudStore](hosted_private_cloud/opcp/cloudstore-getting-started)
+        + [Landing Zone Manager](hosted-private-cloud-hosted-private-cloud-opcp-landing-zone-manager)
+            + [Landing Zone Manager - Creating and using an account](hosted_private_cloud/opcp/landing-zone-manager)
         + [Additional resources](hosted-private-cloud-hosted-private-cloud-opcp-additional-resources)
             + [OPCP - Object Storage features and specifications](hosted_private_cloud/opcp/s3-opcp-limitations)
             + [OPCP - How to create a custom OS image](hosted_private_cloud/opcp/how-to-create-image)


### PR DESCRIPTION
 ## What type of Pull Request is this?

  - New guide(s)
  - Update of existing guide(s)

  ## Description

  Adds the first guide for the **Landing Zone Manager** product under the OPCP universe (new L2 category
  parallel to CloudStore), covering account creation and first login.

  Also updates `cloudstore-getting-started` to:
  - rename "end users" to "Landing Zone Manager users" (terminology alignment)
  - clarify that the CloudStore L3 Keycloak layer is in fact provided by the Landing Zone Manager, an
  independent product whose Keycloak stack is not federated with L1/L2

  `index-translations.*.yaml` entries for the new `landing-zone-manager` L2 category are left to CI/CD.

  ## Mandatory information

The translations in this Pull Request have been done using:
- [] OVHcloud integrated translation LLM <!-- If you're interested in this new option, contact the Guides team -->
- [ ] Systran
- [ ] Other tool (specify which tool was used)
- [ ] This Pull Request didn't require any translation.

