### PR TITLE
[SK-1900] WEB - Emails - all offers  - Webmail - improve display filter mangagement 

### DIFF
--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.de-de.md
@@ -1,34 +1,33 @@
 ---
-title: Verwendung Ihres E-Mail-Accounts mit Roundcube Webmail
-updated: 2025-11-12
+title: 'E-Mail-Adresse über das Roundcube Webmail-Interface verwenden'
+updated: 2026-05-04
 ---
 
 ## Ziel
 
-Mit einem OVHcloud MX Plan können Sie E-Mails über eine Software oder ein Webmail-Interface versenden und empfangen. OVHcloud bietet einen E-Mail-Dienst namens Roundcube, der über  Webbrowser den Zugriff auf E-Mail-Accounts ermöglicht.
+Mit der OVHcloud MX Plan Lösung können Sie E-Mails über eine Drittanbieter-Software oder über Webmail versenden und empfangen. OVHcloud bietet einen Online-E-Mail-Dienst namens Roundcube, mit dem Sie über einen Webbrowser auf einen E-Mail-Account zugreifen können.
 
-**Diese Anleitung erklärt, wie Sie Roundcube Webmail für Ihre OVHcloud E-Mail-Accounts verwenden.**
+**Erfahren Sie, wie Sie das Roundcube Webmail-Interface für Ihre OVHcloud E-Mail-Adressen verwenden.**
 
 ## Voraussetzungen
 
-- Sie verfügen über einen OVHcloud **MX Plan**, als E-Mail-Dienst in unseren [Webhosting-Angeboten](/links/web/hosting) sowie in [Kostenloses Hosting 100M](/links/web/domains-free-hosting) enthalten oder separat als eigenständige Lösung bestellbar.
-- Sie verfügen über die Logindaten des MX Plan E-Mail-Accounts, den Sie verwenden möchten. Weitere Informationen finden Sie in unserer Anleitung "[Erste Schritte mit MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)".
-- Ihre OVHcloud E-Mail-Lösung **MX Plan** muss die Web muss die Webmail-Technologie **Roundcube** verwenden. Um dies zu identifizieren, folgen Sie den unten stehenden Anweisungen.
+- Sie verfügen über eine OVHcloud E-Mail-Lösung **MX Plan**, die in unseren [Webhosting-Angeboten](/links/web/hosting) enthalten ist, in einem [kostenlosen Hosting-Angebot 100M](/links/web/domains-free-hosting) inbegriffen ist oder separat als eigenständige Lösung bestellt wurde.
+- Sie verfügen über die Logindaten der MX Plan E-Mail-Adresse, die Sie verwenden möchten. Weitere Informationen finden Sie in unserer Anleitung [Erste Schritte mit der MX Plan Lösung](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+- Ihre OVHcloud E-Mail-Lösung **MX Plan** muss die Webmail-Technologie **Roundcube** verwenden. Folgen Sie den nachstehenden Anweisungen, um dies zu identifizieren.
 
 > [!primary]
 > 
-> **Wie kann ich die bei meinem MX Plan verwendete Technologie identifizieren?**
+> **Wie identifiziere ich die in meiner MX Plan Lösung verwendete Technologie?**
 >
-> Die für Ihr MX Plan Angebot verwendete E-Mail-Technologie ist durch das Webmail-Interface gekennzeichnet. Um ihn über Ihr Kundencenter zu identifizieren, folgen Sie dem folgenden Pfad:
+> Die für Ihre MX Plan Lösung verwendete E-Mail-Technologie ist anhand des Webmail-Interface erkennbar. Um dies in Ihrem Kundencenter zu identifizieren, folgen Sie diesem Pfad:
 >
-> 1. Verbinden Sie sich mit Ihrem [OVHcloud Kundencenter](/links/manager).
+> 1. Loggen Sie sich in Ihr [OVHcloud Kundencenter](/links/manager) ein.
 > 1. Gehen Sie in den Bereich `Web Cloud`{.action}.
 > 1. Klicken Sie auf `MX Plan`{.action}.
 > 1. Wählen Sie die betreffende Domain aus.
-> 1. Wählen Sie in `Allgemeine Informationen`{.action} die Option „Standard“.
-> 1. Notieren Sie die unter **Webmail** verwendete Technologie.
+> 1. Im Tab `Allgemeine Informationen`{.action} (standardmäßig ausgewählt) prüfen Sie die unter dem Eintrag **Webmail** verwendete Technologie.
 >
-> ![MX PLAN](images/technology-email.png){.thumbnail .w-500}
+> ![MX plan](images/technology-email.png){.thumbnail .w-500}
 
 <!-- CP-NAV-START:web-mx-plan -->
 ---
@@ -45,400 +44,413 @@ Mit einem OVHcloud MX Plan können Sie E-Mails über eine Software oder ein Webm
 
 **Inhaltsübersicht**
 
-- [Einloggen in Roundcube Webmail](#roundcube-connexion)
-- [Roundcube Interface Hauptseite](#general-interface)
+- [Einloggen in das Roundcube Webmail-Interface](#roundcube-connexion)
+- [Hauptseite des Roundcube Webmail](#general-interface)
     - [Ordnerverwaltung (linke Spalte)](#leftcolumn)
-    - [Liste der empfangenen / gesendeten E-Mails (oberes Fenster)](#topwindow)
+    - [Liste der empfangenen/gesendeten E-Mails (oberes Fenster)](#topwindow)
         - [Anzeigetyp](#topwindow-display)
         - [Aktion auf einer ausgewählten E-Mail](#topwindow-action)
-        - [Nach E-Mails suchen](#topwindow-search)
-    - [Inhalt einer E-Mail (unteres Fenster)](#lowerwindow)
+        - [Nach einer E-Mail suchen](#topwindow-search)
+    - [Inhalt der E-Mail (unteres Fenster)](#lowerwindow)
 - [Einstellungen des Roundcube Interface konfigurieren](#roundcube-settings)
     - [Benutzeroberfläche](#user-interface-settings)
     - [Postfachansicht](#mail-view-settings)
-    - [E-Mail-Anzeigeeinstellungen](#mail-display-settings)
+    - [Nachrichtenanzeige](#mail-display-settings)
     - [Nachrichtenerstellung](#mail-writing-settings)
     - [Kontakte](#contacts-settings)
     - [Spezialordner](#special-folder-settings)
     - [Servereinstellungen](#server-settings)
     - [Verschlüsselung](#encryption)
-- [Identitäten und deren Signatur verwalten](#identity-signature)
-    - [Attribute einer Identität einstellen](#identity)
-    - [Signatur hinzufügen](#signature)
+- [Identitäten und ihre Signaturen verwalten](#identity-signature)
+    - [Identität](#identity)
+    - [Signatur](#signature)
 - [Adressbuch](#contact-book)
     - [Gruppen](#group)
     - [Kontakte](#contacts)
     - [Kontakte importieren](#import-contacts)
     - [Kontakte exportieren](#export-contacts)
-- [Schnellantworten (Templates](#responses)
-- [Auto-Responder hinzufügen](#automatic-respond)
+- [Schnellantworten (Templates)](#responses)
+- [Einen Auto-Responder hinzufügen](#automatic-respond)
 - [Passwort Ihres E-Mail-Accounts ändern](#password)
 - [E-Mail verfassen](#email-writing)
-- [Anwendungsfälle](#usecase)
+- [Anwendungsfall](#usecase)
 
-### Einloggen in Roundcube Webmail <a name="#roundcube-connexion"></a>
+### Einloggen in das Roundcube Webmail-Interface <a name="roundcube-connexion"></a>
 
 Gehen Sie auf die Seite [Webmail](/links/web/email). Geben Sie eine E-Mail-Adresse und das Passwort ein und klicken Sie dann auf `Login`{.action}. 
 
-![Hosting](images/webmail_login.png){.thumbnail}
+![hosting](images/webmail_login.png){.thumbnail}
 
-Sie werden dann zum Roundcube Interface weitergeleitet.
+Sie werden anschließend zum Roundcube Interface weitergeleitet.
 
-![Hosting](images/roundcube01.png){.thumbnail}
+![hosting](images/roundcube01.png){.thumbnail}
 
 > [!primary]
 > 
-> Beim ersten Anmelden unterscheidet sich das Roundcube Interface möglicherweise von dem in dieser Anleitung beschriebenen. Dies bedeutet, dass das "klassische" Aussehen auf Ihrem Interface eingestellt wurde. Um es zu ändern, folgen Sie dem Abschnitt "[Benutzeroberfläche](#user-interface-settings)" und wählen Sie die Ansicht "Larry" aus.
-> Das Erscheinungsbild der Benutzeroberfläche hat keinen Einfluss auf die Erläuterungen in dieser Dokumentation.
+> Beim ersten Einloggen in das Roundcube Interface kann das Erscheinungsbild von dem in dieser Dokumentation gezeigten abweichen. Dies bedeutet, dass das "klassische" Erscheinungsbild auf Ihrem Interface eingestellt wurde. Um dies zu ändern, folgen Sie dem Abschnitt "[Benutzeroberfläche](#user-interface-settings)" und wählen Sie die Ansicht "Larry" aus.
+> Das Erscheinungsbild des Interface hat keinen Einfluss auf die nachfolgenden Erklärungen in dieser Dokumentation.
 
 > [!warning]
 > 
-> Wenn Sie auf ein **O**utlook **W**eb **A**pp Interface (OWA) weitergeleitet werden, verwenden Sie die neueste Version des MX Plan Dienstes. Weitere Informationen zu Ihrem MX Plan finden Sie auf unserer Seite "[Erste Schritte mit MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)".
+> Wenn Sie auf ein **O**utlook **W**eb **A**pp Interface (OWA) weitergeleitet werden, bedeutet dies, dass Sie die neueste Version der MX Plan Lösung verwenden. Weitere Informationen zu Ihrer MX Plan Lösung finden Sie auf unserer Seite [Erste Schritte mit der MX Plan Lösung](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 >
-> Um sich mit dem **OWA** Interface vertraut zu machen, lesen Sie unsere [OWA Anleitung](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
+> Um sich mit dem **OWA**-Interface vertraut zu machen, lesen Sie unsere Anleitung [Verwendung eines E-Mail-Accounts mit dem OWA-Interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
-### Roundcube Interface Hauptseite <a name="general-interface"></a>
+### Hauptseite des Roundcube Webmail <a name="general-interface"></a>
 
-Sobald Sie in Ihren E-Mail-Account eingeloggt sind, haben Sie Zugriff auf das Roundcube Hauptfenster, das aus 3 Zonen besteht:
+Sobald Sie in Ihrem E-Mail-Account eingeloggt sind, haben Sie Zugriff auf das Roundcube Hauptfenster, das aus 3 Bereichen besteht:
 
-- [**Linke Spalte**](#leftcolumn): Die Ordnerstruktur Ihres E-Mail-Accounts, bestehend aus Ordnern und Unterordnern. Der Hauptordner ist der `Posteingang`.
+- [**Linke Spalte**](#leftcolumn): die Ordnerstruktur Ihres E-Mail-Accounts, bestehend aus Ordnern und Unterordnern. Der Hauptordner ist der `Posteingang`.
 
-- [**Oberes Fenster**](#topwindow): Die Liste der E-Mails, die im links ausgewählten Ordner enthalten sind.
+- [**Oberes Fenster**](#topwindow): die Liste der E-Mails, die im in der linken Spalte ausgewählten Ordner enthalten sind.
 
-- [**Unteres Fenster**](#lowerwindow): Der Inhalt der im oberen Fenster ausgewählten E-Mail.
+- [**Unteres Fenster**](#lowerwindow): der Inhalt der im oberen Fenster ausgewählten E-Mail.
 
 #### Ordnerverwaltung (linke Spalte) <a name="leftcolumn"></a>
 
 In diesem Bereich werden die Ordner Ihres E-Mail-Accounts angezeigt.
 
-Um die Ordner genauer zu verwalten, klicken Sie auf das Zahnrad am Ende der Spalte und anschließend auf `Ordner verwalten`{.action}.
+Um die Ordner genauer zu verwalten, klicken Sie auf das Zahnradsymbol am unteren Rand der Spalte und anschließend auf `Ordner verwalten`{.action}.
 
-![Hosting](images/roundcube02.png){.thumbnail}
+![hosting](images/roundcube02.png){.thumbnail}
 
-Um einen Ordner zu erstellen, klicken Sie auf `+`{.action} am Ende der Spalte `Ordner`.
+Um einen Ordner zu erstellen, klicken Sie auf den Button `+`{.action} am unteren Rand der Spalte `Ordner`.
 
-Um einen Ordner zu löschen, wählen Sie ihn aus, klicken Sie auf das Zahnrad am Ende der Spalte `Ordner` und dann auf `Löschen`{.action}. Um nur den Inhalt zu löschen und den Ordner zu behalten, klicken Sie auf `Leeren`{.action}.
+Um einen Ordner zu löschen, wählen Sie den betreffenden Ordner aus, klicken Sie auf das Zahnradsymbol am unteren Rand der Spalte `Ordner` und anschließend auf `Löschen`{.action}. Um den Inhalt zu leeren, ohne den Ordner zu entfernen, klicken Sie auf `Leeren`{.action}.
 
-Die Checkboxen entsprechen den "Abonnements". Das Abonnement legt fest, ob der Ordner im Webmail-Interface oder im E-Mail-Programm angezeigt werden soll, unter Beibehaltung des Ordnerinhalts. Dabei geht es lediglich darum, einen Ordner im E-Mail-Account zu verbergen oder anzuzeigen.
+Die Kontrollkästchen neben den Ordnern entsprechen den "Abonnements". Das Abonnement legt fest, ob der Ordner im Webmail-Interface oder in der E-Mail-Software angezeigt wird oder nicht, wobei der Inhalt des Ordners erhalten bleibt. Es geht nur darum, einen Ordner im E-Mail-Account ein- oder auszublenden.
 
 > [!primary]
 >
-> Ordner mit ausgegrauten Haken sind spezielle Ordner. Es ist nicht möglich, sie zu löschen oder ihr Abonnement zu entfernen.
+> Ordner mit einem grauen Kontrollkästchen sind Spezialordner. Sie können diese weder löschen noch ihr Abonnement aufheben.
 
-#### Liste der empfangenen / gesendeten E-Mails (oberes Fenster) <a name="topwindow"></a>
+#### Liste der empfangenen/gesendeten E-Mails (oberes Fenster) <a name="topwindow"></a>
 
-Dieses Fenster zeigt den Inhalt des in der linken Spalte ausgewählten Ordners an.
+Dieses Fenster zeigt den Inhalt des in der linken Spalte ausgewählten Ordners an. 
 
-##### **Anzeigetyp** <a name="topwindow-display"></a>
+##### Anzeigetyp <a name="topwindow-display"></a>
 
-Dieses Fenster kann individuell angepasst werden. Klicken Sie hierzu auf das Zahnrad oben links im Fenster.
+Dieses Fenster wird in einer anpassbaren Form dargestellt. Klicken Sie hierzu auf das Zahnradsymbol oben links im Fenster.
 
-![Hosting](images/roundcube03.png){.thumbnail}
+![hosting](images/roundcube03.png){.thumbnail}
 
-Folgende Einstellungen sind möglich:
+Vier Parameter können konfiguriert werden:
 
-- **Layout**: Ermöglicht die Neuanordnung der Verwaltungsfenster des E-Mail-Accounts.
-- **Spalten**: ermöglicht das Hinzufügen von anzuzeigenden Spalten (Prioritäten der E-Mails etc.).
-- **Sortieren nach**: Erlaubt die Wahl der Spalte, anhand derer die Standardsortierung durchgeführt wird.
-- **Sortierung**: Wechselt zwischen Aufwärtssortierung oder Abwärtssortierung, abhängig von der ausgewählten Spalte.
+- **Layout**: legt fest, wie die Verwaltungsfenster des E-Mail-Accounts angeordnet werden. Drei Optionen:
+    - `Breitbild`{.action}: drei Bereiche nebeneinander – Ordner, E-Mail-Liste und Lesebereich horizontal angeordnet;
+    - `Standard`{.action}: E-Mail-Liste oben, Lesebereich darunter (klassisches Layout);
+    - `Liste`{.action}: kein Lesebereich – E-Mails werden beim Anklicken im Vollbildfenster geöffnet.
 
-##### **Aktion auf einer ausgewählten E-Mail** <a name="topwindow-action"></a>
+- **Listenspalten**: Kontrollkästchen, die festlegen, welche Spalten in der E-Mail-Liste angezeigt werden. Die Spalten **Betreff** und **Threads** sind immer sichtbar. Verfügbare optionale Spalten: `Von`{.action}, `An`{.action}, `Von/An`{.action}, `Antwort an`{.action}, `Kopie`{.action}, `Datum`{.action}, `Größe`{.action}, `Status`{.action}, `Anhang`{.action}, `Markierung`{.action}, `Priorität`{.action}.
 
-Wenn Sie eine E-Mail ausgewählt haben, sind diverse Aktionen1 möglich:
+- **Sortierspalte**: ermöglicht die Auswahl der Standardsortierspalte. Verfügbare Optionen: `Keine`{.action}, `Eingangsdatum`{.action}, `Sendedatum`{.action}, `Betreff`{.action}, `Von`{.action}, `An`{.action}, `Von/An`{.action}, `Kopie`{.action} oder `Größe`{.action}.
 
-- `Antworten`{.action}: Dem Absender direkt antworten.
-- `Allen antworten`{.action}: Allen Empfängern in den Feldern "An" und "Kopie" antworten.
-- `Weiterleiten`{.action}: Die ausgewählte E-Mail an einen oder mehrere Empfänger weiterleiten.
-- `Löschen`{.action}: Die ausgewählte E-Mail in den "Papierkorb" verschieben.
-- `Spam`{.action}: Die ausgewählte E-Mail in den Spam-Ordner (Junk) verschieben.
-- `Markieren`{.action}: Den Status einer E-Mail manuell bestimmen.
+- **Sortierreihenfolge**: aufsteigend oder absteigend.
+
+Klicken Sie auf `Speichern`{.action}, um Ihre Auswahl zu übernehmen.
+
+> [!primary]
+>
+> Sie können die Liste auch **dynamisch sortieren**, indem Sie direkt auf die Kopfzeile einer angezeigten Spalte klicken (zum Beispiel **Datum**, **Betreff** oder **Größe**). Ein zweiter Klick auf dieselbe Spalte kehrt die Reihenfolge um.
+
+##### Aktion auf einer ausgewählten E-Mail <a name="topwindow-action"></a>
+
+Wenn eine E-Mail ausgewählt ist, können Sie verschiedene Aktionen darauf ausführen. Folgende Aktionen sind möglich:
+
+- `Antworten`{.action}: dem Absender direkt antworten.
+- `Allen antworten`{.action}: allen in den Feldern "An" und "Kopie" aufgeführten Empfängern direkt antworten.
+- `Weiterleiten`{.action}: die ausgewählte E-Mail an einen oder mehrere Empfänger weiterleiten.
+- `Löschen`{.action}: die ausgewählte E-Mail in den "Papierkorb" verschieben.
+- `Als Spam markieren`{.action}: die ausgewählte E-Mail direkt in den Spam-Ordner (Junk) verschieben und als **Spam** kennzeichnen.
+- `Markieren`{.action}: den Status einer E-Mail manuell festlegen.
 - `Mehr`{.action} 
     - `Nachricht drucken`{.action}.
-    - `Lokal speichern (.eml)`{.action}: Die komplette E-Mail inklusive Header als Datei sichern.
-    - `Als neue Nachricht öffnen`{.action}: Eine neue E-Mail auf der Grundlage der ausgewählten E-Mail erstellen.
-    - `Quelltext anzeigen`{.action}: Die E-Mail in ihrer Rohform inklusive Header anzeigen.
-    - `Verschieben nach`{.action}: Die E-Mail in einen Ordner verschieben.
-    - `Kopieren nach`{.action}: Die E-Mail in einen Ordner kopieren.
+    - `Lokal speichern (.eml)`{.action}: den Header der E-Mail und ihren Inhalt abrufen.
+    - `Als neue Nachricht öffnen`{.action}: eine neue E-Mail auf der Grundlage der ausgewählten E-Mail erstellen.
+    - `Quelltext anzeigen`{.action}: die E-Mail in ihrer Rohform inklusive Header anzeigen.
+    - `Verschieben nach`{.action}: die E-Mail in einen Ordner verschieben.
+    - `Kopieren nach`{.action}: die E-Mail in einen Ordner kopieren.
     - `In neuem Fenster öffnen`{.action}.
 
-![Hosting](images/roundcube04.png){.thumbnail}
+![hosting](images/roundcube04.png){.thumbnail}
 
 > [!primary]
 >
-> Wenn einer Ihrer Kontakte eine Lesebestätigung für eine E-Mail anfordert, erhalten Sie folgende Nachricht: `Der Absender dieser Nachricht bat um Benachrichtigung, wenn Sie diese Nachricht lesen. Möchten Sie den Absender benachrichtigen`?
-> 
+> Wenn einer Ihrer Kontakte eine Lesebestätigung anfordert, sobald Sie die zugehörige E-Mail lesen, erhalten Sie folgende Nachricht: `Der Absender dieser Nachricht hat um eine Benachrichtigung gebeten, wenn Sie diese Nachricht lesen. Möchten Sie den Absender benachrichtigen?`.
+>
 
-##### **Nach E-Mails suchen** <a name="topwindow-search"></a>
+##### Nach einer E-Mail suchen <a name="topwindow-search"></a>
 
-Im oberen rechten Bereich des Interface ist ein Suchwerkzeug verfügbar.
+Im oberen rechten Bereich des Interface steht ein Suchwerkzeug zur Verfügung.
 
-Klicken Sie auf den Pfeil rechts neben der Lupe, um die Suchfilter anzuzeigen.
+Geben Sie einen Begriff in das Suchfeld ein und bestätigen Sie mit der `Eingabetaste`{.action}: standardmäßig durchsucht Roundcube den gesamten aktuellen Ordner.
 
-#### Inhalt einer E-Mail (unteres Fenster) <a name="lowerwindow"></a>
+Klicken Sie auf den Pfeil rechts neben der Lupe, um die Suchfilter anzuzeigen: Sie können die Suche auf bestimmte Felder beschränken (Betreff, Nachrichtentext, Absender, Empfänger usw.) oder ihren Umfang auf alle Ordner ausweiten.
 
-Wird eine E-Mail aus der Liste ausgewählt, wird sie im unteren Fenster angezeigt.
+#### Inhalt der E-Mail (unteres Fenster) <a name="lowerwindow"></a>
 
-Rechts finden Sie Shortcuts für die folgenden Funktionen:
+Wenn eine E-Mail in der Liste ausgewählt wird, wird sie im unteren Fenster angezeigt.
 
-- Als original HTML anzeigen
-- Als reinen Text anzeigen
-- Antwort verfassen
-- Allen antworten
-- Weiterleiten
-- In neuem Fenster öffnen
+Auf der rechten Seite finden Sie Verknüpfungen für die folgenden Funktionen:
 
-![Hosting](images/roundcube05.png){.thumbnail}
+- `Im HTML-Format anzeigen`{.action} (Standard)
+- `Im Klartextformat anzeigen`{.action}
+- `Antworten`{.action}
+- `Allen antworten`{.action}
+- `Weiterleiten`{.action}
+- `In neuem Fenster öffnen`{.action}
+
+![hosting](images/roundcube05.png){.thumbnail}
 
 ### Einstellungen des Roundcube Interface konfigurieren <a name="roundcube-settings"></a>
 
-Die nachfolgenden Abschnitte entsprechen den Tabs, die den Teil `Einstellungen`{.action} im Abschnitt `Einstellungen`{.action} von Roundcube bilden. Ihre Beschreibung ist nicht erschöpfend.
+Die folgenden Abschnitte dieser Anleitung entsprechen den Tabs, aus denen sich der Bereich `Einstellungen`{.action} der Roundcube `Einstellungen`{.action} zusammensetzt. Ihre Beschreibung ist nicht erschöpfend.
 
-![Hosting](images/roundcube06.png){.thumbnail}
+![hosting](images/roundcube06.png){.thumbnail}
 
 #### Benutzeroberfläche <a name="user-interface-settings"></a>
 
-Hier legen Sie die verwendete `Sprache` des Roundcube Interface, die `Zeitzone`, die `Zeitformatierung` und die `Datumsformatierung` fest.
+Hier legen Sie die `Sprache` des Roundcube Interface, die `Zeitzone`, das `Zeitformat` und das `Datumsformat` fest.
 
-Die Option `Kurze Datumsanzeige` ermöglicht die Anzeige der Empfangs- und Versendedaten mit relativen Begriffen wie "Heute", "Gestern" etc.<br>
+Die Option `Kurze Datumsanzeige` ermöglicht die Anzeige des Empfangs-/Sendedatums mit relativen Begriffen wie "Heute", "Gestern" usw.<br>
+**Zum Beispiel**: Das heutige Datum ist der **19.05.2022**, eine am **17.05.2022** um **17:38** Uhr gesendete/empfangene E-Mail wird als **Di. 17:38** angezeigt, da die E-Mail dem vorhergehenden Dienstag entspricht.
 
-Das Feld `Den nächsten Eintrag nach Löschen oder Verschieben anzeigen` bedeutet, dass nach Löschen oder Verschieben einer E-Mail das Element der unteren Zeile automatisch ausgewählt wird, unabhängig von der Reihenfolge der Sortierung. 
+Das Kontrollkästchen `Den nächsten Eintrag nach Löschen oder Verschieben anzeigen` bedeutet, dass nach dem Löschen oder Verschieben einer E-Mail das Element der unteren Zeile automatisch ausgewählt wird, unabhängig von der Sortierreihenfolge.
 
-Sie können das Erscheinungsbild Ihrer Benutzeroberfläche auswählen. Sie können zwischen der Ansicht **Classic** und der Ansicht **Larry** wählen.
+Sie können das Erscheinungsbild Ihrer Benutzeroberfläche auswählen. Sie haben die Wahl zwischen der Ansicht **Classic** und der Ansicht **Larry**.
 
 #### Postfachansicht <a name="mail-view-settings"></a>
 
-Definieren Sie hier die bevorzugte Art, um E-Mails anzuzeigen und zu bearbeiten. Die Option `Layout` erlaubt es, die 3 im Abschnitt [Roundcube Interface Hauptseite](#topwindow) beschriebenen Fenster neu anzuordnen.
+Legen Sie hier das Layout fest, das zum Anzeigen und Bearbeiten von E-Mails verwendet wird. Die Option `Layout` ermöglicht es, die 3 im Abschnitt [Liste der empfangenen/gesendeten E-Mails](#topwindow) beschriebenen Fenster anzuordnen.
 
-#### E-Mail-Anzeigeeinstellungen <a name="mail-display-settings"></a>
+#### Nachrichtenanzeige <a name="mail-display-settings"></a>
 
 Legen Sie fest, wie E-Mails angezeigt werden.<br>
-Es wird empfohlen, das Feld `HTML anzeigen` anzuhaken, um sicherzustellen, dass vom Absender formatierte E-Mails korrekt angezeigt werden.<br>
-Darüber hinaus ist es ratsam, die Option `Externe Ressourcen erlauben (Bilder, Formate)` auf `nie` zu belassen. Dies verhindert, dass externe Elemente einer E-Mail geladen werden, die Schadcode enthält.
+Wir empfehlen, das Kontrollkästchen `HTML anzeigen` aktiviert zu lassen, um sicherzustellen, dass vom Absender formatierte E-Mails korrekt angezeigt werden.<br>
+Wir empfehlen außerdem, die Option `Externe Ressourcen erlauben (Bilder, Formate)` auf `nie` belassen. So wird verhindert, dass Elemente einer E-Mail geladen werden, die schädlich sein könnten.
 
 #### Nachrichtenerstellung <a name="mail-writing-settings"></a>
 
-Legen Sie die Standardform beim Verfassen einer E-Mail oder Antwort fest.<br>
-Es wird empfohlen, die Option `HTML-Nachrichten verfassen` auf `immer` zu stellen, um vom HTML-Editor zu profitieren und HTML-Signaturen korrekt beizubehalten.
+Legen Sie die Standardform beim Verfassen einer E-Mail oder einer Antwort fest.<br>
+Wir empfehlen, die Option `HTML-Nachrichten verfassen` auf `immer` zu setzen, um standardmäßig von den HTML-Bearbeitungswerkzeugen zu profitieren und eine HTML-Signatur nicht zu verändern.
 
 #### Kontakte <a name="contacts-settings"></a>
 
-Personalisieren Sie hier die Anordnung der Informationen in Ihrem Adressbuch.
+Passen Sie hier die Anordnung der Informationen in Ihrem Adressbuch an.
 
 #### Spezialordner <a name="special-folder-settings"></a>
 
-Roundcube verfügt über 4 Spezialordner: `Entwürfe`, `Gesendet`, `Spam`, `Gelöscht`.
+Roundcube verfügt über 4 Spezialordner: `Entwürfe`, `Gesendet`, `Spam`, `Papierkorb`.
 
-Wir raten dazu, diese nicht zu ändern, aber Sie können über die Drop-down-Menüs die Eigenschaften der Spezialordner neu erstellten Ordnern zuweisen.<br>
+Wir raten davon ab, diese zu ändern. Sie können jedoch das Verhalten eines Spezialordners einem später erstellten Ordner zuweisen, indem Sie die Drop-down-Menüs verwenden.<br>
 
-Sie können beispielsweise die Eigenschaft `Entwürfe` einem anderen Ordner zuweisen, den Sie erstellt haben, indem Sie auf die Dropdownliste klicken und diesen Ordner auswählen. Wenn kein Ordner zugewiesen ist, wird er automatisch auf die Option "Drafts" gesetzt. Die dort gespeicherten E-Mails gelten dann als Entwürfe bis sie tatsächlich versendet werden.
+**Zum Beispiel** können Sie das Verhalten "Entwürfe" einem von Ihnen erstellten Ordner zuweisen, indem Sie auf die Drop-down-Liste klicken und diesen Ordner auswählen. Wenn kein Ordner zugewiesen ist, wird er automatisch auf die Option "Entwürfe" gesetzt. Die dort gespeicherten E-Mails werden dann als Entwürfe betrachtet, bis sie tatsächlich versendet werden.
 
-> Beispiel: Sie erstellen einen Unterordner "Entwürfe von Kunden-E-Mails". Gehen Sie dann zu `Einstellungen`{.action}, `Spezialordner`{.action} und wählen die Option `Entwürfe`. Wählen Sie im Drop-down-Menü den Ordner "Entwürfe von Kunden-E-Mails" aus, um "Drafts" zu ersetzen. In diesem Ordner liegende E-Mails werden als Entwürfe behandelt.
+> In der Praxis erstellen Sie einen Unterordner mit dem Namen "Entwürfe von Kunden-E-Mails". Gehen Sie zu `Einstellungen`{.action} / `Spezialordner`{.action} und wählen Sie die Option "Entwürfe". Wählen Sie im Drop-down-Menü den Ordner "Entwürfe von Kunden-E-Mails" aus, um "Entwürfe" zu ersetzen. In diesem Ordner verfasste E-Mails werden als Entwürfe behandelt.
 
 #### Servereinstellungen <a name="server-settings"></a>
 
-In diesem Tab können Sie den Speicherplatz auf einem E-Mail-Account optimieren. Mit der Option `Papierkorb beim Abmelden leeren` wird vermieden, dass gelöschte Elemente sich dort ansammeln. Die Option `Nachrichten in Spam direkt löschen` löscht automatisch alle als SPAM markierten E-Mails.
+In diesem Tab können Sie den von einem E-Mail-Account belegten Speicherplatz optimieren. Die Option `Papierkorb beim Abmelden leeren` hilft, die Ansammlung gelöschter Elemente zu vermeiden. Die Option `Nachrichten in Spam direkt löschen` löscht automatisch alle als Spam eingestuften E-Mails.
 
 > [!warning]
 > 
-> Es ist nicht ratsam, die Option `Nachrichten in Spam direkt löschen` zu aktivieren, um zu verhindern, dass "False Positives" (fälschlicherweise als "SPAM" erkannte E-Mails) für den Empfangsserver als SPAM deklariert werden. Wenn diese Nachrichten zunächst im Ordner "Spam" abgelegt werden, kann noch überprüft werden, ob sich legitime E-Mails darunter befinden.
+> Wir raten davon ab, die Option `Nachrichten in Spam direkt löschen` zu aktivieren, falls vom Empfangsserver ein "False Positive" (eine fälschlicherweise als "Spam" eingestufte E-Mail) als Spam markiert wird. Wenn eine E-Mail im Ordner "Spam" abgelegt wird, können Sie noch überprüfen, ob die E-Mail legitim ist.
 
 #### Verschlüsselung <a name="encryption"></a>
 
-Wenn Ihr Browser dies zulässt, können Sie die Erweiterung "Mailvelope" installieren und aktivieren. Hierbei handelt es sich um eine Browsererweiterung, die PGP (**P**retty **G**ood **P**rivacy) in Ihre webbasierten E-Mails integriert. Das PGP-Verschlüsselungssystem und somit die Erweiterung "Mailvelope" ermöglichen:
+Wenn Ihr Browser dies zulässt, können Sie die Erweiterung "Mailvelope" installieren und aktivieren. Dabei handelt es sich um eine Browsererweiterung, die PGP (**P**retty **G**ood **P**rivacy) in Ihr Webmail integriert. Das PGP-Verschlüsselungssystem und damit die Erweiterung "Mailvelope" ermöglichen Folgendes:
 
-- Verschlüsseln und Entschlüsseln von E-Mails in Ihrem Browser
-- Inhalt Ihrer E-Mails gegenüber Ihrem E-Mail-Anbieter verbergen
+- E-Mails in Ihrem Browser verschlüsseln und entschlüsseln.
+- Den Inhalt Ihrer E-Mails vor Ihrem E-Mail-Anbieter geheim halten.
 
-So sind Sie allein in der Lage, Ihre E-Mails zu lesen. Diese Endung ist eine Möglichkeit, Ihr Webmail abzusichern, wenn Sie vertrauliche E-Mails erhalten.
+So können nur Sie Ihre E-Mails lesen. Diese Erweiterung ist eine Möglichkeit, Ihr Webmail abzusichern, wenn Sie vertrauliche E-Mails erhalten.
 
-Weitere Informationen finden Sie in den FAQ zu "Mailvelope" unter <https://mailvelope.com/faq>.
+Weitere Informationen finden Sie in den FAQ zu "Mailvelope" unter <https://mailvelope.com/de/faq>.
 
-### Identitäten und deren Signatur verwalten <a name="identity-signature"></a>
+### Identitäten und ihre Signaturen verwalten <a name="identity-signature"></a>
 
-Klicken Sie im oberen Menü auf `Einstellungen`{.action} und im linken Menü auf `Identitäten`{.action}. "Identität" erlaubt es, die an die Empfänger gesendeten Informationen zu personalisieren, wie zum Beispiel den Anzeigenamen oder die Signatur.
+Klicken Sie in Roundcube in der oberen Leiste auf `Einstellungen`{.action} und anschließend in der linken Spalte auf `Identitäten`{.action}. Die "Identität" ermöglicht es Ihnen, die an die Empfänger gesendeten Informationen wie den Anzeigenamen oder die Signatur anzupassen.
 
-![Hosting](images/roundcube07.png){.thumbnail}
+![hosting](images/roundcube07.png){.thumbnail}
 
-#### Attribute einer Identität einstellen <a name="identity"></a>
+#### Attribute einer Identität festlegen <a name="identity"></a>
 
-- **Angezeigter Name**: Dieser Name wird im "Absender" des Empfängers erscheinen.
-- **E-Mail**: Die Adresse, die als Absender der E-Mail angezeigt wird.
-- **Organisation**: Feld für ein Unternehmen, Vereine oder eine andere Einrichtung.
-- **Antwort an**: Eine andere E-Mail-Adresse als die des Absenders zuweisen.
-- **Blindkopie**: Eine Blindkopie an weitere Empfänger senden.
-- **Als Standard**: Gibt es mehrere Identitäten (Signaturen), wird diese bevorzugt angehängt.
-- **Signatur**: Die Fußzeile einer E-Mail bei deren Abfassung anpassen (Name, Vorname, Position, Sätze, Bilder, etc.).
-- **HTML-Signatur**: Aktiviert das HTML-Format für die Signatur.
+- **Angezeigter Name**: Dieser Name erscheint im Bereich "Absender" beim Empfänger.
+- **E-Mail**: Die Adresse, von der die E-Mail gesendet wird.
+- **Organisation**: ein Feld für einen Firmennamen, einen Verein oder eine andere Einrichtung.
+- **Antwort an**: weisen Sie eine andere Antwort-E-Mail-Adresse als die des Absenders zu.
+- **Blindkopie**: senden Sie beim Versand eine Blindkopie an eine E-Mail-Adresse.
+- **Als Standard festlegen**: Bei mehreren Identitäten (Signaturen) legen Sie diese als Standard fest.
+- **Signatur**: passen Sie die Fußzeile einer E-Mail beim Verfassen an (Name, Vorname, Position, Sätze, Bilder usw.).
+- **HTML-Signatur**: aktiviert das HTML-Format für die Signatur.
 
 > [!alert]
-> 
-> Das Feld **E-Mail** mit einer anderen E-Mail-Adresse als einer zu Ihrem Account gehörenden auszufüllen, wird als Absenderverschleierung eingestuft (*Spoofing*). Die für den Versand verwendete IP-Adresse kann bei Ihren Empfängern deshalb als "SPAM" deklariert oder gesperrt werden. 
+>
+> Das Ausfüllen des Feldes **E-Mail** mit einer anderen E-Mail-Adresse als der, mit der Sie eingeloggt sind, gilt als elektronischer Identitätsdiebstahl (*Spoofing*). Die für den Versand verwendete IP-Adresse kann von Ihren Empfängern als "gesperrt" und/oder als "Spam" eingestuft werden.
 
-#### Signatur hinzufügen <a name="signature"></a>
+#### Eine Signatur hinzufügen <a name="signature"></a>
 
-Standardmäßig ist das Feld `Signatur` auf reines Texformat eingestellt. Dieses Format erlaubt keine erweiterte Formatierung oder das Einfügen von Bildern in Ihre Signatur. Um die erweiterten Bearbeitungsoptionen für eine Signatur nutzen zu können, empfehlen wir die Aktivierung des HTML-Modus durch Klicken auf **HTML-Signatur** unter der Texteingabe.
+Standardmäßig ist das Feld `Signatur` im "Klartext"-Format. Dieses Format erlaubt keine erweiterte Bearbeitung oder das Einfügen eines Bildes in Ihre Signatur. Um die erweiterten Bearbeitungsoptionen für eine Signatur zu nutzen, empfehlen wir, den HTML-Modus durch Klicken auf **HTML-Signatur** unter dem Eingabefeld zu aktivieren.
 
 > [!warning]
-> 
-> Wenn die Signatur im HTML-Format vorliegt, muss zur Erstellung einer E-Mail auf den HTML-Modus umgestellt werden. Sie können dies als Standardoption für jede E-Mail-Erstellung im Bereich `Einstellungen`{.action} des Roundcube Interface aktivieren.
 >
-> Klicken Sie in der linken Spalte auf `Einstellungen`{.action} und dann auf `Nachrichtenerstellung`{.action}. Für den Eintrag **HTML-Nachrichten verfassen** wählen Sie `Immer`.
+> Wenn die Signatur im HTML-Format vorliegt, müssen Sie beim Verfassen einer E-Mail in den HTML-Modus wechseln. Sie können diese Option standardmäßig für jede E-Mail, die Sie verfassen, im Bereich `Einstellungen`{.action} des Roundcube Interface aktivieren.
+> Klicken Sie in der linken Spalte auf `Einstellungen`{.action} und dann auf `Nachrichtenerstellung`{.action}. Wählen Sie für den Eintrag **HTML-Nachrichten verfassen** die Option `Immer`.
 >
 
-Um ein Bild in eine Signatur einzufügen, muss die Datei auf einem Server (OVHcloud Hosting oder andere) bereitgestellt werden.<br>
-**Ein von einem lokalen Gerät hochgeladenes Bild wird nicht angezeigt werden.**.
+Um ein Bild in eine Signatur einzufügen, muss das Bild auf einem Server (einem OVHcloud Hosting-Angebot oder einem anderen) bereitgestellt werden.<br>
+**Das Hochladen eines Bildes von einem Computer ermöglicht nicht dessen Anzeige**.
 
-Klicken Sie auf den Button `< >`{.action} in der HTML-Werkzeugleiste und fügen Sie folgenden Code ein, wobei Sie `image-url` mit der Adresse (URL) Ihrer Bilddatei ersetzen und `Alternativtext` mit einem Text, der erscheint, wenn das Bild nicht angezeigt werden kann.
+Klicken Sie auf den Button `< >`{.action} in der HTML-Werkzeugleiste und fügen Sie dann den folgenden Code ein, wobei Sie `your-image-url` durch die URL des Bildes und `text-if-image-is-not-displayed` durch einen Text ersetzen, der das Bild ersetzt, falls es nicht angezeigt werden kann.
 
-```bash
-<img src="image-url" border="0" alt="Alternativtext"/>
+```html
+<img src="your-image-url" border="0" alt="text-if-image-is-not-displayed" />
 ```
 
-![Hosting](images/roundcube08.png){.thumbnail}
+![hosting](images/roundcube08.png){.thumbnail}
 
 ### Adressbuch <a name="contact-book"></a>
 
-Klicken Sie im oberen Menü auf Kontakte`{.action}, um zum Adressbuch zu gelangen. Es ist in **3 Spalten unterteilt**:
+Klicken Sie in der oberen Leiste auf `Kontakte`{.action}, um auf das Adressbuch zuzugreifen. Es ist in **3 Spalten** unterteilt:
 
-- **Gruppen**: Im Adressbuch können Sie Gruppen erstellen, um die Kontakte zu ordnen.
-- **Kontakte**: Kontakte im Adressbuch oder der ausgewählten Gruppe anzeigen.
-- **Kontaktdaten** oder **Kontakt hinzufügen**: Dieses Fenster wird angezeigt, wenn ein Kontakt ausgewählt wird oder erstellt wird. Dort können Sie die Informationen eines Kontakts einsehen oder ändern.
+- **Gruppen**: Im Adressbuch können Sie Gruppen erstellen, um Kontakte zu organisieren.
+- **Kontakte**: Zeigen Sie die Kontakte des Adressbuchs oder der ausgewählten Gruppe an.
+- **Kontakteigenschaften** oder **Kontakt hinzufügen**: Dieses Fenster wird angezeigt, wenn ein Kontakt ausgewählt oder erstellt wird. Sie können die Kontaktinformationen einsehen oder bearbeiten.
 
-![Hosting](images/roundcube09.png){.thumbnail}
+![hosting](images/roundcube09.png){.thumbnail}
 
 #### Gruppen <a name="group"></a>
 
-Gruppen sind Unterkategorien des Adressbuchs. Sie erlauben es, die Kontakte in Untereinheiten zu ordnen. So finden Sie zum Beispiel leichter einen Kontakt in einer Gruppe, die Sie erstellt haben, als im gesamten Adressbuch. So können Sie auch eine E-Mail versenden, indem Sie eine Gruppe pro Empfänger hinzufügen, anstatt die Kontakte der Gruppe einzeln hinzuzufügen.
+Gruppen sind Unterkategorien des Adressbuchs. Sie ermöglichen es Ihnen, Kontakte in Untergruppen zu organisieren. So ist es zum Beispiel einfacher, einen Kontakt in einer von Ihnen erstellten Gruppe zu finden als im gesamten Adressbuch. Sie ermöglichen außerdem das Versenden einer E-Mail, indem Sie eine Gruppe als Empfänger hinzufügen, anstatt die Kontakte der Gruppe einzeln hinzuzufügen.
 
-Um eine Gruppe zu erstellen, klicken Sie unten in der Spalte `Gruppen`{.action} auf den Button `+`. Legen Sie den Namen der Gruppe fest und klicken Sie auf `Speichern`{.action}, um zu bestätigen.
+Um eine Gruppe zu erstellen, klicken Sie auf den Button `+`{.action} am unteren Rand der Spalte `Gruppen`. Legen Sie den Namen der Gruppe fest und klicken Sie auf `Speichern`{.action}, um zu bestätigen.
 
-![Hosting](images/roundcube10.png){.thumbnail}
+![hosting](images/roundcube10.png){.thumbnail}
 
-Um einen Kontakt einer der Gruppen zuzuweisen, wählen Sie den Kontakt in der Spalte `Kontakte` aus und klicken Sie im neuen Fenster auf den Tab `Gruppen`{.action}. Wählen Sie die Gruppe aus, die Sie dem Kontakt zuweisen möchten.
+Um einen Kontakt einer der Gruppen zuzuweisen, wählen Sie einen Kontakt in der Spalte `Kontakte` aus und klicken Sie im erscheinenden Fenster auf den Tab `Gruppen`{.action}. Aktivieren Sie das Kontrollkästchen der Gruppe, die Sie dem Kontakt zuweisen möchten.
 
 #### Kontakte <a name="contacts"></a>
 
 Wählen Sie in der Spalte `Gruppen` das Adressbuch oder eine der Gruppen aus.
 
 > [!primary]
-> 
-> Wenn Sie in der ausgewählten Gruppe einen Kontakt erstellen, wird der Kontakt automatisch zur Gruppe hinzugefügt.
+>
+> Wenn Sie einen Kontakt aus einer ausgewählten Gruppe heraus erstellen, wird der Kontakt automatisch zur Gruppe hinzugefügt.
 
-Klicken Sie auf den Button `+`{.action} unten in der Spalte `Kontakte,` um einen Kontakt zu erstellen.
+Klicken Sie auf den Button `+`{.action} am unteren Rand der Spalte `Kontakte`, um einen Kontakt zu erstellen.
 
-![Hosting](images/roundcube11.png){.thumbnail}
+![hosting](images/roundcube11.png){.thumbnail}
 
 Geben Sie anschließend die Kontaktinformationen ein.
 
 > [!primary]
->
-> Sie können über das Drop-down-Menü `Ein Feld hinzufügen...` unter den Feldern `Name` und `Adresse` weitere Felder hinzufügen.
+> Sie können über das Drop-down-Menü `Feld hinzufügen...`{.action} weitere Felder hinzufügen, das sich unter den Feldern `Vorname` und `Adresse` befindet.
 
 #### Kontakte importieren <a name="import-contacts"></a>
 
 Klicken Sie im Fenster `Kontakte`{.action} in der oberen Leiste auf `Importieren`{.action}, um das Importfenster zu öffnen.
 
-- `Aus Datei importieren`: Wählen Sie eine CSV-Datei oder eine vCard-Datei auf Ihrem Computer aus. Kontakte in einer CSV-Datei müssen durch Kommas getrennt werden. Die Dateigröße darf 20 MB nicht überschreiten.
-- `Gruppenzuordnungen importieren`: Wenn die Kontakte in Ihrer Datei auf Gruppen verteilt sind, können Sie diese Option aktivieren, um diese Organisation wiederherzustellen. Wenn Sie diese Option auf `Keine` belassen, werden den Kontakten keine Gruppen zugewiesen.
-- `Bestehendes Adressbuch komplett ersetzen`: Wenn Ihre Kontakte bereits konfiguriert ist, empfehlen wir Ihnen, das Adressbuch zu exportieren, bevor Sie diese Option nutzen. Haken Sie dies ansonsten nur an, wenn Sie sicher sind, dass Sie das Adressbuch dauerhaft ersetzen möchten.
+- `Aus Datei importieren`: Wählen Sie eine CSV-Datei oder eine vCard-Datei von Ihrem Computer aus. Kontakte in einer CSV-Datei müssen durch Kommas getrennt sein. Die Datei darf nicht größer als 20 MB sein.
+- `Gruppenzuordnungen importieren`: Wenn die Kontakte in Ihrer Datei nach Gruppen sortiert sind, können Sie diese Option aktivieren, um diese Organisation beizubehalten, oder diese Option auf `Keine` belassen, sodass den Kontakten keine Gruppe zugewiesen wird.
+- `Bestehendes Adressbuch komplett ersetzen`: Wenn bereits ein Adressbuch konfiguriert ist, empfehlen wir Ihnen, dieses zu exportieren, bevor Sie diese Option aktivieren, oder sich zu vergewissern, dass Sie es dauerhaft ersetzen möchten.
 
-![Hosting](images/roundcube-import-contact.png){.thumbnail}
+![hosting](images/roundcube-import-contact.png){.thumbnail}
 
 #### Kontakte exportieren <a name="export-contacts"></a>
 
-Klicken Sie im Fenster `Kontakte`{.action} im oberen Menü rechts auf den Pfeil neben der Schaltfläche `Exportieren`{.action}.
+Klicken Sie im Fenster `Kontakte`{.action} in der oberen Leiste auf den Pfeil rechts neben dem Button `Exportieren`{.action}.
 
 Sie haben die Wahl zwischen:
 
-- `Alles exportieren`{.action}: Alle Kontakte werden in eine **.vcf** Datei exportiert.
-- `Auswahl exportieren`{.action}: Exportiert nur die Elemente, die Sie in der Spalte `Kontakte`{.action} ausgewählt haben.
+- `Alles exportieren`{.action}: Alle Kontakte werden in einer **.vcf**-Datei exportiert.
+- `Auswahl exportieren`{.action}: Es werden nur die Elemente exportiert, die Sie in der Spalte `Kontakte`{.action} ausgewählt haben.
 
-![Hosting](images/roundcube-export-contact.png){.thumbnail}
+![hosting](images/roundcube-export-contact.png){.thumbnail}
 
 ### Schnellantworten (Templates) <a name="responses"></a>
 
-Mit dieser Funktion können Sie Templates für das Verfassen einer E-Mail erstellen.
+Mit dieser Funktion können Sie Antwortvorlagen für das Verfassen einer E-Mail erstellen.
 
-Klicken Sie im oberen Menü auf `Einstellungen`{.action} und im linken Menü auf `Schnellantworten`{.action}.
+Klicken Sie in Roundcube in der oberen Leiste auf `Einstellungen`{.action} und anschließend in der linken Spalte auf `Schnellantworten`{.action}.
 
-Um eine Antwort hinzuzufügen, klicken Sie unten in der Spalte `Schnellantworten`{.action} auf den Button `+`{.action}.
+Um eine Antwort hinzuzufügen, klicken Sie auf den Button `+`{.action} am unteren Rand der Spalte `Schnellantworten`.
 
-![Hosting](images/roundcube12.png){.thumbnail}
+![hosting](images/roundcube12.png){.thumbnail}
 
 > [!primary]
-> 
-> "Schnellantworten" sind immer im Textformat verfasst.
+>
+> "Schnellantworten" werden im "Klartext"-Format verfasst.
 
-### Auto-Responder hinzufügen <a name="automatic-respond"></a>
+### Einen Auto-Responder hinzufügen <a name="automatic-respond"></a>
 
-Um Ihrem E-Mail-Account eine automatische Antwort hinzufügen, wenn Sie abwesend oder nicht verfügbar sind, kann ein Auto-Responder genutzt werden. Diese Funktion kann aber nicht im Webmail, sondern nur im [OVHcloud Kundencenter](/links/manager) im Verwaltungsinterface Ihrer E-Mail-Accounts aktiviert werden. Lesen Sie unsere Anleitung "[Einrichten von Auto-Antworten für E-Mails](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
+Sie möchten Ihrer E-Mail-Adresse eine automatische Antwort hinzufügen, wenn Sie abwesend oder nicht verfügbar sind. Diese Funktion kann nicht über das Webmail-Interface aktiviert werden, sondern über Ihr [OVHcloud Kundencenter](/links/manager) im Verwaltungsinterface Ihrer E-Mail-Adressen. Lesen Sie unsere Anleitung "[Einen Auto-Responder für Ihre E-Mail-Adresse erstellen](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
 
 ### Passwort Ihres E-Mail-Accounts ändern <a name="password"></a>
 
-Um das Passwort Ihres E-Mail-Accounts zu ändern, loggen Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager) im Verwaltungsinterface Ihres E-Mail-Accounts ein. Lesen Sie unsere Anleitung "[Passwort eines E-Mail-Accounts ändern](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
+Um Ihr E-Mail-Passwort zu ändern, müssen Sie sich in Ihr [OVHcloud Kundencenter](/links/manager) im Verwaltungsinterface Ihrer E-Mail-Adressen einloggen. Lesen Sie unsere Anleitung "[Passwort einer E-Mail-Adresse ändern](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
 
 ### E-Mail verfassen <a name="email-writing"></a>
 
-Klicken Sie im Tab `E-Mail`{.action} im oberen Menü auf `Verfassen`{.action}.
+Klicken Sie im Tab `E-Mail`{.action} in der oberen Leiste auf `Verfassen`{.action}.
 
-Im Fenster zum Verfassen einer E-Mail finden Sie folgende Felder: 
+Im Fenster zum Verfassen einer E-Mail finden Sie folgende Felder:
 
-- **Von**: eine [Identität](#identity) für den Absender auswählen.
-- **An**: Empfänger und/oder eine [Empfängergruppe hinzufügen](#group).
+- **Von**: Wählen Sie eine [Identität](#identity) aus, um den Absender festzulegen.
+- **An**: Fügen Sie Empfänger und/oder eine [Empfängergruppe](#group) hinzu. Mit dem Button `+`{.action} rechts neben dem Feld können Sie mehrere Adressen eingeben.
 
 > [!primary]
-> 
-> Das Feld "**An**" darf nicht mehr als 100 Empfänger enthalten, die in einer [Gruppe](#group) enthaltenen Kontakte eingeschlossen.
+>
+> Das Feld **"An"** darf 100 Empfänger nicht überschreiten, einschließlich der Kontakte innerhalb einer [Gruppe](#group).
 
-- **Kopie hinzufügen**: Empfänger in Kopie hinzufügen.
-- **Blindkopie hinzufügen**: Empfänger in Blindkopie hinzufügen. Die anderen Empfänger der E-Mail werden die als Bcc eingetragenen Adressen nicht sehen.
-- **Followup-To hinzufügen**: Die E-Mail an Empfänger weiterleiten.
-- **Bearbeitungstyp**:  
-    - `Einfacher Text`: Nur Text ohne Formatierung.
-    - `HTML`: Formatierter Text. Oberhalb des Eingabefensters erscheint eine HTML-Werkzeugleiste.
-- **Priorität** für die E-Mail.
-- **Empfangsbestätigung (MDN)**: Der Empfänger erhält eine Empfangsbestätigungsanfrage.
-- **Übermittlungsbestätigung (DSN)** Statusbenachrichtigung, sobald die E-Mail an den Empfänger übermittelt wurde.
-- **Nachricht speichern in**: Einen Ordner auswählen, in dem eine Kopie der E-Mail gespeichert wird.
+- **Kopie**: Über den Button `Kopie hinzufügen`{.action} fügen Sie Empfänger als einfache Kopie hinzu.
+- **Blindkopie**: Über den Button `Blindkopie hinzufügen`{.action} fügen Sie Empfänger als Blindkopie hinzu. Die anderen Empfänger der E-Mail sehen die in Blindkopie eingetragenen Adressen nicht.
+- **Followup-To**: Über den Button `Followup-To hinzufügen`{.action} leiten Sie die E-Mail an Empfänger weiter.
+- **Bearbeitungstyp**:
+    - `Klartext`: nur Text, ohne Formatierung.
+    - `HTML`: Text mit Formatierung. Eine HTML-Werkzeugleiste erscheint oberhalb des Eingabefensters.
+- **Priorität** der E-Mail.
+- **Empfangsbestätigung**: Vom Empfänger wird eine Lesebestätigung angefordert.
+- **Übermittlungsstatusbenachrichtigung**, sobald die E-Mail erfolgreich an den Empfänger zugestellt wurde.
+- **Gesendete Nachricht speichern in**: Wählen Sie den Ordner aus, in dem eine Kopie der E-Mail gespeichert wird.
 
-Im oberen Menü sind folgende Aktionen verfügbar:
+In der oberen Leiste sind folgende Aktionen verfügbar:
 
-- `Abbrechen`{.action}: Erstellung einer E-Mail nach einer Bestätigungsanfrage abbrechen.
-- `Senden`{.action}: E-Mail versenden.
-- `Speichern`{.action}: E-Mail im Spezialordner "Entwurf" speichern.
-- `Rechtschreibung`{.action}: Überprüft den Text, mit Sprachauswahl.
-- `Anhang`{.action}: Datei an die E-Mail anhängen.
-- `Signatur`{.action}: Fügt die mit der ausgewählten [Identität](#identity) verbundene Signatur hinzu.
-- `Schnellantworten`{.action}: Fügt eine im Abschnitt [Schnellantworten](#responses) gespeicherte Vorlage hinzu.
+- `Abbrechen`{.action}: das Verfassen einer E-Mail abbrechen, mit einer Bestätigungsabfrage.
+- `Senden`{.action}: eine E-Mail versenden.
+- `Speichern`{.action}: eine E-Mail im Spezialordner "Entwürfe" speichern.
+- `Rechtschreibung`{.action}: prüft den Text, mit einem Menü zur Sprachauswahl.
+- `Anhang`{.action}: eine Datei an eine E-Mail anhängen.
+- `Signatur`{.action}: fügt die mit der ausgewählten [Identität](#identity) verknüpfte Signatur hinzu.
+- `Schnellantworten`{.action}: fügt eine zuvor gespeicherte Vorlage aus dem Abschnitt [Schnellantworten](#responses) hinzu.
 
-![Hosting](images/roundcube13.png){.thumbnail}
+![hosting](images/roundcube13.png){.thumbnail}
 
-### Anwendungsfälle <a name="usecase"></a>
+### Anwendungsfall <a name="usecase"></a>
 
 #### Fehler bei der Anforderungsüberprüfung
 
-Wenn Sie versuchen, auf Ihr Roundcube Webmail zuzugreifen, wird folgende Meldung angezeigt:
+Wenn Sie versuchen, auf Ihr Roundcube Webmail-Interface zuzugreifen, wird folgende Meldung angezeigt:
 
 ```console
-FEHLER BEI DER ANFORDERUNGSÜBERPRÜFUNG
+ANFORDERUNGSPRÜFUNG FEHLGESCHLAGEN
 Zu Ihrem Schutz ist der Zugriff auf diese Ressource gegen CSRF-Angriffe geschützt.
-Wenn Sie das sehen, haben Sie sich wahrscheinlich nicht abgemeldet, bevor Sie die Web-App verlassen haben.
-Um fortzufahren, ist nun eine menschliche Interaktion erforderlich.
-Bitte wenden Sie sich an den Administrator Ihres Servers.
+Wenn Sie dies sehen, haben Sie sich vor dem Verlassen der Webanwendung wahrscheinlich nicht abgemeldet.
+Eine Benutzerinteraktion ist jetzt erforderlich, um fortzufahren.
+Bitte wenden Sie sich an Ihren Serveradministrator.
 ```
 
-Wie in der Nachricht angegeben, wird bei Ihrem E-Mail-Account bereits ein Login registriert. Dies bedeutet, dass Ihr E-Mail-Account vom E-Mail-Server bereits verwendet wird und dass diese Sitzung zuerst geschlossen werden muss. Stellen Sie sicher, dass Ihr E-Mail-Account nicht bereits in Roundcube geöffnet ist. Leeren Sie auch den Cache (die zwischengespeicherten Daten) in Ihrem Browser.
+Wie in der Meldung angegeben, gilt Ihr E-Mail-Account als bereits eingeloggt. Dies wird als "Sitzung" bezeichnet. Es bedeutet, dass Ihr E-Mail-Account aus Sicht des E-Mail-Servers bereits in Verwendung ist und dass diese vorherige Sitzung geschlossen werden muss. Prüfen Sie, dass Ihr E-Mail-Account nicht bereits in Roundcube geöffnet ist. Leeren Sie auch die zwischengespeicherten Daten in Ihrem Webbrowser.
 
 ## Weiterführende Informationen
 
-[Erste Schritte mit MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)
+[Erste Schritte mit der MX Plan Lösung](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)
 
 [Passwort einer MX Plan E-Mail-Adresse ändern](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
 
-[Einen Beantworter für seine E-Mail-Adresse erstellen](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
+[Einen Auto-Responder für Ihre E-Mail-Adresse erstellen](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
 
 [Filter für Ihre E-Mail-Adressen erstellen](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_filters)
 
-[E-Mail Weiterleitungen verwenden](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
+[E-Mail-Weiterleitungen verwenden](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 
 Treten Sie unserer [User Community](/links/community) bei.

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.en-gb.md
@@ -1,41 +1,38 @@
 ---
-title: Using your email account via the Roundcube webmail interface
-updated: 2025-11-12
+title: 'Using your email address from the Roundcube webmail interface'
+updated: 2026-05-04
 ---
 
 ## Objective
 
-With the OVHcloud MX Plan, you can send and receive emails from third-party software or via webmail. OVHcloud provides an online email service called Roundcube that allows you to access an email account via a web browser.
+With the OVHcloud MX Plan solution, you can send and receive emails from third-party software or via webmail. OVHcloud provides an online email service called Roundcube that lets you access an email account through a web browser.
 
-**Find out how to use the Roundcube webmail interface for your OVHcloud email addresses**
+**Find out how to use the Roundcube webmail interface for your OVHcloud email addresses.**
 
 ## Requirements
 
-- An OVHcloud **MX Plan** email solution, included in our [web hosting plans](/links/web/hosting), included in a [100M free hosting](/links/web/domains-free-hosting) hosting plan, or ordered separately as a standalone solution.
-- Access to the MX Plan email account you would like to use; for more information, please refer to our guide [Getting started with an MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
-- Your OVHcloud email solution **MX Plan** must use the webmail technology **Roundcube**. To identify it, follow the instructions below.
+- An OVHcloud **MX Plan** email solution, included in our [web hosting plans](/links/web/hosting), included with a [100M free hosting plan](/links/web/domains-free-hosting), or ordered separately as a standalone solution.
+- Access to the login details for the MX Plan email address you want to consult. For more information, see our guide [Getting started with the MX Plan solution](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+- Your OVHcloud **MX Plan** email solution must use the **Roundcube** webmail technology. To identify it, follow the instructions below.
 
-<!-- CP-STEPS-START:identify-mx-plan-technology -->
 > [!primary]
->
+> 
 > **How do I identify the technology used on my MX Plan solution?**
 >
-> The email technology used for your MX Plan solution is characterized by its webmail interface. To identify it via the OVHcloud Control Panel, follow this path:
+> The email technology used for your MX Plan solution is identified by its webmail interface. To identify it from your Control Panel, follow this path:
 >
 > 1. Log in to your [OVHcloud Control Panel](/links/manager).
 > 1. Go to the `Web Cloud`{.action} section.
 > 1. Click `MX Plan`{.action}.
-> 1. Select the domain concerned.
-> 1. From the `General Information`{.action} tab, select by default.
-> 1. Note the technology used as **Webmail**.
+> 1. Select the relevant domain.
+> 1. From the `General information`{.action} tab (selected by default), check the technology used under the **Webmail** entry.
 >
-> ![MX Plan](images/technology-email.png){.thumbnail .w-500}
-<!-- CP-STEPS-END:identify-mx-plan-technology -->
+> ![MX plan](images/technology-email.png){.thumbnail .w-500}
 
 <!-- CP-NAV-START:web-mx-plan -->
 ---
 
-### OVHcloud Control Panel Access
+### OVHcloud Control Panel access
 
 - **Direct link:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Navigation path:** `Web Cloud`{.action} > `MX Plan`{.action} > Select your MX Plan service
@@ -47,18 +44,18 @@ With the OVHcloud MX Plan, you can send and receive emails from third-party soft
 
 **Summary**
 
-- [Logging in to Roundcube](#roundcube-connexion)
+- [Logging in to the Roundcube webmail interface](#roundcube-connexion)
 - [Roundcube webmail main page](#general-interface)
     - [Folder management (left column)](#leftcolumn)
-    - [List of emails received/sent (top window)](#topwindow)
+    - [List of received/sent emails (top window)](#topwindow)
         - [Display type](#topwindow-display)
-        - [Actions on a selected email](#topwindow-action)
-        - [Search for an emai](#topwindow-search)
+        - [Action on a selected email](#topwindow-action)
+        - [Searching for an email](#topwindow-search)
     - [Email content (bottom window)](#lowerwindow)
 - [Configuring Roundcube interface preferences](#roundcube-settings)
     - [User interface](#user-interface-settings)
     - [Mailbox view](#mail-view-settings)
-    - [Displaying messagess](#mail-display-settings)
+    - [Displaying messages](#mail-display-settings)
     - [Composing messages](#mail-writing-settings)
     - [Contacts](#contacts-settings)
     - [Special folders](#special-folder-settings)
@@ -76,11 +73,11 @@ With the OVHcloud MX Plan, you can send and receive emails from third-party soft
 - [Adding an autoresponder](#automatic-respond)
 - [Changing your email password](#password)
 - [Writing an email](#email-writing)
-- [Use cases](#usecase)
+- [Use case](#usecase)
 
-### Logging in to Roundcube <a name="roundcube-connexion"></a>
+### Logging in to the Roundcube webmail interface <a name="roundcube-connexion"></a>
 
-Go to the page [Webmail](/links/web/email). Enter your email address and password, then click `Login`{.action}. 
+Go to the [Webmail](/links/web/email) page. Enter an email address and the password, then click `Login`{.action}. 
 
 ![hosting](images/webmail_login.png){.thumbnail}
 
@@ -90,209 +87,223 @@ You will then be redirected to the Roundcube interface.
 
 > [!primary]
 > 
-> When you first log in to the Roundcube interface, the appearance may be different from what you will see in this documentation. This means that the "classic" appearance has been set on your interface. To change it, follow the steps to access the [user interface settings](#user-interface-settings) and select the "Larry" view.
-> The appearance of the interface will not affect the explanations in this documentation.
+> When you first log in to the Roundcube interface, the appearance may be different from what you will see in this documentation. This means that the "classic" appearance has been set on your interface. To change it, follow the "[User interface](#user-interface-settings)" section and select the "Larry" view.
+> The appearance of the interface will not affect the explanations that follow in this documentation.
 
 > [!warning]
 > 
-> If you are redirected to an **O**utlook **W**eb **A**pp (OWA) interface, this means that you are on the latest version of the MX Plan solution. To find out more about your MX Plan solution, go to our guide [Getting started with an MX Plan solution](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+> If you are redirected to an **O**utlook **W**eb **A**pp (OWA) interface, this means that you are on the latest version of the MX Plan solution. To find out more about your MX Plan solution, see our [Getting started with the MX Plan solution](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) page.
 >
-> To familiarise yourself with the **OWA** interface, please refer to our guide on [Using an email account in the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
+> To familiarise yourself with the **OWA** interface, see our guide [Using an email account from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Roundcube webmail main page <a name="general-interface"></a>
 
-Once logged in to your email account, you have access to the main Roundcube interface, which consists of 3 zones:
+Once logged in to your email account, you have access to the main Roundcube window, which consists of 3 zones:
 
-- [**Left column**](#leftcolumn): Your email account tree, made up of folders and subfolders. The primary folder is the `Inbox`.
+- [**Left column**](#leftcolumn): the tree view of your email account, made up of folders and subfolders. The primary folder is the `Inbox`.
 
-- [**Top window**](#topwindow): The list of emails in the folder selected in the left-hand column.
+- [**Top window**](#topwindow): the list of emails contained in the folder selected in the left column.
 
-- [**Lower window**](#lowerwindow): The content of the email selected in the top window.
+- [**Bottom window**](#lowerwindow): the content of the email selected in the top window.
 
 #### Folder management (left column) <a name="leftcolumn"></a>
 
-In this zone, you will see the folders of your email account.
+In this zone, the folders of your email account are displayed.
 
-To manage folders more precisely, click on the cog at the bottom of the column, then `Manage folders`{.action}
+To manage folders more precisely, click the cog icon at the bottom of the column, then click `Manage folders`{.action}.
 
 ![hosting](images/roundcube02.png){.thumbnail}
 
 To create a folder, click the `+`{.action} button at the bottom of the `Folders` column.
 
-To delete a folder, select it and click the cog at the bottom of the `Folders` column. Click on `Delete`{.action}. To clear the contents but keep the folder, click on `Clear`{.action}.
+To delete a folder, select the relevant folder, click the cog icon at the bottom of the `Folders` column, then click `Delete`{.action}. To clear the contents but keep the folder, click `Empty`{.action}.
 
-The check boxes at the folder level correspond to "subscriptions". The subscription determines whether the folder should be displayed at the webmail interface or the email software level while retaining the folder contents. The only purpose is to hide or display a folder on the email account.
+The check boxes next to the folders correspond to "subscriptions". The subscription determines whether the folder is displayed, or not, in the webmail interface or the email software, while still keeping the folder content. The aim is only to hide or show a folder on the email account.
 
 > [!primary]
 >
-> Folders with a grey check box are special folders. You cannot delete them or remove them from subscriptions.
+> Folders with a grey check box are special folders. You cannot delete them or unsubscribe from them.
 
-#### List of emails received/sent (top window) <a name="topwindow"></a>
+#### List of received/sent emails (top window) <a name="topwindow"></a>
 
-This window displays the contents of the selected folder in the left column. 
+This window displays the contents of the folder selected in the left column. 
 
 ##### Display type <a name="topwindow-display"></a>
 
-This window can be customised by clicking on the cogwheel icon in the top left-hand corner of the window.
+This window is presented in a form that can be customised. To do so, click the cog icon at the top left of the window.
 
 ![hosting](images/roundcube03.png){.thumbnail}
 
-You can set the following:
+Four parameters can be configured:
 
-- **Layout**: Allows you to determine the layout of the management windows for an email account.
-- **List columns**: Allows you to add columns to display (email priorities, etc.).
-- **Sorting column**: Allows you to choose the column by which messages are sorted.
-- **Sorting order**: Allows you to choose the ascending or descending sort order, depending on the sorting column.
+- **Layout**: defines how the email account management windows are arranged. Three options:
+    - `Widescreen`{.action}: three panels side by side — folders, email list and reading pane aligned horizontally;
+    - `Desktop`{.action}: email list at the top, reading pane below (classic layout);
+    - `List`{.action}: no reading pane — emails open in full window when clicked.
 
-##### Actions on a selected email <a name="topwindow-search"></a>
+- **List columns**: check boxes that determine the columns displayed in the email list. The **Subject** and **Threads** columns are always visible. Optional columns available: `From`{.action}, `To`{.action}, `From/To`{.action}, `Reply-To`{.action}, `Cc`{.action}, `Date`{.action}, `Size`{.action}, `Status`{.action}, `Attachment`{.action}, `Flag`{.action}, `Priority`{.action}.
 
-When an email is selected, you can choose an action it. Here are the possible actions:
+- **Sort column**: lets you choose the default sorting column. Available options: `None`{.action}, `Arrival date`{.action}, `Sent date`{.action}, `Subject`{.action}, `From`{.action}, `To`{.action}, `From/To`{.action}, `Cc`{.action} or `Size`{.action}.
 
-- `Reply`{.action}: Reply directly to the sender.
-- `Reply all`{.action}: Reply directly to all recipients listed in the To and Copy fields.
-- `Forward`{.action}: Forward the selected email to one or more recipients.
-- `Delete`{.action}: Move the selected email into the “Trash”.
-- `Spam`{.action}: Place the selected email directly in the Junk folder, labelling it as **Spam**.
-- `Mark`{.action}: Determine the status of an email manually.
+- **Sort order**: ascending or descending.
+
+Click `Save`{.action} to apply your choices.
+
+> [!primary]
+>
+> You can also **sort the list dynamically** by clicking directly on the header of a displayed column (for example **Date**, **Subject** or **Size**). A second click on the same column reverses the order.
+
+##### Action on a selected email <a name="topwindow-action"></a>
+
+When an email is selected, you can perform actions on it. The possible actions are:
+
+- `Reply`{.action}: reply directly to the sender.
+- `Reply all`{.action}: reply directly to all the recipients listed in the "To" and "Cc" fields.
+- `Forward`{.action}: forward the selected email to one or more recipients.
+- `Delete`{.action}: move the selected email to the "Trash".
+- `Mark as junk`{.action}: place the selected email directly in the junk mail folder (Junk), labelling it as **spam**.
+- `Mark`{.action}: manually set the status of an email.
 - `More`{.action} 
     - `Print this message`{.action}.
-    - `Download (.eml)`{.action}: Retrieve the header and the content of the email as a file.
-    - `Edit as new`{.action}: Create a new email based on the selected email.
-    - `Show source`{.action}: Display the email in its raw format, including the header.
-    - `Move to`{.action} : Move the email to a folder.
-    - `Copy to`{.action}: Copy the email to a folder.
+    - `Download (.eml)`{.action}: retrieve the email header and its content.
+    - `Edit as new`{.action}: create a new email based on the selected email.
+    - `Show source`{.action}: display the email in its raw form, including the header.
+    - `Move to`{.action}: move the email to a folder.
+    - `Copy to`{.action}: copy the email to a folder.
     - `Open in a new window`{.action}.
 
 ![hosting](images/roundcube04.png){.thumbnail}
 
 > [!primary]
 >
-> If one of your contacts requests that an acknowledgement be sent back when you read their email, you will get the following message: `The sender of this message has asked to be notified when you read this message. Do you want to notify the sender?`.
-> 
+> If one of your contacts requests an acknowledgement of receipt when you read their email, you will get the following message: `The sender of this message has asked to be notified when you read this message. Do you want to notify the sender?`.
+>
 
-##### Search for an email <a name="topwindow-action"></a>
+##### Searching for an email <a name="topwindow-search"></a>
 
-A search tool is available in the upper right corner of the interface.
+A search tool is available in the upper right-hand part of the interface.
 
-Click the arrow to the right of the magnifying glass to display the search filters.
+Enter a term in the search field, then confirm with the `Enter`{.action} key: by default, Roundcube searches the entire current folder.
+
+Click the arrow to the right of the magnifying glass to display the search filters: you can restrict the search to specific fields (subject, message body, sender, recipients, etc.) or extend its scope to all folders.
 
 #### Email content (bottom window) <a name="lowerwindow"></a>
 
-When an email is selected in the list, it is displayed in the lower window.
+When an email is selected in the list, it is displayed in the bottom window.
 
-On the right-hand side you can find shortcuts for the following functions:
+On the right-hand side, you will find shortcuts for the following functions:
 
-- Display in HTML format (default)
-- Display in plain text format
-- Reply
-- Reply all
-- Forward
-- Open in new window 
+- `Show in HTML format`{.action} (default)
+- `Show in plain text format`{.action}
+- `Reply`{.action}
+- `Reply all`{.action}
+- `Forward`{.action}
+- `Open in a new window`{.action}
 
 ![hosting](images/roundcube05.png){.thumbnail}
 
 ### Configuring Roundcube interface preferences <a name="roundcube-settings"></a>
 
-The following sections in this guide correspond to the tabs that make up the `Preferences`{.action} section of the Roundcube `Settings`{.action}. Their description is not exhaustive.
+The following sections of this guide correspond to the tabs that make up the `Preferences`{.action} part of the Roundcube `Settings`{.action}. Their description is not exhaustive.
 
 ![hosting](images/roundcube06.png){.thumbnail}
 
-#### User Interface <a name="user-interface-settings"></a>
+#### User interface <a name="user-interface-settings"></a>
 
-Set here the `Language` of the Roundcube interface as well as the `Time zone`, the `Time format` and the `Date format`.
+Here, set the `Language` of the Roundcube interface, the `Time zone`, the `Time format` and the `Date format`.
 
-The `Pretty Dates` option allows you to display the received/sent date with relative terms such as `Today`, `Yesterday`, etc.<br>
+The `Pretty dates` option lets you display the date received/sent with relative terms such as "Today", "Yesterday", etc.<br>
+**For example**: today's date is **19/05/2022**, an email sent/received on **17/05/2022** at **17:38** will be displayed as **Tue 17:38**, because the email corresponds to the previous Tuesday.
 
-The `Show next entry in the list after deletion or move` check box means that after a delete or move action on an email, the item in the lower row will then always be selected, regardless of the sort order. 
+The `Display the next message after marking as read or moving` check box means that after a delete or move action on an email, the item in the row below will then always be selected, regardless of the sort order.
 
-You can choose the display style of your interface. You can choose between the **Classic** display or the **Larry** display.
+You can choose the look of your interface display. You have a choice between the **Classic** display or the **Larry** display.
 
-#### Mailbox View <a name="mail-view-settings"></a>
+#### Mailbox view <a name="mail-view-settings"></a>
 
-Set here the usability to view and act on emails. The `Layout` option allows you to arrange the 3 windows described in the [Roundcube webmail main interface section](#topwindow) .
+Here, set the layout used to view and act on emails. The `Layout` option lets you arrange the 3 windows described in the [List of received/sent emails](#topwindow) section.
 
-#### Displaying Messages <a name="mail-display-settings"></a>
+#### Displaying messages <a name="mail-display-settings"></a>
 
-Define how emails are displayed.<br>
-We recommend that you tick the `Display HTML` box, to ensure that emails formatted by the sender are displayed correctly.<br>
-It is also advisable to keep the `Allow remote resources (images, styles)` option on `never`. This avoids loading elements of an email that seems malicious.
+Set how emails are displayed.<br>
+We recommend keeping the `Display HTML` box ticked, to ensure that emails formatted by the sender are displayed correctly.<br>
+We also recommend keeping the `Allow remote resources (images, styles)` option set to `never`. This avoids loading the elements of an email that may seem malicious.
 
-#### Composing Messages <a name="mail-writing-settings"></a>
+#### Composing messages <a name="mail-writing-settings"></a>
 
-Set the default shape when writing an email or reply.<br>
-It is recommended to pass the `Compose HTML messages` option on `always`, to benefit by default from HTML editing tools and not to alter an HTML signature.
+Set the default form when writing an email or a reply.<br>
+We recommend setting the `Compose HTML messages` option to `always`, to benefit from HTML editing tools by default and to avoid altering an HTML signature.
 
 #### Contacts <a name="contacts-settings"></a>
 
-Customise the arrangement of information in your address book here.
+Customise the layout of the information in your address book here.
 
-#### Special Folders <a name="special-folder-settings"></a>
+#### Special folders <a name="special-folder-settings"></a>
 
-Roundcube has 4 special folders: `Drafts`, `Sent`, `Spam`, `Deleted Items`.
+Roundcube has 4 special folders: `Drafts`, `Sent`, `Junk`, `Trash`.
 
-We do not recommend changing them, but you can assign the behaviour of a special folder to another folder created later, using the drop-down menus.
+We do not recommend modifying them, but you can assign the behaviour of a special folder to another folder created later, using the drop-down menus.<br>
 
-You can assign the `Drafts` behaviour to another folder that you created by clicking the drop-down list and choosing that folder. If no folder is assigned, it will be automatically set to the "Drafts" option. The emails saved in there will be considered drafts until they are sent.
+**For example**, you can assign the "Drafts" behaviour to another folder you have created by clicking the drop-down list and choosing that folder. If no folder is assigned to it, it will automatically be set to the "Drafts" option. Emails saved there will then be considered drafts until they are actually sent.
 
-> Example: Create a subfolder called "Drafts client emails". Open `My preferences`{.action} and `Special folders`{.action} and choose the "Drafts" option. In the drop-down menu, select the "Drafts client emails" folder to replace "Drafts". Emails in this folder will be considered drafts.
+> In practice, you create a subfolder called "Client email drafts". Go to `My preferences`{.action} / `Special folders`{.action} and choose the "Drafts" option. In the drop-down menu, select the "Client email drafts" folder to replace "Drafts". Emails written in this folder will be considered drafts.
 
-#### Server Settings <a name="server-settings"></a>
+#### Server settings <a name="server-settings"></a>
 
-In this tab, you can optimise the space occupied by an email account. The option `Clear "Deleted Items" on logout` prevents the messages that have been deleted from accumulating in this folder. The option `Permanently delete messages in the spam folder` will automatically delete all emails marked as spam.
+In this tab, you can optimise the space used by an email account. The `Clear Trash on logout` option helps prevent the build-up of items that have been deleted. The `Directly delete junk` option will automatically delete all emails considered as spam.
 
 > [!warning]
 > 
-> It is not recommended to enable the `Permanently delete messages in the spam folder` option, in the event that false positives (emails falsely declared as "SPAM") are marked as SPAM for the receiving server. When emails are placed in the `Spam` folder, it is still possible to check for legitimate messages.
+> We do not recommend enabling the `Directly delete junk` option in case a false positive (an email wrongly classified as "spam") is flagged as spam by the receiving server. When an email is placed in the "Junk" folder, you can still check whether the email is legitimate.
 
 #### Encryption <a name="encryption"></a>
 
-If your browser allows it, you can install and activate the "Mailvelope" extension. This is a browser extension that integrates PGP (**P**retty **G**ood **P**privacy) into your web mail. The PGP encryption system and, therefore, the "Mailevelope" extension allow you to:
+If your browser allows it, you can install and enable the "Mailvelope" extension. This is a browser extension that integrates PGP (**P**retty **G**ood **P**rivacy) into your webmail. The PGP encryption system, and consequently the "Mailvelope" extension, lets you:
 
 - Encrypt and decrypt emails in your browser.
-- Keep the content of your emails private to your email provider.
+- Keep the content of your emails private from your email provider.
 
-This way, only you can read your emails. This extension is a way to secure your webmail if you receive confidential emails.
+This way, only you can read your emails. This extension is a way to secure your webmail if you receive emails of a confidential nature.
 
-For more information, see the Mailvelope FAQ at <https://mailvelope.com/faq>.
+For more information, see the "Mailvelope" FAQ at <https://mailvelope.com/faq>.
 
 ### Managing identities and their signatures <a name="identity-signature"></a>
 
-In Roundcube, click `Settings`{.action} in the top bar, then `Identities`{.action} in the left column. "Identity" allows you to customise information sent to recipients such as the display name or a signature.
+In Roundcube, click `Settings`{.action} in the top bar, then `Identities`{.action} in the left column. The "Identity" lets you customise the information sent to recipients, such as the display name or the signature.
 
 ![hosting](images/roundcube07.png){.thumbnail}
 
-#### Setting attributes for an identity <a name="identity"></a>
+#### Setting the attributes of an identity <a name="identity"></a>
 
-- **Display Name**: This name will appear in the “sender” section of the recipient.
-- **Email**: This will be displayed as the address from which the email is sent.
-- **Company**: A field for a company name, association, or another entity.
-- **Reply-To**: Assign a reply email address different from the sender.
-- **Bcc**: Send a blind copy to an email address.
-- **Set default**: If there are multiple identities (signatures), assign this one by default.
-- **Signature**: Customise the footer of your emails (surname, first name, job title, sentences, images, etc.).
-- **HTML signature**: Activates the HTML format on the signature. 
+- **Display Name**: this name will appear in the "sender" section for the recipient.
+- **Email**: the address from which the email is sent.
+- **Organization**: a field for a company name, association, or another entity.
+- **Reply-To**: assign a different reply email address from the sender's.
+- **Bcc**: send a blind copy to an email address when sending.
+- **Set default**: when there are several identities (signatures), set this one as the default.
+- **Signature**: customise the footer of an email when writing it (surname, first name, job title, sentences, images, etc.).
+- **HTML signature**: enables HTML format on the signature.
 
 > [!alert]
-> 
-> Filling in the **Email** box with an email address different from the one you are logged in to is considered to be *spoofing*. The IP address used for sending may be banned and/or considered "SPAM" by your recipients. 
+>
+> Filling in the **Email** field with an email address different from the one you are logged in with is considered electronic identity theft (*spoofing*). The IP address used for sending may be "banned" and/or considered "spam" by your recipients.
 
 #### Adding a signature <a name="signature"></a>
 
-By default, the `Signature` box is set to plain text. This format does not allow advanced editing or inserting an image into your signature. For advanced editing options for a signature, it is recommended that you enable HTML mode by clicking **HTML Signature**  under the text frame.
+By default, the `Signature` field is in "plain text". This format does not allow advanced editing or inserting an image into your signature. To benefit from advanced editing options for a signature, we recommend enabling HTML mode by clicking **HTML signature** below the input frame.
 
 > [!warning]
-> 
-> If the signature is in HTML format, it will be necessary to switch to HTML mode for writing an email. You can enable this option by default for each email editing session, in the `Settings`{.action} section of the Roundcube interface.
-> 
-> Click `Preferences`{.action} in the left-hand column, then click `Composing Messages`{.action}. At **Compose HTML messages**, select `Always`.
+>
+> As a result, if the signature is in HTML format, you will need to switch to HTML mode when writing an email. You can enable this option by default for each email you write, from the `Settings`{.action} section of the Roundcube interface.
+> Click `Preferences`{.action} in the left-hand column, then `Composing messages`{.action}. For the **Compose HTML messages** entry, select `Always`.
 >
 
-To insert an image into a signature, the image must be hosted on a server (OVHcloud hosting or another).<br>
-**Uploading an image from your device will not display it.**
+To insert an image into a signature, the image must be hosted on a server (an OVHcloud hosting plan or another).<br>
+**Uploading an image from a computer will not allow it to be displayed**.
 
-Click the `< >`{.action} button in the HTML toolbar, then insert the following code, replacing `your-image-url` with the URL of the image, and `text-if-image-is-not-displayed` with text that replaces the image if it cannot be displayed.
+Click the `< >`{.action} button in the HTML toolbar, then insert the following code, replacing `your-image-url` with the URL of the image and `text-if-image-is-not-displayed` with text that replaces the image if it cannot be displayed.
 
-```bash
+```html
 <img src="your-image-url" border="0" alt="text-if-image-is-not-displayed" />
 ```
 
@@ -302,29 +313,29 @@ Click the `< >`{.action} button in the HTML toolbar, then insert the following c
 
 Click `Contacts`{.action} in the top bar to access the contact book. It is divided into **3 columns**:
 
-- **Groups**: In the address book, you can create groups to classify contacts.
-- **Contacts**: View the contacts for the selected address book or group.
-- **Contact Properties** or **Add Contact**: This window appears when a contact is selected or is being created. You can read or edit contact information.
+- **Groups**: in the address book, you can create groups to organise contacts.
+- **Contacts**: view the contacts of the address book or the selected group.
+- **Contact properties** or **Add contact**: this window appears when a contact is selected or being created. You can read or edit the contact information.
 
 ![hosting](images/roundcube09.png){.thumbnail}
 
 #### Groups <a name="group"></a>
 
-Groups are subcategories of the address book. They can be used to classify contacts into subsets. For example, it is easier to find a contact in a group you have created than in your entire address book. This also allows you to send an email by adding a group as a recipient, instead of adding the group contacts individually.
+Groups are subcategories of the address book. They let you organise contacts into subsets. For example, it is easier to find a contact in a group you have created than in your entire address book. They also let you send an email by adding a group as a recipient, instead of adding the contacts of the group one by one.
 
-To create a group, click the `+`{.action} button at the bottom of the `Groups` column. Set the group name and click `Save`{.action} to validate.
+To create a group, click the `+`{.action} button at the bottom of the `Groups` column. Set the name of the group, then click `Save`{.action} to confirm.
 
 ![hosting](images/roundcube10.png){.thumbnail}
 
-To assign a contact to a group, select a contact in the `Contacts` column. In the window that appears, click on the `Groups`{.action} tab. Select the group you want to assign to the contact.
+To assign a contact to one of the groups, select a contact in the `Contacts` column, then in the window that appears, click the `Groups`{.action} tab. Tick the group you want to assign to the contact.
 
 #### Contacts <a name="contacts"></a>
 
 In the `Groups` column, select the address book or one of the groups.
 
 > [!primary]
-> 
-> When you create a contact from a selected group, the contact will be automatically added to the group.
+>
+> When you create a contact from a selected group, the contact will automatically be added to the group.
 
 Click the `+`{.action} button at the bottom of the `Contacts` column to create a contact.
 
@@ -333,114 +344,110 @@ Click the `+`{.action} button at the bottom of the `Contacts` column to create a
 Then fill in the contact information.
 
 > [!primary]
-> You can add additional fields via the `Add Field...`{.action} drop-down menu, located under the `First name` and `Address` sections.
+> You can add additional fields via the `Add field...`{.action} drop-down menu, located below the `First name` and `Address` fields.
 
-#### Importing Contacts <a name="import-contacts"></a>
+#### Importing contacts <a name="import-contacts"></a>
 
-In the `Contacts`{.action} window in the top bar, click `Import`{.action} to open the import window.
+In the `Contacts`{.action} window, in the top bar, click `Import`{.action} to open the import window.
 
-- `Import from file`: Select a CSV or vCard file on your computer. Contacts within a CSV file must be separated by commas. The file should not be larger than 20 MB.
-- `Import group assignments`: If the contacts in your file are sorted by groups, you can enable this option to import this organisation. If you leave this option on `None`, no groups are assigned to the contacts.
-- `Replace the entire address book`: If you have already configured a contact book, we recommend exporting it before ticking this option, or ensuring that you want to replace it permanently.
+- `Import from file`: select a CSV or vCard file from your computer. Contacts in a CSV file must be separated by commas. The file must not be larger than 20 MB.
+- `Import group assignments`: if the contacts in your file are sorted by groups, you can enable this option to keep this organisation, or leave this option set to `none` so that no group is assigned to the contacts.
+- `Replace the entire address book`: if a contact book is already configured, we recommend exporting it before ticking this option, or making sure you want to replace it permanently.
 
 ![hosting](images/roundcube-import-contact.png){.thumbnail}
 
-#### Exporting Roundcube Contacts <a name="export-contacts"></a>
+#### Exporting contacts <a name="export-contacts"></a>
 
-In the `Contacts`{.action} window in the top bar, click the down arrow to the right of the `Export`{.action} button.
+In the `Contacts`{.action} window, in the top bar, click the down arrow to the right of the `Export`{.action} button.
 
-You can choose between:
+You have the choice between:
 
-- `Export all`{.action}: All contacts will be exported to a **.vcf** file.
-- `Export selected`{.action}: Export only the items you have selected in the `Contacts`{.action} column.
+- `Export all`{.action}: all contacts will be exported in a **.vcf** file.
+- `Export selected`{.action}: export only the items you have selected in the `Contacts`{.action} column.
 
 ![hosting](images/roundcube-export-contact.png){.thumbnail}
 
 ### Responses (templates) <a name="responses"></a>
 
-This feature allows you to create response templates for composing an email.
+This feature lets you create response templates when writing an email.
 
 In Roundcube, click `Settings`{.action} in the top bar, then `Responses`{.action} in the left column.
 
-To add a response, click the `+`{.action} button at the bottom of the `Replies` column.
+To add a response, click the `+`{.action} button at the bottom of the `Responses` column.
 
 ![hosting](images/roundcube12.png){.thumbnail}
 
 > [!primary]
-> 
-> `Responses` are written in plain text format.
+>
+> "Responses" are written in "plain text" format.
 
 ### Adding an autoresponder <a name="automatic-respond"></a>
 
-<!-- CP-STEPS-START:autoresponder-cp-reference -->
-You want to add an automatic reply to your email account when you are absent or unavailable. This feature cannot be enabled via webmail, but via your [OVHcloud Control Panel](/links/manager), in the management interface for your email accounts. Read our guide "[Creating an autoresponder for your email addresses](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
-<!-- CP-STEPS-END:autoresponder-cp-reference -->
+You want to add an automatic reply to your email address when you are away or unavailable. This feature cannot be enabled from the webmail interface, but from your [OVHcloud Control Panel](/links/manager), in the management interface for your email addresses. See our guide "[Creating an autoresponder for your email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
 
 ### Changing your email password <a name="password"></a>
 
-<!-- CP-STEPS-START:change-password-cp-reference -->
-To change your email password, you will need to log in to your [OVHcloud Control Panel](/links/manager), in the interface for managing your email addresses. Read our guide "[Changing an email password](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
-<!-- CP-STEPS-END:change-password-cp-reference -->
+To change your email password, you must log in to your [OVHcloud Control Panel](/links/manager), in the management interface for your email addresses. See our guide "[Changing the password of an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
 
 ### Writing an email <a name="email-writing"></a>
 
-From the `Email`{.action} tab in the top bar, click `Write`{.action}.
+From the `Mail`{.action} tab in the top bar, click `Compose`{.action}.
 
-In the email editing window, you will see the following fields: 
+In the email composition window, you will find the following fields:
 
-- **From**: Choose an [identity](#identity) to define the sender.
-- **To+**: Add recipients and/or a recipient [group](#group).
+- **From**: choose an [identity](#identity) to set the sender.
+- **To**: add recipients and/or a [recipient group](#group). The `+`{.action} button to the right of the field lets you enter several addresses.
 
 > [!primary]
 >
-> The "**To**" field must not exceed 100 recipients, this includes contacts in a [group](#group).
+> The **"To"** field must not exceed 100 recipients, this includes contacts within a [group](#group).
 
-- **Add Cc+**: Add single copy recipients.
-- **Add Bcc+**: Add blind copy recipients. Other recipients of the email will not see addresses in BCC.
-- **Add Followup-To**: Forward the email to recipients.
-- **Editor type**:  
-    - `Plain text`: Text only, without formatting.
-    - `HTML`: Text with formatting. An HTML toolbar appears above the input window.
+- **Cc**: via the `Add Cc`{.action} button, add recipients in simple copy.
+- **Bcc**: via the `Add Bcc`{.action} button, add recipients in blind copy. The other recipients of the email will not see those in Bcc.
+- **Followup-To**: via the `Add Followup-To`{.action} button, forward the email to recipients.
+- **Editor type**:
+    - `Plain text`: text only, without formatting.
+    - `HTML`: text with formatting. An HTML toolbar appears above the input window.
 - **Priority** of the email.
-- **Return receipt**: Acknowledgement of receipt is requested from the recipient.
-- **Delivery status notification** Status notification when the email has been successfully sent to the recipient.
-- **Save sent message in**: Choose the folder where a copy of the email will be stored.
+- **Return receipt**: an acknowledgement of receipt is requested from the recipient.
+- **Delivery status notification** when the email has been successfully delivered to the recipient.
+- **Save sent message in**: choose the folder where a copy of the email will be stored.
 
 In the top bar, the following actions are available:
 
-- `Cancel`{.action} writing an email with a confirmation request.
+- `Cancel`{.action} writing an email, with a confirmation prompt.
 - `Send`{.action} an email.
-- `Save`{.action} an email in the "Draft" special folder.
+- `Save`{.action} an email in the "Drafts" special folder.
 - `Spell`{.action} check the text, with a menu allowing the choice of language.
 - `Attach`{.action} a file to an email.
-- `Signature`{.action} adds the signature attached to [the selected identity](#identity).
-- `Responses`{.action} adds a pre-saved template from the [Responses](#responses) section.
+- `Signature`{.action}: adds the signature attached to the selected [identity](#identity).
+- `Responses`{.action}: adds a pre-saved template from the [Responses](#responses) section.
 
 ![hosting](images/roundcube13.png){.thumbnail}
 
-### Use cases <a name="usecase"></a>
+### Use case <a name="usecase"></a>
 
-#### Request verification failed
+#### Request check failed
 
-When you try to access your Roundcube webmail, you will receive the following message:
+You are getting the following message when trying to access your Roundcube webmail interface:
 
 ```console
 REQUEST CHECK FAILED
-For your protection, access to this resource is secured against CSRF.
-If you see this, you probably didn't log out before leaving the web application.
+For your protection, access to this resource is protected against CSRF attacks.
+If you see this, you probably did not log out before leaving the web application.
 Human interaction is now required to continue.
-Please contact your server-administrator.
+Please contact your server administrator.
 ```
 
-As you will see in the email, your account will be considered as already logged in. This is called a session. It means that your email account is already being used by the email server, and that the previous session must be closed. Check that your email account has not already been opened on Roundcube. You can also clear cached data in your web browser.
+As stated in the message, your email account is considered to be already logged in. This is referred to as a "session". It means that your email account is already in use as far as the email server is concerned, and that this previous session must be closed. Check that your email account is not already open on Roundcube. Also clear the cached data in your web browser.
 
-## Go further <a name="gofurther"></a>
+## Go further
 
 [Getting started with the MX Plan solution](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)
 
-[Changing your password for an MX Plan email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
+[Changing the password of an MX Plan email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
 
-[Creating an auto-reply for an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
+[Creating an autoresponder for your email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
 
 [Creating filters for your email addresses](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_filters)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.en-ie.md
@@ -1,39 +1,38 @@
 ---
-title: Using your email account via the Roundcube webmail interface
-updated: 2025-11-12
+title: 'Using your email address from the Roundcube webmail interface'
+updated: 2026-05-04
 ---
 
 ## Objective
 
-With the OVHcloud MX Plan, you can send and receive emails from third-party software or via webmail. OVHcloud provides an online email service called Roundcube that allows you to access an email account via a web browser.
+With the OVHcloud MX Plan solution, you can send and receive emails from third-party software or via webmail. OVHcloud provides an online email service called Roundcube that lets you access an email account through a web browser.
 
-**Find out how to use the Roundcube webmail interface for your OVHcloud email addresses**
+**Find out how to use the Roundcube webmail interface for your OVHcloud email addresses.**
 
 ## Requirements
 
-- An OVHcloud **MX Plan** email solution, included in our [web hosting plans](/links/web/hosting), included in a [100M free hosting](/links/web/domains-free-hosting) hosting plan, or ordered separately as a standalone solution.
-- Access to the MX Plan email account you would like to use; for more information, please refer to our guide [Getting started with an MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
-- Your OVHcloud email solution **MX Plan** must use the webmail technology **Roundcube**. To identify it, follow the instructions below.
+- An OVHcloud **MX Plan** email solution, included in our [web hosting plans](/links/web/hosting), included with a [100M free hosting plan](/links/web/domains-free-hosting), or ordered separately as a standalone solution.
+- Access to the login details for the MX Plan email address you want to consult. For more information, see our guide [Getting started with the MX Plan solution](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+- Your OVHcloud **MX Plan** email solution must use the **Roundcube** webmail technology. To identify it, follow the instructions below.
 
 > [!primary]
 > 
 > **How do I identify the technology used on my MX Plan solution?**
 >
-> The email technology used for your MX Plan solution is characterized by its webmail interface. To identify it via the OVHcloud Control Panel, follow this path:
+> The email technology used for your MX Plan solution is identified by its webmail interface. To identify it from your Control Panel, follow this path:
 >
 > 1. Log in to your [OVHcloud Control Panel](/links/manager).
 > 1. Go to the `Web Cloud`{.action} section.
 > 1. Click `MX Plan`{.action}.
-> 1. Select the domain concerned.
-> 1. From the `General Information`{.action} tab, select by default.
-> 1. Note the technology used as **Webmail**.
+> 1. Select the relevant domain.
+> 1. From the `General information`{.action} tab (selected by default), check the technology used under the **Webmail** entry.
 >
-> ![MX Plan](images/technology-email.png){.thumbnail .w-500}
+> ![MX plan](images/technology-email.png){.thumbnail .w-500}
 
 <!-- CP-NAV-START:web-mx-plan -->
 ---
 
-### OVHcloud Control Panel Access
+### OVHcloud Control Panel access
 
 - **Direct link:** [MX Plan](/links/control-panel/web-mx-plan)
 - **Navigation path:** `Web Cloud`{.action} > `MX Plan`{.action} > Select your MX Plan service
@@ -45,18 +44,18 @@ With the OVHcloud MX Plan, you can send and receive emails from third-party soft
 
 **Summary**
 
-- [Logging in to Roundcube](#roundcube-connexion)
+- [Logging in to the Roundcube webmail interface](#roundcube-connexion)
 - [Roundcube webmail main page](#general-interface)
     - [Folder management (left column)](#leftcolumn)
-    - [List of emails received/sent (top window)](#topwindow)
+    - [List of received/sent emails (top window)](#topwindow)
         - [Display type](#topwindow-display)
-        - [Actions on a selected email](#topwindow-action)
-        - [Search for an emai](#topwindow-search)
+        - [Action on a selected email](#topwindow-action)
+        - [Searching for an email](#topwindow-search)
     - [Email content (bottom window)](#lowerwindow)
 - [Configuring Roundcube interface preferences](#roundcube-settings)
     - [User interface](#user-interface-settings)
     - [Mailbox view](#mail-view-settings)
-    - [Displaying messagess](#mail-display-settings)
+    - [Displaying messages](#mail-display-settings)
     - [Composing messages](#mail-writing-settings)
     - [Contacts](#contacts-settings)
     - [Special folders](#special-folder-settings)
@@ -74,11 +73,11 @@ With the OVHcloud MX Plan, you can send and receive emails from third-party soft
 - [Adding an autoresponder](#automatic-respond)
 - [Changing your email password](#password)
 - [Writing an email](#email-writing)
-- [Use cases](#usecase)
+- [Use case](#usecase)
 
-### Logging in to Roundcube <a name="roundcube-connexion"></a>
+### Logging in to the Roundcube webmail interface <a name="roundcube-connexion"></a>
 
-Go to the page [Webmail](/links/web/email). Enter your email address and password, then click `Login`{.action}. 
+Go to the [Webmail](/links/web/email) page. Enter an email address and the password, then click `Login`{.action}. 
 
 ![hosting](images/webmail_login.png){.thumbnail}
 
@@ -88,209 +87,223 @@ You will then be redirected to the Roundcube interface.
 
 > [!primary]
 > 
-> When you first log in to the Roundcube interface, the appearance may be different from what you will see in this documentation. This means that the "classic" appearance has been set on your interface. To change it, follow the [User Interface](#user-interface-settings) topic and select the "Larry" view.
+> When you first log in to the Roundcube interface, the appearance may be different from what you will see in this documentation. This means that the "classic" appearance has been set on your interface. To change it, follow the "[User interface](#user-interface-settings)" section and select the "Larry" view.
 > The appearance of the interface will not affect the explanations that follow in this documentation.
 
 > [!warning]
 > 
-> If you are redirected to an **O**utlook **W**eb **A**pp (OWA) interface, this means that you are on the latest version of the MX Plan solution. To find out more about your MX Plan solution, go to our guide [Getting started with an MX Plan solution](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+> If you are redirected to an **O**utlook **W**eb **A**pp (OWA) interface, this means that you are on the latest version of the MX Plan solution. To find out more about your MX Plan solution, see our [Getting started with the MX Plan solution](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) page.
 >
-> To familiarise yourself with the **OWA** interface, please refer to our guide on [Using an email account in the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
+> To familiarise yourself with the **OWA** interface, see our guide [Using an email account from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Roundcube webmail main page <a name="general-interface"></a>
 
-Once logged in to your email account, you have access to the main Roundcube interface, which consists of 3 zones:
+Once logged in to your email account, you have access to the main Roundcube window, which consists of 3 zones:
 
-- [**Left column**](#leftcolumn): Your email account tree, made up of folders and subfolders. The primary folder is the `Inbox`.
+- [**Left column**](#leftcolumn): the tree view of your email account, made up of folders and subfolders. The primary folder is the `Inbox`.
 
-- [**Top window**](#topwindow): The list of emails in the folder selected in the left-hand column.
+- [**Top window**](#topwindow): the list of emails contained in the folder selected in the left column.
 
-- [**Lower window**](#lowerwindow): The content of the email selected in the top window.
+- [**Bottom window**](#lowerwindow): the content of the email selected in the top window.
 
 #### Folder management (left column) <a name="leftcolumn"></a>
 
-In this zone, you will see the folders of your email account.
+In this zone, the folders of your email account are displayed.
 
-To manage folders more precisely, click on the cog at the bottom of the column, then `Manage folders`{.action}
+To manage folders more precisely, click the cog icon at the bottom of the column, then click `Manage folders`{.action}.
 
 ![hosting](images/roundcube02.png){.thumbnail}
 
 To create a folder, click the `+`{.action} button at the bottom of the `Folders` column.
 
-To delete a folder, select it and click the cog at the bottom of the `Folders` column. Click on `Delete`{.action}. To clear the contents but keep the folder, click on `Clear`{.action}.
+To delete a folder, select the relevant folder, click the cog icon at the bottom of the `Folders` column, then click `Delete`{.action}. To clear the contents but keep the folder, click `Empty`{.action}.
 
-The check boxes at the folder level correspond to "subscriptions". The subscription determines whether the folder should be displayed at the webmail interface or the email software level while retaining the folder contents. The only purpose is to hide or display a folder on the email account.
+The check boxes next to the folders correspond to "subscriptions". The subscription determines whether the folder is displayed, or not, in the webmail interface or the email software, while still keeping the folder content. The aim is only to hide or show a folder on the email account.
 
 > [!primary]
 >
-> Folders with a grey check box are special folders. You cannot delete them or remove them from subscriptions.
+> Folders with a grey check box are special folders. You cannot delete them or unsubscribe from them.
 
-#### List of emails received/sent (top window) <a name="topwindow"></a>
+#### List of received/sent emails (top window) <a name="topwindow"></a>
 
-This window displays the contents of the selected folder in the left column. 
+This window displays the contents of the folder selected in the left column. 
 
 ##### Display type <a name="topwindow-display"></a>
 
-This window can be customised by clicking on the cogwheel icon in the top left-hand corner of the window.
+This window is presented in a form that can be customised. To do so, click the cog icon at the top left of the window.
 
 ![hosting](images/roundcube03.png){.thumbnail}
 
-You can set the following:
+Four parameters can be configured:
 
-- **Layout**: Allows you to determine the layout of the management windows for an email account.
-- **List columns**: Allows you to add columns to display (email priorities, etc.).
-- **Sorting column**: Allows you to choose the column by which messages are sorted.
-- **Sorting order**: Allows you to choose the ascending or descending sort order, depending on the sorting column.
+- **Layout**: defines how the email account management windows are arranged. Three options:
+    - `Widescreen`{.action}: three panels side by side — folders, email list and reading pane aligned horizontally;
+    - `Desktop`{.action}: email list at the top, reading pane below (classic layout);
+    - `List`{.action}: no reading pane — emails open in full window when clicked.
 
-##### Actions on a selected email <a name="topwindow-search"></a>
+- **List columns**: check boxes that determine the columns displayed in the email list. The **Subject** and **Threads** columns are always visible. Optional columns available: `From`{.action}, `To`{.action}, `From/To`{.action}, `Reply-To`{.action}, `Cc`{.action}, `Date`{.action}, `Size`{.action}, `Status`{.action}, `Attachment`{.action}, `Flag`{.action}, `Priority`{.action}.
 
-When an email is selected, you can choose an action it. Here are the possible actions:
+- **Sort column**: lets you choose the default sorting column. Available options: `None`{.action}, `Arrival date`{.action}, `Sent date`{.action}, `Subject`{.action}, `From`{.action}, `To`{.action}, `From/To`{.action}, `Cc`{.action} or `Size`{.action}.
 
-- `Reply`{.action}: Reply directly to the sender.
-- `Reply all`{.action}: Reply directly to all recipients listed in the To and Copy fields.
-- `Forward`{.action}: Forward the selected email to one or more recipients.
-- `Delete`{.action}: Move the selected email into the “Trash”.
-- `Spam`{.action}: Place the selected email directly in the Junk folder, labelling it as **Spam**.
-- `Mark`{.action}: Determine the status of an email manually.
+- **Sort order**: ascending or descending.
+
+Click `Save`{.action} to apply your choices.
+
+> [!primary]
+>
+> You can also **sort the list dynamically** by clicking directly on the header of a displayed column (for example **Date**, **Subject** or **Size**). A second click on the same column reverses the order.
+
+##### Action on a selected email <a name="topwindow-action"></a>
+
+When an email is selected, you can perform actions on it. The possible actions are:
+
+- `Reply`{.action}: reply directly to the sender.
+- `Reply all`{.action}: reply directly to all the recipients listed in the "To" and "Cc" fields.
+- `Forward`{.action}: forward the selected email to one or more recipients.
+- `Delete`{.action}: move the selected email to the "Trash".
+- `Mark as junk`{.action}: place the selected email directly in the junk mail folder (Junk), labelling it as **spam**.
+- `Mark`{.action}: manually set the status of an email.
 - `More`{.action} 
     - `Print this message`{.action}.
-    - `Download (.eml)`{.action}: Retrieve the header and the content of the email as a file.
-    - `Edit as new`{.action}: Create a new email based on the selected email.
-    - `Show source`{.action}: Display the email in its raw format, including the header.
-    - `Move to`{.action} : Move the email to a folder.
-    - `Copy to`{.action}: Copy the email to a folder.
+    - `Download (.eml)`{.action}: retrieve the email header and its content.
+    - `Edit as new`{.action}: create a new email based on the selected email.
+    - `Show source`{.action}: display the email in its raw form, including the header.
+    - `Move to`{.action}: move the email to a folder.
+    - `Copy to`{.action}: copy the email to a folder.
     - `Open in a new window`{.action}.
 
 ![hosting](images/roundcube04.png){.thumbnail}
 
 > [!primary]
 >
-> If one of your contacts requests that an acknowledgement be sent back when you read their email, you will get the following message: `The sender of this message has asked to be notified when you read this message. Do you want to notify the sender?`.
-> 
+> If one of your contacts requests an acknowledgement of receipt when you read their email, you will get the following message: `The sender of this message has asked to be notified when you read this message. Do you want to notify the sender?`.
+>
 
-##### Search for an email <a name="topwindow-action"></a>
+##### Searching for an email <a name="topwindow-search"></a>
 
-A search tool is available in the upper right corner of the interface.
+A search tool is available in the upper right-hand part of the interface.
 
-Click the arrow to the right of the magnifying glass to display the search filters.
+Enter a term in the search field, then confirm with the `Enter`{.action} key: by default, Roundcube searches the entire current folder.
+
+Click the arrow to the right of the magnifying glass to display the search filters: you can restrict the search to specific fields (subject, message body, sender, recipients, etc.) or extend its scope to all folders.
 
 #### Email content (bottom window) <a name="lowerwindow"></a>
 
-When an email is selected in the list, it is displayed in the lower window.
+When an email is selected in the list, it is displayed in the bottom window.
 
-On the right-hand side you can find shortcuts for the following functions:
+On the right-hand side, you will find shortcuts for the following functions:
 
-- Display in HTML format (default)
-- Display in plain text format
-- Reply
-- Reply all
-- Forward
-- Open in new window 
+- `Show in HTML format`{.action} (default)
+- `Show in plain text format`{.action}
+- `Reply`{.action}
+- `Reply all`{.action}
+- `Forward`{.action}
+- `Open in a new window`{.action}
 
 ![hosting](images/roundcube05.png){.thumbnail}
 
 ### Configuring Roundcube interface preferences <a name="roundcube-settings"></a>
 
-The following sections in this guide correspond to the tabs that make up the `Preferences`{.action} section of the Roundcube `Settings`{.action}. Their description is not exhaustive.
+The following sections of this guide correspond to the tabs that make up the `Preferences`{.action} part of the Roundcube `Settings`{.action}. Their description is not exhaustive.
 
 ![hosting](images/roundcube06.png){.thumbnail}
 
-#### User Interface <a name="user-interface-settings"></a>
+#### User interface <a name="user-interface-settings"></a>
 
-Set here the `Language` of the Roundcube interface as well as the `Time zone`, the `Time format` and the `Date format`.
+Here, set the `Language` of the Roundcube interface, the `Time zone`, the `Time format` and the `Date format`.
 
-The `Pretty Dates` option allows you to display the received/sent date with relative terms such as `Today`, `Yesterday`, etc.<br>
+The `Pretty dates` option lets you display the date received/sent with relative terms such as "Today", "Yesterday", etc.<br>
+**For example**: today's date is **19/05/2022**, an email sent/received on **17/05/2022** at **17:38** will be displayed as **Tue 17:38**, because the email corresponds to the previous Tuesday.
 
-The `Show next entry in the list after deletion or move` check box means that after a delete or move action on an email, the item in the lower row will then always be selected, regardless of the sort order. 
+The `Display the next message after marking as read or moving` check box means that after a delete or move action on an email, the item in the row below will then always be selected, regardless of the sort order.
 
-You can choose the display aesthetics of your interface. You can choose between the **Classic** display or the **Larry** display.
+You can choose the look of your interface display. You have a choice between the **Classic** display or the **Larry** display.
 
-#### Mailbox View <a name="mail-view-settings"></a>
+#### Mailbox view <a name="mail-view-settings"></a>
 
-Set here the usability to view and act on emails. The `Layout` option allows you to arrange the 3 windows described in the [Roundcube webmail main interface section](#topwindow) .
+Here, set the layout used to view and act on emails. The `Layout` option lets you arrange the 3 windows described in the [List of received/sent emails](#topwindow) section.
 
-#### Displaying Messages <a name="mail-display-settings"></a>
+#### Displaying messages <a name="mail-display-settings"></a>
 
-Define how emails are displayed.<br>
-We recommend that you tick the `Display HTML` box, to ensure that emails formatted by the sender are displayed correctly.<br>
-It is also advisable to keep the `Allow remote resources (images, styles)` option on `never`. This avoids loading elements of an email that seems malicious.
+Set how emails are displayed.<br>
+We recommend keeping the `Display HTML` box ticked, to ensure that emails formatted by the sender are displayed correctly.<br>
+We also recommend keeping the `Allow remote resources (images, styles)` option set to `never`. This avoids loading the elements of an email that may seem malicious.
 
-#### Composing Messages <a name="mail-writing-settings"></a>
+#### Composing messages <a name="mail-writing-settings"></a>
 
-Set the default shape when writing an email or reply.<br>
-It is recommended to pass the `Compose HTML messages` option on `always`, to benefit by default from HTML editing tools and not to alter an HTML signature.
+Set the default form when writing an email or a reply.<br>
+We recommend setting the `Compose HTML messages` option to `always`, to benefit from HTML editing tools by default and to avoid altering an HTML signature.
 
 #### Contacts <a name="contacts-settings"></a>
 
-Customise the arrangement of information in your address book here.
+Customise the layout of the information in your address book here.
 
-#### Special Folders <a name="special-folder-settings"></a>
+#### Special folders <a name="special-folder-settings"></a>
 
-Roundcube has 4 special folders: `Drafts`, `Sent`, `Spam`, `Deleted Items`.
+Roundcube has 4 special folders: `Drafts`, `Sent`, `Junk`, `Trash`.
 
-We do not recommend changing them, but you can assign the behaviour of a special folder to another folder created later, using the drop-down menus.<br>
+We do not recommend modifying them, but you can assign the behaviour of a special folder to another folder created later, using the drop-down menus.<br>
 
-**For example**, you can assign the "Drafts" behavior to another folder that you created by clicking the drop-down list and choosing that folder. If no folder is assigned to it, it will be automatically set to the "Drafts" option. The emails saved there will then be treated as drafts until they are sent.
+**For example**, you can assign the "Drafts" behaviour to another folder you have created by clicking the drop-down list and choosing that folder. If no folder is assigned to it, it will automatically be set to the "Drafts" option. Emails saved there will then be considered drafts until they are actually sent.
 
-> In practice, I create a sub-folder called “Drafts emails clients”. I go to `My preferences`{.action} / `Special folders`{.action} and choose the “Drafts” option. In the dropdown menu, I select the “Drafts emails clients” folder to replace “Drafts”. Emails in this folder will be considered drafts.
+> In practice, you create a subfolder called "Client email drafts". Go to `My preferences`{.action} / `Special folders`{.action} and choose the "Drafts" option. In the drop-down menu, select the "Client email drafts" folder to replace "Drafts". Emails written in this folder will be considered drafts.
 
-#### Server Settings <a name="server-settings"></a>
+#### Server settings <a name="server-settings"></a>
 
-In this tab, you can optimise the space occupied by an email account. The option `Clear "Deleted Items" on logout` prevents the messages that have been deleted from accumulating in this folder. The option `Permanently delete messages in the spam folder` will automatically delete all emails marked as spam.
+In this tab, you can optimise the space used by an email account. The `Clear Trash on logout` option helps prevent the build-up of items that have been deleted. The `Directly delete junk` option will automatically delete all emails considered as spam.
 
 > [!warning]
 > 
-> It is not recommended to enable the `Permanently delete messages in the spam folder` option, in the event that false positives (emails falsely declared as "SPAM") are marked as SPAM for the receiving server. When emails are placed in the `Spam` folder, it is still possible to check for legitimate messages.
+> We do not recommend enabling the `Directly delete junk` option in case a false positive (an email wrongly classified as "spam") is flagged as spam by the receiving server. When an email is placed in the "Junk" folder, you can still check whether the email is legitimate.
 
 #### Encryption <a name="encryption"></a>
 
-If your browser allows it, you can install and activate the "Mailvelope" extension. This is a browser extension that integrates PGP (**P**retty **G**ood **P**privacy) into your web mail. The PGP encryption system and, therefore, the "Mailevelope" extension allow you to:
+If your browser allows it, you can install and enable the "Mailvelope" extension. This is a browser extension that integrates PGP (**P**retty **G**ood **P**rivacy) into your webmail. The PGP encryption system, and consequently the "Mailvelope" extension, lets you:
 
 - Encrypt and decrypt emails in your browser.
-- Keep the content of your emails private to your email provider.
+- Keep the content of your emails private from your email provider.
 
-This way, only you can read your emails. This extension is a way to secure your webmail if you receive confidential emails.
+This way, only you can read your emails. This extension is a way to secure your webmail if you receive emails of a confidential nature.
 
-For more information, see the Mailvelope FAQ at <https://mailvelope.com/faq>.
+For more information, see the "Mailvelope" FAQ at <https://mailvelope.com/faq>.
 
 ### Managing identities and their signatures <a name="identity-signature"></a>
 
-In Roundcube, click `Settings`{.action} in the top bar, then `Identities`{.action} in the left column. "Identity" allows you to customise information sent to recipients such as the display name or a signature.
+In Roundcube, click `Settings`{.action} in the top bar, then `Identities`{.action} in the left column. The "Identity" lets you customise the information sent to recipients, such as the display name or the signature.
 
 ![hosting](images/roundcube07.png){.thumbnail}
 
-#### Setting attributes for an identity <a name="identity"></a>
+#### Setting the attributes of an identity <a name="identity"></a>
 
-- **Display Name**: This name will appear in the “sender” section of the recipient.
-- **Email**: This will be displayed as the address from which the email is sent.
-- **Company**: A field for a company name, association, or another entity.
-- **Reply-To**: Assign a reply email address different from the sender.
-- **Bcc**: Send a blind copy to an email address.
-- **Set default**: If there are multiple identities (signatures), assign this one by default.
-- **Signature**: Customise the footer of your emails (surname, first name, job title, sentences, images, etc.).
-- **HTML signature**: Activates the HTML format on the signature. 
+- **Display Name**: this name will appear in the "sender" section for the recipient.
+- **Email**: the address from which the email is sent.
+- **Organization**: a field for a company name, association, or another entity.
+- **Reply-To**: assign a different reply email address from the sender's.
+- **Bcc**: send a blind copy to an email address when sending.
+- **Set default**: when there are several identities (signatures), set this one as the default.
+- **Signature**: customise the footer of an email when writing it (surname, first name, job title, sentences, images, etc.).
+- **HTML signature**: enables HTML format on the signature.
 
 > [!alert]
-> 
-> Filling in the **Email** box with an email address different from the one you are logged in to is considered to be *spoofing*. The IP address used for sending may be banned and/or considered "SPAM" by your recipients. 
+>
+> Filling in the **Email** field with an email address different from the one you are logged in with is considered electronic identity theft (*spoofing*). The IP address used for sending may be "banned" and/or considered "spam" by your recipients.
 
 #### Adding a signature <a name="signature"></a>
 
-By default, the `Signature` box is set to plain text. This format does not allow advanced editing or inserting an image into your signature. For advanced editing options for a signature, it is recommended that you enable HTML mode by clicking **HTML Signature**  under the text frame.
+By default, the `Signature` field is in "plain text". This format does not allow advanced editing or inserting an image into your signature. To benefit from advanced editing options for a signature, we recommend enabling HTML mode by clicking **HTML signature** below the input frame.
 
 > [!warning]
-> 
-> If the signature is in HTML format, it will be necessary to switch to HTML mode for writing an email. You can enable this option by default for each email editing session, in the `Settings`{.action} section of the Roundcube interface.
-> 
-> Click `Preferences`{.action} in the left-hand column, then click `Composing Messages`{.action}. At **Compose HTML messages**, select `Always`.
+>
+> As a result, if the signature is in HTML format, you will need to switch to HTML mode when writing an email. You can enable this option by default for each email you write, from the `Settings`{.action} section of the Roundcube interface.
+> Click `Preferences`{.action} in the left-hand column, then `Composing messages`{.action}. For the **Compose HTML messages** entry, select `Always`.
 >
 
-To insert an image into a signature, the image must be hosted on a server (OVHcloud hosting or another).<br>
-**Uploading an image from your device will not display it.**
+To insert an image into a signature, the image must be hosted on a server (an OVHcloud hosting plan or another).<br>
+**Uploading an image from a computer will not allow it to be displayed**.
 
-Click the `< >`{.action} button in the HTML toolbar, then insert the following code, replacing `your-image-url` with the URL of the image, and `text-if-image-is-not-displayed` with text that replaces the image if it cannot be displayed.
+Click the `< >`{.action} button in the HTML toolbar, then insert the following code, replacing `your-image-url` with the URL of the image and `text-if-image-is-not-displayed` with text that replaces the image if it cannot be displayed.
 
-```bash
+```html
 <img src="your-image-url" border="0" alt="text-if-image-is-not-displayed" />
 ```
 
@@ -300,29 +313,29 @@ Click the `< >`{.action} button in the HTML toolbar, then insert the following c
 
 Click `Contacts`{.action} in the top bar to access the contact book. It is divided into **3 columns**:
 
-- **Groups**: In the address book, you can create groups to classify contacts.
-- **Contacts**: View the contacts for the selected address book or group.
-- **Contact Properties** or **Add Contact**: This window appears when a contact is selected or is being created. You can read or edit contact information.
+- **Groups**: in the address book, you can create groups to organise contacts.
+- **Contacts**: view the contacts of the address book or the selected group.
+- **Contact properties** or **Add contact**: this window appears when a contact is selected or being created. You can read or edit the contact information.
 
 ![hosting](images/roundcube09.png){.thumbnail}
 
 #### Groups <a name="group"></a>
 
-Groups are subcategories of the address book. They can be used to classify contacts into subsets. For example, it is easier to find a contact in a group you have created than in your entire address book. This also allows you to send an email by adding a group as a recipient, instead of adding the group contacts individually.
+Groups are subcategories of the address book. They let you organise contacts into subsets. For example, it is easier to find a contact in a group you have created than in your entire address book. They also let you send an email by adding a group as a recipient, instead of adding the contacts of the group one by one.
 
-To create a group, click the `+`{.action} button at the bottom of the `Groups` column. Set the group name and click `Save`{.action} to validate.
+To create a group, click the `+`{.action} button at the bottom of the `Groups` column. Set the name of the group, then click `Save`{.action} to confirm.
 
 ![hosting](images/roundcube10.png){.thumbnail}
 
-To assign a contact to a group, select a contact in the `Contacts` column. In the window that appears, click on the `Groups`{.action} tab. Select the group you want to assign to the contact.
+To assign a contact to one of the groups, select a contact in the `Contacts` column, then in the window that appears, click the `Groups`{.action} tab. Tick the group you want to assign to the contact.
 
 #### Contacts <a name="contacts"></a>
 
 In the `Groups` column, select the address book or one of the groups.
 
 > [!primary]
-> 
-> When you create a contact from a selected group, the contact will be automatically added to the group.
+>
+> When you create a contact from a selected group, the contact will automatically be added to the group.
 
 Click the `+`{.action} button at the bottom of the `Contacts` column to create a contact.
 
@@ -331,110 +344,110 @@ Click the `+`{.action} button at the bottom of the `Contacts` column to create a
 Then fill in the contact information.
 
 > [!primary]
-> You can add additional fields via the `Add Field...`{.action} drop-down menu, located under the `First name` and `Address` sections.
+> You can add additional fields via the `Add field...`{.action} drop-down menu, located below the `First name` and `Address` fields.
 
-#### Importing Contacts <a name="import-contacts"></a>
+#### Importing contacts <a name="import-contacts"></a>
 
-In the `Contacts`{.action} window in the top bar, click `Import`{.action} to open the import window.
+In the `Contacts`{.action} window, in the top bar, click `Import`{.action} to open the import window.
 
-- `Import from file`: Select a CSV or vCard file on your computer. Contacts within a CSV file must be separated by commas. The file should not be larger than 20 MB.
-- `Import group assignments`: If the contacts in your file are sorted by groups, you can enable this option to import this organisation. If you leave this option on `None`, no groups are assigned to the contacts.
-- `Replace the entire address book`: If you have already configured a contact book, we recommend exporting it before ticking this option, or ensuring that you want to replace it permanently.
+- `Import from file`: select a CSV or vCard file from your computer. Contacts in a CSV file must be separated by commas. The file must not be larger than 20 MB.
+- `Import group assignments`: if the contacts in your file are sorted by groups, you can enable this option to keep this organisation, or leave this option set to `none` so that no group is assigned to the contacts.
+- `Replace the entire address book`: if a contact book is already configured, we recommend exporting it before ticking this option, or making sure you want to replace it permanently.
 
 ![hosting](images/roundcube-import-contact.png){.thumbnail}
 
-#### Exporting Roundcube Contacts <a name="export-contacts"></a>
+#### Exporting contacts <a name="export-contacts"></a>
 
-In the `Contacts`{.action} window in the top bar, click the down arrow to the right of the `Export`{.action} button.
+In the `Contacts`{.action} window, in the top bar, click the down arrow to the right of the `Export`{.action} button.
 
-You can choose between:
+You have the choice between:
 
-- `Export all`{.action}: All contacts will be exported to a **.vcf** file.
-- `Export selected`{.action}: Export only the items you have selected in the `Contacts`{.action} column.
+- `Export all`{.action}: all contacts will be exported in a **.vcf** file.
+- `Export selected`{.action}: export only the items you have selected in the `Contacts`{.action} column.
 
 ![hosting](images/roundcube-export-contact.png){.thumbnail}
 
 ### Responses (templates) <a name="responses"></a>
 
-This feature allows you to create response templates for composing an email.
+This feature lets you create response templates when writing an email.
 
 In Roundcube, click `Settings`{.action} in the top bar, then `Responses`{.action} in the left column.
 
-To add a response, click the `+`{.action} button at the bottom of the `Replies` column.
+To add a response, click the `+`{.action} button at the bottom of the `Responses` column.
 
 ![hosting](images/roundcube12.png){.thumbnail}
 
 > [!primary]
-> 
-> `Responses` are written in plain text format.
+>
+> "Responses" are written in "plain text" format.
 
 ### Adding an autoresponder <a name="automatic-respond"></a>
 
-You want to add an automatic reply to your email account when you are absent or unavailable. This feature cannot be enabled via webmail, but via your [OVHcloud Control Panel](/links/manager), in the management interface for your email accounts. Read our guide "[Creating an autoresponder for your email addresses](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
+You want to add an automatic reply to your email address when you are away or unavailable. This feature cannot be enabled from the webmail interface, but from your [OVHcloud Control Panel](/links/manager), in the management interface for your email addresses. See our guide "[Creating an autoresponder for your email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
 
 ### Changing your email password <a name="password"></a>
 
-To change your email password, you will need to log in to your [OVHcloud Control Panel](/links/manager), in the interface for managing your email addresses. Read our guide "[Changing an email password](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
+To change your email password, you must log in to your [OVHcloud Control Panel](/links/manager), in the management interface for your email addresses. See our guide "[Changing the password of an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
 
 ### Writing an email <a name="email-writing"></a>
 
-From the `Email`{.action} tab in the top bar, click `Write`{.action}.
+From the `Mail`{.action} tab in the top bar, click `Compose`{.action}.
 
-In the email editing window, you will see the following fields: 
+In the email composition window, you will find the following fields:
 
-- **From**: Choose an [identity](#identity) to define the sender.
-- **To+**: Add recipients and/or a recipient [group](#group).
+- **From**: choose an [identity](#identity) to set the sender.
+- **To**: add recipients and/or a [recipient group](#group). The `+`{.action} button to the right of the field lets you enter several addresses.
 
 > [!primary]
 >
-> The "**To**" field must not exceed 100 recipients, this includes contacts in a [group](#group).
+> The **"To"** field must not exceed 100 recipients, this includes contacts within a [group](#group).
 
-- **Add Cc+**: Add single copy recipients.
-- **Add Bcc+**: Add blind copy recipients. Other recipients of the email will not see addresses in BCC.
-- **Add Followup-To**: Forward the email to recipients.
-- **Editor type**:  
-    - `Plain text`: Text only, without formatting.
-    - `HTML`: Text with formatting. An HTML toolbar appears above the input window.
+- **Cc**: via the `Add Cc`{.action} button, add recipients in simple copy.
+- **Bcc**: via the `Add Bcc`{.action} button, add recipients in blind copy. The other recipients of the email will not see those in Bcc.
+- **Followup-To**: via the `Add Followup-To`{.action} button, forward the email to recipients.
+- **Editor type**:
+    - `Plain text`: text only, without formatting.
+    - `HTML`: text with formatting. An HTML toolbar appears above the input window.
 - **Priority** of the email.
-- **Return receipt**: Acknowledgement of receipt is requested from the recipient.
-- **Delivery status notification** Status notification when the email has been successfully sent to the recipient.
-- **Save sent message in**: Choose the folder where a copy of the email will be stored.
+- **Return receipt**: an acknowledgement of receipt is requested from the recipient.
+- **Delivery status notification** when the email has been successfully delivered to the recipient.
+- **Save sent message in**: choose the folder where a copy of the email will be stored.
 
 In the top bar, the following actions are available:
 
-- `Cancel`{.action} writing an email with a confirmation request.
+- `Cancel`{.action} writing an email, with a confirmation prompt.
 - `Send`{.action} an email.
-- `Save`{.action} an email in the "Draft" special folder.
+- `Save`{.action} an email in the "Drafts" special folder.
 - `Spell`{.action} check the text, with a menu allowing the choice of language.
 - `Attach`{.action} a file to an email.
-- `Signature`{.action} adds the signature attached to [the selected identity](#identity).
-- `Responses`{.action} adds a pre-saved template from the [Responses](#responses) section.
+- `Signature`{.action}: adds the signature attached to the selected [identity](#identity).
+- `Responses`{.action}: adds a pre-saved template from the [Responses](#responses) section.
 
 ![hosting](images/roundcube13.png){.thumbnail}
 
-### Use cases <a name="usecase"></a>
+### Use case <a name="usecase"></a>
 
-#### Request verification failed
+#### Request check failed
 
-When you try to access your Roundcube webmail, you will receive the following message:
+You are getting the following message when trying to access your Roundcube webmail interface:
 
 ```console
 REQUEST CHECK FAILED
-For your protection, access to this resource is secured against CSRF.
-If you see this, you probably didn't log out before leaving the web application.
+For your protection, access to this resource is protected against CSRF attacks.
+If you see this, you probably did not log out before leaving the web application.
 Human interaction is now required to continue.
-Please contact your server-administrator.
+Please contact your server administrator.
 ```
 
-As you will see in the email, your account will be considered as already logged in. This is called a session. It means that your email account is already being used by the email server, and that the previous session must be closed. Check that your email account has not already been opened on Roundcube. You can also clear cached data in your web browser.
+As stated in the message, your email account is considered to be already logged in. This is referred to as a "session". It means that your email account is already in use as far as the email server is concerned, and that this previous session must be closed. Check that your email account is not already open on Roundcube. Also clear the cached data in your web browser.
 
-## Go further <a name="gofurther"></a>
+## Go further
 
 [Getting started with the MX Plan solution](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)
 
-[Changing your password for an MX Plan email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
+[Changing the password of an MX Plan email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
 
-[Creating an auto-reply for an email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
+[Creating an autoresponder for your email address](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
 
 [Creating filters for your email addresses](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_filters)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.es-es.md
@@ -1,32 +1,31 @@
 ---
-title: 'Webmail: Guía de uso de Roundcube'
-updated: 2025-11-12
+title: 'Utilizar su dirección de correo desde el webmail Roundcube'
+updated: 2026-05-04
 ---
 
 ## Objetivo
 
-Con el MX Plan de OVHcloud, puede enviar y recibir mensajes de correo desde un programa de terceros o a través de un webmail. OVHcloud ofrece un servicio de correo en línea llamado Roundcube, que permite acceder a una cuenta de correo a través de un navegador web.
+Con la solución MX Plan de OVHcloud, puede enviar y recibir correos electrónicos desde un programa de terceros o a través de un webmail. OVHcloud ofrece un servicio de mensajería en línea llamado Roundcube que permite, mediante un navegador web, acceder a una cuenta de correo electrónico.
 
-**Cómo utilizar el webmail Roundcube para sus direcciones de correo de OVHcloud**
+**Descubra cómo utilizar el webmail Roundcube para sus direcciones de correo electrónico de OVHcloud.**
 
 ## Requisitos
 
-- Disponer de una solución de correo **MX Plan** de OVHcloud, [incluida](/links/web/hosting) con un [Alojamiento gratuito 100M](/links/web/domains-free-hosting) o contratada por separado como solución autónoma.
-- Disponer de los datos de conexión a la dirección de correo electrónico MX Plan que quiera consultar. Para más información, consulte nuestra guía Primeros [pasos con la solución MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
-- Su solución de correo electrónico de OVHcloud **MX Plan** debe utilizar la tecnología de webmail **Roundcube**. Para identificar esta, siga las instrucciones a continuación.
+- Disponer de una solución de correo **MX Plan** de OVHcloud, propuesta entre nuestras [ofertas de alojamiento web](/links/web/hosting), incluida en un [alojamiento gratuito 100M](/links/web/domains-free-hosting), o contratada por separado como solución autónoma.
+- Disponer de los datos de conexión a la dirección de correo electrónico MX Plan que desea consultar. Para más información, consulte nuestra guía [Primeros pasos con la solución MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+- Su solución de correo electrónico **MX Plan** de OVHcloud debe utilizar la tecnología de webmail **Roundcube**. Para identificarla, siga las siguientes instrucciones.
 
 > [!primary]
 > 
 > **¿Cómo identificar la tecnología utilizada en mi solución MX Plan?**
 >
-> La tecnología de correo utilizada en su solución MX Plan se caracteriza por la interfaz de su webmail. Para identificarlo desde el área de cliente, acceda a la siguiente ruta:
+> La tecnología de correo electrónico utilizada para su solución MX Plan se caracteriza por la interfaz de su webmail. Para identificarla desde su área de cliente, siga la siguiente ruta:
 >
 > 1. Conéctese a su [área de cliente de OVHcloud](/links/manager).
 > 1. Acceda al apartado `Web Cloud`{.action}.
 > 1. Haga clic en `MX Plan`{.action}.
-> 1. Seleccione el dominio.
-> 1. En la pestaña `Información general`{.action}, seleccionada por defecto.
-> 1. Revise la tecnología utilizada en la etiqueta **Webmail**.
+> 1. Seleccione el dominio correspondiente.
+> 1. En la pestaña `Información general`{.action} (seleccionada por defecto), revise la tecnología utilizada bajo la indicación **Webmail**.
 >
 > ![MX plan](images/technology-email.png){.thumbnail .w-500}
 
@@ -36,45 +35,45 @@ Con el MX Plan de OVHcloud, puede enviar y recibir mensajes de correo desde un p
 ### Acceso al área de cliente de OVHcloud
 
 - **Enlace directo:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Ruta de navegación:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleccione su servicio MX Plan
+- **Para acceder a sus servicios:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleccione su servicio MX Plan
 
 ---
 <!-- CP-NAV-END:web-mx-plan -->
 
 ## Procedimiento
 
-**sumario**
+**Sumario**
 
 - [Conectarse al webmail Roundcube](#roundcube-connexion)
 - [Interfaz general del webmail Roundcube](#general-interface)
     - [Gestión de carpetas (columna izquierda)](#leftcolumn)
-    - [Lista de mensajes recibidos/enviados (ventana superior)](#topwindow)
+    - [Lista de correos electrónicos recibidos / enviados (ventana superior)](#topwindow)
         - [Tipo de visualización](#topwindow-display)
-        - [Acción sobre un mensaje de correo electrónico seleccionado](#topwindow-action)
-        - [Buscar un email](#topwindow-search)
-    - [Contenido de un mensaje de correo (ventana inferior)](#lowerwindow)
-- [Configurar preferencias de la interfaz de Roundcube](#roundcube-settings)
-    - [Interfaz de Usuario](#user-interface-settings)
-    - [Vista de Buzón](#mail-view-settings)
-    - [Vista de Mensajes](#mail-display-settings)
-    - [Composición de Mensajes](#mail-writing-settings)
+        - [Acción sobre un correo electrónico seleccionado](#topwindow-action)
+        - [Buscar un correo electrónico](#topwindow-search)
+    - [Contenido de un correo electrónico (ventana inferior)](#lowerwindow)
+- [Configurar las preferencias de la interfaz Roundcube](#roundcube-settings)
+    - [Interfaz de usuario](#user-interface-settings)
+    - [Vista del buzón de correo](#mail-view-settings)
+    - [Visualización de los correos electrónicos](#mail-display-settings)
+    - [Redacción de correos electrónicos](#mail-writing-settings)
     - [Contactos](#contacts-settings)
     - [Carpetas especiales](#special-folder-settings)
-    - [Configuración del servidor](#server-settings)
+    - [Parámetros del servidor](#server-settings)
     - [Cifrado](#encryption)
 - [Gestionar las identidades y su firma](#identity-signature)
-    - [Configurar atributos de identidad](#identity)
-    - [Añadir una firma](#signature)
+    - [Identidad](#identity)
+    - [Firma](#signature)
 - [Agenda de contactos](#contact-book)
     - [Grupos](#group)
     - [Contactos](#contacts)
     - [Importar contactos](#import-contacts)
-    - [Exportar contactos](#export-contacts)
+    - [Exportar los contactos](#export-contacts)
 - [Respuestas (plantillas)](#responses)
 - [Añadir un contestador o respuesta automática](#automatic-respond)
-- [Cambiar la contraseña de su dirección de correo](#password)
-- [Redacción de un email](#email-writing)
-- [casos de uso](#usecase)
+- [Cambiar la contraseña de su dirección de correo electrónico](#password)
+- [Redacción de un correo electrónico](#email-writing)
+- [Casos de uso](#usecase)
 
 ### Conectarse al webmail Roundcube <a name="roundcube-connexion"></a>
 
@@ -88,137 +87,152 @@ El sistema le redirigirá a la interfaz Roundcube.
 
 > [!primary]
 > 
-> La primera vez que se conecte a Roundcube, la apariencia puede ser diferente de la que se muestra en esta guía. Esto significa que el aspecto "clásico" se ha definido en su interfaz. Para cambiarla, vaya a la sección «[Interfaz de usuario](#user-interface-settings)» y seleccione la vista "Larry".
-> La apariencia de la interfaz no afectará a las siguientes explicaciones de esta documentación.
+> Cuando se conecte por primera vez a la interfaz Roundcube, su apariencia puede ser diferente de la que verá en esta documentación. Esto significa que se ha definido la apariencia "clásica" en su interfaz. Para cambiarla, siga el apartado "[Interfaz de usuario](#user-interface-settings)" y seleccione la visualización "Larry".
+> La apariencia de la interfaz no afectará a las explicaciones que siguen en esta documentación.
 
 > [!warning]
 > 
-> Si es redirigido a una interfaz **O**utlook **W**eb **A**pp (OWA), significa que está en la última versión de la solución MX Plan. Para más información sobre la solución MX Plan, consulte nuestra página [Primeros pasos con la solución MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+> Si es redirigido a una interfaz **O**utlook **W**eb **A**pp (OWA), significa que se encuentra en la última versión de la solución MX Plan. Para más información sobre su solución MX Plan, consulte nuestra página [Primeros pasos con la solución MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 >
-> Para familiarizarse con la interfaz **OWA**, consulte nuestra guía [Consultar su cuenta de correo desde la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
+> Para familiarizarse con la interfaz **OWA**, consulte nuestra guía [Consultar su cuenta de correo electrónico desde la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
 ### Interfaz general del webmail Roundcube <a name="general-interface"></a>
 
-Una vez que se haya conectado a su cuenta de correo, acceda a la ventana principal de Roundcube, que se compone de 3 zonas:
+Una vez conectado a su cuenta de correo electrónico, accederá a la ventana principal de Roundcube, que se compone de 3 zonas:
 
-- [**Columna izquierda**](#leftcolumn): el árbol de su cuenta e-mail, compuesto de carpetas y subcarpetas. La carpeta principal es la `bandeja de entrada`.
+- [**Columna izquierda**](#leftcolumn): el árbol de su cuenta de correo electrónico, compuesto de carpetas y subcarpetas. La carpeta principal es la `Bandeja de entrada`.
 
-- [**Ventana superior**](#topwindow): la lista de mensajes de correo de la carpeta seleccionada en la columna izquierda.
+- [**Ventana superior**](#topwindow): la lista de correos electrónicos contenidos en la carpeta seleccionada en la columna izquierda.
 
 - [**Ventana inferior**](#lowerwindow): el contenido del correo electrónico seleccionado en la ventana superior.
 
 #### Gestión de carpetas (columna izquierda) <a name="leftcolumn"></a>
 
-En esta área aparecen las carpetas de su cuenta de correo.
+En esta zona aparecen las carpetas presentes en su cuenta de correo electrónico.
 
-Para gestionar con mayor precisión las carpetas, haga clic en la rueda dentada situada en la parte inferior de la columna y seleccione `Administrar carpetas`{.action}
+Para gestionar las carpetas con mayor precisión, haga clic en la rueda dentada situada en la parte inferior de la columna y, a continuación, en `Administrar carpetas`{.action}.
 
 ![hosting](images/roundcube02.png){.thumbnail}
 
 Para crear una carpeta, haga clic en el botón `+`{.action} en la parte inferior de la columna `Carpetas`.
 
-Para eliminar una carpeta, seleccione la carpeta correspondiente, haga clic en el icono con forma de rueda dentada situado en la parte inferior de la columna `Carpetas` y seleccione `Eliminar`{.action}. Para borrar el contenido pero mantener la carpeta, haga clic en `Vaciar`{.action}.
+Para eliminar una carpeta, seleccione la carpeta correspondiente, haga clic en la rueda dentada situada en la parte inferior de la columna `Carpetas` y, a continuación, en `Eliminar`{.action}. Para borrar el contenido pero conservar la carpeta, haga clic en `Vaciar`{.action}.
 
-Las casillas de verificación de las carpetas corresponden a "suscripciones". La suscripción determina si la carpeta debe mostrarse o no a nivel de la interfaz webmail o del cliente de correo, conservando el contenido de la carpeta. El objetivo es solo ocultar o mostrar una carpeta en la cuenta de correo.
+Las casillas de verificación de las carpetas corresponden a las "suscripciones". La suscripción determina si la carpeta debe mostrarse o no en la interfaz del webmail o del cliente de correo electrónico, conservando el contenido de la carpeta. El objetivo es únicamente ocultar o mostrar una carpeta en la cuenta de correo electrónico.
 
 > [!primary]
 >
-> Las carpetas con una casilla de verificación gris son carpetas especiales. No es posible eliminarlas o retirarlas.
+> Las carpetas que presentan una casilla de verificación gris son carpetas especiales. No es posible eliminarlas ni anular su suscripción.
 
-#### Lista de mensajes recibidos/enviados (ventana superior) <a name="topwindow"></a>
+#### Lista de correos electrónicos recibidos / enviados (ventana superior) <a name="topwindow"></a>
 
 Esta ventana muestra el contenido de la carpeta seleccionada en la columna izquierda. 
 
 ##### Tipo de visualización <a name="topwindow-display"></a>
 
-Esta ventana se presenta en una forma que se puede personalizar. Para ello, haga clic en la rueda dentada situada en la parte superior izquierda de esta ventana.
+Esta ventana se presenta de una forma que se puede personalizar. Para ello, haga clic en la rueda dentada situada en la parte superior izquierda de esta ventana.
 
 ![hosting](images/roundcube03.png){.thumbnail}
 
-Es posible configurar los siguientes elementos:
+Pueden configurarse cuatro parámetros:
 
-- **Disposición**: permite determinar la disposición de las ventanas de gestión de una cuenta de correo.
-- **Listar columnas**: permite añadir columnas (prioridades del correo, etc.).
-- **Columna de ordenación**: permite elegir la columna en la que se realizará la ordenación predeterminada.
-- **Criterio de ordenación**: permite elegir el orden ascendente o descendente, en función de la columna de orden.
+- **Disposición**: define la organización de las ventanas de gestión de una cuenta de correo electrónico. Tres opciones:
+    - `Pantalla ancha`{.action} (*Widescreen*): tres paneles uno al lado del otro — carpetas, lista de correos electrónicos y panel de lectura alineados horizontalmente;
+    - `Escritorio`{.action} (*Desktop*): lista de correos electrónicos en la parte superior, panel de lectura debajo (disposición clásica);
+    - `Lista`{.action} (*List*): sin panel de lectura — los correos electrónicos se abren en pantalla completa al hacer clic.
 
-##### Acción sobre un mensaje de correo electrónico seleccionado <a name="topwindow-action"></a>
+- **Columnas de la lista**: casillas de verificación que determinan las columnas mostradas en la lista de correos electrónicos. Las columnas **Asunto** e **Hilos de discusión** siempre están visibles. Columnas opcionales disponibles: `De`{.action}, `Para`{.action}, `De/Para`{.action}, `Responder a`{.action}, `Copia`{.action}, `Fecha`{.action}, `Tamaño`{.action}, `Estado leído`{.action}, `Adjuntos`{.action}, `Indicador`{.action}, `Prioridad`{.action}.
 
-Cuando se selecciona un mensaje de correo electrónico, es posible realizar cambios en el mismo. Acceda a las siguientes acciones:
+- **Columna de ordenación**: permite elegir la columna de ordenación predeterminada. Opciones disponibles: `Ninguno`{.action}, `Fecha de llegada`{.action}, `Fecha de envío`{.action}, `Asunto`{.action}, `De`{.action}, `Para`{.action}, `De/Para`{.action}, `Copia`{.action} o `Tamaño`{.action}.
+
+- **Orden de clasificación**: ascendente o descendente.
+
+Haga clic en `Guardar`{.action} para aplicar sus elecciones.
+
+> [!primary]
+>
+> También puede **ordenar dinámicamente la lista** haciendo clic directamente en el encabezado de una columna mostrada (por ejemplo **Fecha**, **Asunto** o **Tamaño**). Un segundo clic en la misma columna invierte el orden.
+
+##### Acción sobre un correo electrónico seleccionado <a name="topwindow-action"></a>
+
+Cuando se selecciona un correo electrónico, es posible actuar sobre el mismo. Estas son las acciones posibles:
 
 - `Responder`{.action}: responder directamente al remitente.
-- `Responder a todos`{.action}: responder directamente a todos los destinatarios de los campos "A" y "Copia".
-- `Reenviar`{.action}: transferir el mensaje seleccionado a uno o más destinatarios.
-- `Eliminar`{.action}: poner el e-mail seleccionado a la papelera.
-- `SPAM`{.action}: colocar el correo electrónico seleccionado directamente en la bandeja de correo basura (Junk), etiquetarlo como **spam**.
-- `Marcar`{.action}: determinar manualmente el estado de un email.
+- `Responder a todos`{.action}: responder directamente a todos los destinatarios presentes en los campos "Para" y "Copia".
+- `Reenviar`{.action}: reenviar el correo electrónico seleccionado a uno o varios destinatarios.
+- `Eliminar`{.action}: enviar el correo electrónico seleccionado a la "Papelera".
+- `SPAM`{.action}: colocar el correo electrónico seleccionado directamente en la bandeja de correo no deseado (Junk), calificarlo como **spam**.
+- `Marcar`{.action}: determinar manualmente el estado de un correo electrónico.
 - `Más`{.action} 
-    - `Imprimir este email`{.action}.
-    - `Descargar (.eml)`{.action}: cargar la cabecera del mensaje de correo electrónico y su contenido.
-    - `Editar como nuevo`{.action}: crear un nuevo mensaje de correo electrónico basado en la dirección de correo electrónico seleccionada.
-    - `Mostrar código`{.action}: mostrar el mensaje de correo en bruto con el encabezado.
-    - `Mover a`{.action}: mover el email a una carpeta.
-    - `Copiar a`{.action}: copiar el email a una carpeta.
+    - `Imprimir este correo electrónico`{.action}.
+    - `Descargar (.eml)`{.action}: recuperar el encabezado del correo electrónico y su contenido.
+    - `Editar como nuevo`{.action}: crear un nuevo correo electrónico basándose en el correo electrónico seleccionado.
+    - `Mostrar código`{.action}: mostrar el correo electrónico en su forma sin procesar con el encabezado.
+    - `Mover a`{.action}: mover el correo electrónico a una carpeta.
+    - `Copiar a`{.action}: copiar el correo electrónico en una carpeta.
     - `Abrir en una nueva ventana`{.action}.
 
 ![hosting](images/roundcube04.png){.thumbnail}
 
 > [!primary]
 >
-> Si uno de sus interlocutores solicita que se le acuse de lectura al leer su mensaje de correo electrónico, recibirá el siguiente mensaje: `el remitente de este mensaje ha solicitado que le avisen cuando lea este mensaje. ¿Desea avisar al remitente ?`
-> 
+> Si uno de sus interlocutores solicita un acuse de lectura cuando lea su correo electrónico, recibirá el siguiente mensaje: `el remitente de este mensaje ha solicitado ser notificado cuando lea este mensaje. ¿Desea avisar al remitente?`.
+>
 
-##### Buscar un email <a name="topwindow-search"></a>
+##### Buscar un correo electrónico <a name="topwindow-search"></a>
 
-Una herramienta de búsqueda está disponible en la parte superior derecha de la interfaz.
+Hay una herramienta de búsqueda disponible en la parte superior derecha de la interfaz.
 
-Haga clic en la flecha situada a la derecha de la lupa para ver los filtros de búsqueda.
+Introduzca un término en el campo de búsqueda y valide con la tecla `Intro`{.action}: Roundcube efectúa por defecto la búsqueda en toda la carpeta actual.
 
-#### Contenido de un mensaje de correo (ventana inferior) <a name="lowerwindow"></a>
+Haga clic en la flecha situada a la derecha de la lupa para mostrar los filtros de búsqueda: puede restringir la búsqueda a determinados campos (asunto, cuerpo del mensaje, remitente, destinatarios, etc.) o ampliar su alcance a todas las carpetas.
 
-Cuando se selecciona un mensaje de correo electrónico en la lista, éste se muestra en la ventana inferior.
+#### Contenido de un correo electrónico (ventana inferior) <a name="lowerwindow"></a>
 
-A la derecha encontrará los atajos para las siguientes funciones:
+Cuando se selecciona un correo electrónico en la lista, este se muestra en la ventana inferior.
 
-- Mostrar en formato HTML (predeterminado)
-- Mostrar en formato de texto simple
-- Responder
-- Responder a todos
-- Reenviar
-- Abrir en nueva ventana
+A la derecha encontrará los atajos de las siguientes funciones:
+
+- `Mostrar en formato HTML`{.action} (por defecto)
+- `Mostrar en formato de texto sin formato`{.action}
+- `Responder`{.action}
+- `Responder a todos`{.action}
+- `Reenviar`{.action}
+- `Mostrar en una nueva ventana`{.action}
 
 ![hosting](images/roundcube05.png){.thumbnail}
 
-### Configurar preferencias de la interfaz de Roundcube <a name="roundcube-settings"></a>
+### Configurar las preferencias de la interfaz Roundcube <a name="roundcube-settings"></a>
 
-Los siguientes capítulos de esta guía corresponden a las pestañas que componen la sección `Preferencias`{.action} de `Configuración`{.action} de Roundcube. Su descripción es incompleta.
+Los siguientes capítulos de esta guía corresponden a las pestañas que componen la sección `Preferencias`{.action} de la `Configuración`{.action} de Roundcube. Su descripción no es exhaustiva.
 
 ![hosting](images/roundcube06.png){.thumbnail}
 
-#### Interfaz de Usuario <a name="user-interface-settings"></a>
+#### Interfaz de usuario <a name="user-interface-settings"></a>
 
-Establezca aquí el `idioma` de uso de la interfaz de usuario Roundcube, la `zona horaria`, el `formato de hora` y el `formato de fecha`.
+Defina aquí el `idioma` de uso de la interfaz Roundcube, la `zona horaria`, el `formato horario` y el `formato de fecha`.
 
-La opción `Transformar fechas recientes` permite mostrar la fecha de recepción/envío con términos relativos como "Hoy", "Ayer", etc.<br>
+La opción `Fechas amigables` permite mostrar la fecha de recepción/envío con términos relativos como "Hoy", "Ayer", etc.<br>
+**Por ejemplo**: estamos a **19/05/2022**, un correo electrónico enviado/recibido el **17/05/2022** a las **17:38** se mostrará como **Mar 17:38**, ya que el correo electrónico corresponde al martes anterior.
 
-La casilla `Display next list entry after delete/move` significa que después de realizar una acción de borrado o mover a un email, el elemento de la línea inferior se seleccionará sistemáticamente, independientemente del orden de clasificación. 
+La casilla `Mostrar la siguiente entrada de la lista tras eliminar o mover` significa que, tras una acción de eliminación o movimiento sobre un correo electrónico, se seleccionará sistemáticamente el elemento de la línea inferior, sea cual sea el orden de clasificación.
 
-Puede elegir la estética de visualización de su interfaz. Puede elegir entre mostrar **Classic** o **Larry**.
+Puede elegir la estética de visualización de su interfaz. Puede elegir entre la visualización **Classic** o la visualización **Larry**.
 
-#### Vista de Buzón <a name="mail-view-settings"></a>
+#### Vista del buzón de correo <a name="mail-view-settings"></a>
 
-Establezca aquí la usabilidad para visualizar y actuar en el correo. La opción `Disposición` permite organizar las 3 ventanas descritas en la sección [Interfaz general del webmail Roundcube](#topwindow).
+Defina aquí la ergonomía para visualizar y actuar sobre los correos electrónicos. La opción `Disposición` permite organizar las 3 ventanas descritas en el apartado [Lista de correos electrónicos recibidos / enviados](#topwindow).
 
-#### Vista de Mensajes <a name="mail-display-settings"></a>
+#### Visualización de los correos electrónicos <a name="mail-display-settings"></a>
 
-Indique cómo se muestran los mensajes de correo.<br>
-Es recomendable que la casilla `Mostrar en HTML` esté marcada para asegurarse de que los mensajes que haya recibido el remitente se muestren correctamente.<br>
-También se recomienda mantener la opción `Allow remote resources (images, styles)` en `nunca`. para evitar que se carguen los elementos de un mensaje de correo electrónico que parezca malicioso.
+Defina la forma en que se muestran los correos electrónicos.<br>
+Es recomendable tener marcada la casilla `Mostrar en HTML`, para asegurarse de que los correos electrónicos formateados por el remitente se muestren correctamente.<br>
+También se recomienda mantener la opción `Permitir recursos remotos (imágenes, estilos)` en `nunca`. Así se evita cargar los elementos de un correo electrónico que parezca malicioso.
 
-#### Composición de Mensajes <a name="mail-writing-settings"></a>
+#### Redacción de correos electrónicos <a name="mail-writing-settings"></a>
 
-Establezca la forma predeterminada para redactar un mensaje de correo o una respuesta.<br>
-Le recomendamos que elija la opción `Redactar mensajes HTML` para `siempre`, ya que por defecto la herramienta de edición HTML no alterará la firma HTML.
+Defina la forma predeterminada al redactar un correo electrónico o una respuesta.<br>
+Se recomienda configurar la opción `Redactar correos electrónicos en HTML` en `siempre`, para beneficiarse por defecto de las herramientas de edición HTML y no alterar una firma HTML.
 
 #### Contactos <a name="contacts-settings"></a>
 
@@ -226,70 +240,70 @@ Personalice aquí la organización de los datos en su libreta de direcciones.
 
 #### Carpetas especiales <a name="special-folder-settings"></a>
 
-Roundcube dispone de 4 carpetas especiales: `Borradores`, `Enviados`, `SPAM`, `Papelera`.
+Roundcube dispone de 4 carpetas especiales: `Borradores`, `Enviados`, `Correo no deseado`, `Papelera`.
 
-No recomendamos cambiarlos, pero es posible atribuir el comportamiento de una carpeta especial a otra carpeta creada posteriormente, gracias a los menús desplegables.<br>
+No recomendamos modificarlas, pero es posible asignar el comportamiento de una carpeta especial a otra carpeta creada posteriormente, gracias a los menús desplegables.<br>
 
-**Por ejemplo**, puede asignar el comportamiento « Borradores » a otra carpeta que haya creado haciendo clic en la lista desplegable y eligiendo esa carpeta. Si no se le asigna ninguna carpeta, se pondrá automáticamente en la opción « Drafts ». Los mensajes de correo electrónico que se guarden en dicha carpeta se considerarán borradores hasta que se envíen.
+**Por ejemplo**, puede asignar el comportamiento "Borradores" a otra carpeta que haya creado, haciendo clic en la lista desplegable y eligiendo dicha carpeta. Si no se le asigna ninguna carpeta, se establecerá automáticamente en la opción "Drafts". Los correos electrónicos guardados en ella se considerarán borradores hasta su envío efectivo.
 
-> En la práctica, creo una subcarpeta denominada Borradores de correo de clientes. Voy a `Mis preferencias`{.action} / `Carpetas especiales`{.action} y elijo la opción «Borradores». En el menú desplegable, selecciono la carpeta "Borradores de mensajes de correo de clientes" para sustituir "Drafts". Los mensajes redactados en esta carpeta se considerarán borradores.
+> En la práctica, creo una subcarpeta "Borradores correos clientes". Voy a `Mis preferencias`{.action} / `Carpetas especiales`{.action} y elijo la opción "Borradores". En el menú desplegable, selecciono la carpeta "Borradores correos clientes" para reemplazar "Drafts". Los correos electrónicos redactados en esta carpeta se considerarán borradores.
 
-#### Configuración del servidor <a name="server-settings"></a>
+#### Parámetros del servidor <a name="server-settings"></a>
 
-En esta pestaña, puede optimizar el espacio ocupado de una cuenta de correo. La opción `Vaciar Papelera al cerrar sesión` permite evitar la acumulación de elementos eliminados. La opción `Directamente eliminar mensajes en SPAM` eliminará automáticamente todos los emails considerados como spam.
+En esta pestaña, puede optimizar el espacio ocupado en una cuenta de correo electrónico. La opción `Vaciar la papelera al cerrar sesión` permite evitar la acumulación de elementos eliminados. La opción `Eliminar directamente el correo no deseado` eliminará automáticamente todos los correos electrónicos considerados como spam.
 
 > [!warning]
 > 
-> No es recomendable activar la opción `Vaciar Papelera al cerrar sesión`, en caso de que un falso positivo (correo electrónico erróneamente declarado como "spam") se declare como spam para el servidor de recepción. De hecho, cuando un mensaje de correo electrónico se incluye en la carpeta "Correo electrónico", es posible comprobar si el correo es legítimo.
+> No se recomienda activar la opción `Eliminar directamente el correo no deseado`, en el caso de que un falso positivo (correo electrónico declarado erróneamente como "spam") se identifique como spam por el servidor de recepción. De hecho, cuando un correo electrónico se coloca en la carpeta "Correo no deseado", aún es posible verificar si el correo electrónico es legítimo.
 
 #### Cifrado <a name="encryption"></a>
 
-Si su navegador lo permite, puede instalar y activar la extensión "Mailvelope". Se trata de una extensión de navegador que integra el PGP (**P**retty **G**ood **P**rivacy) en su mensajería web. El sistema de cifrado PGP y, por consiguiente, la extensión "Mailvelope" permiten:
+Si su navegador se lo permite, puede instalar y activar la extensión "Mailvelope". Se trata de una extensión de navegador que integra el PGP (**P**retty **G**ood **P**rivacy) en su mensajería web. El sistema de cifrado PGP y, por consiguiente, la extensión "Mailvelope" permiten:
 
-- Cifrar y descifrar mensajes de correo en su navegador.
-- Conservar el contenido de sus mensajes de correo en privado con respecto a su proveedor de correo.
+- Cifrar y descifrar correos electrónicos en su navegador.
+- Mantener el contenido de sus correos electrónicos privado frente a su proveedor de mensajería.
 
-Solo usted podrá leer sus mensajes de correo. Esta extensión es una forma de proteger su webmail si recibe mensajes de correo de naturaleza confidencial.
+De este modo, solo usted podrá leer sus correos electrónicos. Esta extensión es una manera de proteger su webmail si recibe correos electrónicos de naturaleza confidencial.
 
-Para más información, consulte las FAQ de "Mailvelope" en <https://mailvelope.com/faq>.
+Para más información, consulte la FAQ de "Mailvelope" en la dirección <https://mailvelope.com/es/faq>.
 
 ### Gestionar las identidades y su firma <a name="identity-signature"></a>
 
-En Roundcube, haga clic en `Configuración`{.action} en la barra superior y seleccione `Identidades`{.action} en la columna izquierda. "La identidad" permite personalizar los datos enviados a los destinatarios como, por ejemplo, el nombre de muestra o la firma.
+Desde Roundcube, haga clic en `Configuración`{.action} en la barra superior y, a continuación, en `Identidades`{.action} en la columna izquierda. "La identidad" permite personalizar los datos enviados a los destinatarios como, por ejemplo, el nombre de visualización o la firma.
 
 ![hosting](images/roundcube07.png){.thumbnail}
 
-#### Configurar atributos de identidad <a name="identity"></a>
+#### Configurar los atributos de una identidad <a name="identity"></a>
 
-- **Nombre de visualización**: este nombre aparecerá en el apartado "Remitente" del destinatario.
-- **Correo electrónico**: es la dirección desde la que se envía el email.
-- **Organización**: campo destinado al nombre de empresa, asociación, u otra entidad.
-- **Responder a**: asignar otra dirección de correo electrónico de respuesta distinta de la del remitente.
-- **Cco**: copiar una dirección de correo en caché durante un envío.
-- **Establecer como predeterminado**: si hay varias identidades (firmas), esta se asigna por defecto.
-- **Firma**: personalizar el pie de página de un mensaje de correo electrónico al redactar el código (nombre, apellidos, cargo ocupado, frases, imágenes..).
-- **Firma HTML**: activa el formato HTML para la firma. 
+- **Nombre de visualización**: este nombre aparecerá en la sección "remitente" del destinatario.
+- **Correo electrónico**: corresponde a la dirección desde la cual se envía el correo electrónico.
+- **Responder a**: asignar otra dirección de correo electrónico de respuesta distinta a la del remitente.
+- **Organización**: campo destinado al nombre de empresa, asociación u otra entidad.
+- **Cco**: poner en copia oculta una dirección de correo electrónico al enviar.
+- **Establecer como predeterminado**: cuando hay varias identidades (firmas), asigna esta por defecto.
+- **Firma**: personalizar el pie de página de un correo electrónico al redactarlo (nombre, apellidos, cargo, frases, imágenes...).
+- **Firma HTML**: activa el formato HTML en la firma.
 
 > [!alert]
-> 
-> Completar la casilla **Correo electrónico** con una dirección de correo electrónico distinta de la que está conectado se considera una usurpación de identidad electrónica (*spoofing*). La dirección IP utilizada para el envío podría estar "prohibida" y/o considerarse "spam" ante sus destinatarios. 
+>
+> Completar la casilla **Correo electrónico** con una dirección de correo electrónico distinta de aquella con la que está conectado se considera una usurpación de identidad electrónica (*spoofing*). La dirección IP utilizada para el envío puede ser "vetada" y/o considerada como "spam" por sus destinatarios.
 
 #### Añadir una firma <a name="signature"></a>
 
-Por defecto, la casilla de `firma` es "texto en claro". Este formato no permite editar o insertar una imagen en la firma. Para disfrutar de las opciones de edición avanzada para una firma, le recomendamos que active el modo HTML haciendo clic en **Firma HTML** bajo el recuadro de entrada.
+Por defecto, la casilla `firma` está en "texto sin formato". Este formato no permite una edición avanzada ni insertar una imagen en su firma. Para beneficiarse de las opciones de edición avanzada para una firma, se recomienda activar el modo HTML haciendo clic en **Firma HTML** debajo del cuadro de entrada.
 
 > [!warning]
-> 
-> Por lo tanto, si la firma está en formato HTML, deberá pasar a modo HTML para redactar un mensaje de correo. Puede activar esta opción predeterminada para cada cuenta de correo electrónico desde la sección `Configuración`{.action} de la interfaz de Roundcube.
-> Haga clic en `Preferencias`{.action} en la columna izquierda y seleccione `Composición de Mensajes`{.action}. Para la opción **Redactar mensajes HTMLL**, seleccione `Siempre`.
+>
+> Por consiguiente, si la firma está en formato HTML, será necesario pasar al modo HTML para la redacción de un correo electrónico. Puede activar esta opción por defecto para cada redacción de correo electrónico, desde la sección `Configuración`{.action} de la interfaz Roundcube.
+> Haga clic en `Preferencias`{.action} en la columna izquierda y, a continuación, en `Redacción de correos electrónicos`{.action}. Para la indicación **Redactar correos electrónicos en HTML**, seleccione `Siempre`.
 >
 
-Para insertar una imagen en una firma, la imagen debe alojarse en un servidor (un alojamiento de OVHcloud u otro).<br>
-**Importar una imagen desde un ordenador no permitirá su visualización**.
+Para insertar una imagen en una firma, la imagen debe estar alojada en un servidor (un alojamiento OVHcloud u otro).<br>
+**Cargar una imagen desde un ordenador no permitirá su visualización**.
 
-Haga clic en el botón `< >`{.action} de la barra de herramientas HTML e inserte el siguiente código, sustituyendo `your-image-url` por la dirección (URL) de la imagen y `text-if-image-is-not-displayed` por un texto que sustituya a la imagen si no puede mostrarse.
+Haga clic en el botón `< >`{.action} de la barra de herramientas HTML y, a continuación, inserte el siguiente código, sustituyendo `your-image-url` por la dirección (URL) de la imagen y `text-if-image-is-not-displayed` por un texto que sustituya la imagen si esta no puede mostrarse.
 
-```bash
+```html
 <img src="your-image-url" border="0" alt="text-if-image-is-not-displayed" />
 ```
 
@@ -297,19 +311,19 @@ Haga clic en el botón `< >`{.action} de la barra de herramientas HTML e inserte
 
 ### Agenda de contactos <a name="contact-book"></a>
 
-En la barra superior, haga clic en `Contactos`{.action} para acceder a la agenda de contactos. Este se divide en **3 columnas**:
+Haga clic en `Contactos`{.action} en la barra superior, para acceder a la agenda de contactos. Esta se divide en **3 columnas**:
 
 - **Grupos**: en la libreta de direcciones, puede crear grupos para clasificar los contactos.
 - **Contactos**: visualice los contactos de la libreta de direcciones o del grupo seleccionado.
-- **Propiedades del contacto** o **Añadir contacto**: esta ventana aparece cuando se selecciona un contacto o se crea. Puede leer o modificar la información de un contacto.
+- **Propiedades del contacto** o **Añadir un contacto**: esta ventana aparece cuando se selecciona un contacto o cuando se está creando. Puede leer o modificar la información de un contacto.
 
 ![hosting](images/roundcube09.png){.thumbnail}
 
 #### Grupos <a name="group"></a>
 
-Los grupos son subcategorías de la libreta de direcciones. Permiten clasificar los contactos en subconjuntos. Por ejemplo, encontrará más fácilmente un contacto en un grupo que haya creado que en el conjunto de su libreta de direcciones. También permite enviar mensajes de correo electrónico añadiendo un grupo al destinatario, en lugar de añadir uno a uno de los contactos del grupo.
+Los grupos son subcategorías de la libreta de direcciones. Permiten clasificar los contactos en subconjuntos. Por ejemplo, encontrará más fácilmente un contacto en un grupo que haya creado que en el conjunto de su libreta de direcciones. Esto también le permite enviar un correo electrónico añadiendo un grupo como destinatario, en lugar de añadir uno por uno los contactos del grupo.
 
-Para crear un grupo, haga clic en el botón `+`{.action} en la parte inferior de la columna `Grupos`. Indique el nombre del grupo y haga clic en `Guardar`{.action} para aceptar.
+Para crear un grupo, haga clic en el botón `+`{.action} en la parte inferior de la columna `Grupos`. Defina el nombre del grupo y haga clic en `Guardar`{.action} para validar.
 
 ![hosting](images/roundcube10.png){.thumbnail}
 
@@ -320,123 +334,123 @@ Para asignar un contacto a uno de los grupos, seleccione un contacto en la colum
 En la columna `Grupos`, seleccione la libreta de direcciones o uno de los grupos.
 
 > [!primary]
-> 
-> Cuando se crea un contacto desde un grupo seleccionado, el contacto se añadirá automáticamente al grupo.
+>
+> Cuando crea un contacto desde un grupo seleccionado, el contacto se añadirá automáticamente al grupo.
 
-Haga clic en el botón `+`{.action} de la columna `Contactos` para crear un contacto.
+Haga clic en el botón `+`{.action} en la parte inferior de la columna `Contactos` para crear un contacto.
 
 ![hosting](images/roundcube11.png){.thumbnail}
 
-Introduzca la información del contacto.
+A continuación, complete la información del contacto.
 
 > [!primary]
-> Puede añadir campos adicionales en el menú desplegable `Añadir campo...`{.action}, situado bajo los campos `Nombre` y `Dirección`.
+> Puede añadir campos adicionales mediante el menú desplegable `Añadir un campo...`{.action}, situado bajo los campos `Nombre` y `Dirección`.
 
 #### Importar contactos <a name="import-contacts"></a>
 
-En la barra superior de la ventana de `Contactos`{.action}, haga clic en `importar`{.action} para abrir la ventana de importación.
+Desde la ventana `Contactos`{.action}, en la barra superior, haga clic en `importar`{.action} para abrir la ventana de importación.
 
-- `Importar desde archivo`: seleccione un archivo CSV o vCard en su ordenador. Los contactos dentro de un archivo CSV deben estar separados por comas. El archivo no debe tener más de 20 MB.
-- `Importar asignaciones de grupo`: Si los contactos de su archivo están repartidos por grupos, puede activar esta opción para volver a esta organización o dejar esta opción en `ninguna` para que ningún grupo esté asignado a los contactos.
-- `Reemplazar toda la lista de contactos`: Si ya tiene configurada una agenda, le recomendamos que la exporte antes de marcar esta opción o que esté seguro de que quiere reemplazarla definitivamente.
+- `Importar desde un archivo`: seleccione un archivo CSV o un archivo vCard en su ordenador. Los contactos en un archivo CSV deben estar separados por comas. El archivo no debe pesar más de 20 MB.
+- `Importar las asignaciones de grupo`: si los contactos de su archivo están repartidos por grupos, puede activar esta opción para conservar esta organización o dejar esta opción en `ninguna` para que no se asigne ningún grupo a los contactos.
+- `Reemplazar toda la libreta de direcciones`: si ya tiene configurada una libreta, le recomendamos exportarla antes de marcar esta opción o estar seguro de querer reemplazarla definitivamente.
 
 ![hosting](images/roundcube-import-contact.png){.thumbnail}
 
-#### Exportar contactos <a name="export-contacts"></a>
+#### Exportar los contactos <a name="export-contacts"></a>
 
-En la ventana `Contactos`{.action}, haga clic en la flecha situada en la esquina superior derecha del botón `Exportar`{.action}.
+Desde la ventana `Contactos`{.action}, en la barra superior, haga clic en la flecha apuntando hacia abajo a la derecha del botón `Exportar`{.action}.
 
 Puede elegir entre:
 
-- `Exportar todo`{.action} y todos los contactos se exportará a un archivo **.vcf**.
-- `Exportar seleccionados`{.action} para exportar sólo los elementos seleccionados en la columna `Contactos`{.action}.
+- `Exportar todo`{.action} y todos los contactos se exportarán en un archivo **.vcf**.
+- `Exportar la selección`{.action} para exportar únicamente los elementos que haya seleccionado en la columna `Contactos`{.action}.
 
 ![hosting](images/roundcube-export-contact.png){.thumbnail}
 
 ### Respuestas (plantillas) <a name="responses"></a>
 
-Esta función permite crear plantillas de respuesta al redactar un mensaje de correo electrónico.
+Esta función permite crear plantillas de respuesta al redactar un correo electrónico.
 
-En Roundcube, haga clic en `Configuración`{.action} en la columna izquierda y seleccione `Respuestas`{.action}.
+Desde Roundcube, haga clic en `Configuración`{.action} en la barra superior y, a continuación, en `Respuestas`{.action} en la columna izquierda.
 
-Para añadir una respuesta, haga clic en el botón `+`{.action} situado en la parte inferior de la columna `Respuestas`.
+Para añadir una respuesta, haga clic en el botón `+`{.action} en la parte inferior de la columna `Respuestas`.
 
 ![hosting](images/roundcube12.png){.thumbnail}
 
 > [!primary]
-> 
-> Las "respuestas" se redactan en el formato "texto en claro".
+>
+> Las "respuestas" se redactan en formato "texto sin formato".
 
 ### Añadir un contestador o respuesta automática <a name="automatic-respond"></a>
 
-Desea añadir una respuesta automática a su dirección de correo cuando esté ausente o no esté disponible. Esta función no puede activarse desde el webmail, sino desde el [área de cliente de OVHcloud](/links/manager), en la interfaz de gestión de sus direcciones de correo. Consulte nuestra guía "[Crear un contestador para su dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)".
+Si desea añadir una respuesta automática a su dirección de correo electrónico cuando esté ausente o no disponible, esta función no puede activarse desde el webmail, sino desde su [área de cliente de OVHcloud](/links/manager), en la interfaz de gestión de sus direcciones de correo electrónico. Consulte nuestra guía "[Crear un contestador para su dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
 
-### Cambiar la contraseña de su dirección de correo <a name="password"></a>
+### Cambiar la contraseña de su dirección de correo electrónico <a name="password"></a>
 
-Para cambiar la contraseña de una dirección de correo electrónico, conéctese al [área de cliente de OVHcloud](/links/manager) desde el área de cliente de OVHcloud. Para más información, consulte nuestra guía "[Cambiar la contraseña de una dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
+Para cambiar la contraseña de su dirección de correo electrónico, debe conectarse a su [área de cliente de OVHcloud](/links/manager), en la interfaz de gestión de sus direcciones de correo electrónico. Consulte nuestra guía "[Cambiar la contraseña de una dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
 
-### Redacción de un email <a name="email-writing"></a>
+### Redacción de un correo electrónico <a name="email-writing"></a>
 
-En la pestaña `Correo electrónico`{.action} de la barra superior, haga clic en `Editar`{.action}.
+Desde la pestaña `Correo electrónico`{.action} en la barra superior, haga clic en `Redactar`{.action}.
 
-En la ventana de redacción de un mensaje de correo electrónico, encontrará los siguientes campos: 
+En la ventana de redacción de un correo electrónico, encontrará los siguientes campos:
 
 - **De**: elegir una [identidad](#identity) para definir el remitente.
-- **Destinatario** : añadir destinatarios y/o un [grupo de destinatarios](#group).
+- **Para**: añadir destinatarios y/o un [grupo de destinatarios](#group). El botón `+`{.action} a la derecha del campo permite introducir varias direcciones.
 
 > [!primary]
-> 
-> El campo **"Destinatario"** no debe tener más de 100 destinatarios, sino que incluye los contactos contenidos en un [grupo](#group).
+>
+> El campo **"Para"** no debe superar los 100 destinatarios, lo que incluye los contactos contenidos en un [grupo](#group).
 
-- **Añadir Cc** : añadir destinatarios en una simple copia.
-- **Añadir Cco+** : añadir destinatarios en copia oculta. Los demás destinatarios del mensaje de correo electrónico no verán estos en Cci.
-- **Añadir Seguir a** : enviar el mensaje de correo electrónico a los destinatarios.
-- **Tipo de editor**:  
-    - `sólo texto`: sólo texto sin formato.
-    - `HTML`: texto con formato. Una barra de herramientas HTML aparece sobre la ventana de entrada.
-- **Prioridad** del email.
-- **Confirmación de recibo**: se solicita un acuse de recibo al destinatario.
-- **Notificación de estado de la entrega** cuando el correo electrónico se haya enviado al destinatario.
-- **Guardar mensaje enviado en**: elegir la carpeta en la que se almacenará una copia del email.
+- **Cc**: a través del botón `Añadir Cc`{.action}, añadir destinatarios en copia simple.
+- **Cco**: a través del botón `Añadir Cco`{.action}, añadir destinatarios en copia oculta. Los demás destinatarios del correo electrónico no verán a los que están en Cco.
+- **Reenviar a**: a través del botón `Añadir Reenviar a`{.action}, reenviar el correo electrónico a destinatarios.
+- **Tipo de editor**:
+    - `Texto sin formato`: únicamente texto sin formato.
+    - `HTML`: texto con formato. Aparece una barra de herramientas HTML sobre la ventana de entrada.
+- **Prioridad** del correo electrónico.
+- **Aviso de apertura del correo electrónico**: se solicita un acuse de recibo al destinatario.
+- **Notificación del estado de entrega** cuando el correo electrónico haya sido transmitido correctamente al destinatario.
+- **Guardar el correo electrónico enviado en**: elegir la carpeta en la que se almacenará una copia del correo electrónico.
 
-En la barra superior, puede elegir entre las siguientes acciones:
+En la barra superior, están disponibles las siguientes acciones:
 
-- `Cancelar`{.action} la redacción de un email con una solicitud de confirmación.
-- `Enviar`{.action} un email.
-- `Guardar`{.action} un email en la carpeta especial "borrado"
-- ` Corrector ortográfico`{.action}, para verificar el texto, con un menú que permite elegir el idioma.
-- `Adjuntar`{.action} un archivo a un email.
+- `Cancelar`{.action} la redacción de un correo electrónico con una solicitud de confirmación.
+- `Enviar`{.action} un correo electrónico.
+- `Guardar`{.action} un correo electrónico en la carpeta especial "borrador".
+- `Ortografía`{.action}, para verificar el texto, con un menú que permite elegir el idioma.
+- `Adjuntar`{.action} un archivo a un correo electrónico.
 - `Firma`{.action}: añade la firma asociada a [la identidad](#identity) seleccionada.
 - `Respuestas`{.action}: añade una plantilla preregistrada en la sección [Respuestas](#responses).
 
 ![hosting](images/roundcube13.png){.thumbnail}
 
-### casos de uso <a name="usecase"></a>
+### Casos de uso <a name="usecase"></a>
 
-#### Error de comprobación de solicitud
+#### Error de comprobación de la solicitud
 
-Cuando intente acceder a su webmail Roundcube, recibirá el siguiente mensaje:
+Recibe el siguiente mensaje cuando intenta acceder a su webmail Roundcube:
 
 ```console
-ERROR DE COMPROBACIÓN DE SOLICITUD
+ERROR DE VERIFICACIÓN DE LA SOLICITUD
 Para su protección, el acceso a este recurso está protegido contra los ataques CSRF.
-Si ve esto, probablemente no cerró la sesión antes de abandonar la aplicación Web.
-Ahora se requiere la interacción humana para poder continuar.
-Póngase en contacto con el administrador del servidor.
+Si ve este mensaje, probablemente no se haya desconectado antes de salir de la aplicación web.
+Ahora se requiere una interacción humana para continuar.
+Póngase en contacto con el administrador de su servidor.
 ```
 
-Como se indica en el mensaje, su cuenta de correo se considera ya conectada. Esto se conoce como "sesión". Esto significa que su cuenta de correo ya está en uso a los ojos del servidor de correo y que esta sesión anterior debe ser cerrada . Compruebe que su cuenta de correo electrónico no está abierta en roundcube. También puede vaciar los datos almacenados en caché en su navegador de internet.
+Como se indica en el mensaje, su cuenta de correo electrónico se considera ya conectada. Aquí hablamos de "sesión". Esto significa que su cuenta de correo electrónico ya está en uso a ojos del servidor de correo electrónico y que esta sesión anterior debe cerrarse. Compruebe que su cuenta de correo electrónico no está ya abierta en Roundcube. Vacíe también los datos en caché de su navegador de Internet.
 
 ## Más información
 
 [Primeros pasos con la solución MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)
 
-[Cambiar la contraseña de una dirección de correo MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
+[Cambiar la contraseña de una dirección de correo electrónico MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
 
-[Crear un contestador para su dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)
+[Crear un contestador para su dirección de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
 
-[Crear filtros para sus direcciones de correo](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_filters)
+[Crear filtros para sus direcciones de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_filters)
 
-[Utilizar las redirecciones de correo](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
+[Utilizar las redirecciones de correo electrónico](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.fr-fr.md
@@ -136,7 +136,7 @@ Cette fenêtre est présentée sous une forme qui peut être personnalisée. Pou
 
 Quatre paramètres sont configurables :
 
-- **Disposition** : détermine la disposition des fenêtres de gestion d'un compte e-mail. Trois options :
+- **Disposition** : définit l'agencement des fenêtres de gestion d'un compte e-mail. Trois options :
     - `Écran large`{.action} (*Widescreen*) : trois panneaux côte à côte — dossiers, liste des e-mails et volet de lecture alignés horizontalement ;
     - `Bureau`{.action} (*Desktop*) : liste des e-mails en haut, volet de lecture en dessous (disposition classique) ;
     - `Liste`{.action} (*List*) : pas de volet de lecture — les e-mails s'ouvrent en pleine fenêtre au clic.
@@ -191,7 +191,7 @@ Cliquez sur la flèche située à droite de la loupe pour afficher les filtres d
 
 Lorsqu'un e-mail est sélectionné dans la liste, celui-ci s'affiche dans la fenêtre inférieure.
 
-Retrouvez les raccourcis, sur la droite, des fonctions ci-dessous :
+Sur la droite, retrouvez les raccourcis des fonctions ci-dessous :
 
 - `Afficher au format HTML`{.action} (par défaut)
 - `Afficher au format texte en clair`{.action}
@@ -396,7 +396,7 @@ Depuis l'onglet `Courriel`{.action} dans la barre supérieure, cliquez sur `Réd
 Dans la fenêtre de rédaction d'un e-mail, on retrouve les champs suivants :
 
 - **De** : choisir une [identité](#identity) pour définir l'expéditeur.
-- **À** : ajouter des destinataires et/ou un [groupe de destinataires](#group). Utilisez le bouton `+`{.action} à droite du champ pour saisir plusieurs adresses.
+- **À** : ajouter des destinataires et/ou un [groupe de destinataires](#group). Le bouton `+`{.action} à droite du champ permet de saisir plusieurs adresses.
 
 > [!primary]
 >

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
 title: 'Utiliser son adresse e-mail depuis le webmail Roundcube'
-updated: 2025-11-12
+updated: 2026-05-04
 ---
 
 ## Objectif
@@ -25,7 +25,7 @@ Avec l'offre MX Plan OVHcloud, vous pouvez envoyer et recevoir des e-mails depui
 > 1. Rendez-vous dans la partie `Web Cloud`{.action}.
 > 1. Cliquez sur `MX Plan`{.action}.
 > 1. Sélectionnez le domaine concerné.
-> 1. Depuis l'onglet `Informations Générales`{.action} (sélectionné par défaut), relevez la technologie utilisée sous la mention **Webmail**.
+> 1. Depuis l'onglet `Informations générales`{.action} (sélectionné par défaut), relevez la technologie utilisée sous la mention **Webmail**.
 >
 > ![MX plan](images/technology-email.png){.thumbnail .w-500}
 
@@ -265,7 +265,7 @@ Si votre navigateur vous le permet, vous pouvez installer et activer l'extension
 
 Vous êtes ainsi seul à pouvoir lire vos e-mails. Cette extension est un moyen de sécuriser votre webmail si vous recevez des e-mails de nature confidentielle.
 
-Pour plus d'informations, consultez la FAQ de « Mailvelope » à l'adresse <https://mailvelope.com/faq>.
+Pour plus d'informations, consultez la FAQ de « Mailvelope » à l'adresse <https://mailvelope.com/fr/faq>.
 
 ### Gérer les identités et leur signature <a name="identity-signature"></a>
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.fr-fr.md
@@ -13,7 +13,7 @@ Avec l'offre MX Plan OVHcloud, vous pouvez envoyer et recevoir des e-mails depui
 
 - Disposer d'une solution e-mail OVHcloud **MX Plan**, proposée parmi nos [offres d’hébergement web](/links/web/hosting), incluse dans un [hébergement gratuit 100M](/links/web/domains-free-hosting), ou commandée séparément comme solution autonome.
 - Disposer des informations de connexion à l’adresse e-mail MX Plan que vous souhaitez consulter. Pour plus d'informations, consultez notre guide [Premiers pas avec l'offre MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
-- Votre solution e-mail OVHcloud **MX Plan** doit utiliser la technologie webmail **Roundcube**. Pour identifgier celle-ci, suivez les instructions ci-dessous.
+- Votre solution e-mail OVHcloud **MX Plan** doit utiliser la technologie webmail **Roundcube**. Pour l'identifier, suivez les instructions ci-dessous.
 
 > [!primary]
 > 
@@ -25,8 +25,7 @@ Avec l'offre MX Plan OVHcloud, vous pouvez envoyer et recevoir des e-mails depui
 > 1. Rendez-vous dans la partie `Web Cloud`{.action}.
 > 1. Cliquez sur `MX Plan`{.action}.
 > 1. Sélectionnez le domaine concerné.
-> 1. Depuis l'onglet `Informations Générales`{.action}, sélectionné par défaut.
-> 1. Relevez la technologie utilisée sous la mention **Webmail**.
+> 1. Depuis l'onglet `Informations Générales`{.action} (sélectionné par défaut), relevez la technologie utilisée sous la mention **Webmail**.
 >
 > ![MX plan](images/technology-email.png){.thumbnail .w-500}
 
@@ -63,18 +62,18 @@ Avec l'offre MX Plan OVHcloud, vous pouvez envoyer et recevoir des e-mails depui
     - [Paramètres du serveur](#server-settings)
     - [Chiffrement](#encryption)
 - [Gérer les identités et leur signature](#identity-signature)
-    - [Identity](#identity)
+    - [Identité](#identity)
     - [Signature](#signature)
 - [Carnet de contacts](#contact-book)
     - [Groupes](#group)
     - [Contacts](#contacts)
     - [Importer des Contacts](#import-contacts)
-    - [Exporter les Contacts Roundcube](#export-contacts)
+    - [Exporter les contacts](#export-contacts)
 - [Réponses (gabarits)](#responses)
 - [Ajouter un répondeur ou réponse automatique](#automatic-respond)
-- [Modifier le mot de passe de votre adresse-mail](#password)
+- [Modifier le mot de passe de votre adresse e-mail](#password)
 - [Rédaction d'un e-mail](#email-writing)
-- [Cas d'usages](#usecase)
+- [Cas d'usage](#usecase)
 
 ### Se connecter au webmail Roundcube <a name="roundcube-connexion"></a>
 
@@ -129,20 +128,32 @@ Les cases à cocher au niveau des dossiers correspondent aux « abonnements ». 
 
 Cette fenêtre affiche le contenu du dossier sélectionné dans la colonne de gauche. 
 
-##### **Type d'affichage** <a name="topwindow-display"></a>
+##### Type d'affichage <a name="topwindow-display"></a>
 
 Cette fenêtre est présentée sous une forme qui peut être personnalisée. Pour cela, cliquez sur la roue crantée située en haut à gauche de cette fenêtre.
 
 ![hosting](images/roundcube03.png){.thumbnail}
 
-Il est possible de paramétrer les éléments suivants :
+Quatre paramètres sont configurables :
 
-- **Disposition** : permet de déterminer la disposition des fenêtres de gestion d'un compte e-mail.
-- **Colonnes de la liste** : permet d'ajouter des colonnes à afficher (priorités des e-mails, etc.).
-- **Colonne de tri** : permet de choisir la colonne sur laquelle le tri par défaut sera effectué.
-- **Ordre de tri** : permet de choisir l'ordre de tri ascendant ou descendant, en fonction de la colonne de tri.
+- **Disposition** : détermine la disposition des fenêtres de gestion d'un compte e-mail. Trois options :
+    - `Écran large`{.action} (*Widescreen*) : trois panneaux côte à côte — dossiers, liste des e-mails et volet de lecture alignés horizontalement ;
+    - `Bureau`{.action} (*Desktop*) : liste des e-mails en haut, volet de lecture en dessous (disposition classique) ;
+    - `Liste`{.action} (*List*) : pas de volet de lecture — les e-mails s'ouvrent en pleine fenêtre au clic.
 
-##### **Action sur un e-mail sélectionné** <a name="topwindow-action"></a>
+- **Colonnes de la liste** : cases à cocher déterminant les colonnes affichées dans la liste des e-mails. Les colonnes **Sujet** et **Fils de discussion** sont toujours visibles. Colonnes optionnelles disponibles : `De`{.action}, `Pour`{.action}, `De/Pour`{.action}, `Répondre à`{.action}, `Copie`{.action}, `Date`{.action}, `Taille`{.action}, `État lu`{.action}, `Pièces jointes`{.action}, `Indicateur`{.action}, `Priorité`{.action}.
+
+- **Colonne de tri** : choisit la colonne utilisée pour le tri par défaut. Options disponibles : `Aucun`{.action}, `Date d'arrivée`{.action}, `Date d'envoi`{.action}, `Sujet`{.action}, `De`{.action}, `Pour`{.action}, `De/Pour`{.action}, `Copie`{.action} ou `Taille`{.action}.
+
+- **Ordre de tri** : ascendant ou descendant.
+
+Cliquez sur `Enregistrer`{.action} pour appliquer vos choix.
+
+> [!primary]
+>
+> Vous pouvez aussi **trier dynamiquement la liste** en cliquant directement sur l'en-tête d'une colonne affichée (par exemple **Date**, **Sujet** ou **Taille**). Un second clic sur la même colonne inverse l'ordre.
+
+##### Action sur un e-mail sélectionné <a name="topwindow-action"></a>
 
 Lorsqu'un e-mail est sélectionné, il est possible d'agir sur celui-ci. Voici les actions possibles :
 
@@ -168,24 +179,26 @@ Lorsqu'un e-mail est sélectionné, il est possible d'agir sur celui-ci. Voici l
 > Si l'un de vos correspondants demande à ce qu'un accusé de lecture lui soit adressé lorsque vous lisez son e-mail, vous obtiendrez le message suivant : `l'expéditeur de ce message a demandé d'être prévenu quand vous lirez ce message. Souhaitez-vous prévenir l'expéditeur ?`.
 >
 
-##### **Rechercher un e-mail** <a name="topwindow-search"></a>
+##### Rechercher un e-mail <a name="topwindow-search"></a>
 
 Un outil de recherche est disponible dans la partie supérieure droite de l'interface.
 
-Cliquez sur la flèche située à droite de la loupe pour afficher les filtres de recherche.
+Saisissez un terme dans le champ de recherche, puis validez avec la touche `Entrée` : Roundcube effectue par défaut la recherche sur l'ensemble du dossier courant.
+
+Cliquez sur la flèche située à droite de la loupe pour afficher les filtres de recherche : vous pouvez restreindre la recherche à certains champs (sujet, corps du message, expéditeur, destinataires, etc.) ou étendre sa portée à tous les dossiers.
 
 #### Contenu d'un e-mail (fenêtre inférieure) <a name="lowerwindow"></a>
 
 Lorsqu'un e-mail est sélectionné dans la liste, celui-ci s'affiche dans la fenêtre inférieure.
 
-Retrouvez les raccourcies, sur la droite, des fonctions suivantes :
+Retrouvez les raccourcis, sur la droite, des fonctions suivantes :
 
-- Afficher au format HTML (par défaut)
-- Afficher  au format texte en clair
-- Répondre
-- Répondre à tous
-- Transférer
-- Afficher dans une nouvelle fenêtre 
+- `Afficher au format HTML`{.action} (par défaut)
+- `Afficher au format texte en clair`{.action}
+- `Répondre`{.action}
+- `Répondre à tous`{.action}
+- `Transférer`{.action}
+- `Afficher dans une nouvelle fenêtre`{.action}
 
 ![hosting](images/roundcube05.png){.thumbnail}
 
@@ -197,18 +210,18 @@ Les chapitres suivants de ce guide correspondent aux onglets qui composent la pa
 
 #### Interface utilisateur <a name="user-interface-settings"></a>
 
-Définissez ici la `langue` d'usage de l'interface Roundcube, le `fuseau horaire`,le `format horaire` et le `format de date`.
+Définissez ici la `langue` d'usage de l'interface Roundcube, le `fuseau horaire`, le `format horaire` et le `format de date`.
 
 L'option `Jolies dates` permet d'afficher la date de réception/d'envoi avec des termes relatifs tels qu’« Aujourd’hui », « Hier », etc.<br>
 **Par exemple** : nous sommes le **19/05/2022**, un e-mail envoyé/reçu le **17/05/2022** à **17:38** sera affiché **Mar 17:38**, car l'email correspond au mardi qui précède.
 
-La case `Afficher la prochaine entrée de la liste après suppression ou déplacement` signifie qu'après une action de suppression ou déplacement sur un e-mail, l'élément de la ligne inférieure sera alors systématiquement sélectionné, quelque soit l'ordre de tri.
+La case `Afficher la prochaine entrée de la liste après suppression ou déplacement` signifie qu'après une action de suppression ou déplacement sur un e-mail, l'élément de la ligne inférieure sera alors systématiquement sélectionné, quel que soit l'ordre de tri.
 
 Vous pouvez choisir l'esthétique d'affichage de votre interface. Vous avez le choix entre l'affichage **Classic** ou l'affichage **Larry**.
 
 #### Vue de la boîte de courriels <a name="mail-view-settings"></a>
 
-Définissez ici l'ergonomie pour visualiser et agir sur les e-mails. L'option `Disposition` permet d'agencer les 3 fenêtres décrites dans la partie [Interface générale du webmail Roundcube](#topwindow).
+Définissez ici l'ergonomie pour visualiser et agir sur les e-mails. L'option `Disposition` permet d'agencer les 3 fenêtres décrites dans la partie [Liste des e-mails reçus / envoyés](#topwindow).
 
 #### Affichage des courriels <a name="mail-display-settings"></a>
 
@@ -237,7 +250,7 @@ Nous ne conseillons pas de les modifier mais il est possible d'attribuer le comp
 
 #### Paramètres du serveur <a name="server-settings"></a>
 
-Dans cet onglet, vous pouvez optimiser l'espace occupé sur un compte e-mail. En effet, l'option `Vider la corbeille à la déconnexion` permet d'éviter le cumul des éléments qui ont été supprimés . L'option `Supprimer directement les pourriels` supprimera automatiquement tous les e-mail considérés comme SPAM.
+Dans cet onglet, vous pouvez optimiser l'espace occupé sur un compte e-mail. En effet, l'option `Vider la corbeille à la déconnexion` permet d'éviter le cumul des éléments qui ont été supprimés. L'option `Supprimer directement les pourriels` supprimera automatiquement tous les e-mail considérés comme SPAM.
 
 > [!warning]
 > 
@@ -245,10 +258,10 @@ Dans cet onglet, vous pouvez optimiser l'espace occupé sur un compte e-mail. En
 
 #### Chiffrement <a name="encryption"></a>
 
-Si votre navigateur vous le permet, vous pouvez installer et activer l'extension « Mailvelope ». Il s'agit d'une extension de navigateur qui intègre le PGP (**P**retty **G**ood **P**rivacy) dans votre messagerie web. Le système de chiffrement PGP et, par conséquent, l'extension « Mailveloppe » permettent de :
+Si votre navigateur vous le permet, vous pouvez installer et activer l'extension « Mailvelope ». Il s'agit d'une extension de navigateur qui intègre le PGP (**P**retty **G**ood **P**rivacy) dans votre messagerie web. Le système de chiffrement PGP et, par conséquent, l'extension « Mailvelope » permettent de :
 
 - Chiffrer et déchiffrer des e-mails dans votre navigateur.
-- Garder le contenu de vos e-mails privé vis à vis de votre fournisseur de messagerie.
+- Garder le contenu de vos e-mails privé vis-à-vis de votre fournisseur de messagerie.
 
 Vous êtes ainsi seul à pouvoir lire vos e-mails. Cette extension est un moyen de sécuriser votre webmail si vous recevez des e-mails de nature confidentielle.
 
@@ -262,7 +275,7 @@ Depuis Roundcube, cliquez sur `Paramètres`{.action} dans la barre supérieure, 
 
 #### Paramétrer les attributs d'une identité <a name="identity"></a>
 
-- **Nom d'affichage** : ce nom apparaîtra dans la partie « expéditeur » du destinataire
+- **Nom d'affichage** : ce nom apparaîtra dans la partie « expéditeur » du destinataire.
 - **Courriel** : correspond à l'adresse depuis laquelle est envoyé l'e-mail.
 - **Organisation** : champ destiné au nom de société, association, ou une autre entité.
 - **Répondre à** : attribuer une autre adresse e-mail de réponse que celle de l'expéditeur.
@@ -290,9 +303,8 @@ Pour insérer une image dans une signature, l'image doit être hébergée sur un
 
 Cliquez sur le bouton `< >`{.action} dans la barre d'outils HTML, puis insérez le code suivant, en remplaçant `your-image-url` par l'adresse (URL) de l'image et `text-if-image-is-not-displayed` par un texte qui remplace l'image si celle-ci ne peut pas s'afficher.
 
-```bash
+```html
 <img src="your-image-url" border="0" alt="text-if-image-is-not-displayed" />
-
 ```
 
 ![hosting](images/roundcube08.png){.thumbnail}
@@ -303,7 +315,7 @@ Cliquez sur `Contacts`{.action}, dans la barre supérieure, pour accéder au car
 
 - **Groupes** : dans le carnet d'adresses, vous pouvez créer des groupes pour classer les contacts.
 - **Contacts** : visualisez les contacts du carnet d'adresses ou du groupe sélectionné.
-- **Propriétés du contact** ou **Ajouter un contact** : cette fenêtre s'affiche lorsque qu'un contact est sélectionné ou lorsqu'il est en création. Vous pouvez y lire ou modifier les informations d'un contact.
+- **Propriétés du contact** ou **Ajouter un contact** : cette fenêtre s'affiche lorsqu'un contact est sélectionné ou lorsqu'il est en création. Vous pouvez y lire ou modifier les informations d'un contact.
 
 ![hosting](images/roundcube09.png){.thumbnail}
 
@@ -339,14 +351,14 @@ Complétez ensuite les informations du contact.
 Depuis la fenêtre `Contacts`{.action}, dans la barre supérieure, cliquez sur `importer`{.action} pour ouvrir la fenêtre d'importation.
 
 - `Importer d’un fichier` : sélectionnez un fichier CSV ou un fichier vCard sur votre ordinateur. Les contacts au sein d'un fichier CSV doivent être séparés par des virgules. Le fichier ne doit pas faire plus de 20 Mo.
-- `Importer les affectations de groupe` : Si les contacts de votre fichier sont répartis par groupes, vous pouvez activer cette option pour retrouver cette organisaton ou bien laisser cette option sur `aucune` pour qu'aucun groupe ne soit affecté aux contacts.
+- `Importer les affectations de groupe` : Si les contacts de votre fichier sont répartis par groupes, vous pouvez activer cette option pour retrouver cette organisation ou bien laisser cette option sur `aucune` pour qu'aucun groupe ne soit affecté aux contacts.
 - `Remplacer le carnet d’adresses entier`: Si un carnet est déjà configuré, nous vous conseillons de l'exporter avant de cocher cette option ou d'être certain de vouloir définitivement le remplacer.
 
 ![hosting](images/roundcube-import-contact.png){.thumbnail}
 
-#### Exporter les Contacts <a name="export-contacts"></a>
+#### Exporter les contacts <a name="export-contacts"></a>
 
-Depuis la fenêtre `Contacts`{.action}, dans la barre supérieure, cliquez sur la flêche pointant vers le bas à droite du bouton `Exporter`{.action}.
+Depuis la fenêtre `Contacts`{.action}, dans la barre supérieure, cliquez sur la flèche pointant vers le bas à droite du bouton `Exporter`{.action}.
 
 Vous avez le choix entre :
 
@@ -373,7 +385,7 @@ Pour ajouter une réponse, cliquez sur le bouton `+`{.action} en bas de la colon
 
 Vous souhaitez ajouter une réponse automatique à votre adresse e-mail lorsque vous êtes absent ou indisponible. Cette fonction ne peut pas s'activer depuis le webmail mais depuis votre [espace client OVHcloud](/links/manager), dans l'interface de gestion de vos adresses e-mail. Consultez notre guide « [Créer un répondeur pour son adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/) ».
 
-### Modifier le mot de passe de votre adresse-mail <a name="password"></a>
+### Modifier le mot de passe de votre adresse e-mail <a name="password"></a>
 
 Pour modifier le mot de passe de votre adresse e-mail, vous devez vous connecter à votre [espace client OVHcloud](/links/manager), dans l'interface de gestion de vos adresses e-mail. Consultez notre guide « [Modifier le mot de passe d'une adresse e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/) ».
 
@@ -384,15 +396,15 @@ Depuis l'onglet `Courriel`{.action} dans la barre supérieure, cliquez sur `Réd
 Dans la fenêtre de rédaction d'un e-mail, on retrouve les champs suivants :
 
 - **De** : choisir une [identité](#identity) pour définir l'expéditeur.
-- **À+** : ajouter des destinataires et/ou un [groupe de destinataires](#group).
+- **À** : ajouter des destinataires et/ou un [groupe de destinataires](#group). Utilisez le bouton `+`{.action} à droite du champ pour saisir plusieurs adresses.
 
 > [!primary]
 >
-> Le champ **«À»** ne doit pas excéder les 100 destinataires, cela inclut les contacts contenus dans un [groupe](#group).
+> Le champ **« À »** ne doit pas excéder les 100 destinataires, cela inclut les contacts contenus dans un [groupe](#group).
 
-- **Ajouter Cc+** : ajouter des destinataires en copie simple.
-- **Ajouter Cci+** : ajouter des destinataires en copie cachée. Les autres destinataires de l'e-mail ne verront pas ceux en Cci.
-- **Ajouter Transférer à** : faire suivre l'e-mail à des destinataires.
+- **Cc** : via le bouton `Ajouter Cc`{.action}, ajouter des destinataires en copie simple.
+- **Cci** : via le bouton `Ajouter Cci`{.action}, ajouter des destinataires en copie cachée. Les autres destinataires de l'e-mail ne verront pas ceux en Cci.
+- **Transférer à** : via le bouton `Ajouter Transférer à`{.action}, faire suivre l'e-mail à des destinataires.
 - **Type d'éditeur** :
     - `Texte en clair` : uniquement du texte sans mise en forme.
     - `HTML`: texte avec mise en forme. Une barre d'outils HTML apparaît au-dessus de la fenêtre de saisie.
@@ -405,7 +417,7 @@ Dans la barre supérieure, les actions suivantes sont disponibles :
 
 - `Annuler`{.action} la rédaction d'un e-mail avec une demande de confirmation.
 - `Envoyer`{.action} un e-mail.
-- `Enregistrer`{.action} un e-mail dans le dossier spécial « brouillon »
+- `Enregistrer`{.action} un e-mail dans le dossier spécial « brouillon ».
 - `Orthographe`{.action}, pour vérifier le texte, avec un menu permettant le choix de la langue.
 - `Joindre`{.action} un fichier à un e-mail.
 - `Signature`{.action} : ajoute la signature attachée à [l'identité](#identity) sélectionnée.
@@ -413,7 +425,7 @@ Dans la barre supérieure, les actions suivantes sont disponibles :
 
 ![hosting](images/roundcube13.png){.thumbnail}
 
-### Cas d'usages <a name="usecase"></a>
+### Cas d'usage <a name="usecase"></a>
 
 #### Échec de la vérification de la demande
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.fr-fr.md
@@ -67,7 +67,7 @@ Avec l'offre MX Plan OVHcloud, vous pouvez envoyer et recevoir des e-mails depui
 - [Carnet de contacts](#contact-book)
     - [Groupes](#group)
     - [Contacts](#contacts)
-    - [Importer des Contacts](#import-contacts)
+    - [Importer des contacts](#import-contacts)
     - [Exporter les contacts](#export-contacts)
 - [Réponses (gabarits)](#responses)
 - [Ajouter un répondeur ou réponse automatique](#automatic-respond)
@@ -143,7 +143,7 @@ Quatre paramètres sont configurables :
 
 - **Colonnes de la liste** : cases à cocher déterminant les colonnes affichées dans la liste des e-mails. Les colonnes **Sujet** et **Fils de discussion** sont toujours visibles. Colonnes optionnelles disponibles : `De`{.action}, `Pour`{.action}, `De/Pour`{.action}, `Répondre à`{.action}, `Copie`{.action}, `Date`{.action}, `Taille`{.action}, `État lu`{.action}, `Pièces jointes`{.action}, `Indicateur`{.action}, `Priorité`{.action}.
 
-- **Colonne de tri** : choisit la colonne utilisée pour le tri par défaut. Options disponibles : `Aucun`{.action}, `Date d'arrivée`{.action}, `Date d'envoi`{.action}, `Sujet`{.action}, `De`{.action}, `Pour`{.action}, `De/Pour`{.action}, `Copie`{.action} ou `Taille`{.action}.
+- **Colonne de tri** : permet de choisir la colonne de tri par défaut. Options disponibles : `Aucun`{.action}, `Date d'arrivée`{.action}, `Date d'envoi`{.action}, `Sujet`{.action}, `De`{.action}, `Pour`{.action}, `De/Pour`{.action}, `Copie`{.action} ou `Taille`{.action}.
 
 - **Ordre de tri** : ascendant ou descendant.
 
@@ -183,7 +183,7 @@ Lorsqu'un e-mail est sélectionné, il est possible d'agir sur celui-ci. Voici l
 
 Un outil de recherche est disponible dans la partie supérieure droite de l'interface.
 
-Saisissez un terme dans le champ de recherche, puis validez avec la touche `Entrée` : Roundcube effectue par défaut la recherche sur l'ensemble du dossier courant.
+Saisissez un terme dans le champ de recherche, puis validez avec la touche `Entrée`{.action} : Roundcube effectue par défaut la recherche sur l'ensemble du dossier courant.
 
 Cliquez sur la flèche située à droite de la loupe pour afficher les filtres de recherche : vous pouvez restreindre la recherche à certains champs (sujet, corps du message, expéditeur, destinataires, etc.) ou étendre sa portée à tous les dossiers.
 
@@ -191,7 +191,7 @@ Cliquez sur la flèche située à droite de la loupe pour afficher les filtres d
 
 Lorsqu'un e-mail est sélectionné dans la liste, celui-ci s'affiche dans la fenêtre inférieure.
 
-Retrouvez les raccourcis, sur la droite, des fonctions suivantes :
+Retrouvez les raccourcis, sur la droite, des fonctions ci-dessous :
 
 - `Afficher au format HTML`{.action} (par défaut)
 - `Afficher au format texte en clair`{.action}
@@ -213,7 +213,7 @@ Les chapitres suivants de ce guide correspondent aux onglets qui composent la pa
 Définissez ici la `langue` d'usage de l'interface Roundcube, le `fuseau horaire`, le `format horaire` et le `format de date`.
 
 L'option `Jolies dates` permet d'afficher la date de réception/d'envoi avec des termes relatifs tels qu’« Aujourd’hui », « Hier », etc.<br>
-**Par exemple** : nous sommes le **19/05/2022**, un e-mail envoyé/reçu le **17/05/2022** à **17:38** sera affiché **Mar 17:38**, car l'email correspond au mardi qui précède.
+**Par exemple** : nous sommes le **19/05/2022**, un e-mail envoyé/reçu le **17/05/2022** à **17:38** sera affiché **Mar 17:38**, car l'e-mail correspond au mardi qui précède.
 
 La case `Afficher la prochaine entrée de la liste après suppression ou déplacement` signifie qu'après une action de suppression ou déplacement sur un e-mail, l'élément de la ligne inférieure sera alors systématiquement sélectionné, quel que soit l'ordre de tri.
 
@@ -250,11 +250,11 @@ Nous ne conseillons pas de les modifier mais il est possible d'attribuer le comp
 
 #### Paramètres du serveur <a name="server-settings"></a>
 
-Dans cet onglet, vous pouvez optimiser l'espace occupé sur un compte e-mail. En effet, l'option `Vider la corbeille à la déconnexion` permet d'éviter le cumul des éléments qui ont été supprimés. L'option `Supprimer directement les pourriels` supprimera automatiquement tous les e-mail considérés comme SPAM.
+Dans cet onglet, vous pouvez optimiser l'espace occupé sur un compte e-mail. En effet, l'option `Vider la corbeille à la déconnexion` permet d'éviter le cumul des éléments qui ont été supprimés. L'option `Supprimer directement les pourriels` supprimera automatiquement tous les e-mails considérés comme spam.
 
 > [!warning]
 > 
-> Il est déconseillé d'activer l'option `Supprimer directement les pourriels`, dans le cas de figure où un faux positif (e-mail déclaré à tort comme « SPAM ») se retrouverait déclaré comme SPAM pour le serveur de réception. En effet, lorsqu'un e-mail est placé dans le dossier « Pourriels », il est encore possible de vérifier si l'e-mail est légitime.
+> Il est déconseillé d'activer l'option `Supprimer directement les pourriels`, dans le cas de figure où un faux positif (e-mail déclaré à tort comme « spam ») se retrouverait déclaré comme spam pour le serveur de réception. En effet, lorsqu'un e-mail est placé dans le dossier « Pourriels », il est encore possible de vérifier si l'e-mail est légitime.
 
 #### Chiffrement <a name="encryption"></a>
 
@@ -286,7 +286,7 @@ Depuis Roundcube, cliquez sur `Paramètres`{.action} dans la barre supérieure, 
 
 > [!alert]
 >
-> Compléter la case **Courriel** par une adresse e-mail différente de celle sur laquelle vous êtes connecté est considéré comme une usurpation d'identité électronique (*spoofing*). L'adresse IP utilisée pour l'envoi risque d'être « bannie » et/ou considérée comme « SPAM » auprès de vos destinataires.
+> Compléter la case **Courriel** par une adresse e-mail différente de celle sur laquelle vous êtes connecté est considéré comme une usurpation d'identité électronique (*spoofing*). L'adresse IP utilisée pour l'envoi risque d'être « bannie » et/ou considérée comme « spam » auprès de vos destinataires.
 
 #### Ajouter une signature <a name="signature"></a>
 
@@ -346,7 +346,7 @@ Complétez ensuite les informations du contact.
 > [!primary]
 > Vous pouvez ajouter des champs supplémentaires via le menu déroulant `Ajouter un champ...`{.action}, situé sous les champs `Prénom` et `Adresse`.
 
-#### Importer des Contacts <a name="import-contacts"></a>
+#### Importer des contacts <a name="import-contacts"></a>
 
 Depuis la fenêtre `Contacts`{.action}, dans la barre supérieure, cliquez sur `importer`{.action} pour ouvrir la fenêtre d'importation.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.it-it.md
@@ -1,32 +1,31 @@
 ---
-title: 'Webmail: guida all’utilizzo di Roundcube'
-updated: 2025-11-12
+title: 'Utilizzare il proprio indirizzo e-mail dalla webmail Roundcube'
+updated: 2026-05-04
 ---
 
 ## Obiettivo
 
-Con la soluzione MX Plan OVHcloud, potete inviare e ricevere email da un software di terze parti o tramite una webmail. OVHcloud fornisce un servizio di posta online chiamato Roundcube che permette l'accesso a un account email tramite un browser.
+Con la soluzione MX Plan OVHcloud, puoi inviare e ricevere e-mail da un software di terze parti o tramite una webmail. OVHcloud fornisce un servizio di messaggistica online chiamato Roundcube che permette, tramite un browser web, di accedere a un account e-mail.
 
-**Come utilizzare la Webmail Roundcube per i tuoi indirizzi email OVHcloud**
+**Scopri come utilizzare la webmail Roundcube per i tuoi indirizzi e-mail OVHcloud**
 
 ## Prerequisiti
 
-- Disporre di una soluzione email OVHcloud **MX Plan**, inclusa nelle nostre [soluzioni di hosting Web](/links/web/hosting), inclusa in un [Hosting gratuito 100M](/links/web/domains-free-hosting) o ordinata separatamente come soluzione autonoma
-- Disporre delle informazioni di connessione all'indirizzo email MX Plan che vuoi consultare Per maggiori informazioni, consulta la nostra guida Iniziare a [utilizzare la soluzione MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+- Disporre di una soluzione e-mail OVHcloud **MX Plan**, proposta tra le nostre [offerte di hosting Web](/links/web/hosting), inclusa in un [hosting gratuito 100M](/links/web/domains-free-hosting), o ordinata separatamente come soluzione autonoma.
+- Disporre delle informazioni di connessione all'indirizzo e-mail MX Plan che desideri consultare. Per maggiori informazioni, consulta la nostra guida [Iniziare a utilizzare la soluzione MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 - La tua soluzione e-mail OVHcloud **MX Plan** deve utilizzare la tecnologia webmail **Roundcube**. Per identificarla, segui le istruzioni riportate di seguito.
 
 > [!primary]
 > 
-> **Come identificare la tecnologia utilizzata sulla tua offerta MX Plan?**
+> **Come identificare la tecnologia utilizzata sulla mia offerta MX Plan?**
 >
-> La tecnologia di posta utilizzata per il servizio MX Plan è caratterizzata dall’interfaccia della sua Webmail. Per identificarlo dallo Spazio Cliente, segui questo percorso:
+> La tecnologia e-mail utilizzata per la tua offerta MX Plan è caratterizzata dall'interfaccia della sua webmail. Per identificarla dal tuo Spazio Cliente, segui questo percorso:
 >
-> 1. Accedi allo [Spazio Cliente OVHcloud](/links/manager).
+> 1. Accedi al tuo [Spazio Cliente OVHcloud](/links/manager).
 > 1. Accedi alla sezione `Web Cloud`{.action}.
 > 1. Clicca su `MX Plan`{.action}.
-> 1. Seleziona il dominio.
-> 1. Nella scheda `Informazioni generali`{.action}, selezionata di default.
-> 1. Aumenta la tecnologia utilizzata sotto la voce **Webmail**.
+> 1. Seleziona il dominio interessato.
+> 1. Dalla scheda `Informazioni generali`{.action} (selezionata di default), individua la tecnologia utilizzata sotto la voce **Webmail**.
 >
 > ![MX plan](images/technology-email.png){.thumbnail .w-500}
 
@@ -36,7 +35,7 @@ Con la soluzione MX Plan OVHcloud, potete inviare e ricevere email da un softwar
 ### Accesso allo Spazio Cliente OVHcloud
 
 - **Link diretto:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Percorso di navigazione:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo servizio MX Plan
+- **Per accedere ai tuoi servizi:** `Web Cloud`{.action} > `MX Plan`{.action} > Seleziona il tuo servizio MX Plan
 
 ---
 <!-- CP-NAV-END:web-mx-plan -->
@@ -45,397 +44,413 @@ Con la soluzione MX Plan OVHcloud, potete inviare e ricevere email da un softwar
 
 **Sommario**
 
-- [Accedi alla Webmail Roundcube](#roundcube-connexion)
-- [Interfaccia generale della Webmail Roundcube](#general-interface)
+- [Accedere alla webmail Roundcube](#roundcube-connexion)
+- [Interfaccia generale della webmail Roundcube](#general-interface)
     - [Gestione delle cartelle (colonna di sinistra)](#leftcolumn)
-    - [Lista delle email ricevute/inviate (finestra superiore)](#topwindow)
+    - [Lista delle e-mail ricevute / inviate (finestra superiore)](#topwindow)
         - [Tipo di visualizzazione](#topwindow-display)
-        - [Azione su un'email selezionata](#topwindow-action)
-        - [Ricerca un'email](#topwindow-search)
-    - [Contenuto di un'email (finestra inferiore)](#lowerwindow)
-- [Configura le preferenze dell'interfaccia Roundcube](#roundcube-settings)
+        - [Azione su un'e-mail selezionata](#topwindow-action)
+        - [Cercare un'e-mail](#topwindow-search)
+    - [Contenuto di un'e-mail (finestra inferiore)](#lowerwindow)
+- [Configurare le preferenze dell'interfaccia Roundcube](#roundcube-settings)
     - [Interfaccia utente](#user-interface-settings)
-    - [Impaginazione messaggi](#mail-view-settings)
-    - [Visualizzazione messaggi](#mail-display-settings)
-    - [Composizione messaggi](#mail-writing-settings)
+    - [Vista della casella di posta](#mail-view-settings)
+    - [Visualizzazione dei messaggi](#mail-display-settings)
+    - [Composizione dei messaggi](#mail-writing-settings)
     - [Contatti](#contacts-settings)
     - [Cartelle speciali](#special-folder-settings)
     - [Impostazioni del server](#server-settings)
     - [Cifratura](#encryption)
-- [Gestisci le identità e la loro firma](#identity-signature)
-    - [Impostare gli attributi di un'identità](#identity)
-    - [Aggiungere una firma](#signature)
-- [Rubrica di contatti](#contact-book)
+- [Gestire le identità e la loro firma](#identity-signature)
+    - [Identità](#identity)
+    - [Firma](#signature)
+- [Rubrica dei contatti](#contact-book)
     - [Gruppi](#group)
     - [Contatti](#contacts)
-    - [Importa contatti](#import-contacts)
-    - [Esporta i contatti](#export-contacts)
-- [Risposte (template)](#responses)
-- [Aggiungi una risposta automatica](#automatic-respond)
-- [Modificare la password del tuo indirizzo email](#password)
-- [Redazione di un'email](#email-writing)
-- [casi d'uso](#usecase)
+    - [Importare contatti](#import-contacts)
+    - [Esportare i contatti](#export-contacts)
+- [Risposte (modelli)](#responses)
+- [Aggiungere una risposta automatica](#automatic-respond)
+- [Modificare la password del tuo indirizzo e-mail](#password)
+- [Redazione di un'e-mail](#email-writing)
+- [Casi d'uso](#usecase)
 
-### Accedi alla Webmail Roundcube <a name="roundcube-connexion"></a>
+### Accedere alla webmail Roundcube <a name="roundcube-connexion"></a>
 
-Accedi alla pagina [Webmail](/links/web/email). Inserisci un indirizzo email e la password e clicca su `Connessione`{.action}. 
+Accedi alla pagina [Webmail](/links/web/email). Inserisci un indirizzo e-mail e la password, poi clicca su `Connessione`{.action}. 
 
 ![hosting](images/webmail_login.png){.thumbnail}
 
-Verrai reindirizzato all'interfaccia Roundcube.
+Verrai quindi reindirizzato all'interfaccia Roundcube.
 
 ![hosting](images/roundcube01.png){.thumbnail}
 
 > [!primary]
 > 
-> Quando ti connetti per la prima volta all'interfaccia Roundcube, l'aspetto potrebbe essere diverso da quello che vedrai in questa guida. Questo significa che l’aspetto "classico" è stato definito sull’interfaccia. Per cambiarla, segui la sezione "[Interfaccia utente](#user-interface-settings)" e seleziona la visualizzazione "Larry".
-> L'aspetto dell'interfaccia non influirà sulle spiegazioni riportate di seguito in questa documentazione.
+> Quando ti connetti per la prima volta all'interfaccia Roundcube, l'aspetto può essere diverso da quello che vedrai in questa documentazione. Significa che è stato impostato l'aspetto "classico" sulla tua interfaccia. Per modificarlo, segui la sezione "[Interfaccia utente](#user-interface-settings)" e seleziona la visualizzazione "Larry".
+> L'aspetto dell'interfaccia non avrà alcuna incidenza sulle spiegazioni che seguono in questa documentazione.
 
 > [!warning]
 > 
-> Se il server è reindirizzato a un'interfaccia **O**utlook **W**eb **A**pp (OWA), significa che sei sull'ultima versione della soluzione MX Plan. Per maggiori informazioni sulla soluzione MX Plan, consulta la pagina [Iniziare a utilizzare la soluzione MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+> Se vieni reindirizzato a un'interfaccia **O**utlook **W**eb **A**pp (OWA), significa che ti trovi sull'ultima versione dell'offerta MX Plan. Per maggiori informazioni sulla tua offerta MX Plan, consulta la nostra pagina [Iniziare a utilizzare la soluzione MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 >
-> Per familiarizzare con l'interfaccia **OWA**, consulta la nostra guida [Consultare il suo account email dall'interfaccia OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
+> Per familiarizzare con l'interfaccia **OWA**, consulta la nostra guida [Consultare il proprio account e-mail dall'interfaccia OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
-### Interfaccia generale della Webmail Roundcube <a name="general-interface"></a>
+### Interfaccia generale della webmail Roundcube <a name="general-interface"></a>
 
-Una volta connesso al tuo account email, hai accesso alla finestra principale di Roundcube, composta da 3 zone:
+Una volta connesso al tuo account e-mail, hai accesso alla finestra principale di Roundcube, composta da 3 zone:
 
-- [**Colonna di sinistra**](#leftcolumn): cartelle e sottocartelle dell'account email La cartella principale è la `Posta in arrivo`.
+- [**Colonna di sinistra**](#leftcolumn): l'albero del tuo account e-mail, composto da cartelle e sottocartelle. La cartella principale è la `Posta in arrivo`.
 
-- [**Finestra superiore**](#topwindow): elenco delle email contenute nella cartella selezionata nella colonna di sinistra.
+- [**Finestra superiore**](#topwindow): l'elenco delle e-mail contenute nella cartella selezionata nella colonna di sinistra.
 
-- [**Finestra inferiore**](#lowerwindow): il contenuto dell'email selezionata nella finestra superiore.
+- [**Finestra inferiore**](#lowerwindow): il contenuto dell'e-mail selezionata nella finestra superiore.
 
 #### Gestione delle cartelle (colonna di sinistra) <a name="leftcolumn"></a>
 
-In questa sezione vengono mostrate le cartelle presenti nel tuo account email.
+In questa zona compaiono le cartelle presenti nel tuo account e-mail.
 
-Per maggiori informazioni sulle cartelle, clicca sull'icona a forma di ingranaggio in fondo alla colonna e seleziona `Gestione cartelle`{.action}
+Per gestire più precisamente le cartelle, clicca sull'icona a forma di ingranaggio in fondo alla colonna e poi su `Gestione cartelle`{.action}.
 
 ![hosting](images/roundcube02.png){.thumbnail}
 
 Per creare una cartella, clicca sul pulsante `+`{.action} in fondo alla colonna `Cartelle`.
 
-Per eliminare una cartella, seleziona la cartella, clicca sull'icona a forma di ingranaggio in fondo alla colonna `Cartelle` e seleziona `Elimina`{.action}. Per cancellare il contenuto e conservare la cartella, clicca su `Svuota`{.action}.
+Per eliminare una cartella, seleziona la cartella interessata, clicca sull'icona a forma di ingranaggio in fondo alla colonna `Cartelle` e poi su `Elimina`{.action}. Per cancellare il contenuto ma conservare la cartella, clicca su `Svuota`{.action}.
 
-Le caselle da barrare a livello delle cartelle corrispondono alle "iscrizioni". L'abbonamento determina se la cartella deve essere visualizzata o meno a livello dell'interfaccia Webmail o del client di posta conservando il contenuto della cartella. con lo scopo di nascondere o visualizzare una cartella sull'account email.
+Le caselle da spuntare a livello delle cartelle corrispondono alle "iscrizioni". L'iscrizione determina se la cartella deve essere visualizzata o meno a livello dell'interfaccia webmail o del client di posta, conservando comunque il contenuto della cartella. Lo scopo è soltanto nascondere o visualizzare una cartella sull'account e-mail.
 
 > [!primary]
 >
-> I fascicoli che presentano una casella da barrare grigia sono fascicoli speciali. Non è possibile cancellarli o ritirarli.
+> Le cartelle che presentano una casella da spuntare grigia sono cartelle speciali. Non è possibile eliminarle o rimuoverne l'iscrizione.
 
-#### Lista delle email ricevute/inviate (finestra superiore) <a name="topwindow"></a>
+#### Lista delle e-mail ricevute / inviate (finestra superiore) <a name="topwindow"></a>
 
-In questa finestra è mostrato il contenuto della cartella selezionata nella colonna di sinistra. 
+Questa finestra mostra il contenuto della cartella selezionata nella colonna di sinistra. 
 
 ##### Tipo di visualizzazione <a name="topwindow-display"></a>
 
-Questa finestra è presentata in una forma personalizzata. Clicca sull'icona a forma di ingranaggio in alto a sinistra da questa finestra.
+Questa finestra è presentata in una forma personalizzabile. Per farlo, clicca sull'icona a forma di ingranaggio situata in alto a sinistra di questa finestra.
 
 ![hosting](images/roundcube03.png){.thumbnail}
 
-È possibile configurare questi elementi:
+Sono configurabili quattro parametri:
 
-- **Disposizione**: permette di determinare la disposizione delle finestre di gestione di un account email.
-- **Colonne dell'elenco**: permette di aggiungere colonne da visualizzare (priorità delle email, ecc...).
-- **Colonna di selezione**: permette di scegliere la colonna su cui effettuare la selezione di default.
-- **Ordine di selezione**: permette di scegliere l'ordine di selezione ascendente o discendente, in funzione della colonna di selezione.
+- **Disposizione**: definisce la disposizione delle finestre di gestione di un account e-mail. Tre opzioni:
+    - `Schermo largo`{.action} (*Widescreen*): tre pannelli affiancati — cartelle, lista delle e-mail e riquadro di lettura allineati orizzontalmente;
+    - `Desktop`{.action} (*Desktop*): lista delle e-mail in alto, riquadro di lettura sotto (disposizione classica);
+    - `Lista`{.action} (*List*): nessun riquadro di lettura — le e-mail si aprono a tutto schermo al clic.
 
-##### Azione su un'email selezionata <a name="topwindow-action"></a>
+- **Colonne della lista**: caselle da spuntare che determinano le colonne visualizzate nella lista delle e-mail. Le colonne **Oggetto** e **Discussioni** sono sempre visibili. Colonne opzionali disponibili: `Da`{.action}, `A`{.action}, `Da/A`{.action}, `Rispondi a`{.action}, `Copia`{.action}, `Data`{.action}, `Dimensione`{.action}, `Stato lettura`{.action}, `Allegati`{.action}, `Indicatore`{.action}, `Priorità`{.action}.
 
-Quando viene selezionata un'email, è possibile agire su di essa. Ecco le azioni possibili:
+- **Colonna di ordinamento**: permette di scegliere la colonna di ordinamento predefinita. Opzioni disponibili: `Nessuno`{.action}, `Data di arrivo`{.action}, `Data di invio`{.action}, `Oggetto`{.action}, `Da`{.action}, `A`{.action}, `Da/A`{.action}, `Copia`{.action} o `Dimensione`{.action}.
+
+- **Ordine di ordinamento**: ascendente o discendente.
+
+Clicca su `Salva`{.action} per applicare le tue scelte.
+
+> [!primary]
+>
+> Puoi anche **ordinare dinamicamente la lista** cliccando direttamente sull'intestazione di una colonna visualizzata (ad esempio **Data**, **Oggetto** o **Dimensione**). Un secondo clic sulla stessa colonna inverte l'ordine.
+
+##### Azione su un'e-mail selezionata <a name="topwindow-action"></a>
+
+Quando un'e-mail è selezionata, è possibile agire su di essa. Ecco le azioni possibili:
 
 - `Rispondi`{.action}: rispondere direttamente al mittente.
-- `Rispondere a tutti`{.action}: rispondere direttamente a tutti i destinatari presenti nei campi "A" e "Copia".
-- `Inoltra`{.action}: trasferire l'email selezionata a uno o più destinatari.
-- `Elimina`{.action}: inserisci l'email selezionata in "Corbeille".
-- `SPAM`{.action}: inserire l'email selezionata direttamente nella casella della posta indesiderata (Junk), qualificarla come **spam**.
-- `Contrassegna`{.action}: determinare manualmente lo stato di un'email.
-- `Azioni`{.action} 
-    - `Stampa il messagio`{.action}.
-    - `Scarica (.eml)`{.action}: recuperare l'intestazione dell'email e il suo contenuto.
-    - `Modifica come nuovo`{.action}: creare una nuova email utilizzando l'email selezionata.
-    - `Visualizza sorgente messaggio`{.action}: visualizzare l'email nella forma grezza con l'intestazione.
-    - `Sposta in...`{.action}: spostare l'email in una cartella
-    - `Copia su...`{.action}: copia l'email in una cartella
+- `Rispondi a tutti`{.action}: rispondere direttamente a tutti i destinatari presenti nei campi "A" e "Copia".
+- `Inoltra`{.action}: inoltrare l'e-mail selezionata a uno o più destinatari.
+- `Elimina`{.action}: spostare l'e-mail selezionata nel "Cestino".
+- `Indesiderata`{.action}: inserire l'e-mail selezionata direttamente nella casella della posta indesiderata (Junk), qualificarla come **spam**.
+- `Contrassegna`{.action}: determinare manualmente lo stato di un'e-mail.
+- `Altro`{.action} 
+    - `Stampa questo messaggio`{.action}.
+    - `Scarica (.eml)`{.action}: recuperare l'intestazione dell'e-mail e il suo contenuto.
+    - `Modifica come nuovo`{.action}: creare una nuova e-mail basandosi sull'e-mail selezionata.
+    - `Visualizza sorgente`{.action}: visualizzare l'e-mail nella sua forma grezza con l'intestazione.
+    - `Sposta in`{.action}: spostare l'e-mail in una cartella.
+    - `Copia in`{.action}: copiare l'e-mail in una cartella.
     - `Apri in una nuova finestra`{.action}.
 
 ![hosting](images/roundcube04.png){.thumbnail}
 
 > [!primary]
 >
-> Se uno dei tuoi interlocutori richiede che gli sia inviato un messaggio di conferma durante la lettura della sua email, riceverai questo messaggio: `il mittente di questo messaggio ha chiesto di essere avvisato quando leggerai questo messaggio. Desiderate avvisare il mittente?`.
-> 
+> Se uno dei tuoi corrispondenti chiede di ricevere una conferma di lettura quando leggi la sua e-mail, otterrai il seguente messaggio: `il mittente di questo messaggio ha chiesto di essere avvisato quando leggerai questo messaggio. Desideri avvisare il mittente?`.
+>
 
-##### Ricerca un'email <a name="topwindow-search"></a>
+##### Cercare un'e-mail <a name="topwindow-search"></a>
 
-È disponibile uno strumento di ricerca nella parte superiore destra dell'interfaccia.
+Uno strumento di ricerca è disponibile nella parte superiore destra dell'interfaccia.
 
-Clicca sulla freccia a destra della lente di ingrandimento per visualizzare i filtri di ricerca.
+Inserisci un termine nel campo di ricerca, poi conferma con il tasto `Invio`{.action}: Roundcube effettua per impostazione predefinita la ricerca su tutta la cartella corrente.
 
-#### Contenuto di un'email (finestra inferiore) <a name="lowerwindow"></a>
+Clicca sulla freccia situata a destra della lente di ingrandimento per visualizzare i filtri di ricerca: puoi limitare la ricerca a determinati campi (oggetto, corpo del messaggio, mittente, destinatari, ecc.) o estenderne la portata a tutte le cartelle.
 
-Quando un'email è selezionata nella lista, compare nella finestra inferiore.
+#### Contenuto di un'e-mail (finestra inferiore) <a name="lowerwindow"></a>
 
-Visualizza le scorciatoie, a destra, delle funzioni seguenti:
+Quando un'e-mail è selezionata nella lista, questa viene visualizzata nella finestra inferiore.
 
-- Visualizza in formato HTML (di default)
-- Mostra nel formato testo semplice
-- Rispondere
-- Rispondere a tutti
-- Inoltra
-- Apri in una nuova finestra
+A destra, trovi le scorciatoie delle funzioni qui sotto:
+
+- `Visualizza in formato HTML`{.action} (predefinito)
+- `Visualizza in formato testo semplice`{.action}
+- `Rispondi`{.action}
+- `Rispondi a tutti`{.action}
+- `Inoltra`{.action}
+- `Apri in una nuova finestra`{.action}
 
 ![hosting](images/roundcube05.png){.thumbnail}
 
-### Configura le preferenze dell'interfaccia Roundcube <a name="roundcube-settings"></a>
+### Configurare le preferenze dell'interfaccia Roundcube <a name="roundcube-settings"></a>
 
-I seguenti capitoli della guida corrispondono alle schede che compongono la parte `Preferenze`{.action} delle `Impostazioni`{.action} di Roundcube. La loro descrizione non è esaustiva.
+I capitoli seguenti di questa guida corrispondono alle schede che compongono la sezione `Preferenze`{.action} delle `Impostazioni`{.action} di Roundcube. La loro descrizione non è esaustiva.
 
 ![hosting](images/roundcube06.png){.thumbnail}
 
 #### Interfaccia utente <a name="user-interface-settings"></a>
 
-Definisci qui la `lingua` d'uso dell'interfaccia Roundcube, il `fuso orario`, il `formato orario` e il `formato data`.
+Definisci qui la `lingua` di utilizzo dell'interfaccia Roundcube, il `fuso orario`, il `formato orario` e il `formato data`.
 
-Con l'opzione `Date più leggibilie` graziose è possibile visualizzare la data di ricezione/invio con termini relativi come "Oggi", "Ieri", ecc.<br>
+L'opzione `Date più leggibili` permette di visualizzare la data di ricezione/invio con termini relativi come "Oggi", "Ieri", ecc.<br>
+**Ad esempio**: oggi è il **19/05/2022**, un'e-mail inviata/ricevuta il **17/05/2022** alle **17:38** sarà visualizzata come **Mar 17:38**, perché l'e-mail corrisponde al martedì precedente.
 
-La casella `Display next list entry after delete/move` significa che, dopo un'operazione di eliminazione o spostamento su un'email, l'elemento della linea inferiore sarà sistematicamente selezionato, indipendentemente dall'ordine di selezione. 
+La casella `Visualizza la voce successiva della lista dopo eliminazione o spostamento` significa che, dopo un'azione di eliminazione o spostamento su un'e-mail, l'elemento della riga inferiore sarà sistematicamente selezionato, indipendentemente dall'ordine di ordinamento.
 
-È possibile scegliere l'estetica di visualizzazione della propria interfaccia. È possibile scegliere tra la visualizzazione **Classic** o la visualizzazione **Larry**.
+Puoi scegliere l'estetica di visualizzazione della tua interfaccia. Hai la scelta tra la visualizzazione **Classic** o la visualizzazione **Larry**.
 
-#### Impaginazione messaggi <a name="mail-view-settings"></a>
+#### Vista della casella di posta <a name="mail-view-settings"></a>
 
-Definisci qui l'ergonomia per visualizzare e agire sulle email. L'opzione `Layout` permette di configurare le 3 finestre descritte nella sezione [Interfaccia generale della Webmail Roundcube](#topwindow).
+Definisci qui l'ergonomia per visualizzare e agire sulle e-mail. L'opzione `Disposizione` permette di disporre le 3 finestre descritte nella sezione [Lista delle e-mail ricevute / inviate](#topwindow).
 
-#### Visualizzazione messaggi <a name="mail-display-settings"></a>
+#### Visualizzazione dei messaggi <a name="mail-display-settings"></a>
 
-Definisci come visualizzare le email.<br>
-Ti consigliamo di avere la casella `Mostra HTML` selezionata, per assicurarti che le email formattate dal mittente siano correttamente visualizzate.<br>
-Ti consigliamo inoltre di mantenere l'opzione `Permetti risorse remote (immagini, stili)` per `mai`. in quanto evita di caricare gli elementi di un'email che sembra malevolo.
+Definisci la modalità di visualizzazione delle e-mail.<br>
+È consigliato avere la casella `Mostra HTML` selezionata, per assicurarsi che le e-mail formattate dal mittente vengano visualizzate correttamente.<br>
+È inoltre consigliato mantenere l'opzione `Consenti risorse remote (immagini, stili)` su `mai`. Questo evita di caricare gli elementi di un'e-mail che sembra malevola.
 
-#### Composizione messaggi <a name="mail-writing-settings"></a>
+#### Composizione dei messaggi <a name="mail-writing-settings"></a>
 
-Definisci la forma predefinita durante la redazione di un'email o di una risposta.<br>
-Ti consigliamo di utilizzare l'opzione `Scrivi i messaggi in HTML` su `sempre`, per utilizzare di default gli strumenti HTML e non alterare la firma HTML.
+Definisci la forma predefinita durante la redazione di un'e-mail o di una risposta.<br>
+È consigliato impostare l'opzione `Componi e-mail HTML` su `sempre`, per beneficiare per impostazione predefinita degli strumenti di modifica HTML e non alterare una firma HTML.
 
 #### Contatti <a name="contacts-settings"></a>
 
-Personalizza qui la configurazione delle informazioni nella tua rubrica.
+Personalizza qui la disposizione delle informazioni nella tua rubrica.
 
 #### Cartelle speciali <a name="special-folder-settings"></a>
 
-Roundcube dispone di 4 cartelle speciali: `Bozze`, `Inviate`, `Marce`, `Cestino`.
+Roundcube dispone di 4 cartelle speciali: `Bozze`, `Inviata`, `Indesiderata`, `Cestino`.
 
-Non consigliamo di modificarli, ma è possibile attribuire il comportamento di una cartella speciale a un'altra cartella creata successivamente, grazie ai menu a tendina.<br>
+Sconsigliamo di modificarle, ma è possibile attribuire il comportamento di una cartella speciale a un'altra cartella creata successivamente, grazie ai menu a tendina.<br>
 
-**Ad esempio**, è possibile assegnare il comportamento Bozze a un'altra cartella creata facendo clic sull'elenco a discesa e selezionando la cartella. Se non gli viene assegnata nessuna cartella, verrà automaticamente impostata sull’opzione "Drafts". Le email che saranno salvate lì saranno considerate bozze fino all'invio effettivo.
+**Ad esempio**, puoi attribuire il comportamento "Bozze" a un'altra cartella che hai creato cliccando sulla lista a tendina e scegliendo la cartella. Se nessuna cartella le è attribuita, sarà automaticamente impostata sull'opzione "Drafts". Le e-mail che vi saranno salvate verranno considerate come bozze fino al loro invio effettivo.
 
-> In pratica, creo una sottocartella "Bozze email dei clienti". Accedi alla sezione `Preferenze`{.action} / `Cartelle speciali`{.action} e seleziona l’opzione "Bozze". Nel menu a tendina, seleziona la cartella "Bozze e-mail clienti" per sostituire "Drafts". Le email scritte in questa cartella verranno considerate bozze.
+> In pratica, creo una sottocartella "Bozze e-mail clienti". Accedo a `Le mie preferenze`{.action} / `Cartelle speciali`{.action} e scelgo l'opzione "Bozze". Nel menu a tendina, seleziono la cartella "Bozze e-mail clienti" per sostituire "Drafts". Le e-mail redatte in questa cartella saranno considerate come bozze.
 
 #### Impostazioni del server <a name="server-settings"></a>
 
-In questa scheda è possibile ottimizzare lo spazio occupato su un account email. Infatti, l'opzione `Svuota il cestino all'uscita` permette di evitare il cumulo degli elementi che sono stati eliminati. L'opzione `Elimina direttamente i messaggi in Spam` eliminerà automaticamente tutte le email considerate SPAM.
+In questa scheda, puoi ottimizzare lo spazio occupato su un account e-mail. Infatti, l'opzione `Svuota il cestino alla disconnessione` permette di evitare l'accumulo degli elementi che sono stati eliminati. L'opzione `Elimina direttamente le e-mail indesiderate` eliminerà automaticamente tutte le e-mail considerate spam.
 
 > [!warning]
 > 
-> Si sconsiglia di attivare l'opzione `Elimina direttamente i messaggi in Spam` nel caso in cui un falso positivo (e-mail erroneamente dichiarato come "SPAM") si trovi dichiarato SPAM per il server ricevente. Infatti, quando un'email è inserita nella cartella "Posta elettronica", è ancora possibile verificare se l'email è legittima.
+> È sconsigliato attivare l'opzione `Elimina direttamente le e-mail indesiderate`, nel caso in cui un falso positivo (e-mail dichiarata erroneamente come "spam") venga dichiarato come spam dal server di ricezione. Infatti, quando un'e-mail è inserita nella cartella "Indesiderata", è ancora possibile verificare se l'e-mail è legittima.
 
-#### Crittografia <a name="encryption"></a>
+#### Cifratura <a name="encryption"></a>
 
-Se il browser lo consente, è possibile installare e attivare l’estensione "Mailvelope". È un'estensione del browser che integra il PGP (**P**retty **G**ood **P**rivacy) nella tua messaggeria Web. Il sistema di cifratura PGP e, di conseguenza, l'estensione "Mailvelope" permettono di:
+Se il tuo browser te lo permette, puoi installare e attivare l'estensione "Mailvelope". Si tratta di un'estensione del browser che integra il PGP (**P**retty **G**ood **P**rivacy) nella tua messaggistica web. Il sistema di cifratura PGP e, di conseguenza, l'estensione "Mailvelope" permettono di:
 
-- Cifrare e decrittografare le email nel tuo browser.
-- Mantenere privato il contenuto delle tue email nei confronti del tuo provider di posta.
+- Cifrare e decifrare e-mail nel tuo browser.
+- Mantenere il contenuto delle tue e-mail privato nei confronti del tuo fornitore di posta.
 
-Sarete così soli a poter leggere le vostre email. Questa estensione è un modo per proteggere la tua Webmail se ricevi email di natura confidenziale.
+Sei quindi l'unico a poter leggere le tue e-mail. Questa estensione è un modo per proteggere la tua webmail se ricevi e-mail di natura confidenziale.
 
-Per maggiori informazioni, consulta le FAQ "Mailvelope" all'indirizzo <https://mailvelope.com/faq>.
+Per maggiori informazioni, consulta la FAQ di "Mailvelope" all'indirizzo <https://mailvelope.com/faq>.
 
-### Gestisci le identità e la loro firma <a name="identity-signature"></a>
+### Gestire le identità e la loro firma <a name="identity-signature"></a>
 
-Clicca su `Impostazioni`{.action} nella barra superiore e seleziona `Identità`{.action} nella colonna di sinistra. "L'identità" permette di personalizzare le informazioni inviate ai destinatari, come ad esempio il nome visualizzato o la firma.
+Da Roundcube, clicca su `Impostazioni`{.action} nella barra superiore, poi su `Identità`{.action} nella colonna di sinistra. "L'identità" permette di personalizzare le informazioni inviate ai destinatari come, ad esempio, il nome visualizzato o la firma.
 
 ![hosting](images/roundcube07.png){.thumbnail}
 
-#### Impostare gli attributi di un'identità <a name="identity"></a>
+#### Configurare gli attributi di un'identità <a name="identity"></a>
 
-- **Nome visualizzato**: questo nome comparirà nella sezione "Mittente" del destinatario
-- **E-mail**: corrisponde all'indirizzo da cui è stata inviata l'email.
-- **Società**: campo destinato al nome della società, associazione o altro ente.
-- **Rispondere a**: attribuire un indirizzo email di risposta diverso da quello del mittente.
-- **Ccn**: inviare in copia nascosta un indirizzo email durante un invio.
-- **Imposta predefinita**: se vi sono più identità (firme), attribuirla di default.
-- **Firma**: personalizzare la firma di un'email durante la redazione (cognome, nome, posizione occupata, frasi, immagini...).
-- **Firma HTML**: attiva il formato HTML sulla firma. 
+- **Nome visualizzato**: questo nome apparirà nella sezione "mittente" del destinatario.
+- **E-mail**: corrisponde all'indirizzo da cui viene inviata l'e-mail.
+- **Organizzazione**: campo destinato al nome di un'azienda, associazione o altra entità.
+- **Rispondi a**: attribuire un altro indirizzo e-mail di risposta diverso da quello del mittente.
+- **Ccn**: mettere in copia nascosta un indirizzo e-mail durante un invio.
+- **Imposta come predefinito**: quando ci sono più identità (firme), attribuire questa per impostazione predefinita.
+- **Firma**: personalizzare il piè di pagina di un'e-mail durante la sua redazione (cognome, nome, posizione occupata, frasi, immagini...).
+- **Firma HTML**: attiva il formato HTML sulla firma.
 
 > [!alert]
-> 
-> Completare la casella **E-mail** con un indirizzo email diverso da quello a cui sei connesso è considerato un'usurpazione di identità elettronica (*spoofing*). L'indirizzo IP utilizzato per l'invio rischia di essere "bandito" e/o considerato "SPAM" presso i tuoi destinatari. 
+>
+> Compilare la casella **E-mail** con un indirizzo e-mail diverso da quello a cui sei connesso è considerato un'usurpazione di identità elettronica (*spoofing*). L'indirizzo IP utilizzato per l'invio rischia di essere "bandito" e/o considerato come "spam" presso i tuoi destinatari.
 
 #### Aggiungere una firma <a name="signature"></a>
 
-Di default, la casella `firma` è in "testo chiaro". Questo formato non consente di effettuare modifiche avanzate o di inserire un'immagine nella firma. Per usufruire delle opzioni di modifica avanzate per una firma, ti consigliamo di attivare la modalità HTML cliccando su **Firma HTML** sotto il riquadro di registrazione.
+Per impostazione predefinita, la casella `firma` è in "testo semplice". Questo formato non permette una modifica avanzata o di inserire un'immagine nella tua firma. Per beneficiare delle opzioni di modifica avanzata per una firma, è consigliato attivare la modalità HTML cliccando su **Firma HTML** sotto il riquadro di inserimento.
 
 > [!warning]
-> 
-> Pertanto, se la firma è in formato HTML, sarà necessario passare in modalità HTML per la redazione di un'email. Puoi attivare di default questa opzione per ogni redazione di email, dalla sezione `Impostazioni`{.action} dell'interfaccia Roundcube.
-> Clicca su `Preferenze`{.action} nella colonna di sinistra e poi su `Composizione messaggi`{.action}. Per la voce **Redigere email HTML**, seleziona `Sempre`.
+>
+> Di conseguenza, se la firma è in formato HTML, sarà necessario passare alla modalità HTML per la redazione di un'e-mail. Puoi attivare questa opzione per impostazione predefinita per ogni redazione di e-mail, dalla sezione `Impostazioni`{.action} dell'interfaccia Roundcube.
+> Clicca su `Preferenze`{.action} nella colonna di sinistra, poi su `Composizione dei messaggi`{.action}. Per la voce **Componi e-mail HTML**, seleziona `Sempre`.
 >
 
 Per inserire un'immagine in una firma, l'immagine deve essere ospitata su un server (un hosting OVHcloud o altro).<br>
-**Scaricare un'immagine da un computer non ne permetterà la visualizzazione**.
+**Caricare un'immagine da un computer non ne permetterà la visualizzazione**.
 
-Clicca sul pulsante `< >`{.action} nella barra degli strumenti HTML e inserisci il codice seguente, sostituendo `your-image-url` con l'indirizzo (URL) dell'immagine e `text-if-image-is-not displayed` con un testo che sostituisce l'immagine se questa non può essere visualizzata.
+Clicca sul pulsante `< >`{.action} nella barra degli strumenti HTML, poi inserisci il codice seguente, sostituendo `your-image-url` con l'indirizzo (URL) dell'immagine e `text-if-image-is-not-displayed` con un testo che sostituisca l'immagine se questa non può essere visualizzata.
 
-```bash
+```html
 <img src="your-image-url" border="0" alt="text-if-image-is-not-displayed" />
 ```
 
 ![hosting](images/roundcube08.png){.thumbnail}
 
-### Rubrica di contatti <a name="contact-book"></a>
+### Rubrica dei contatti <a name="contact-book"></a>
 
-Clicca su `Contatti`{.action} nella barra superiore per accedere alla rubrica. Esso è diviso in **3 colonne**:
+Clicca su `Contatti`{.action}, nella barra superiore, per accedere alla rubrica dei contatti. Questa è suddivisa in **3 colonne**:
 
-- **Gruppi**: nella rubrica indirizzi, potete creare gruppi per classificare i contatti.
-- **Contatti**: visualizza i contatti della rubrica o del gruppo selezionato.
-- **Proprietà contatto** o **Aggiungi contatto**: questa finestra si apre quando viene selezionato un contatto o quando è in fase di creazione. È possibile leggere o modificare le informazioni di un contatto.
+- **Gruppi**: nella rubrica indirizzi, puoi creare gruppi per classificare i contatti.
+- **Contatti**: visualizza i contatti della rubrica indirizzi o del gruppo selezionato.
+- **Proprietà del contatto** o **Aggiungi un contatto**: questa finestra appare quando un contatto è selezionato o in fase di creazione. Puoi leggere o modificare le informazioni di un contatto.
 
 ![hosting](images/roundcube09.png){.thumbnail}
 
 #### Gruppi <a name="group"></a>
 
-I gruppi sono sottocategorie della rubrica. Permettono di classificare i contatti in sottounità. Ad esempio, è più facile trovare un contatto in un gruppo che hai creato piuttosto che nell'intera rubrica indirizzi. per permetterti di inviare un'email aggiungendo un gruppo di destinatari, invece di aggiungerne uno a uno.
+I gruppi sono sottocategorie della rubrica indirizzi. Permettono di classificare i contatti in sottoinsiemi. Ad esempio, ritroverai più facilmente un contatto in un gruppo che avrai creato piuttosto che nell'insieme della tua rubrica indirizzi. Questo ti permette inoltre di inviare un'e-mail aggiungendo un gruppo come destinatario, invece di aggiungere uno a uno i contatti del gruppo.
 
-Per creare un gruppo, clicca sul pulsante `+`{.action} in fondo alla colonna `Gruppi`. Definisci il nome del gruppo e clicca su `Salva`{.action} per confermare l'operazione.
+Per creare un gruppo, clicca sul pulsante `+`{.action} in fondo alla colonna `Gruppi`. Definisci il nome del gruppo, poi clicca su `Salva`{.action} per confermare.
 
 ![hosting](images/roundcube10.png){.thumbnail}
 
-Per assegnare un contatto a uno dei gruppi, seleziona un contatto nella colonna `Contatti` e, nella finestra che appare, clicca sulla scheda `Gruppi`{.action}. Seleziona il gruppo che vuoi assegnare al contatto.
+Per assegnare un contatto a uno dei gruppi, seleziona un contatto nella colonna `Contatti` poi, nella finestra che appare, clicca sulla scheda `Gruppi`{.action}. Spunta il gruppo che vuoi assegnare al contatto.
 
 #### Contatti <a name="contacts"></a>
 
-Nella colonna `Gruppi`, seleziona la rubrica o uno dei gruppi.
+Nella colonna `Gruppi`, seleziona la rubrica indirizzi o uno dei gruppi.
 
 > [!primary]
-> 
-> Quando crei un contatto a partire da un gruppo selezionato, il contatto sarà aggiunto automaticamente al gruppo.
+>
+> Quando crei un contatto a partire da un gruppo selezionato, il contatto verrà automaticamente aggiunto al gruppo.
 
 Clicca sul pulsante `+`{.action} in fondo alla colonna `Contatti` per creare un contatto.
 
 ![hosting](images/roundcube11.png){.thumbnail}
 
-Inserisci le informazioni del contatto.
+Compila quindi le informazioni del contatto.
 
 > [!primary]
-> Aggiungi campi supplementari tramite il menu a tendina `Aggiungi campo...`{.action}, sotto i campi `Nome` e `Indirizzo`.
+> Puoi aggiungere campi supplementari tramite il menu a tendina `Aggiungi un campo...`{.action}, situato sotto i campi `Nome` e `Indirizzo`.
 
-#### Importa contatti <a name="import-contacts"></a>d
+#### Importare contatti <a name="import-contacts"></a>
 
-Dalla finestra `Contatti`{.action}, nella barra superiore, clicca su `importare`{.action} per aprire la finestra di importazione.
+Dalla finestra `Contatti`{.action}, nella barra superiore, clicca su `importa`{.action} per aprire la finestra di importazione.
 
-- `Importa da file`: seleziona un file CSV o vCard sul tuo computer. I contatti all'interno di un file CSV devono essere separati da virgola. Il file non deve superare i 20 MB.
-- `Importa le assegnazioni di gruppo`: Se i contatti del tuo file sono ripartiti per gruppi, puoi attivare questa opzione per trovare questa organizzazione o lasciare questa opzione su `zero` affinché nessun gruppo sia assegnato ai contatti.
-- `Sostituisci l'intera rubrica`: Se hai già configurato una rubrica, ti consigliamo di esportarla prima di selezionare questa opzione o di essere sicuro di voler definitivamente sostituirla.
+- `Importa da un file`: seleziona un file CSV o un file vCard sul tuo computer. I contatti all'interno di un file CSV devono essere separati da virgole. Il file non deve superare i 20 MB.
+- `Importa le assegnazioni di gruppo`: se i contatti del tuo file sono ripartiti per gruppi, puoi attivare questa opzione per ritrovare questa organizzazione oppure lasciare questa opzione su `nessuna` affinché nessun gruppo sia assegnato ai contatti.
+- `Sostituisci l'intera rubrica indirizzi`: se una rubrica è già configurata, ti consigliamo di esportarla prima di selezionare questa opzione o di essere certo di volerla definitivamente sostituire.
 
 ![hosting](images/roundcube-import-contact.png){.thumbnail}
 
-#### Esporta i contatti Roundcube <a name="export-contacts"></a>
+#### Esportare i contatti <a name="export-contacts"></a>
 
-Dalla finestra `Contatti`{.action}, nella barra superiore, clicca sulla freccia verso il basso a destra del pulsante `Esporta`{.action}.
+Dalla finestra `Contatti`{.action}, nella barra superiore, clicca sulla freccia rivolta verso il basso a destra del pulsante `Esporta`{.action}.
 
-Puoi scegliere tra:
+Hai la scelta tra:
 
-- `Esporta tutto`{.action} i contatti saranno poi esportati in un file **vcf**.
-- `Esporta selezionati`{.action} per esportare solo gli elementi selezionati nella colonna `Contatti`{.action}.
+- `Esporta tutto`{.action} e l'insieme dei contatti sarà quindi esportato in un file **.vcf**.
+- `Esporta la selezione`{.action} per esportare solo gli elementi che avrai scelto nella colonna `Contatti`{.action}.
 
 ![hosting](images/roundcube-export-contact.png){.thumbnail}
 
-### Risposte (template) <a name="responses"></a>
+### Risposte (modelli) <a name="responses"></a>
 
-Questa funzione permette di creare template di risposta durante la redazione di un'email.
+Questa funzione permette di creare modelli di risposta durante la redazione di un'e-mail.
 
-Clicca su `Impostazioni`{.action} nella barra superiore e seleziona `Risposte`{.action} nella colonna di sinistra.
+Da Roundcube, clicca su `Impostazioni`{.action} nella barra superiore, poi su `Risposte`{.action} nella colonna di sinistra.
 
 Per aggiungere una risposta, clicca sul pulsante `+`{.action} in fondo alla colonna `Risposte`.
 
 ![hosting](images/roundcube12.png){.thumbnail}
 
 > [!primary]
-> 
-> Le "risposte" sono redatte in formato "testo chiaro".
+>
+> Le "risposte" si redigono in formato "testo semplice".
 
-### Aggiungi una risposta automatica <a name="automatic-respond"></a>
+### Aggiungere una risposta automatica <a name="automatic-respond"></a>
 
-Aggiungi una risposta automatica al tuo indirizzo email quando sei assente o non sei disponibile. Questa funzione non può essere attivata dalla Webmail ma dallo [Spazio Cliente OVHcloud](/links/manager), nell’interfaccia di gestione degli indirizzi email. Consulta la nostra guida "[Creare una risposta automatica per il proprio indirizzo email](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
+Vuoi aggiungere una risposta automatica al tuo indirizzo e-mail quando sei assente o non disponibile. Questa funzione non può essere attivata dalla webmail ma dal tuo [Spazio Cliente OVHcloud](/links/manager), nell'interfaccia di gestione dei tuoi indirizzi e-mail. Consulta la nostra guida "[Creare una risposta automatica per il proprio indirizzo e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
 
-### Modificare la password del tuo indirizzo email <a name="password"></a>
+### Modificare la password del tuo indirizzo e-mail <a name="password"></a>
 
-Per modificare la password di un indirizzo email è necessario accedere allo [Spazio Cliente OVHcloud](/links/manager), nell’interfaccia di gestione degli indirizzi email. Consulta la nostra guida "[Modificare la password di un indirizzo email](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
+Per modificare la password del tuo indirizzo e-mail, devi accedere al tuo [Spazio Cliente OVHcloud](/links/manager), nell'interfaccia di gestione dei tuoi indirizzi e-mail. Consulta la nostra guida "[Modificare la password di un indirizzo e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
 
-### Redazione di un'email <a name="email-writing"></a>
+### Redazione di un'e-mail <a name="email-writing"></a>
 
-Nella scheda `E-mail`{.action} nella barra superiore, clicca su `Nuovo messaggio`{.action}.
+Dalla scheda `E-mail`{.action} nella barra superiore, clicca su `Componi`{.action}.
 
-Nella finestra di redazione di un'email sono disponibili questi campi: 
+Nella finestra di redazione di un'e-mail, ritroviamo i seguenti campi:
 
-- **Mittente**: scegli un'[identità](#identity) per definire il mittente.
-- **Destinatario+**: aggiungere destinatari e/o un [gruppo di destinatari](#group).
+- **Da**: scegli un'[identità](#identity) per definire il mittente.
+- **A**: aggiungere destinatari e/o un [gruppo di destinatari](#group). Il pulsante `+`{.action} a destra del campo permette di inserire più indirizzi.
 
 > [!primary]
-> 
-> Il campo **"Destinatario"** non deve superare i 100 destinatari, include i contatti contenuti in un [gruppo](#group).
+>
+> Il campo **"A"** non deve superare i 100 destinatari, inclusi i contatti contenuti in un [gruppo](#group).
 
-- **Aggiungi Cc+**: aggiungere destinatari in copia semplice.
-- **Aggiungi Ccn+**: aggiungere destinatari in copia nascosta. Gli altri destinatari dell'email non vedranno questi in Cci.
-- **Aggiungi Followup-To**: inviare l'email ai destinatari
-- **Tipo editor**:  
-    - `Testo semplice`: solo testo senza forma.
-    - `HTML`: testo riformato. Si apre una barra degli strumenti HTML sopra la finestra di inserimento.
-- **Priorità** dell'email
-- **Ricevuta di ritorno**: al destinatario è richiesto un avviso di ricevimento.
-- **Notifica di consegna** quando l'email è stata trasmessa al destinatario.
-- **Salva i messaggi inviati in**: scegli la cartella in cui verrà salvata una copia dell'email.
+- **Cc**: tramite il pulsante `Aggiungi Cc`{.action}, aggiungere destinatari in copia semplice.
+- **Ccn**: tramite il pulsante `Aggiungi Ccn`{.action}, aggiungere destinatari in copia nascosta. Gli altri destinatari dell'e-mail non vedranno quelli in Ccn.
+- **Inoltra a**: tramite il pulsante `Aggiungi Inoltra a`{.action}, inoltrare l'e-mail a dei destinatari.
+- **Tipo di editor**:
+    - `Testo semplice`: solo testo senza formattazione.
+    - `HTML`: testo con formattazione. Una barra degli strumenti HTML appare sopra la finestra di inserimento.
+- **Priorità** dell'e-mail.
+- **Conferma di apertura dell'e-mail**: viene richiesto al destinatario un avviso di ricevimento.
+- **Notifica dello stato di consegna** quando l'e-mail è stata correttamente trasmessa al destinatario.
+- **Salva l'e-mail inviata in**: scegli la cartella in cui sarà conservata una copia dell'e-mail.
 
-Nella barra superiore sono disponibili le seguenti azioni:
+Nella barra superiore, sono disponibili le seguenti azioni:
 
-- `Annulla`{.action} la redazione di un'email con una richiesta di conferma
-- `Invia`{.action} un'email.
-- `Salva`{.action} un'email nella cartella speciale "bozza"
-- `Controllo ortografico`{.action}, per verificare il testo, con un menù che permette la scelta della lingua.
-- `Allegare`{.action} un file a un'email
+- `Annulla`{.action} la redazione di un'e-mail con una richiesta di conferma.
+- `Invia`{.action} un'e-mail.
+- `Salva`{.action} un'e-mail nella cartella speciale "bozza".
+- `Ortografia`{.action}, per verificare il testo, con un menu che permette la scelta della lingua.
+- `Allega`{.action} un file a un'e-mail.
 - `Firma`{.action}: aggiunge la firma associata all'[identità](#identity) selezionata.
-- `Risposte`{.action}: aggiungi un template pre-registrato nella sezione [Risposte](#responses).
+- `Risposte`{.action}: aggiunge un modello preregistrato nella sezione [Risposte](#responses).
 
 ![hosting](images/roundcube13.png){.thumbnail}
 
-### casi d'uso <a name="usecase"></a>
+### Casi d'uso <a name="usecase"></a>
 
 #### Verifica della richiesta non riuscita
 
-Quando si tenta di accedere alla Webmail Roundcube, viene visualizzato il seguente messaggio:
+Riscontri il seguente messaggio quando provi ad accedere alla tua webmail Roundcube:
 
 ```console
-IMPOSSIBILE VERIFICARE LA RICHIESTA
+VERIFICA DELLA RICHIESTA NON RIUSCITA
 Per la tua protezione, l'accesso a questa risorsa è protetto dagli attacchi CSRF.
-Se vedi questo, probabilmente non ti sei disconnesso prima di uscire dall'applicazione Web.
-Per continuare, è necessaria l'interazione umana.
+Se visualizzi questo messaggio, probabilmente non hai effettuato la disconnessione prima di uscire dall'applicazione web.
+È ora richiesta un'interazione umana per continuare.
+Contatta l'amministratore del tuo server.
 ```
 
-Come indicato nel messaggio, l’account email è considerato già connesso. Parliamo di "sessione". Ciò significa che il tuo account email è già in uso dal server di posta e che la sessione precedente deve essere chiusa. Verifica che il tuo account email non sia già aperto su roundcube. Cancella anche i dati in cache sul tuo browser.
+Come precisato nel messaggio, il tuo account e-mail è considerato come già connesso. Si parla qui di "sessione". Significa che il tuo account e-mail è già in fase di utilizzo agli occhi del server e-mail e che questa sessione precedente deve essere chiusa. Verifica che il tuo account e-mail non sia già aperto su roundcube. Svuota anche i dati nella cache del tuo browser internet.
 
 ## Per saperne di più
 
 [Iniziare a utilizzare la soluzione MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)
 
-[Modifica la password di un indirizzo email MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
+[Modificare la password di un indirizzo e-mail MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
 
-[Creare una risposta automatica per il proprio indirizzo email](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
+[Creare una risposta automatica per il proprio indirizzo e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
 
-[Crea filtri per i tuoi indirizzi email](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_filters)
+[Creare filtri per i tuoi indirizzi e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_filters)
 
-[Utilizza i reindirizzamenti email](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
+[Utilizzare i reindirizzamenti e-mail](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 
 Contatta la nostra [Community di utenti](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.pl-pl.md
@@ -1,33 +1,31 @@
 ---
-title: 'Korzystanie z konta e-mail w interfejsie Webmail Roundcube'
-updated: 2025-11-12
+title: 'Korzystanie z konta e-mail za pośrednictwem interfejsu webmail Roundcube'
+updated: 2026-05-04
 ---
-
 
 ## Wprowadzenie
 
-Dzięki usłudze MX Plan OVHcloud możesz wysyłać i odbierać e-maile za pośrednictwem programu pocztowego lub webmaila. OVHcloud dostarcza usługę poczty elektronicznej o nazwie Roundcube, która pozwala za pośrednictwem przeglądarki internetowej na dostęp do konta e-mail.
+Dzięki rozwiązaniu OVHcloud MX Plan możesz wysyłać i odbierać e-maile za pośrednictwem programu pocztowego lub webmaila. OVHcloud udostępnia usługę poczty elektronicznej online o nazwie Roundcube, która pozwala na dostęp do konta e-mail za pośrednictwem przeglądarki internetowej.
 
-**Dowiedz się, jak korzystać z interfejsu Webmail Roundcube dla kont e-mail OVHcloud**
+**Dowiedz się, jak korzystać z interfejsu webmail Roundcube dla Twoich adresów e-mail OVHcloud.**
 
 ## Wymagania początkowe
 
-- Posiadanie rozwiązania poczty elektronicznej OVHcloud **MX Plan**, zaproponowanego w naszej [ofercie hostingu www](/links/web/hosting), zawartego w [Darmowy hosting 100M](/links/web/domains-free-hosting) lub zamówionego oddzielnie jako rozwiązanie autonomiczne.
-- Dane do logowania do konta e-mail MX Plan, które chcesz sprawdzić Więcej informacji znajdziesz w przewodniku [Pierwsze kroki z usługą MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
-- Twoje rozwiązanie e-mail w chmurze OVHcloud **MX Plan** musi korzystać z technologii webmaila **Roundcube**. Aby to zidentyfikować, postępuj zgodnie z poniższymi instrukcjami.
+- Posiadanie rozwiązania pocztowego OVHcloud **MX Plan**, zawartego w naszych [ofertach hostingu www](/links/web/hosting), zawartego w [darmowej ofercie hostingu 100M](/links/web/domains-free-hosting) lub zamówionego oddzielnie jako rozwiązanie autonomiczne.
+- Posiadanie danych logowania do adresu e-mail MX Plan, który chcesz sprawdzić. Więcej informacji znajdziesz w naszym przewodniku [Pierwsze kroki z rozwiązaniem MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+- Twoje rozwiązanie pocztowe OVHcloud **MX Plan** musi korzystać z technologii webmail **Roundcube**. Aby to sprawdzić, postępuj zgodnie z poniższymi wskazówkami.
 
 > [!primary]
 > 
-> **Jak sprawdzić technologię używaną w ofercie MX Plan?**
+> **Jak rozpoznać technologię używaną w mojej usłudze MX Plan?**
 >
-> Technologia poczty elektronicznej używana w usłudze MX Plan jest scharakteryzowana przez interfejs jej interfejsu webmail. Aby ją zidentyfikować w Panelu klienta:
+> Technologia poczty używana dla Twojego rozwiązania MX Plan jest rozpoznawana po jej interfejsie webmail. Aby ją zidentyfikować z poziomu Panelu klienta, postępuj zgodnie z poniższą ścieżką:
 >
 > 1. Zaloguj się do [Panelu klienta OVHcloud](/links/manager).
 > 1. Przejdź do sekcji `Web Cloud`{.action}.
-> 1. Kliknij opcję `MX Plan`{.action}.
+> 1. Kliknij `MX Plan`{.action}.
 > 1. Wybierz odpowiednią domenę.
-> 1. Wybierz domyślnie w zakładce `Informacje ogólne`{.action}.
-> 1. Sprawdź technologię używaną pod napisem **Webmail**.
+> 1. Z poziomu zakładki `Informacje ogólne`{.action} (wybranej domyślnie) sprawdź technologię używaną w pozycji **Webmail**.
 >
 > ![MX plan](images/technology-email.png){.thumbnail .w-500}
 
@@ -37,7 +35,7 @@ Dzięki usłudze MX Plan OVHcloud możesz wysyłać i odbierać e-maile za pośr
 ### Dostęp do Panelu klienta OVHcloud
 
 - **Link bezpośredni:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz usługę MX Plan
+- **Ścieżka nawigacji:** `Web Cloud`{.action} > `MX Plan`{.action} > Wybierz Twoją usługę MX Plan
 
 ---
 <!-- CP-NAV-END:web-mx-plan -->
@@ -47,39 +45,39 @@ Dzięki usłudze MX Plan OVHcloud możesz wysyłać i odbierać e-maile za pośr
 **Podsumowanie**
 
 - [Logowanie do interfejsu webmail Roundcube](#roundcube-connexion)
-- [Ogólny interfejs interfejsu Webmail Roundcube](#general-interface)
+- [Główna strona webmail Roundcube](#general-interface)
     - [Zarządzanie folderami (lewa kolumna)](#leftcolumn)
-    - [Lista otrzymanych / wysłanych e-maili (górne okno)](#topwindow)
+    - [Lista odebranych/wysłanych e-maili (górne okno)](#topwindow)
         - [Typ wyświetlania](#topwindow-display)
-        - [Operacja na wybranym e-mailu](#topwindow-action)
-        - [Wyszukaj e-mail](#topwindow-search)
-    - [Treść e-maila (w dolnym oknie)](#lowerwindow)
-- [Konfiguruj preferencje interfejsu Roundcube](#roundcube-settings)
+        - [Operacje na wybranym e-mailu](#topwindow-action)
+        - [Wyszukiwanie e-maila](#topwindow-search)
+    - [Treść e-maila (dolne okno)](#lowerwindow)
+- [Konfiguracja preferencji interfejsu Roundcube](#roundcube-settings)
     - [Interfejs użytkownika](#user-interface-settings)
-    - [Widok skrzynki e-mail](#mail-view-settings)
-    - [Wyświetlanie e-maili](#mail-display-settings)
-    - [Tworzenie wiadomości e-mail](#mail-writing-settings)
-    - [Contacts](#contacts-settings)
+    - [Widok skrzynki pocztowej](#mail-view-settings)
+    - [Wyświetlanie wiadomości](#mail-display-settings)
+    - [Tworzenie wiadomości](#mail-writing-settings)
+    - [Kontakty](#contacts-settings)
     - [Foldery specjalne](#special-folder-settings)
     - [Ustawienia serwera](#server-settings)
     - [Szyfrowanie](#encryption)
-- [Zarządzaj tożsamościami i ich podpisami](#identity-signature)
-    - [Identity](#identity)
+- [Zarządzanie tożsamościami i ich podpisami](#identity-signature)
+    - [Tożsamość](#identity)
     - [Podpis](#signature)
 - [Książka adresowa](#contact-book)
     - [Grupy](#group)
-    - [Contacts](#contacts)
-    - [Importuj kontakty](#import-contacts)
-    - [Eksportuj kontakty](#export-contacts)
+    - [Kontakty](#contacts)
+    - [Importowanie kontaktów](#import-contacts)
+    - [Eksportowanie kontaktów](#export-contacts)
 - [Odpowiedzi (szablony)](#responses)
-- [Dodaj autoresponder lub automatyczną odpowiedź](#automatic-respond)
-- [Zmień hasło do Twojego konta e-mail](#password)
-- [Tworzenie wiadomości e-mail](#email-writing)
-- [Przykłady zastosowania](#usecase)
+- [Dodanie autorespondera](#automatic-respond)
+- [Zmiana hasła do konta e-mail](#password)
+- [Pisanie e-maila](#email-writing)
+- [Przykład zastosowania](#usecase)
 
-### Logowanie do interfejsu Webmail Roundcube <a name="roundcube-connexion"></a>
+### Logowanie do interfejsu webmail Roundcube <a name="roundcube-connexion"></a>
 
-Do zobaczenia na stronie [Webmail](/links/web/email). Wprowadź adres e-mail i hasło, a następnie kliknij `Łącze`{.action}. 
+Przejdź na stronę [Webmail](/links/web/email). Wpisz adres e-mail i hasło, a następnie kliknij `Zaloguj`{.action}. 
 
 ![hosting](images/webmail_login.png){.thumbnail}
 
@@ -89,355 +87,369 @@ Zostaniesz wówczas przekierowany do interfejsu Roundcube.
 
 > [!primary]
 > 
-> Podczas pierwszego logowania do interfejsu Roundcube wygląd interfejsu może się różnić od tego, który zobaczysz w niniejszej dokumentacji. Oznacza to, że wygląd "klasyczny" został zdefiniowany w Twoim interfejsie. Aby go zmienić, przejdź do sekcji "[Interface użytkownika](#user-interface-settings)" i wybierz widok "Larry".
-> Wygląd interfejsu nie będzie miał wpływu na poniższe wyjaśnienia w niniejszej dokumentacji.
+> Podczas pierwszego logowania do interfejsu Roundcube wygląd może się różnić od tego, który zobaczysz w niniejszej dokumentacji. Oznacza to, że na Twoim interfejsie został ustawiony wygląd "klasyczny". Aby go zmienić, postępuj zgodnie z sekcją "[Interfejs użytkownika](#user-interface-settings)" i wybierz widok "Larry".
+> Wygląd interfejsu nie wpłynie na dalsze wyjaśnienia w niniejszej dokumentacji.
 
 > [!warning]
 > 
-> Jeśli zostaniesz przekierowany do interfejsu **O**utlook **W**eb **A**pp (OWA), oznacza to, że jesteś na najnowszej wersji usługi MX Plan. Aby uzyskać więcej informacji na temat oferty MX Plan, sprawdź naszą stronę [Pierwsze kroki z ofertą MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+> Jeśli zostaniesz przekierowany do interfejsu **O**utlook **W**eb **A**pp (OWA), oznacza to, że posiadasz najnowszą wersję rozwiązania MX Plan. Aby uzyskać więcej informacji na temat Twojego rozwiązania MX Plan, zapoznaj się z naszą stroną [Pierwsze kroki z rozwiązaniem MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 >
-> Aby zapoznać się z interfejsem **OWA**, zapoznaj się z naszym przewodnikiem [Sprawdź jego konto e-mail w interfejsie OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
+> Aby zapoznać się z interfejsem **OWA**, sprawdź nasz przewodnik [Korzystanie z konta e-mail za pośrednictwem interfejsu OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa).
 
-### Ogólny interfejs webmail Roundcube <a name="general-interface"></a>
+### Główna strona webmail Roundcube <a name="general-interface"></a>
 
 Po zalogowaniu się do konta e-mail masz dostęp do głównego okna Roundcube, które składa się z 3 stref:
 
-- [**Lewa**](#leftcolumn) kolumna: drzewo konta e-mail, składające się z folderów i podfolderów. Głównym folderem jest `Odebrane`.
+- [**Lewa kolumna**](#leftcolumn): widok drzewa Twojego konta e-mail, składający się z folderów i podfolderów. Głównym folderem jest `Odebrane`.
 
-- [**Okno wyższe**](#topwindow): listę e-maili zawartych w wybranym katalogu w kolumnie z lewej strony.
+- [**Górne okno**](#topwindow): lista e-maili znajdujących się w folderze wybranym w lewej kolumnie.
 
-- [**Okno dolne**](#lowerwindow): treść wybranego e-maila w górnej części okna.
+- [**Dolne okno**](#lowerwindow): treść e-maila wybranego w górnym oknie.
 
-#### Zarządzanie folderami (kolumna po lewej stronie) <a name="leftcolumn"></a>
+#### Zarządzanie folderami (lewa kolumna) <a name="leftcolumn"></a>
 
-W tej strefie znajdują się katalogi znajdujące się na Twoim koncie e-mail.
+W tej strefie wyświetlane są foldery Twojego konta e-mail.
 
-Aby lepiej zarządzać folderami, kliknij koło zębate na dole kolumny, a następnie kliknij `Zarządzaj folderami`{.action}
+Aby dokładniej zarządzać folderami, kliknij ikonę koła zębatego w dolnej części kolumny, a następnie kliknij `Zarządzaj folderami`{.action}.
 
 ![hosting](images/roundcube02.png){.thumbnail}
 
-Aby utworzyć katalog, kliknij przycisk `+`{.action} na dole kolumny `Foldery`.
+Aby utworzyć folder, kliknij przycisk `+`{.action} w dolnej części kolumny `Foldery`.
 
-Aby usunąć katalog, wybierz odpowiedni folder, kliknij koło zębate w dolnej kolumnie `Foldery`, a następnie `Usuń`{.action}. Aby usunąć zawartość, ale zachować folder, kliknij `Opróżnij`{.action}.
+Aby usunąć folder, wybierz odpowiedni folder, kliknij ikonę koła zębatego w dolnej części kolumny `Foldery`, a następnie kliknij `Usuń`{.action}. Aby opróżnić zawartość, ale zachować folder, kliknij `Opróżnij`{.action}.
 
-Pola, które należy zaznaczyć na poziomie katalogów odpowiadają "subskrypcjom". Subskrypcja określa, czy folder ma się wyświetlać na poziomie interfejsu webmail lub programu pocztowego, zachowując jednocześnie zawartość folderu. Celem jest tylko ukrycie lub wyświetlenie folderu na koncie e-mail.
+Pola wyboru obok folderów odpowiadają "subskrypcjom". Subskrypcja określa, czy folder jest wyświetlany w interfejsie webmail lub w programie pocztowym, zachowując jednocześnie zawartość folderu. Celem jest tylko ukrycie lub wyświetlenie folderu na koncie e-mail.
 
 > [!primary]
 >
-> Katalogi z szarym kratką do zaznaczenia są specjalnymi katalogami. Nie można ich usunąć lub usunąć z abonamentu.
+> Foldery z szarym polem wyboru to foldery specjalne. Nie możesz ich usunąć ani z nich zrezygnować.
 
-#### Lista e-maili otrzymanych / wysłanych (okno wyższe) <a name="topwindow"></a>
+#### Lista odebranych/wysłanych e-maili (górne okno) <a name="topwindow"></a>
 
-W oknie tym wyświetla się zawartość wybranego katalogu w kolumnie z lewej strony. 
+W tym oknie wyświetlana jest zawartość folderu wybranego w lewej kolumnie. 
 
-##### Typ wyświetlacza <a name="topwindow-display"></a>
+##### Typ wyświetlania <a name="topwindow-display"></a>
 
-Okno jest przedstawione w formie, która może być spersonalizowana. W tym celu kliknij ikonkę koła zębatego w lewym górnym rogu tego okna.
+To okno jest prezentowane w formie, którą można dostosować. W tym celu kliknij ikonę koła zębatego w lewym górnym rogu okna.
 
 ![hosting](images/roundcube03.png){.thumbnail}
 
-Można dokonać konfiguracji:
+Można skonfigurować cztery parametry:
 
-- **Układ**: pozwala określić sposób instalacji okna do zarządzania kontem e-mail.
-- **Kolumny**: pozwala na dodawanie kolumn do wyświetlania (priorytety dla e-maili, itp.).
-- **Porządek sortowania**: pozwala wybrać kolumnę, w której zostanie przeprowadzona domyślna sortowanie.
-- **Kierunek sortowania**: pozwala wybrać kolejność sortowania w górę lub w dół, w zależności od kolumny sortowania.
+- **Układ**: określa sposób rozmieszczenia okien zarządzania kontem e-mail. Trzy opcje:
+    - `Szeroki ekran`{.action}: trzy panele obok siebie — foldery, lista e-maili i panel czytania ułożone poziomo;
+    - `Pulpit`{.action}: lista e-maili u góry, panel czytania poniżej (układ klasyczny);
+    - `Lista`{.action}: brak panelu czytania — e-maile otwierają się w pełnym oknie po kliknięciu.
 
-##### Operacja na wybranym e e-mailu <a name="topwindow-action"></a>
+- **Kolumny listy**: pola wyboru określające kolumny wyświetlane na liście e-maili. Kolumny **Temat** i **Wątki** są zawsze widoczne. Dostępne kolumny opcjonalne: `Od`{.action}, `Do`{.action}, `Od/Do`{.action}, `Odpowiedz do`{.action}, `Cc`{.action}, `Data`{.action}, `Rozmiar`{.action}, `Status`{.action}, `Załącznik`{.action}, `Flaga`{.action}, `Priorytet`{.action}.
 
-Jeśli wybrano wiadomość e-mail, możesz podjąć działania w tym celu. Poniżej możesz wykonać następujące czynności:
+- **Kolumna sortowania**: pozwala wybrać domyślną kolumnę sortowania. Dostępne opcje: `Brak`{.action}, `Data otrzymania`{.action}, `Data wysłania`{.action}, `Temat`{.action}, `Od`{.action}, `Do`{.action}, `Od/Do`{.action}, `Cc`{.action} lub `Rozmiar`{.action}.
 
-- `Odpowiedz`{.action}: odpowiadać bezpośrednio do nadawcy.
-- `Odpowiedz wszystkim`{.action}: odpowiadać bezpośrednio wszystkim odbiorcom w polach "A" i "Copie".
-- `Przekaż`{.action}: przenieść wybrany e-mail do jednego lub kilku odbiorców.
-- `Usuń`{.action}: umieścić wybrany e-mail w sekcji "Kosz".
-- `Spam`{.action}: umieść wybrany e-mail bezpośrednio w skrzynce pocztowej ("Junk"), zakwalifikować go jako **spam**.
-- `Oznacz`{.action}: określić ręcznie status e-maila.
+- **Kierunek sortowania**: rosnąco lub malejąco.
+
+Kliknij `Zapisz`{.action}, aby zastosować wybrane ustawienia.
+
+> [!primary]
+>
+> Możesz również **dynamicznie sortować listę**, klikając bezpośrednio nagłówek wyświetlanej kolumny (na przykład **Data**, **Temat** lub **Rozmiar**). Drugie kliknięcie tej samej kolumny odwraca kolejność.
+
+##### Operacje na wybranym e-mailu <a name="topwindow-action"></a>
+
+Po wybraniu e-maila możesz wykonać na nim operacje. Możliwe są następujące działania:
+
+- `Odpowiedz`{.action}: odpowiedz bezpośrednio nadawcy.
+- `Odpowiedz wszystkim`{.action}: odpowiedz bezpośrednio wszystkim odbiorcom wymienionym w polach "Do" i "Cc".
+- `Przekaż`{.action}: prześlij wybrany e-mail dalej do jednego lub kilku odbiorców.
+- `Usuń`{.action}: przenieś wybrany e-mail do folderu "Kosz".
+- `Oznacz jako spam`{.action}: umieść wybrany e-mail bezpośrednio w folderze niechcianej poczty (Junk), oznaczając go jako **spam**.
+- `Oznacz`{.action}: ręcznie ustaw status e-maila.
 - `Więcej`{.action} 
     - `Drukuj wiadomość`{.action}.
-    - `Pobierz (.eml)`{.action}: pobrać nagłówek wiadomości e-mail i jej treść.
-    - `Edytuj jako nową`{.action}: utworzyć nowy e-mail na podstawie wybranego e-maila.
-    - `Pokaź źródło`{.action}: wyświetlić email w jego wersji pierwotnej w nagłówku.
-    - `Przenieś do`{.action}: przenieść e-mail do folderu.
-    - `Kopiuj do`{.action}: skopiować e-mail do folderu.
+    - `Pobierz (.eml)`{.action}: pobierz nagłówek e-maila i jego treść.
+    - `Edytuj jako nową`{.action}: utwórz nowy e-mail na podstawie wybranego e-maila.
+    - `Pokaż źródło`{.action}: wyświetl e-mail w formie surowej, łącznie z nagłówkiem.
+    - `Przenieś do`{.action}: przenieś e-mail do folderu.
+    - `Kopiuj do`{.action}: skopiuj e-mail do folderu.
     - `Otwórz w nowym oknie`{.action}.
 
 ![hosting](images/roundcube04.png){.thumbnail}
 
 > [!primary]
 >
-> Jeśli osoba z Twojej korespondencji poprosi o przesłanie jej wiadomości e-mail z potwierdzeniem odbioru, otrzymasz następujący komunikat: `nadawca tej wiadomości poprosił o powiadomienie, kiedy przeczytasz tę wiadomość. Czy chcesz poinformować nadawcę?`.
-> 
+> Jeśli jeden z Twoich kontaktów żąda potwierdzenia odbioru przy odczycie jego e-maila, otrzymasz następujący komunikat: `Nadawca tej wiadomości poprosił o powiadomienie, gdy ją przeczytasz. Czy chcesz powiadomić nadawcę?`.
+>
 
-##### Wyszukaj e-mail <a name="topwindow-search"></a>
+##### Wyszukiwanie e-maila <a name="topwindow-search"></a>
 
-Narzędzie wyszukiwania jest dostępne w górnej prawej części interfejsu.
+W prawej górnej części interfejsu dostępne jest narzędzie wyszukiwania.
 
-Kliknij strzałkę po prawej stronie lupy, aby wyświetlić filtry wyszukiwania.
+Wpisz termin w polu wyszukiwania, a następnie zatwierdź klawiszem `Enter`{.action}: domyślnie Roundcube przeszukuje cały bieżący folder.
 
-#### Treść wiadomości e-mail (okno dolne) <a name="lowerwindow"></a>
+Kliknij strzałkę po prawej stronie lupy, aby wyświetlić filtry wyszukiwania: możesz ograniczyć wyszukiwanie do określonych pól (temat, treść wiadomości, nadawca, odbiorcy itp.) lub rozszerzyć jego zakres na wszystkie foldery.
 
-Jeśli na liście zostanie wybrany e-mail, zostanie on wyświetlony w dolnym oknie.
+#### Treść e-maila (dolne okno) <a name="lowerwindow"></a>
 
-Skróty po prawej stronie znajdują się następujące funkcje:
+Po wybraniu e-maila z listy jest on wyświetlany w dolnym oknie.
 
-- Wyświetl w formacie HTML (domyślnie)
-- Wyświetl w formacie tekstowym
-- Odpowiedz
-- Odpowiedz wszystkim
-- Przekaż
-- Otwórz w nowym oknie 
+Po prawej stronie znajdziesz skróty do następujących funkcji:
+
+- `Wyświetl w formacie HTML`{.action} (domyślnie)
+- `Wyświetl w formacie tekstowym`{.action}
+- `Odpowiedz`{.action}
+- `Odpowiedz wszystkim`{.action}
+- `Przekaż`{.action}
+- `Otwórz w nowym oknie`{.action}
 
 ![hosting](images/roundcube05.png){.thumbnail}
 
-### Konfiguracja ustawień interfejsu Roundcube <a name="roundcube-settings"></a>
+### Konfiguracja preferencji interfejsu Roundcube <a name="roundcube-settings"></a>
 
-Kolejne rozdziały niniejszego przewodnika odpowiadają zakładkom, które tworzą część `Preferencje`{.action} w `Ustawienia`{.action} Roundcube. Opis jest niewyczerpujący.
+Kolejne sekcje tego przewodnika odpowiadają zakładkom składającym się na część `Preferencje`{.action} `Ustawień`{.action} Roundcube. Ich opis nie jest wyczerpujący.
 
 ![hosting](images/roundcube06.png){.thumbnail}
 
 #### Interfejs użytkownika <a name="user-interface-settings"></a>
 
-Tutaj zdefiniuj `język`, w którym interfejs Roundcube jest używany, `strefę czasową`, `format godzinowy` i `format daty`.
+Tutaj ustaw `Język` interfejsu Roundcube, `Strefę czasową`, `Format godziny` i `Format daty`.
 
-Opcja `ładne daty` pozwala na wyświetlenie daty odbioru/wysłania z terminami względnymi, takimi jak "Dzisiaj", "Wczoraj", itp.<br>
-**Na przykład**: jesteśmy **19/05/2022**, e-mail wysłany/otrzymany w dniu **17/05/2002** o **17:38** zostanie wyświetlony w dniu **Śro 17:38**, ponieważ e-mail odpowiada poprzedniemu wtorkowi.
+Opcja `Ładne daty` pozwala wyświetlać datę otrzymania/wysłania w formie względnych terminów, takich jak "Dzisiaj", "Wczoraj" itp.<br>
+**Na przykład**: dzisiejsza data to **19/05/2022**, e-mail wysłany/otrzymany w dniu **17/05/2022** o godzinie **17:38** zostanie wyświetlony jako **Wt 17:38**, ponieważ e-mail odpowiada poprzedniemu wtorkowi.
 
-W polu `Po usunięciu elementu listy wyświetl następny` oznacza, że po usunięciu lub przesunięciu w e-mailu element dolnej linii zostanie systematycznie wybrany, niezależnie od kolejności sortowania.
+Pole wyboru `Wyświetl następną wiadomość po oznaczeniu jako przeczytaną lub przeniesieniu` oznacza, że po wykonaniu operacji usunięcia lub przeniesienia e-maila zawsze zostanie zaznaczony element w wierszu poniżej, niezależnie od kolejności sortowania.
 
-Możesz wybrać estetykę wyświetlania w Twoim interfejsie. Do wyboru jest widok **Classic** lub **Larry**.
+Możesz wybrać wygląd wyświetlania interfejsu. Masz do wyboru wygląd **Classic** lub **Larry**.
 
 #### Widok skrzynki pocztowej <a name="mail-view-settings"></a>
 
-Zdefiniuj tutaj ergonomię, aby wyświetlać i działać na e-mailach. Opcja `Układ` pozwala na wyświetlenie 3 okna opisanych w ogólnej części [Interfejs interfejsu Webmail Roundcube](#topwindow).
+Tutaj ustaw układ używany do przeglądania e-maili i wykonywania na nich operacji. Opcja `Układ` pozwala rozmieścić 3 okna opisane w sekcji [Lista odebranych/wysłanych e-maili](#topwindow).
 
 #### Wyświetlanie wiadomości <a name="mail-display-settings"></a>
 
-Określ sposób wyświetlania e-maili.<br>
-Zalecamy posiadanie kratki `Domyślny HTML`, aby upewnić się, że e-maile sformatowane przez nadawcę wyświetlają się poprawnie.<br>
-Zalecamy również zachowanie opcji `Zezwól na zdalne zasoby (obrazki, style)` na `nigdy`. Dzięki temu nie można ładować elementów e-maila, który wygląda złośliwie.
+Ustaw sposób wyświetlania e-maili.<br>
+Zalecamy zachowanie zaznaczonego pola `Wyświetlaj HTML`, aby zapewnić poprawne wyświetlanie e-maili sformatowanych przez nadawcę.<br>
+Zalecamy również pozostawienie opcji `Zezwalaj na zdalne zasoby (obrazy, style)` ustawionej na `nigdy`. Pozwala to uniknąć ładowania elementów e-maila, które mogą wydawać się złośliwe.
 
 #### Tworzenie wiadomości <a name="mail-writing-settings"></a>
 
-Określ domyślną formę podczas tworzenia wiadomości e-mail lub odpowiedzi.<br>
-Zalecamy, aby włączyć opcję `Twórz wiadomości HTML` na `zawsze`, aby korzystać domyślnie z narzędzi edycji HTML i nie zmieniać podpisu HTML.
+Ustaw domyślną formę podczas pisania e-maila lub odpowiedzi.<br>
+Zalecamy ustawienie opcji `Twórz wiadomości HTML` na `zawsze`, aby domyślnie korzystać z narzędzi edycji HTML i uniknąć zmiany podpisu HTML.
 
 #### Kontakty <a name="contacts-settings"></a>
 
-Spersonalizuj układ informacji w książce adresowej.
+Tutaj dostosuj układ informacji w Twojej książce adresowej.
 
 #### Foldery specjalne <a name="special-folder-settings"></a>
 
-Roundcube dysponuje 4 specjalnymi katalogami: `Kopie robocze`, `Wysłane`, `Spam`, `Kosz`.
+Roundcube posiada 4 foldery specjalne: `Wersje robocze`, `Wysłane`, `Spam`, `Kosz`.
 
-Nie zalecamy ich modyfikacji, ale możliwe jest przypisanie zachowania jednego folderu innemu folderowi utworzonemu w późniejszym czasie dzięki rozwijanym menu.<br>
+Nie zalecamy ich modyfikowania, ale możesz przypisać zachowanie folderu specjalnego do innego utworzonego później folderu, korzystając z menu rozwijanych.<br>
 
-**Na przykład** zachowanie "Wersje robocze" można przypisać do innego utworzonego folderu, klikając listę rozwijaną i wybierając ten folder. Jeśli nie zostanie do niego przypisany żaden folder, zostanie on automatycznie ustawiony na opcję "Drafts". E-maile, które będą w nim przechowywane, będą traktowane jako wersje robocze do momentu ich faktycznego wysłania.
+**Na przykład** możesz przypisać zachowanie "Wersje robocze" do innego utworzonego folderu, klikając listę rozwijaną i wybierając ten folder. Jeśli nie zostanie do niego przypisany żaden folder, zostanie on automatycznie ustawiony na opcję "Wersje robocze". E-maile w nim zapisane będą uznawane za wersje robocze do momentu ich faktycznego wysłania.
 
-> W praktyce tworzę podkatalog "Szablony e-maili klientów". Udaję się do `Moje preferencje`{.action} / `Foldery specjalne`{.action} i wybieram opcję "Szablony". Z rozwijanego menu wybierz folder "Wersje robocze e-maili klientów", aby zastąpić "Drafty". Wiadomości e-mail zawarte w tym folderze będą traktowane jako wersje robocze.
+> W praktyce tworzysz podfolder o nazwie "Wersje robocze e-maili klienta". Przejdź do `Moje preferencje`{.action} / `Foldery specjalne`{.action} i wybierz opcję "Wersje robocze". W menu rozwijanym wybierz folder "Wersje robocze e-maili klienta", aby zastąpić "Wersje robocze". E-maile zapisane w tym folderze będą uznawane za wersje robocze.
 
 #### Ustawienia serwera <a name="server-settings"></a>
 
-W tej zakładce możesz zoptymalizować obszar zajęty na koncie e-mail. Opcja `Przy wylogowaniu opróżnij Kosz` pozwala bowiem uniknąć kumulacji elementów, które zostały usunięte. Opcja `Kasuj wiadomości bezpośrednio w folderze Spam` automatycznie usunie wszystkie e-maile uznawane za SPAM.
+W tej zakładce możesz zoptymalizować przestrzeń wykorzystywaną przez konto e-mail. Opcja `Opróżnij Kosz przy wylogowaniu` pomaga zapobiegać gromadzeniu się usuniętych elementów. Opcja `Bezpośrednio usuwaj spam` automatycznie usunie wszystkie e-maile uznane za spam.
 
 > [!warning]
 > 
-> Odradzamy włączenie opcji `Kasuj wiadomości bezpośrednio w folderze Spam` IP w przypadku, gdy fałszywie dodatni (błędnie zadeklarowany jako "SPAM") zostanie uznany za SPAM dla serwera poczty przychodzącej. W przypadku gdy e-mail jest umieszczony w folderze "Porady", istnieje możliwość sprawdzenia, czy e-mail jest zgodny z prawem.
+> Nie zalecamy włączania opcji `Bezpośrednio usuwaj spam` w przypadku, gdy fałszywie pozytywny e-mail (e-mail błędnie zaklasyfikowany jako "spam") zostanie oznaczony jako spam przez serwer odbiorczy. Gdy e-mail trafia do folderu "Spam", możesz nadal sprawdzić, czy jest on prawidłowy.
 
-### Szyfrowanie <a name="encryption"></a>
+#### Szyfrowanie <a name="encryption"></a>
 
-Jeśli Twoja przeglądarka na to pozwala, możesz zainstalować i włączyć rozszerzenie "Mailvelope". Jest to rozszerzenie przeglądarki, które integruje protokół PGP (**P**retty **G**ood **P**rivacy) z pocztą elektroniczną. System szyfrowania PGP i, co za tym idzie, rozszerzenie "Mailveloppe" umożliwiają:
+Jeśli Twoja przeglądarka na to pozwala, możesz zainstalować i włączyć rozszerzenie "Mailvelope". Jest to rozszerzenie przeglądarki, które integruje protokół PGP (**P**retty **G**ood **P**rivacy) z Twoim webmailem. System szyfrowania PGP, a co za tym idzie rozszerzenie "Mailvelope", umożliwia:
 
-- Szyfrowanie i odszyfrowywanie e-maili w przeglądarce.
-- Zachowaj prywatność poczty elektronicznej w relacjach z dostawcą poczty.
+- Szyfrowanie i deszyfrowanie e-maili w przeglądarce.
+- Zachowanie prywatności treści e-maili wobec dostawcy poczty.
 
-Tylko Ty możesz czytać e-maile. Rozszerzenie to jest jednym ze sposobów na zabezpieczenie poczty webmail, jeśli otrzymujesz e-maile o charakterze poufnym.
+Dzięki temu tylko Ty możesz czytać Twoje e-maile. To rozszerzenie jest sposobem na zabezpieczenie webmaila, jeśli otrzymujesz e-maile o charakterze poufnym.
 
-Aby uzyskać więcej informacji, sprawdź FAQ programu "Mailvelope" pod adresem <https://mailvelope.com/faq>.
+Aby uzyskać więcej informacji, zapoznaj się z FAQ "Mailvelope" pod adresem <https://mailvelope.com/faq>.
 
-### Zarządzanie tożsamością i jej podpisem <a name="identity-signature"></a>
+### Zarządzanie tożsamościami i ich podpisami <a name="identity-signature"></a>
 
-W Roundcube kliknij `Ustawienia`{.action} na górnym pasku, a następnie `Tożsamości`{.action} w kolumnie po lewej stronie. "Tożsamości" umożliwia personalizację informacji wysyłanych do odbiorców, np. nazwy wyświetlacza lub podpisu.
+W Roundcube kliknij `Ustawienia`{.action} na górnym pasku, a następnie `Tożsamości`{.action} w lewej kolumnie. "Tożsamość" pozwala dostosować informacje wysyłane do odbiorców, takie jak nazwa wyświetlana lub podpis.
 
 ![hosting](images/roundcube07.png){.thumbnail}
 
-#### Skonfiguruj atrybuty tożsamości <a name="identity"></a>
+#### Ustawianie atrybutów tożsamości <a name="identity"></a>
 
-- **Nazwa wyświetlacza**: nazwa ta pojawi się w części "nadawca" odbiorcy
-- **E-mail**: odpowiada adresowi, z którego wysłany jest e-mail.
-- **Organizacja**: pole przeznaczone dla nazwy spółki, stowarzyszenia lub innego podmiotu.
-- **Odpowiedz**: przypisać inny adres e-mail odpowiedzi niż adres nadawcy.
-- **Odpowiedź do**: umieścić w ukrytej kopii adres e-mail podczas wysyłki.
-- **Ukryta kopia**: w przypadku gdy istnieje więcej niż jedna tożsamość (podpisy), domyślnie przydziela się tę tożsamość.
-- **Podpis**: personalizuj stopkę e-maila podczas jego pisania (nazwisko, imię, stanowisko zajęte, zdania, zdjęcia...).
-- **Podpis w HTML**: aktywuje format HTML na podpisze. 
+- **Nazwa wyświetlana**: ta nazwa pojawi się w sekcji "nadawca" u odbiorcy.
+- **E-mail**: adres, z którego wysyłany jest e-mail.
+- **Organizacja**: pole na nazwę firmy, stowarzyszenia lub innego podmiotu.
+- **Odpowiedz do**: przypisz inny adres e-mail odpowiedzi niż adres nadawcy.
+- **Bcc**: wyślij ukrytą kopię na adres e-mail przy wysyłaniu.
+- **Ustaw jako domyślną**: gdy istnieje kilka tożsamości (podpisów), ustaw tę jako domyślną.
+- **Podpis**: dostosuj stopkę e-maila podczas jego pisania (nazwisko, imię, stanowisko, zdania, obrazy itp.).
+- **Podpis HTML**: włącza format HTML podpisu.
 
 > [!alert]
-> 
-> Uzupełnienie pola **E-mail** innym adresem e-mail niż adres, na którym jesteś zalogowany, jest uważane za kradzież tożsamości elektronicznej (*spoofing*). Adres IP używany do wysyłki może być "zablokowany" i/lub oznaczony jako "SPAM" u odbiorców. 
+>
+> Wypełnienie pola **E-mail** adresem e-mail innym niż ten, na którym jesteś zalogowany, jest uznawane za kradzież tożsamości elektronicznej (*spoofing*). Adres IP używany do wysyłki może zostać "zablokowany" i/lub uznany za "spam" przez Twoich odbiorców.
 
 #### Dodanie podpisu <a name="signature"></a>
 
-Domyślnie pole `Podpis` znajduje się w "tekście niekodowanym". Format ten nie pozwala na zaawansowane edycje lub wstawić obrazek do podpisu. Aby móc korzystać z zaawansowanych opcji edycji podpisu, zaleca się aktywację trybu HTML, klikając **Podpis HTML** pod ramką wprowadzania.
+Domyślnie pole `Podpis` jest w "tekście niesformatowanym". Format ten nie pozwala na zaawansowaną edycję ani wstawianie obrazu do podpisu. Aby skorzystać z zaawansowanych opcji edycji podpisu, zalecamy włączenie trybu HTML, klikając **Podpis HTML** pod ramką wprowadzania.
 
 > [!warning]
-> 
-> W związku z tym, jeśli podpis jest w formacie HTML, konieczne będzie przejście do trybu HTML do napisania e-maila. Możesz aktywować tę opcję domyślnie dla każdej edycji wiadomości e-mail, w sekcji `Ustawienia`{.action} interfejsu Roundcube.
-> Kliknij `Preferencje`{.action} w kolumnie po lewej stronie, a następnie `Tworzenie wiadomości`{.action}. W celu uzupełnienia **Zapisz e-maile HTML** wybierz `Zawsze`.
+>
+> W rezultacie, jeśli podpis jest w formacie HTML, podczas pisania e-maila konieczne będzie przejście do trybu HTML. Możesz włączyć tę opcję domyślnie dla każdego pisanego e-maila w sekcji `Ustawienia`{.action} interfejsu Roundcube.
+> Kliknij `Preferencje`{.action} w lewej kolumnie, a następnie `Tworzenie wiadomości`{.action}. Dla pozycji **Twórz wiadomości HTML** wybierz `Zawsze`.
 >
 
-Aby dodać obraz do podpisu, obraz musi być przechowywany na serwerze (hosting OVHcloud lub inny).<br>
-**Telewizja obrazu z komputera nie pozwoli na jego wyświetlanie**.
+Aby wstawić obraz do podpisu, obraz musi być przechowywany na serwerze (hosting OVHcloud lub inny).<br>
+**Wgrywanie obrazu z komputera nie pozwoli na jego wyświetlenie**.
 
-Kliknij przycisk `< >`{.action} na pasku narzędzi HTML, następnie wprowadź następujący kod, zastępując `your-image-url` adresem (URL) obrazu i `text-if-image-is-not-displayed` tekstem, który zastępuje obraz, jeśli nie może się wyświetlić.
+Kliknij przycisk `< >`{.action} na pasku narzędzi HTML, a następnie wstaw poniższy kod, zastępując `your-image-url` adresem URL obrazu, a `text-if-image-is-not-displayed` tekstem zastępującym obraz, jeśli nie może zostać wyświetlony.
 
-```bash
+```html
 <img src="your-image-url" border="0" alt="text-if-image-is-not-displayed" />
 ```
 
 ![hosting](images/roundcube08.png){.thumbnail}
 
-### Książka kontaktów <a name="contact-book"></a>
+### Książka adresowa <a name="contact-book"></a>
 
-Kliknij `Kontakty`{.action} na górnym pasku, aby uzyskać dostęp do książki kontaktów. Jest on podzielony na **3 kolumny**:
+Kliknij `Kontakty`{.action} na górnym pasku, aby uzyskać dostęp do książki adresowej. Jest ona podzielona na **3 kolumny**:
 
-- **Grupy**: w książce adresowej możesz tworzyć grupy, aby sortować kontakty.
-- **Kontakt**: wyświetl kontakty w wybranej grupie lub książce adresowej.
-- **Właściwości kontaktu** lub **Dodaj kontakt**: okno to wyświetla się, gdy wybrany zostanie kontakt lub gdy zostanie utworzony. Możesz przeczytać lub zmienić dane kontaktu.
+- **Grupy**: w książce adresowej możesz tworzyć grupy w celu organizowania kontaktów.
+- **Kontakty**: wyświetl kontakty z książki adresowej lub z wybranej grupy.
+- **Właściwości kontaktu** lub **Dodaj kontakt**: to okno pojawia się po wybraniu kontaktu lub podczas jego tworzenia. Możesz odczytać lub edytować dane kontaktu.
 
 ![hosting](images/roundcube09.png){.thumbnail}
 
 #### Grupy <a name="group"></a>
 
-Grupy to podkategorie książki adresowej. Umożliwiają klasyfikowanie kontaktów jako podzbiorów. Na przykład, możesz łatwiej znaleźć kontakt w grupie, którą stworzyłeś, niż w całej książce adresowej. Dzięki temu możesz również wysyłać e-maile dodając grupę na odbiorcę, zamiast dodawać jeden do jednego z kontaktów grupy.
+Grupy są podkategoriami książki adresowej. Pozwalają one organizować kontakty w podzbiory. Na przykład łatwiej znaleźć kontakt w utworzonej grupie niż w całej książce adresowej. Pozwalają również wysłać e-mail, dodając grupę jako odbiorcę, zamiast dodawać kontakty z grupy pojedynczo.
 
-Aby utworzyć grupę, kliknij przycisk `+`{.action} w dolnej części kolumny `Grupy`. Zdefiniuj nazwę grupy i kliknij przycisk `Zapisz`{.action}, aby zatwierdzić.
+Aby utworzyć grupę, kliknij przycisk `+`{.action} w dolnej części kolumny `Grupy`. Ustaw nazwę grupy, a następnie kliknij `Zapisz`{.action}, aby zatwierdzić.
 
 ![hosting](images/roundcube10.png){.thumbnail}
 
-Aby przypisać kontakt do jednej z grup, wybierz kontakt w kolumnie `Kontakty`, a następnie w oknie, które się pojawi, kliknij zakładkę `Grupy`{.action}. Zaznacz grupę, którą chcesz przydzielić do kontaktu.
+Aby przypisać kontakt do jednej z grup, wybierz kontakt w kolumnie `Kontakty`, a następnie w wyświetlonym oknie kliknij zakładkę `Grupy`{.action}. Zaznacz grupę, którą chcesz przypisać do kontaktu.
 
 #### Kontakty <a name="contacts"></a>
 
 W kolumnie `Grupy` wybierz książkę adresową lub jedną z grup.
 
 > [!primary]
-> 
-> Po utworzeniu kontaktu z wybranej grupy kontakt zostanie automatycznie dodany do grupy.
+>
+> Gdy tworzysz kontakt z poziomu wybranej grupy, kontakt zostanie automatycznie dodany do grupy.
 
 Kliknij przycisk `+`{.action} w dolnej części kolumny `Kontakty`, aby utworzyć kontakt.
 
 ![hosting](images/roundcube11.png){.thumbnail}
 
-Następnie uzupełnij dane kontaktu.
+Następnie wypełnij dane kontaktu.
 
 > [!primary]
-> Możesz dodawać pola poprzez rozwijane menu `Dodaj pole...`{.action}, znajduje się pod polami `Imię` i `adres`.
+> Możesz dodać dodatkowe pola za pomocą rozwijanego menu `Dodaj pole...`{.action}, znajdującego się pod polami `Imię` i `Adres`.
 
-#### Importuj kontakty <a name="import-contacts"></a>
+#### Importowanie kontaktów <a name="import-contacts"></a>
 
-W oknie `Kontakty`{.action} na górnym pasku kliknij `importuj`{.action}, aby otworzyć okno importu.
+W oknie `Kontakty`{.action} na górnym pasku kliknij `Importuj`{.action}, aby otworzyć okno importu.
 
-- `Import z pliku`: wybierz plik CSV lub plik vCard na Twoim komputerze. Kontakty w pliku CSV muszą być oddzielone przecinkami. Plik nie może mieć więcej niż 20 MB.
-- `Importuj powiązania z grupami`: Jeśli kontakty w Twoim pliku są podzielone na grupy, możesz włączyć tę opcję, aby odnaleźć tę organizację lub pozostawić tę opcję na `żadnej` grupie, aby nie przydzielać do kontaktów.
-- `Zastąp całą książkę adresową`: Jeśli książka jest już skonfigurowana, zalecamy wyeksportowanie jej przed zaznaczeniem tej opcji lub upewnić się, że chcesz ją wymienić.
+- `Importuj z pliku`: wybierz plik CSV lub vCard z Twojego komputera. Kontakty w pliku CSV muszą być oddzielone przecinkami. Plik nie może być większy niż 20 MB.
+- `Importuj przypisania do grup`: jeśli kontakty w Twoim pliku są posortowane według grup, możesz włączyć tę opcję, aby zachować tę organizację, lub pozostawić tę opcję ustawioną na `brak`, aby do kontaktów nie była przypisywana żadna grupa.
+- `Zastąp całą książkę adresową`: jeśli książka adresowa jest już skonfigurowana, zalecamy wyeksportowanie jej przed zaznaczeniem tej opcji lub upewnienie się, że chcesz ją trwale zastąpić.
 
 ![hosting](images/roundcube-import-contact.png){.thumbnail}
 
-#### Eksportuj Kontakty Roundcube <a name="export-contacts"></a>
+#### Eksportowanie kontaktów <a name="export-contacts"></a>
 
-W oknie `Kontakty`{.action} na górnym pasku kliknij ikonkę skierowaną w dół po prawej stronie przycisku `Eksportuj`{.action}.
+W oknie `Kontakty`{.action} na górnym pasku kliknij strzałkę w dół po prawej stronie przycisku `Eksportuj`{.action}.
 
-Możesz wybrać:
+Masz do wyboru:
 
-- `Eksportuj wszystkie`{.action} całości i wszystkich kontaktów będzie wywożone do pliku **.vcf**.
-- `Eksportuj zaznaczone`{.action}, aby wyeksportować tylko te elementy, które wybiorą Cię w kolumnie `Kontakty`{.action}.
+- `Eksportuj wszystko`{.action}: wszystkie kontakty zostaną wyeksportowane do pliku **.vcf**.
+- `Eksportuj zaznaczone`{.action}: wyeksportuj tylko elementy, które zaznaczyłeś w kolumnie `Kontakty`{.action}.
 
 ![hosting](images/roundcube-export-contact.png){.thumbnail}
 
 ### Odpowiedzi (szablony) <a name="responses"></a>
 
-Funkcja ta pozwala na tworzenie szablonów odpowiedzi podczas tworzenia wiadomości e-mail.
+Funkcja ta pozwala tworzyć szablony odpowiedzi podczas pisania e-maila.
 
-W Roundcube kliknij `Ustawienia`{.action} na górnym pasku, a następnie `Odpowiedzi`{.action} w kolumnie po lewej stronie.
+W Roundcube kliknij `Ustawienia`{.action} na górnym pasku, a następnie `Odpowiedzi`{.action} w lewej kolumnie.
 
 Aby dodać odpowiedź, kliknij przycisk `+`{.action} w dolnej części kolumny `Odpowiedzi`.
 
 ![hosting](images/roundcube12.png){.thumbnail}
 
 > [!primary]
-> 
-> "Odpowiedzi" mają formę "tekstu niekodowanego".
+>
+> "Odpowiedzi" są zapisywane w formacie "tekstu niesformatowanego".
 
-### Dodaj autoresponder lub automatyczną odpowiedź <a name="automatic-respond"></a>
+### Dodanie autorespondera <a name="automatic-respond"></a>
 
-Chcesz dodać automatyczną odpowiedź do Twojego konta e-mail, gdy jesteś nieobecny lub niedostępny. Funkcja ta nie może zostać aktywowana w interfejsie webmail, ale w [Panelu klienta OVHcloud](/links/manager) w interfejsie zarządzania Twoimi adresami e-mail. Zapoznaj się z przewodnikiem "[Tworzenie autorespondera dla konta e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
+Chcesz dodać automatyczną odpowiedź do Twojego adresu e-mail, gdy jesteś nieobecny lub niedostępny. Funkcji tej nie można włączyć z poziomu interfejsu webmail, lecz z [Panelu klienta OVHcloud](/links/manager), w interfejsie zarządzania Twoimi adresami e-mail. Sprawdź nasz przewodnik "[Tworzenie autorespondera dla Twojego adresu e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
 
-### Zmiana hasła do Twojego konta e-mail <a name="password"></a>
+### Zmiana hasła do konta e-mail <a name="password"></a>
 
-Aby zmienić hasło do Twojego konta e-mail, zaloguj się do [Panelu klienta OVHcloud](/links/manager), w interfejsie zarządzania Twoimi adresami e-mail. Zapoznaj się z naszym przewodnikiem "[Zmiana hasła do konta e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
+Aby zmienić hasło do konta e-mail, zaloguj się do [Panelu klienta OVHcloud](/links/manager), w interfejsie zarządzania Twoimi adresami e-mail. Sprawdź nasz przewodnik "[Zmiana hasła adresu e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
 
-### Redakcja e-maila <a name="email-writing"></a>
+### Pisanie e-maila <a name="email-writing"></a>
 
-W zakładce `Poczta`{.action} na górnym pasku kliknij `Zapisz`{.action}.
+W zakładce `Poczta`{.action} na górnym pasku kliknij `Utwórz`{.action}.
 
-W oknie wiadomości e-mail znajdują się następujące pola: 
+W oknie tworzenia e-maila znajdziesz następujące pola:
 
-- **Od**: wybrać [tożsamość](#identity) do określenia nadawcy.
-- **Do+**: dodać odbiorców i/lub [grupę odbiorców](#group).
+- **Od**: wybierz [tożsamość](#identity), aby ustawić nadawcę.
+- **Do**: dodaj odbiorców i/lub [grupę odbiorców](#group). Przycisk `+`{.action} po prawej stronie pola pozwala wpisać kilka adresów.
 
 > [!primary]
-> 
-> Pole **"Do"** nie może przekraczać 100 odbiorców, obejmuje to kontakty zawarte w [grupie](#group).
+>
+> Pole **"Do"** nie może zawierać więcej niż 100 odbiorców, w tym kontaktów z [grupy](#group).
 
-- **Dodaj Cc+**: dodawanie odbiorców w prostej kopii.
-- **Dodaj Bcc +**: dodawanie odbiorców w ukrytej kopii. Pozostali odbiorcy wiadomości e-mail nie zobaczą adresów w tym e-mailu.
-- **Dodaj Followup-To**: wysyłać wiadomości do odbiorców.
-- **Typ edytora**:  
-    - `Tekst niekodowany`: tylko tekst bez formatu.
-    - `HTML`: tekst w formie. Pasek narzędzi HTML pojawia się nad oknem wprowadzania danych.
-- **Priorytet** dla e-maila.
-- **Potwierdzenie odbioru**: adresat jest proszony o potwierdzenie odbioru.
-- **Status dostarczenia (DSN)**, jeżeli e-mail został wysłany do odbiorcy.
-- **Zapisz wiadomość w**: wybrać katalog, w którym będzie przechowywana kopia e-maila.
+- **Cc**: za pomocą przycisku `Dodaj Cc`{.action} dodaj odbiorców w kopii zwykłej.
+- **Bcc**: za pomocą przycisku `Dodaj Bcc`{.action} dodaj odbiorców w kopii ukrytej. Pozostali odbiorcy e-maila nie zobaczą tych wymienionych w Bcc.
+- **Followup-To**: za pomocą przycisku `Dodaj Followup-To`{.action} przekaż e-mail do odbiorców.
+- **Typ edytora**:
+    - `Tekst niesformatowany`: tylko tekst, bez formatowania.
+    - `HTML`: tekst z formatowaniem. Pasek narzędzi HTML pojawia się nad oknem wprowadzania.
+- **Priorytet** e-maila.
+- **Potwierdzenie odbioru**: od odbiorcy żądane jest potwierdzenie odbioru.
+- **Powiadomienie o statusie dostarczenia**, gdy e-mail został pomyślnie dostarczony do odbiorcy.
+- **Zapisz wysłaną wiadomość w**: wybierz folder, w którym zostanie zapisana kopia e-maila.
 
 Na górnym pasku dostępne są następujące operacje:
 
-- `Anuluj`{.action} pisanie wiadomości e-mail, korzystając z prośby o potwierdzenie.
+- `Anuluj`{.action} pisanie e-maila, z prośbą o potwierdzenie.
 - `Wyślij`{.action} e-mail.
-- `Zapisz`{.action} e-mail w specjalnym folderze "szkic"
-- `Pisownia`{.action}, aby sprawdzić tekst, z menu umożliwiającego wybór języka.
-- `Załącz`{.action} plik do wiadomości e-mail.
-- `Podpis`{.action}: dodaje podpis przypisany [do wybranej tożsamości](#identity).
-- `Odpowiedzi`{.action}: dodaje wstępnie zarejestrowany szablon w części [Odpowiedzi](#responses).
+- `Zapisz`{.action} e-mail w folderze specjalnym "Wersje robocze".
+- `Pisownia`{.action} sprawdź tekst, z menu umożliwiającym wybór języka.
+- `Załącz`{.action} plik do e-maila.
+- `Podpis`{.action}: dodaje podpis przypisany do wybranej [tożsamości](#identity).
+- `Odpowiedzi`{.action}: dodaje wcześniej zapisany szablon z sekcji [Odpowiedzi](#responses).
 
 ![hosting](images/roundcube13.png){.thumbnail}
 
-### Przykłady zastosowania <a name="usecase"></a>
+### Przykład zastosowania <a name="usecase"></a>
 
 #### Weryfikacja żądania nie powiodła się
 
-Przy próbie dostępu do interfejsu Webmail Roundcube pojawi się następujący komunikat:
+Podczas próby uzyskania dostępu do interfejsu webmail Roundcube otrzymujesz następujący komunikat:
 
 ```console
-NIEPOWODZENIE WERYFIKACJI ŻĄDANIA
-Aby zapewnić ochronę, dostęp do tego zasobu jest chroniony przed atakami CSRF.
-Jeśli to widzisz, prawdopodobnie nie wylogowałeś się przed zamknięciem aplikacji sieci Web.
-Aby kontynuować, konieczna jest interakcja z człowiekiem.
+WERYFIKACJA ŻĄDANIA NIEUDANA
+Dla Twojego bezpieczeństwa dostęp do tego zasobu jest chroniony przed atakami CSRF.
+Jeśli widzisz tę wiadomość, prawdopodobnie nie wylogowałeś się przed opuszczeniem aplikacji internetowej.
+Aby kontynuować, wymagana jest teraz interakcja użytkownika.
 Skontaktuj się z administratorem serwera.
 ```
 
-Jak wskazano w wiadomości, Twoje konto e-mail jest uważane za już zalogowane. Mówimy tu o "sesji". Oznacza to, że Twoje konto e-mail jest już używane dla serwera e-mail i należy zamknąć poprzednią sesję. Upewnij się, że Twoje konto e-mail nie jest jeszcze otwarte w interfejsie Roundcube. Pamięć podręczną należy również czyścić w przeglądarce internetowej.
+Jak wskazuje komunikat, Twoje konto e-mail jest uważane za już zalogowane. Mówi się o "sesji". Oznacza to, że dla serwera poczty Twoje konto e-mail jest już używane i poprzednia sesja musi zostać zamknięta. Sprawdź, czy Twoje konto e-mail nie jest już otwarte w Roundcube. Wyczyść również dane z pamięci podręcznej Twojej przeglądarki.
 
 ## Sprawdź również
 
-[Pierwsze kroki z usługą MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)
+[Pierwsze kroki z rozwiązaniem MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)
 
-[Zmiana hasła do konta e-mail MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
+[Zmiana hasła do adresu e-mail MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
 
-[Tworzenie autorespondera dla konta e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
+[Tworzenie autorespondera dla Twojego adresu e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
 
-[Tworzenie filtrów dla Twoich kont e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_filters)
+[Tworzenie filtrów dla Twoich adresów e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_filters)
 
 [Korzystanie z przekierowań e-mail](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube/guide.pt-pt.md
@@ -1,42 +1,41 @@
 ---
-title: 'Webmail: Guia de utilização do Roundcube'
-updated: 2025-11-12
+title: 'Utilizar o seu endereço de e-mail a partir do webmail Roundcube'
+updated: 2026-05-04
 ---
 
 ## Objetivo
 
-Com a oferta MX Plan OVHcloud, pode enviar e-mails a partir de um software de terceiros ou através de um webmail. A OVHcloud oferece um serviço de e-mail online chamado Roundcube que permite o acesso a uma conta de e-mail através de um browser web.
+Com a oferta MX Plan da OVHcloud, pode enviar e receber e-mails a partir de um software de terceiros ou através de um webmail. A OVHcloud disponibiliza um serviço de mensagens online denominado Roundcube que permite, através de um browser web, aceder a uma conta de e-mail.
 
 **Saiba como utilizar o webmail Roundcube para os seus endereços de e-mail OVHcloud**
 
 ## Requisitos
 
-- Dispor de uma solução de e-mail OVHcloud **MX Plan**, proposta entre as nossas [ofertas de alojamento web](/links/web/hosting), incluída num [Alojamento gratuito 100M](/links/web/domains-free-hosting), ou encomendada separadamente como solução autónoma.
-- Ter acesso às informações de acesso ao endereço de e-mail MX Plan que pretende consultar. Para mais informações, consulte o nosso guia [Primeiros passos com a oferta MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+- Dispor de uma solução de e-mail OVHcloud **MX Plan**, proposta entre as nossas [ofertas de alojamento web](/links/web/hosting), incluída num [alojamento gratuito 100M](/links/web/domains-free-hosting), ou encomendada separadamente como solução autónoma.
+- Dispor das informações de ligação ao endereço de e-mail MX Plan que pretende consultar. Para mais informações, consulte o nosso guia [Primeiros passos com a oferta MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 - A sua solução de e-mail OVHcloud **MX Plan** deve utilizar a tecnologia de webmail **Roundcube**. Para a identificar, siga as instruções abaixo.
 
 > [!primary]
 > 
 > **Como identificar a tecnologia utilizada na minha oferta MX Plan?**
 >
-> A tecnologia de e-mail utilizada para a oferta MX Plan é caracterizada pela interface do seu webmail. Para o identificar a partir da Área de Cliente, siga o seguinte caminho:
+> A tecnologia de e-mail utilizada para a sua oferta MX Plan é caracterizada pela interface do seu webmail. Para a identificar a partir da sua área de cliente, siga o caminho abaixo:
 >
-> 1. Aceda à [Área de Cliente OVHcloud](/links/manager).
+> 1. Aceda à sua [área de cliente OVHcloud](/links/manager).
 > 1. Aceda à secção `Web Cloud`{.action}.
 > 1. Clique em `MX Plan`{.action}.
 > 1. Selecione o domínio em questão.
-> 1. No separador `Informações gerais`{.action}, selecione por predefinição.
-> 1. Registe a tecnologia utilizada como **Webmail**.
+> 1. No separador `Informações gerais`{.action} (selecionado por predefinição), verifique a tecnologia utilizada na menção **Webmail**.
 >
 > ![MX plan](images/technology-email.png){.thumbnail .w-500}
 
 <!-- CP-NAV-START:web-mx-plan -->
 ---
 
-### Acesso à Área de Cliente OVHcloud
+### Acesso à área de cliente OVHcloud
 
 - **Ligação direta:** [MX Plan](/links/control-panel/web-mx-plan)
-- **Caminho de navegação:** `Web Cloud`{.action} > `MX Plan`{.action} > Selecione o seu serviço MX Plan
+- **Para aceder aos seus serviços:** `Web Cloud`{.action} > `MX Plan`{.action} > Selecione o seu serviço MX Plan
 
 ---
 <!-- CP-NAV-END:web-mx-plan -->
@@ -48,38 +47,37 @@ Com a oferta MX Plan OVHcloud, pode enviar e-mails a partir de um software de te
 - [Aceder ao webmail Roundcube](#roundcube-connexion)
 - [Interface geral do webmail Roundcube](#general-interface)
     - [Gestão das pastas (coluna da esquerda)](#leftcolumn)
-    - [Lista de e-mails recebidos/enviados (parte superior)](#topwindow)
+    - [Lista de e-mails recebidos / enviados (janela superior)](#topwindow)
         - [Tipo de visualização](#topwindow-display)
         - [Ação sobre um e-mail selecionado](#topwindow-action)
         - [Procurar um e-mail](#topwindow-search)
-    - [Conteúdo de mensagem de correio eletrónico (janela inferior)](#lowerwindow)
+    - [Conteúdo de um e-mail (janela inferior)](#lowerwindow)
 - [Configurar as preferências da interface Roundcube](#roundcube-settings)
-    - [Interface de Utilizador](#user-interface-settings)
+    - [Interface do utilizador](#user-interface-settings)
     - [Vista da caixa de correio](#mail-view-settings)
-    - [Ver mensagens de correio eletrónico](#mail-display-settings)
-    - [Correio eletrónico](#mail-writing-settings)
+    - [Apresentação dos e-mails](#mail-display-settings)
+    - [Redação de e-mails](#mail-writing-settings)
     - [Contactos](#contacts-settings)
-    - [Pastas especiais (predefinidas)](#special-folder-settings)
+    - [Pastas especiais](#special-folder-settings)
     - [Definições do servidor](#server-settings)
     - [Encriptação](#encryption)
-- [Gerir identidades e respetivas assinaturas](#identity-signature)
-    - [Identity](#identity)
+- [Gerir as identidades e as suas assinaturas](#identity-signature)
+    - [Identidade](#identity)
     - [Assinatura](#signature)
 - [Livro de contactos](#contact-book)
     - [Grupos](#group)
     - [Contactos](#contacts)
-    - [Importar Contactos](#import-contacts)
-    - [Exportar os Contactos Roundcube](#export-contacts)
-- [Respostas (templates)](#responses)
-- [Adicionar uma resposta automática ou resposta automática](#automatic-respond)
+    - [Importar contactos](#import-contacts)
+    - [Exportar os contactos](#export-contacts)
+- [Respostas (modelos)](#responses)
+- [Adicionar um respondedor ou resposta automática](#automatic-respond)
 - [Alterar a palavra-passe do seu endereço de e-mail](#password)
-- [Escrevendo um e-mail](#email-writing)
+- [Redação de um e-mail](#email-writing)
 - [Casos práticos](#usecase)
-
 
 ### Aceder ao webmail Roundcube <a name="roundcube-connexion"></a>
 
-Aceda à página [Webmail](/links/web/email). Introduza um endereço de e-mail e a password, e depois clique em `Ligação`{.action}. 
+Aceda à página [Webmail](/links/web/email). Introduza um endereço de e-mail e a palavra-passe e, em seguida, clique em `Ligação`{.action}. 
 
 ![alojamento](images/webmail_login.png){.thumbnail}
 
@@ -89,8 +87,8 @@ Será então redirecionado para a interface Roundcube.
 
 > [!primary]
 > 
-> Ao fazer login pela primeira vez na interface Roundcube, o aspeto pode ser diferente daquele que você verá neste manual. Isto significa que a aparência "clássica" foi definida na sua interface. Para alterar esta informação, vá à secção "[Interface do Utilizador](#user-interface-settings)" e selecione a visualização "Larry".
-> O aspeto da interface não irá afetar as seguintes explicações neste manual.
+> Quando se ligar pela primeira vez à interface Roundcube, o aspeto pode ser diferente daquele que verá nesta documentação. Isto significa que o aspeto "clássico" foi definido na sua interface. Para o alterar, siga a secção "[Interface do utilizador](#user-interface-settings)" e selecione o aspeto "Larry".
+> O aspeto da interface não terá impacto nas explicações que se seguem nesta documentação.
 
 > [!warning]
 > 
@@ -100,9 +98,9 @@ Será então redirecionado para a interface Roundcube.
 
 ### Interface geral do webmail Roundcube <a name="general-interface"></a>
 
-Depois de aceder à sua conta de e-mail, terá acesso à janela principal de Roundcube, que é composta por 3 zonas:
+Depois de se ligar à sua conta de e-mail, tem acesso à janela principal do Roundcube, que é composta por 3 zonas:
 
-- [**Coluna da esquerda**](#leftcolumn): a arborescência da sua conta de e-mail, composta por pastas e sub-pastas. A pasta principal é a `caixa de entrada`.
+- [**Coluna da esquerda**](#leftcolumn): a árvore da sua conta de e-mail, composta por pastas e subpastas. A pasta principal é a `Caixa de entrada`.
 
 - [**Janela superior**](#topwindow): a lista dos e-mails contidos na pasta selecionada na coluna da esquerda.
 
@@ -112,53 +110,65 @@ Depois de aceder à sua conta de e-mail, terá acesso à janela principal de Rou
 
 Nesta zona, aparecem as pastas presentes na sua conta de e-mail.
 
-Para gerir com mais precisão as pastas, clique na roda dentada na parte inferior da coluna e, a seguir, em `Gerir pastas.`{.action}
+Para gerir as pastas com mais precisão, clique na roda dentada na parte inferior da coluna e, em seguida, em `Gerir pastas`{.action}.
 
 ![alojamento](images/roundcube02.png){.thumbnail}
 
 Para criar uma pasta, clique no botão `+`{.action} no fundo da coluna `Pastas`.
 
-Para eliminar uma pasta, selecione a pasta em causa, clique na roda dentada no fundo da coluna `Pastas` e, a seguir, em `Eliminar`{.action}. Para apagar o conteúdo mas guardar a pasta, clique em `Esvaziar`{.action}.
+Para eliminar uma pasta, selecione a pasta em questão, clique na roda dentada no fundo da coluna `Pastas` e, em seguida, em `Eliminar`{.action}. Para apagar o conteúdo, mas manter a pasta, clique em `Esvaziar`{.action}.
 
-As casas a assinalar ao nível dos dossiers correspondem às "assinaturas". A subscrição determina se a pasta deve ou não ser apresentada na interface webmail ou no software de correio, conservando o conteúdo da pasta. O objetivo é apenas ocultar ou apresentar uma pasta na conta de e-mail.
+As caixas a assinalar ao nível das pastas correspondem às "subscrições". A subscrição determina se a pasta deve ser apresentada, ou não, na interface webmail ou no software de mensagens, mantendo o conteúdo da pasta. O objetivo é apenas ocultar ou mostrar uma pasta na conta de e-mail.
 
 > [!primary]
 >
-> As pastas com uma opção cinzenta são pastas especiais. Não é possível eliminá-los ou retirá-los.
+> As pastas que apresentam uma caixa a assinalar cinzenta são pastas especiais. Não é possível eliminá-las ou retirar a sua subscrição.
 
-#### Lista dos e-mails recebidos/enviados (janela superior) <a name="topwindow"></a>
+#### Lista de e-mails recebidos / enviados (janela superior) <a name="topwindow"></a>
 
 Esta janela apresenta o conteúdo da pasta selecionada na coluna da esquerda. 
 
 ##### Tipo de visualização <a name="topwindow-display"></a>
 
-Esta janela é apresentada de forma personalizada. Para isso, clique na roda dentada situada no canto superior esquerdo desta janela.
+Esta janela é apresentada de uma forma que pode ser personalizada. Para tal, clique na roda dentada situada no canto superior esquerdo desta janela.
 
 ![alojamento](images/roundcube03.png){.thumbnail}
 
-É possível configurar os seguintes elementos:
+É possível configurar quatro parâmetros:
 
-- **Disposição**: permite determinar a disposição das janelas de gestão de uma conta de e-mail.
-- **Colunas da lista**: permite adicionar colunas a apresentar (prioridades dos e-mails, etc.).
-- **Coluna de triagem**: permite escolher a coluna na qual a triagem predefinida será efetuada.
-- **Ordem de triagem**: permite escolher a ordem de triagem ascendente ou descendente, em função da coluna de triagem.
+- **Disposição**: define a organização das janelas de gestão de uma conta de e-mail. Três opções:
+    - `Ecrã grande`{.action} (*Widescreen*): três painéis lado a lado — pastas, lista de e-mails e painel de leitura alinhados horizontalmente;
+    - `Secretária`{.action} (*Desktop*): lista de e-mails na parte superior, painel de leitura por baixo (disposição clássica);
+    - `Lista`{.action} (*List*): sem painel de leitura — os e-mails abrem-se em janela inteira ao clicar.
+
+- **Colunas da lista**: caixas a assinalar que determinam as colunas apresentadas na lista de e-mails. As colunas **Assunto** e **Tópico de discussão** estão sempre visíveis. Colunas opcionais disponíveis: `De`{.action}, `Para`{.action}, `De/Para`{.action}, `Responder a`{.action}, `Cópia`{.action}, `Data`{.action}, `Tamanho`{.action}, `Estado de leitura`{.action}, `Anexos`{.action}, `Indicador`{.action}, `Prioridade`{.action}.
+
+- **Coluna de ordenação**: permite escolher a coluna de ordenação por predefinição. Opções disponíveis: `Nenhum`{.action}, `Data de receção`{.action}, `Data de envio`{.action}, `Assunto`{.action}, `De`{.action}, `Para`{.action}, `De/Para`{.action}, `Cópia`{.action} ou `Tamanho`{.action}.
+
+- **Ordem de ordenação**: ascendente ou descendente.
+
+Clique em `Guardar`{.action} para aplicar as suas opções.
+
+> [!primary]
+>
+> Pode também **ordenar dinamicamente a lista** clicando diretamente no cabeçalho de uma coluna apresentada (por exemplo **Data**, **Assunto** ou **Tamanho**). Um segundo clique na mesma coluna inverte a ordem.
 
 ##### Ação sobre um e-mail selecionado <a name="topwindow-action"></a>
 
-Quando um e-mail é selecionado, pode alterar o sistema. Veja as ações possíveis:
+Quando um e-mail é selecionado, é possível agir sobre o mesmo. Estas são as ações possíveis:
 
-- `Responder`{.action}: responder diretamente ao expedidor.
+- `Responder`{.action}: responder diretamente ao remetente.
 - `Responder a todos`{.action}: responder diretamente a todos os destinatários presentes nos campos "A" e "Cópia".
-- `Reencaminhar`{.action}: transferir o e-mail selecionado para um ou vários destinatários.
-- `Eliminar`{.action}: colocar o e-mail selecionado no "Corbeille".
-- `Spam`{.action}: colocar o e-mail selecionado diretamente na caixa de correio indesejável (Junk), qualificá-lo como **spam**.
-- `Marcar`{.action}: determinar manualmente o estado de um e-mail.
+- `Reencaminhar`{.action}: reencaminhar o e-mail selecionado a um ou vários destinatários.
+- `Eliminar`{.action}: colocar o e-mail selecionado na "Reciclagem".
+- `Indesejados`{.action}: colocar o e-mail selecionado diretamente na caixa de correio indesejado (Junk), classificá-lo como **spam**.
+- `Marcar`{.action}: definir manualmente o estado de um e-mail.
 - `Mais`{.action} 
-    - `Imprimir`{.action}.
-    - `Guardar como (.eml)`{.action}: recuperar o cabeçalho do e-mail e o seu conteúdo.
+    - `Imprimir este e-mail`{.action}.
+    - `Transferir (.eml)`{.action}: recuperar o cabeçalho do e-mail e o seu conteúdo.
     - `Editar como novo`{.action}: criar um novo e-mail com base no e-mail selecionado.
-    - `Mostrar código fonte`{.action}: mostrar o e-mail na sua forma bruta com o cabeçalho.
-    - `Migrar para`{.action}: mover o e-mail para uma pasta.
+    - `Mostrar a fonte`{.action}: apresentar o e-mail na sua forma bruta com o cabeçalho.
+    - `Mover para`{.action}: mover o e-mail para uma pasta.
     - `Copiar para`{.action}: copiar o e-mail para uma pasta.
     - `Abrir numa nova janela`{.action}.
 
@@ -166,268 +176,270 @@ Quando um e-mail é selecionado, pode alterar o sistema. Veja as ações possív
 
 > [!primary]
 >
-> Se um dos seus correspondentes solicitar que lhe seja enviado um aviso de leitura ao ler o seu e-mail, receberá a seguinte mensagem: `o remetente desta mensagem pediu para ser avisado quando ler esta mensagem. Deseja avisar o remetente?`.
-> 
+> Se um dos seus correspondentes solicitar que lhe seja enviado um aviso de leitura quando ler o seu e-mail, obterá a seguinte mensagem: `o remetente desta mensagem solicitou ser avisado quando ler esta mensagem. Pretende avisar o remetente?`.
+>
 
 ##### Procurar um e-mail <a name="topwindow-search"></a>
 
-Uma ferramenta de pesquisa está disponível na parte superior direita da interface.
+Está disponível uma ferramenta de pesquisa na parte superior direita da interface.
 
-Clique na seta situada à direita da lupa para apresentar os filtros de pesquisa.
+Introduza um termo no campo de pesquisa e, em seguida, valide com a tecla `Enter`{.action}: por predefinição, o Roundcube efetua a pesquisa em toda a pasta atual.
+
+Clique na seta situada à direita da lupa para apresentar os filtros de pesquisa: pode restringir a pesquisa a determinados campos (assunto, corpo da mensagem, remetente, destinatários, etc.) ou alargar o seu âmbito a todas as pastas.
 
 #### Conteúdo de um e-mail (janela inferior) <a name="lowerwindow"></a>
 
-Quando um e-mail é selecionado na lista, aparece na janela inferior.
+Quando um e-mail é selecionado na lista, este é apresentado na janela inferior.
 
-Encontre os atalhos, à direita, das seguintes funções:
+À direita, encontram-se os atalhos das funções abaixo:
 
-- Apresentar em formato HTML (predefinido)
-- Apresentar em formato texto claro
-- Responder
-- Responder a todos
-- Reencaminhar
-- Abrir numa nova janela 
+- `Apresentar em formato HTML`{.action} (predefinição)
+- `Apresentar em formato de texto simples`{.action}
+- `Responder`{.action}
+- `Responder a todos`{.action}
+- `Reencaminhar`{.action}
+- `Apresentar numa nova janela`{.action}
 
 ![alojamento](images/roundcube05.png){.thumbnail}
 
 ### Configurar as preferências da interface Roundcube <a name="roundcube-settings"></a>
 
-Os capítulos seguintes deste guia correspondem aos separadores que compõem a parte `Preferências`{.action} dos `Definições`{.action} de Roundcube. A sua descrição não é exaustiva.
+Os capítulos seguintes deste guia correspondem aos separadores que compõem a parte `Preferências`{.action} das `Definições`{.action} do Roundcube. A sua descrição não é exaustiva.
 
 ![alojamento](images/roundcube06.png){.thumbnail}
 
 #### Interface do utilizador <a name="user-interface-settings"></a>
 
-Defina aqui a `Idioma` de utilização da interface Roundcube, o `fuso horário`, o `formato da hora` e o `formato de data`.
+Defina aqui o `idioma` de utilização da interface Roundcube, o `fuso horário`, o `formato horário` e o `formato de data`.
 
-A opção `Formatar datas` permite apresentar a data de receção/envio com termos relativos como "Hoje", "Ontem", etc.<br>
-**Por exemplo**: somos a **19/05/2022**, um e-mail enviado/recebido a **17/05/2022** às **17:38** será apresentado **Ter 17:38**, pois o email corresponde à terça-feira anterior.
+A opção `Datas amigáveis` permite apresentar a data de receção/envio com termos relativos como "Hoje", "Ontem", etc.<br>
+**Por exemplo**: estamos a **19/05/2022**, um e-mail enviado/recebido a **17/05/2022** às **17:38** será apresentado **Ter 17:38**, pois o e-mail corresponde à terça-feira anterior.
 
-A casa `Mostrar próxima entrada da lista após eliminar/mover` significa que, após uma ação de supressão ou migração para um e-mail, o elemento da linha inferior será sistematicamente selecionado, seja qual for a ordem de escolha. 
+A caixa `Mostrar a próxima entrada da lista após eliminar ou mover` significa que, após uma ação de eliminação ou de deslocação de um e-mail, o elemento da linha inferior será sistematicamente selecionado, qualquer que seja a ordem de ordenação.
 
-Pode escolher a estética de afixação da sua interface. Pode escolher entre exibir **Classic** ou **Larry**.
+Pode escolher a estética de apresentação da sua interface. Pode optar entre o aspeto **Classic** ou o aspeto **Larry**.
 
-#### Visualização da Caixa de Entrada <a name="mail-view-settings"></a>
+#### Vista da caixa de correio <a name="mail-view-settings"></a>
 
-Defina aqui a ergonomia para visualizar e agir sobre os e-mails. A opção `Modelo` permite organizar as 3 janelas descritas na parte [Interface geral do webmail Roundcube](#topwindow).
+Defina aqui a ergonomia para visualizar e agir sobre os e-mails. A opção `Disposição` permite organizar as 3 janelas descritas na parte [Lista de e-mails recebidos / enviados](#topwindow).
 
-#### Visualização de mensagens <a name="mail-display-settings"></a>
+#### Apresentação dos e-mails <a name="mail-display-settings"></a>
 
 Defina a forma como os e-mails são apresentados.<br>
-Para assegurar que os e-mails formatados pelo remetente se apresentam corretamente, é aconselhável ter a opção `Mostrar mensagens em HTML` selecionado.<br>
-Também é aconselhável manter a opção `Permitir recursos remotos (imagens, estilos)` para `nunca`. Isto evita carregar os elementos de um e-mail que parece malicioso.
+É aconselhável manter a caixa `Apresentar em HTML` selecionada, para garantir que os e-mails formatados pelo remetente sejam apresentados corretamente.<br>
+Também é aconselhável manter a opção `Permitir recursos remotos (imagens, estilos)` em `nunca`. De facto, isto evita o carregamento dos elementos de um e-mail que pareça malicioso.
 
-#### Composição de mensagens <a name="mail-writing-settings"></a>
+#### Redação de e-mails <a name="mail-writing-settings"></a>
 
-Defina a forma padrão aquando da redação de um e-mail ou de uma resposta.<br>
-É aconselhável passar a opção `Escrever mensagens em HTML` sempre de forma `sempre`, para beneficiar por defeito das ferramentas de edição HTML e não alterar uma assinatura HTML.
+Defina o formato por predefinição quando da redação de um e-mail ou de uma resposta.<br>
+É aconselhável passar a opção `Redigir e-mails em HTML` para `sempre`, para beneficiar por predefinição das ferramentas de edição HTML e não alterar uma assinatura HTML.
 
 #### Contactos <a name="contacts-settings"></a>
 
-Personalize aqui a disposição das informações no seu diretório de endereços.
+Personalize aqui a organização das informações no seu livro de endereços.
 
-#### Pastas especiais (predefinidas) <a name="special-folder-settings"></a>
+#### Pastas especiais <a name="special-folder-settings"></a>
 
-Roundcube dispõe de 4 dossiers especiais: `Rascunhos`, `Itens Enviados`, `Spam`, `Reciclagem`.
+O Roundcube dispõe de 4 pastas especiais: `Rascunhos`, `Enviados`, `Indesejados`, `Reciclagem`.
 
-Não aconselhamos a sua alteração, mas é possível atribuir o comportamento de uma pasta especial a outra criada posteriormente, graças aos menus confusos.<br>
+Não aconselhamos a sua alteração, mas é possível atribuir o comportamento de uma pasta especial a outra pasta criada posteriormente, através dos menus pendentes.<br>
 
-**Por exemplo**, você pode atribuir o comportamento « Rascunhos » a outra pasta que você criou clicando na lista suspensa e selecionando essa pasta. Se nenhuma pasta for atribuída a ele, ele será automaticamente colocado na opção « Drafts ». Os e-mails que forem registados serão considerados como rascunhos até que sejam enviados.
+**Por exemplo**, pode atribuir o comportamento "Rascunhos" a outra pasta que tenha criado, clicando na lista pendente e selecionando essa pasta. Se nenhuma pasta lhe for atribuída, será automaticamente colocada na opção "Drafts". Os e-mails que aí forem guardados serão considerados rascunhos até ao seu envio efetivo.
 
-> Na prática, eu crio uma sub-pasta « Rascunhos de e-mails de clientes ». Vou a `As minhas preferências`{.action} / `Pastas especiais`{.action} e escolho a opção "Rascunhos". No menu suspenso, seleciono a pasta "Rascunhos de e-mails de clientes" para substituir "Drafts". Os e-mails redigidos nesta pasta serão considerados rascunhos.
+> Na prática, crio uma subpasta "Rascunhos de e-mails de clientes". Acedo a `As minhas preferências`{.action} / `Pastas especiais`{.action} e escolho a opção "Rascunhos". No menu pendente, seleciono a pasta "Rascunhos de e-mails de clientes" para substituir "Drafts". Os e-mails redigidos nesta pasta serão considerados rascunhos.
 
 #### Definições do servidor <a name="server-settings"></a>
 
-Neste separador, pode otimizar o espaço ocupado numa conta de e-mail. Com efeito, a opção `Esvaziar a Reciclagem ao sair` permite evitar a acumulação dos elementos que foram suprimidos. A opção `Eliminar diretamente as mensagens no Spam` eliminará automaticamente todos os e-mails considerados como SPAM.
+Neste separador, pode otimizar o espaço ocupado numa conta de e-mail. De facto, a opção `Esvaziar a reciclagem ao terminar a sessão` permite evitar a acumulação dos elementos que foram eliminados. A opção `Eliminar diretamente os indesejados` eliminará automaticamente todos os e-mails considerados como spam.
 
 > [!warning]
 > 
-> Não é aconselhável ativar a opção `Eliminar diretamente as mensagens no Spam` eletrónico quando um falso positivo (e-mail erradamente declarado como "SPAM") for declarado como spam para o servidor de receção. Com efeito, quando um e-mail é colocado na pasta "Por correio eletrónico", é ainda possível verificar se o e-mail é legítimo.
+> Não é aconselhável ativar a opção `Eliminar diretamente os indesejados`, no caso de um falso positivo (e-mail erradamente declarado como "spam") ser declarado como spam pelo servidor de receção. De facto, quando um e-mail é colocado na pasta "Indesejados", ainda é possível verificar se o e-mail é legítimo.
 
 #### Encriptação <a name="encryption"></a>
 
-Se o seu browser lhe permitir, pode instalar e ativar a extensão "Mailvelope". Trata-se de uma extensão do browser que integra o PGP (**P**retty **G**ood **P**rivacy) no seu serviço de mensagens web. O sistema de encriptação PGP e, por conseguinte, a extensão "Mailvelope" permitem:
+Se o seu browser o permitir, pode instalar e ativar a extensão "Mailvelope". Trata-se de uma extensão de browser que integra o PGP (**P**retty **G**ood **P**rivacy) no seu serviço de mensagens web. O sistema de encriptação PGP e, por conseguinte, a extensão "Mailvelope" permitem:
 
-- Encriptar e desencriptar os e-mails no seu browser.
-- Guardar o conteúdo do seu e-mail privado para o seu fornecedor de e-mail.
+- Encriptar e desencriptar e-mails no seu browser.
+- Manter o conteúdo dos seus e-mails privado face ao seu fornecedor de e-mail.
 
-Só você poderá ler os seus e-mails. Esta extensão é um meio de proteger o seu webmail se receber e-mails de natureza confidencial.
+Assim, só você pode ler os seus e-mails. Esta extensão é uma forma de proteger o seu webmail se receber e-mails de natureza confidencial.
 
-Para mais informações, consulte a FAQ da "Maildeve" em <https://mailvelope.com/faq>.
+Para mais informações, consulte a FAQ do "Mailvelope" no endereço <https://mailvelope.com/faq>.
 
-### Gerir as identidades e a sua assinatura <a name="identity-signature"></a>
+### Gerir as identidades e as suas assinaturas <a name="identity-signature"></a>
 
-A partir do Roundcube, clique em `Definições`{.action} na barra superior e, a seguir, em `Identidades`{.action} na coluna da esquerda. A "identidade" permite personalizar as informações enviadas aos destinatários como, por exemplo, o nome do ecrã ou a assinatura.
+A partir do Roundcube, clique em `Definições`{.action} na barra superior e, em seguida, em `Identidades`{.action} na coluna da esquerda. A "identidade" permite personalizar as informações enviadas aos destinatários como, por exemplo, o nome a apresentar ou a assinatura.
 
 ![alojamento](images/roundcube07.png){.thumbnail}
 
-#### Parametrizar os atributos de uma identidade <a name="identity"></a>
+#### Definir os atributos de uma identidade <a name="identity"></a>
 
-- **Nome completo**: este nome aparecerá na parte "expedidor" do destinatário
+- **Nome a apresentar**: este nome aparecerá na parte "remetente" do destinatário.
 - **E-mail**: corresponde ao endereço a partir do qual é enviado o e-mail.
 - **Organização**: campo destinado ao nome de uma sociedade, associação ou outra entidade.
 - **Responder a**: atribuir um endereço de e-mail de resposta diferente do do remetente.
 - **Bcc**: colocar em cópia oculta um endereço de e-mail aquando de um envio.
-- **Marcar como predefinido**: quando houver várias identidades (assinaturas), atribuí-la-á por predefinição.
-- **Assinatura**: personalizar o pé de página de um e-mail aquando da sua redação (apelido, nome próprio, cargo ocupado, frases, imagens..).
-- **Assinatura HTML**: Ativar o formato HTML na assinatura. 
+- **Definir como predefinição**: quando existem várias identidades (assinaturas), atribui esta por predefinição.
+- **Assinatura**: personalizar o rodapé de um e-mail aquando da sua redação (apelido, nome próprio, cargo ocupado, frases, imagens...).
+- **Assinatura HTML**: ativa o formato HTML na assinatura.
 
 > [!alert]
-> 
-> Preencher a caixa de **E-mail** com um endereço de e-mail diferente daquele em que está ligado é considerado um usurpação de identidade eletrónica (*spoofing*). O endereço IP utilizado para o envio pode ser "banido" e/ou considerado "SPAM" junto dos seus destinatários. 
+>
+> Preencher a caixa **E-mail** com um endereço de e-mail diferente daquele com o qual está ligado é considerado uma usurpação de identidade eletrónica (*spoofing*). O endereço IP utilizado para o envio corre o risco de ser "banido" e/ou considerado como "spam" pelos seus destinatários.
 
 #### Adicionar uma assinatura <a name="signature"></a>
 
-Por predefinição, a casa `assinatura` é em "texto em claro". Este formato não permite uma edição avançada ou a inserção de uma imagem na sua assinatura. Para beneficiar das opções de edição avançada para uma assinatura, aconselhamos que ative o modo HTML ao clicar em **Assinatura HTML** no quadro de introdução.
+Por predefinição, a caixa `assinatura` está em "texto simples". Este formato não permite uma edição avançada nem inserir uma imagem na sua assinatura. Para beneficiar das opções de edição avançada para uma assinatura, é aconselhável ativar o modo HTML clicando em **Assinatura HTML** sob a caixa de introdução.
 
 > [!warning]
-> 
-> Assim, se a assinatura estiver em formato HTML, será necessário passar para HTML para a redação de um e-mail. Pode ativar esta opção por predefinição para cada redação de e-mail, a partir da secção `Definições`{.action} da interface Roundcube.
-> Clique em `Preferências`{.action} na coluna da esquerda e, a seguir, em `Composição de mensagens`{.action}. Para a menção **Redigir e-mails HTML**, selecione `Sempre`.
+>
+> Por conseguinte, se a assinatura estiver em formato HTML, será necessário passar para o modo HTML para a redação de um e-mail. Pode ativar esta opção por predefinição para cada redação de e-mail, a partir da secção `Definições`{.action} da interface Roundcube.
+> Clique em `Preferências`{.action} na coluna da esquerda e, em seguida, em `Redação de e-mails`{.action}. Para a menção **Redigir e-mails em HTML**, selecione `Sempre`.
 >
 
-Para inserir uma imagem numa assinatura, a imagem deve ser alojada num servidor (alojamento OVHcloud ou outro).<br>
-**A transmissão de uma imagem a partir de um computador não permitirá a sua visualização**.
+Para inserir uma imagem numa assinatura, a imagem deve estar alojada num servidor (um alojamento OVHcloud ou outro).<br>
+**Carregar uma imagem a partir de um computador não permitirá a sua apresentação**.
 
-Clique no botão `< >`{.action} na barra de ferramentas HTML e insira o seguinte código, substituindo `your-image-url` pelo endereço (URL) da imagem e `text-if-image-is-not-displayed` por um texto que substitui a imagem se esta não puder ser apresentada.
+Clique no botão `< >`{.action} na barra de ferramentas HTML e, em seguida, insira o seguinte código, substituindo `your-image-url` pelo endereço (URL) da imagem e `text-if-image-is-not-displayed` por um texto que substitua a imagem caso esta não possa ser apresentada.
 
-```bash
+```html
 <img src="your-image-url" border="0" alt="text-if-image-is-not-displayed" />
 ```
 
 ![alojamento](images/roundcube08.png){.thumbnail}
 
-### Diretório de contactos <a name="contact-book"></a>
+### Livro de contactos <a name="contact-book"></a>
 
-Clique em `Contactos`{.action}, na barra superior, para aceder ao diretório de contactos. Esta é dividida em **3 colunas**:
+Clique em `Contactos`{.action}, na barra superior, para aceder ao livro de contactos. Este está dividido em **3 colunas**:
 
-- **Grupos**: no diretório de endereços, pode criar grupos para classificar os contactos.
-- **Contactos**: visualize os contactos do diretório de endereços ou do grupo selecionado.
-- **Propriedades do contacto** ou **Adicionar um contacto**: esta janela surge quando um contacto é selecionado ou quando está em criação. Pode ler ou alterar as informações de um contacto.
+- **Grupos**: no livro de endereços, pode criar grupos para classificar os contactos.
+- **Contactos**: visualize os contactos do livro de endereços ou do grupo selecionado.
+- **Propriedades do contacto** ou **Adicionar um contacto**: esta janela apresenta-se quando um contacto é selecionado ou está em criação. Aí pode ler ou modificar as informações de um contacto.
 
 ![alojamento](images/roundcube09.png){.thumbnail}
 
 #### Grupos <a name="group"></a>
 
-Os grupos são subcategorias do diretório de endereços. Permitem classificar os contactos em subconjuntos. Por exemplo, poderá encontrar mais facilmente um contacto num grupo que criou do que no conjunto do seu diretório de endereços. Isto também permite-lhe enviar um e-mail adicionando um grupo ao destinatário, em vez de adicionar um a um os contactos do grupo.
+Os grupos são subcategorias do livro de endereços. Permitem classificar os contactos em subconjuntos. Por exemplo, encontrará mais facilmente um contacto num grupo que tenha criado do que no conjunto do seu livro de endereços. Permitem-lhe também enviar um e-mail adicionando um grupo como destinatário, em vez de adicionar um a um os contactos do grupo.
 
-Para criar um grupo, clique no botão `+`{.action} no fundo da coluna `Grupos`. Defina o nome do grupo e clique em `Guardar`{.action} para validar.
+Para criar um grupo, clique no botão `+`{.action} no fundo da coluna `Grupos`. Defina o nome do grupo e, em seguida, clique em `Guardar`{.action} para validar.
 
 ![alojamento](images/roundcube10.png){.thumbnail}
 
-Para afetar um contacto a um dos grupos, selecione um contacto na coluna `Contactos` e, na janela que aparecer, clique no separador `Grupos`{.action}. Selecione o grupo que deseja atribuir ao contacto.
+Para atribuir um contacto a um dos grupos, selecione um contacto na coluna `Contactos` e, na janela que aparece, clique no separador `Grupos`{.action}. Assinale o grupo que pretende atribuir ao contacto.
 
 #### Contactos <a name="contacts"></a>
 
-Na coluna `Grupos`, selecione o diretório de endereços ou um dos grupos.
+Na coluna `Grupos`, selecione o livro de endereços ou um dos grupos.
 
 > [!primary]
-> 
-> Quando criar um contacto a partir de um grupo selecionado, o contacto será automaticamente adicionado ao grupo.
+>
+> Quando cria um contacto a partir de um grupo selecionado, o contacto será automaticamente adicionado ao grupo.
 
 Clique no botão `+`{.action} no fundo da coluna `Contactos` para criar um contacto.
 
 ![alojamento](images/roundcube11.png){.thumbnail}
 
-De seguida, introduza as informações do contacto.
+Em seguida, preencha as informações do contacto.
 
 > [!primary]
-> Pode adicionar campos adicionais através do menu pendente `Adicionar campo...`{.action}, situado sob os campos `Primeiro nome` e `Endereço`.
+> Pode adicionar campos suplementares através do menu pendente `Adicionar campo...`{.action}, situado por baixo dos campos `Nome próprio` e `Endereço`.
 
-#### Importar Contatos <a name="import-contacts"></a>
+#### Importar contactos <a name="import-contacts"></a>
 
-Na janela `Contatos`{.action}, na barra superior, clique em `importar`{.action} para abrir a janela de importação.
+A partir da janela `Contactos`{.action}, na barra superior, clique em `Importar`{.action} para abrir a janela de importação.
 
-- `Importar do arquivo`: selecione um ficheiro CSV ou um ficheiro vCard no seu computador. Os contactos no seio de um ficheiro CSV devem ser separados por vírgulas. O ficheiro não deve ter mais de 20MB.
-- `Importar atribuições do grupo`: Se os contactos do seu ficheiro estão repartidos por grupos, pode ativar esta opção para encontrar esta organização ou deixar esta opção em `nenhuma` para que nenhum grupo seja afetado aos contactos.
-- `Substituir o catálogo de endereços atual`: Se o diretório já estiver configurado, recomendamos que o exporte antes de selecionar esta opção ou de ter a certeza de que quer substituí-lo definitivamente.
+- `Importar de um ficheiro`: selecione um ficheiro CSV ou um ficheiro vCard no seu computador. Os contactos num ficheiro CSV devem ser separados por vírgulas. O ficheiro não deve ter mais de 20 MB.
+- `Importar as atribuições de grupo`: se os contactos do seu ficheiro estiverem distribuídos por grupos, pode ativar esta opção para manter esta organização ou deixar esta opção em `nenhuma` para que nenhum grupo seja atribuído aos contactos.
+- `Substituir todo o livro de endereços`: se já estiver configurado um livro, aconselhamo-lo a exportá-lo antes de assinalar esta opção ou a certificar-se de que pretende substituí-lo definitivamente.
 
 ![alojamento](images/roundcube-import-contact.png){.thumbnail}
 
-#### Exportar os Contactos Roundcube <a name="export-contacts"></a>
+#### Exportar os contactos <a name="export-contacts"></a>
 
-Na janela `Contatos`{.action}, no canto superior direito, clique no botão `Exportar`{.action}, no botão virado para baixo.
+A partir da janela `Contactos`{.action}, na barra superior, clique na seta apontada para baixo à direita do botão `Exportar`{.action}.
 
 Pode escolher entre:
 
-- `Exportar todos`{.action} e o conjunto dos contactos será então exportado num ficheiro **.vcf**.
-- `Exportar a selecionados`{.action} para exportar unicamente os elementos que escolheu na coluna `Contatos`{.action}.
+- `Exportar tudo`{.action} e o conjunto dos contactos será então exportado num ficheiro **.vcf**.
+- `Exportar a seleção`{.action} para exportar unicamente os elementos que tiver escolhido na coluna `Contactos`{.action}.
 
 ![alojamento](images/roundcube-export-contact.png){.thumbnail}
 
-### Respostas (templates) <a name="responses"></a>
+### Respostas (modelos) <a name="responses"></a>
 
-Esta função permite criar templates de resposta aquando da redação de um e-mail.
+Esta função permite criar modelos de respostas aquando da redação de um e-mail.
 
-No Roundcube, clique em `Definiçõe`{.action} na barra superior e, a seguir, em `Respostas`{.action} na coluna da esquerda.
+A partir do Roundcube, clique em `Definições`{.action} na barra superior e, em seguida, em `Respostas`{.action} na coluna da esquerda.
 
 Para adicionar uma resposta, clique no botão `+`{.action} no fundo da coluna `Respostas`.
 
 ![alojamento](images/roundcube12.png){.thumbnail}
 
 > [!primary]
-> 
-> As "respostas" são redigidas no formato de "texto em branco".
+>
+> As "respostas" redigem-se no formato de "texto simples".
 
-### Adicionar uma resposta automática ou resposta automática <a name="automatic-respond"></a>
+### Adicionar um respondedor ou resposta automática <a name="automatic-respond"></a>
 
-Deseja adicionar uma resposta automática ao seu endereço de e-mail quando estiver ausente ou indisponível. Esta função não pode ser ativada a partir do webmail, mas sim a partir da [Área de Cliente OVHcloud](/links/manager), na interface de gestão dos seus endereços de e-mail. Consulte o guia "[Criar uma resposta automática para o endereço de e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)".
+Pretende adicionar uma resposta automática ao seu endereço de e-mail quando estiver ausente ou indisponível. Esta função não pode ser ativada a partir do webmail, mas sim a partir da sua [área de cliente OVHcloud](/links/manager), na interface de gestão dos seus endereços de e-mail. Consulte o nosso guia "[Criar um respondedor para o seu endereço de e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)".
 
-### Alterar a palavra-passe do endereço de e-mail <a name="password"></a>
+### Alterar a palavra-passe do seu endereço de e-mail <a name="password"></a>
 
-Para alterar a palavra-passe do seu endereço de e-mail, deve ligar-se à [Área de Cliente OVHcloud](/links/manager), na interface de gestão dos seus endereços de e-mail. Consulte o guia "[Alterar a palavra-passe de um endereço de e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)".
+Para alterar a palavra-passe do seu endereço de e-mail, deve ligar-se à sua [área de cliente OVHcloud](/links/manager), na interface de gestão dos seus endereços de e-mail. Consulte o nosso guia "[Alterar a palavra-passe de um endereço de e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password/)".
 
 ### Redação de um e-mail <a name="email-writing"></a>
 
-No separador `E-mail`{.action} na barra superior, clique em `Ediger`{.action}.
+A partir do separador `E-mail`{.action} na barra superior, clique em `Redigir`{.action}.
 
-Na janela de redação de um e-mail, encontram-se os seguintes campos: 
+Na janela de redação de um e-mail, encontram-se os seguintes campos:
 
-- **Remetente**: escolher uma [identidade](#identity) para definir o remetente.
-- **Para+**: adicionar destinatários e/ou um [grupo de destinatários](#group).
+- **De**: escolher uma [identidade](#identity) para definir o remetente.
+- **Para**: adicionar destinatários e/ou um [grupo de destinatários](#group). O botão `+`{.action} à direita do campo permite introduzir vários endereços.
 
 > [!primary]
-> 
-> O campo **"A"** não deve exceder os 100 destinatários, incluindo os contactos contidos num [grupo](#group).
+>
+> O campo **"Para"** não deve exceder os 100 destinatários, incluindo os contactos contidos num [grupo](#group).
 
-- **Adicionar Cc+**: adicionar destinatários em cópia simples.
-- **Adicionar Bcc+**: adicionar destinatários em cópia oculta. Os outros destinatários do e-mail não verão estes no Cci.
-- **Adicionar Responder para**: enviar o e-mail aos destinatários.
-- **Tipo de editor**:  
-    - `Texto claro`: apenas do texto sem qualquer forma.
-    - `HTML`: texto com forma. Aparecerá uma barra de ferramentas HTML acima da janela de introdução.
+- **Cc**: através do botão `Adicionar Cc`{.action}, adicionar destinatários em cópia simples.
+- **Bcc**: através do botão `Adicionar Bcc`{.action}, adicionar destinatários em cópia oculta. Os outros destinatários do e-mail não verão os que estão em Bcc.
+- **Reencaminhar para**: através do botão `Adicionar Reencaminhar para`{.action}, reencaminhar o e-mail a destinatários.
+- **Tipo de editor**:
+    - `Texto simples`: apenas texto sem formatação.
+    - `HTML`: texto com formatação. Aparece uma barra de ferramentas HTML acima da janela de introdução.
 - **Prioridade** do e-mail.
-- **Recibo de leitura**: é pedido ao destinatário um aviso de receção.
-- **Recibo de entrega** quando o e-mail foi enviado ao destinatário.
-- **Guardar mensagem enviada em**: escolher a pasta na qual uma cópia do e-mail será armazenada.
+- **Aviso de abertura do e-mail**: é solicitado um aviso de receção ao destinatário.
+- **Notificação de estado de entrega** quando o e-mail tiver sido devidamente entregue ao destinatário.
+- **Guardar o e-mail enviado em**: escolher a pasta na qual será guardada uma cópia do e-mail.
 
 Na barra superior, estão disponíveis as seguintes ações:
 
 - `Cancelar`{.action} a redação de um e-mail com um pedido de confirmação.
 - `Enviar`{.action} um e-mail.
-- `Guardar`{.action} um e-mail na pasta especial "rascunho"
-- ` Corretor ortográfico`{.action}, para verificar o texto, com um menu que permite a escolha da língua.
+- `Guardar`{.action} um e-mail na pasta especial "rascunho".
+- `Ortografia`{.action}, para verificar o texto, com um menu que permite escolher o idioma.
 - `Anexar`{.action} um ficheiro a um e-mail.
-- `Assinatura`{.action}: adiciona a assinatura associada [à identidade](#identity) selecionada.
-- `Respostas`{.action}: adiciona um template pré-registado na parte [Respostas](#responses).
+- `Assinatura`{.action}: adiciona a assinatura associada à [identidade](#identity) selecionada.
+- `Respostas`{.action}: adiciona um modelo pré-registado na parte [Respostas](#responses).
 
 ![alojamento](images/roundcube13.png){.thumbnail}
 
-### Casos de utilização <a name="usecase"></a>
+### Casos práticos <a name="usecase"></a>
 
 #### Falha na verificação do pedido
 
-Ao tentar acessar seu webmail Roundcube, você encontrará a seguinte mensagem:
+Encontra a seguinte mensagem ao tentar aceder ao seu webmail Roundcube:
 
 ```console
 FALHA NA VERIFICAÇÃO DO PEDIDO
 Para sua proteção, o acesso a este recurso está protegido contra ataques CSRF.
-Se você ver isso, provavelmente você não se desconectou antes de sair do aplicativo da Web.
-A interação humana é agora necessária para continuar.
+Se vê esta mensagem, provavelmente não terminou sessão antes de sair da aplicação web.
+É necessária uma interação humana para continuar.
 Contacte o administrador do seu servidor.
 ```
 
-Como indicado nesta mensagem, a sua conta de e-mail já se encontra online. Estamos a falar "sessão". Isto significa que a sua conta de e-mail já se encontra em curso de utilização aos olhos do servidor de e-mail e que esta sessão anterior deve ser encerrada Certifique-se de que a sua conta de e-mail não está já aberta no roundcube. Esvazie igualmente os dados em cache no seu browser.
+Tal como é indicado na mensagem, a sua conta de e-mail é considerada como já ligada. Falamos aqui de "sessão". Isto significa que a sua conta de e-mail já está a ser utilizada do ponto de vista do servidor de e-mail e que esta sessão anterior deve ser fechada. Verifique se a sua conta de e-mail não está já aberta no Roundcube. Esvazie igualmente os dados em cache no seu browser.
 
 ## Quer saber mais?
 
@@ -435,10 +447,10 @@ Como indicado nesta mensagem, a sua conta de e-mail já se encontra online. Esta
 
 [Alterar a palavra-passe de um endereço de e-mail MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_change_password)
 
-[Criar uma resposta automática para o endereço de e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses)
+[Criar um respondedor para o seu endereço de e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_auto_responses/)
 
 [Criar filtros para os seus endereços de e-mail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/feature_filters)
 
 [Utilizar os reencaminhamentos de e-mail](/pages/web_cloud/email_and_collaborative_solutions/common_email_features/feature_redirections)
 
-Fale com nossa [comunidade de utilizadores](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.fr-fr.md
@@ -75,7 +75,7 @@ Pour consulter vos e-mails, sélectionnez un dossier sur le côté gauche. Les e
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-Pour lire un e-mail, sélectionnez son dossier si nécessaire. Cliquez ensuite sur l’e-mail pour afficher son contenu dans le volet de lecture. Les messages non lus apparaissent en gras afin de les distinguer de ceux qui ont été lus.
+Pour lire un e-mail, sélectionnez son dossier si nécessaire. Cliquez ensuite sur l’e-mail pour afficher son contenu dans le volet de lecture. Les messages non lus apparaissent en gras pour les distinguer des messages lus.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
@@ -87,7 +87,7 @@ En haut à droite de la liste des messages, le bouton `Filtrer`{.action} ouvre u
 
 - **Trier par** : survolez l'entrée `Trier par`{.action} pour choisir le critère de classement des e-mails : **Date**, **De**, **À**, **Objet**, **Pièces jointes**, **Importance** ou **Taille**. La flèche à gauche du critère indique l'ordre courant ; cliquez à nouveau sur le même critère pour l'inverser.
 
-- **Afficher comme** : survolez l'entrée `Afficher comme`{.action} pour basculer entre l'affichage **Messages** pour un e-mail par ligne ou **Conversations** pour regrouper les e-mails d'un même fil de discussion.
+- **Afficher comme** : survolez l'entrée `Afficher comme`{.action} pour basculer entre l'affichage **Messages** (un e-mail par ligne) ou **Conversations** (e-mails regroupés par fil de discussion).
 
 ### Envoyer et répondre
 
@@ -121,7 +121,7 @@ Pour créer un nouveau dossier, faites un clic droit sur le nom de votre adresse
 #### Déplacer des e-mails
 
 Pour **déplacer un e-mail**, vous pouvez simplement le glisser-déposer dans le dossier cible ou faire un clic droit et sélectionner `Déplacer`{.action}.
-Pour simultanément **déplacer plusieurs e-mails**, sélectionnez-les tous grâce à leur case à cocher. Ensuite cliquez sur `Déplacer`{.action} (sur le côté droit) ou sur `Déplacer vers`{.action} (dans la section supérieure). Choisissez ensuite le dossier de destination.
+Pour simultanément **déplacer plusieurs e-mails**, sélectionnez-les tous grâce à leur case à cocher. Ensuite, cliquez sur `Déplacer`{.action} (sur le côté droit) ou sur `Déplacer vers`{.action} (dans la section supérieure). Choisissez ensuite le dossier de destination.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
@@ -135,7 +135,7 @@ Pour créer et gérer des règles, cliquez d’abord sur l'icône d'engrenage en
 
 Dans la nouvelle page qui s’ouvre, cliquez sur `Règles de boîte de réception et de rangement`{.action} qui se trouve dans le menu de gauche. Dans l’arborescence « Options », vous pouvez trouver cette fonctionnalité dans « Courrier », sous « Traitement automatique ». Ici, vous pouvez créer, modifier et déplacer des règles de la liste. 
 
-Pour ajouter une nouvelle règle, cliquez sur le bouton `+`{.action}
+Pour ajouter une nouvelle règle, cliquez sur le bouton `+`{.action}.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.fr-fr.md
@@ -12,20 +12,23 @@ Avec les solutions e-mail OVHcloud, vous pouvez envoyer et recevoir vos e-mails 
 
 ## Prérequis
 
-- Disposer d'une solution e-mail OVHcloud qui doit avoir été configurée au préalable (**MX Plan**, proposée parmi nos [offres d’hébergement web](/links/web/hosting), incluse dans un [hébergement gratuit 100M](/links/web/domains-free-hosting) ou commandée séparément comme solution autonome, telles que [**Hosted Exchange**](/links/web/emails-hosted-exchange) ou [**Email Pro**](/links/web/email-pro))
-- Connaître les identifiants de connexion de l’adresse e-mail que vous souhaitez configurer
+- Disposer d'une solution e-mail OVHcloud configurée au préalable, parmi les offres suivantes :
+    - [**MX Plan**](/links/web/hosting), proposée avec nos offres d'hébergement web, incluse dans l'[hébergement gratuit 100M](/links/web/domains-free-hosting) ou commandée comme solution autonome ;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange) ;
+    - [**Email Pro**](/links/web/email-pro).
+- Connaître les identifiants de connexion de l’adresse e-mail à utiliser.
 
 ## En pratique
 
 Ce guide vous permettra de mieux comprendre les tâches habituelles disponibles dans un compte de messagerie sous OWA. Cependant, comme cette interface n'a pas été créée à l'origine par OVHcloud, nous ne pouvons pas fournir des instructions spécifiques sur des paramètres non abordés dans ce guide.
 
-Concernant les fonctionnalités spécifiques à Exchange, vous pourrez retrouver quelques guides supplémentaires dans la section [Aller plus loin](./#aller-plus-loin_1) en bas de ce guide.
+Concernant les fonctionnalités spécifiques à Exchange, vous pourrez retrouver quelques guides supplémentaires dans la section [Aller plus loin](./#aller-plus-loin) en bas de ce guide.
 
 > [!primary]
 >
-> Après les deux premières étapes, il n'est pas nécessaire de suivre les instructions dans l'ordre donné.
+> Après la connexion et la prise en main de l'interface, il n'est pas nécessaire de suivre les instructions dans l'ordre donné.
 
-### Étape 1 : Se connecter à OWA
+### Se connecter à OWA
 
 Pour vous connecter à OWA avec votre adresse e-mail, ouvrez la page de [connexion au webmail](/links/web/email). Saisissez entièrement votre adresse e-mail et votre mot de passe. Ensuite, cliquez sur `Connexion`{.action}.
 
@@ -51,7 +54,7 @@ Dorénavant, votre boîte de réception apparaîtra par défaut dès que vous se
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### Étape 2 : Comprendre l’affichage d’OWA
+### Comprendre l’affichage d’OWA
 
 L'interface OWA comporte plusieurs sections. Veuillez vous référer au tableau et à l'image ci-dessous pour vous familiariser avec celle-ci.
 
@@ -72,13 +75,23 @@ Pour consulter vos e-mails, sélectionnez un dossier sur le côté gauche. Les e
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-Pour lire un e-mail, sélectionnez son dossier si nécessaire. Cliquez ensuite sur l’e-mail pour afficher son contenu dans le coin de lecture. Une couleur différente est utilisée pour les messages non lus afin de les distinguer de ceux qui ont été lus.
+Pour lire un e-mail, sélectionnez son dossier si nécessaire. Cliquez ensuite sur l’e-mail pour afficher son contenu dans le volet de lecture. Les messages non lus apparaissent en gras afin de les distinguer de ceux qui ont été lus.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Trier et filtrer les e-mails
+
+En haut à droite de la liste des messages, le bouton `Filtrer`{.action} ouvre un menu qui regroupe toutes les options d'affichage du dossier sélectionné.
+
+- **Filtrer par catégorie** : sélectionnez une entrée pour n'afficher qu'une sélection d'e-mails parmi `Tout`{.action}, `Non lu`{.action}, `À moi`{.action} (e-mails adressés directement à votre adresse), `Avec indicateur`{.action} (e-mails signalés pour le suivi) ou `Mentions`{.action} (e-mails dans lesquels votre adresse est mentionnée).
+
+- **Trier par** : survolez l'entrée `Trier par`{.action} pour choisir le critère de classement des e-mails : **Date**, **De**, **À**, **Objet**, **Pièces jointes**, **Importance** ou **Taille**. La flèche à gauche du critère indique l'ordre courant ; cliquez à nouveau sur le même critère pour l'inverser.
+
+- **Afficher comme** : survolez l'entrée `Afficher comme`{.action} pour basculer entre l'affichage **Messages** pour un e-mail par ligne ou **Conversations** pour regrouper les e-mails d'un même fil de discussion.
+
 ### Envoyer et répondre
 
-Pour **envoyer un nouveau message**, cliquez sur l'icône `Nouveau`{.action} en haut de l'interface du webmail. Le volet d’édition apparaîtra sur le côté droit. Remplissez les champs de votre e-mail (destinataires, objet, corps du message, pièces jointes). Cliquez sur `Envoyer`{.action} une fois votre e-mail rédigé.
+Pour **envoyer un nouveau message**, cliquez sur l'icône `Nouveau`{.action} en haut de l'interface OWA. Le volet d’édition apparaîtra sur le côté droit. Remplissez les champs de votre e-mail (destinataires, objet, corps du message, pièces jointes). Cliquez sur `Envoyer`{.action} une fois votre e-mail rédigé.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
@@ -96,7 +109,8 @@ OWA propose plusieurs façons d'organiser votre messagerie. Vous pouvez :
 
 - [créer des dossiers et des sous-dossiers](./#creer-un-dossier),
 - [déplacer des e-mails](./#deplacer-des-e-mails),
-- [définir des règles](./#creer-des-regles-de-gestion-de-la-messagerie) afin d’effectuer automatiquement des actions dès la réception d'un nouvel e-mail.
+- [définir des règles](./#creer-des-regles-de-gestion-de-la-messagerie) afin d’effectuer automatiquement des actions dès la réception d'un nouvel e-mail,
+- [bloquer un expéditeur](./#bloquer-un-expediteur) pour ne plus recevoir ses messages.
 
 #### Créer un dossier
 
@@ -107,7 +121,7 @@ Pour créer un nouveau dossier, faites un clic droit sur le nom de votre adresse
 #### Déplacer des e-mails
 
 Pour **déplacer un e-mail**, vous pouvez simplement le glisser-déposer dans le dossier cible ou faire un clic droit et sélectionner `Déplacer`{.action}.
-Pour simultanément **déplacer plusieurs e-mails**, sélectionnez les tous grâce à leur case à cocher. Ensuite cliquez sur  `Déplacer`{.action} (sur le coté droit) ou sur `Déplacer vers`{.action} (dans la section supérieure). Choisissez ensuite le dossier de destination.
+Pour simultanément **déplacer plusieurs e-mails**, sélectionnez-les tous grâce à leur case à cocher. Ensuite cliquez sur `Déplacer`{.action} (sur le côté droit) ou sur `Déplacer vers`{.action} (dans la section supérieure). Choisissez ensuite le dossier de destination.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
@@ -121,7 +135,7 @@ Pour créer et gérer des règles, cliquez d’abord sur l'icône d'engrenage en
 
 Dans la nouvelle page qui s’ouvre, cliquez sur `Règles de boîte de réception et de rangement`{.action} qui se trouve dans le menu de gauche. Dans l’arborescence « Options », vous pouvez trouver cette fonctionnalité dans « Courrier », sous « Traitement automatique ». Ici, vous pouvez créer, modifier et déplacer des règles de la liste. 
 
-Pour ajouter une nouvelle règle, cliquez sur le bouton `+`{.action}  
+Pour ajouter une nouvelle règle, cliquez sur le bouton `+`{.action}
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
@@ -141,19 +155,23 @@ Dans la section « **Expéditeurs bloqués** », tapez une adresse e-mail ou un 
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Gérer une liste de contacts
+### Gérer vos contacts
 
-Pour gérer vos contacts, cliquez d’abord sur le bouton bleu du « App launcher » en haut de la page, ensuite sur `Contacts`{.action}.
+Pour gérer vos contacts, cliquez d’abord sur le bouton bleu du lanceur d’applications en haut à gauche de la page (qui donne également accès au calendrier, aux tâches et à d’autres modules), puis sur `Contacts`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
 Dans la nouvelle page, vous pouvez ajouter un nouveau contact, créer une liste de contacts et supprimer des contacts existants.
 
-Pour **ajouter un nouveau contact**, cliquez sur `Nouveau`{.action}, et introduisez les coordonnées du contact à ajouter. Une fois cela fait, cliquez sur `Enregistrer`{.action}.
+#### Ajouter un contact
+
+Cliquez sur `Nouveau`{.action}, puis saisissez les coordonnées du contact à ajouter. Une fois cela fait, cliquez sur `Enregistrer`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-Pour **créer une liste de contacts**, cliquez sur la flèche vers le bas à côté de « Nouveau », puis cliquez sur `Liste de contacts`{.action}. Donnez-lui un nom, ajoutez-y des contacts et cliquez sur `Enregistrer`{.action}.
+#### Créer une liste de contacts
+
+Cliquez sur la flèche vers le bas à côté de `Nouveau`{.action}, puis sur `Liste de contacts`{.action}. Donnez-lui un nom, ajoutez-y des contacts et cliquez sur `Enregistrer`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
@@ -173,7 +191,7 @@ Dans la nouvelle fenêtre qui s'ouvre, entrez votre mot de passe actuel. Saisiss
 
 > [!primary]
 >
-> N'oubliez pas d’enter votre nouveau mot de passe sur tous vos appareils utilisés pour accéder à ce compte (par exemple dans le logiciel client de messagerie). En cas de difficultés avec votre mot de passe, contactez votre administrateur de services.
+> N'oubliez pas d’entrer votre nouveau mot de passe sur tous vos appareils utilisés pour accéder à ce compte (par exemple dans le logiciel client de messagerie). En cas de difficultés avec votre mot de passe, contactez votre administrateur de services.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
@@ -188,11 +206,11 @@ Dans la fenêtre qui s’ouvre, sélectionnez l’option « Envoyer des répons
 - envoyer des e-mails de réponse automatique pendant un intervalle de temps fixe, ou en continu jusqu'à ce qu'il soit désactivé manuellement
 - définir les expéditeurs qui recevront les e-mails de réponse automatique (expéditeurs internes uniquement, ou inclure les expéditeurs externes)
 
-Remplissez les informations demandées en fonction de la tâche que vous voudrez effectuer grâce à cette règle. Une fois cela fait, cliquez sur OK.
+Remplissez les informations demandées en fonction de la tâche que vous voudrez effectuer grâce à cette règle. Une fois cela fait, cliquez sur `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-Pour des instructions plus détaillées sur la création des règles de gestion de messagerie, veuillez vous référer à notre guide : [Créer un répondeur automatique sous OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
+Pour des instructions plus détaillées sur la création de réponses automatiques, veuillez vous référer à notre guide : [Créer un répondeur automatique sous OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Ajouter une signature
 


### PR DESCRIPTION
## What type of Pull Request is this?

- Update of existing guide(s)
- Optimization

## Description

### OWA (fr-fr):
- Add new "Trier et filtrer les e-mails" section documenting the Filter menu (filter categories, sort criteria, Messages/Conversations view)
- Reorder sections: "Afficher les e-mails" now precedes "Trier et filtrer"
- Fix structural inconsistencies (obsolete "two first steps" callout, broken #aller-plus-loin_1 anchor, H3/H4 hierarchy for display/filter)
- Add Contacts H4 subsections (Ajouter un contact, Créer une liste)
- Replace "App launcher" with French wording and mention calendar/tasks
- Refactor prerequisites for readability
- Misc fixes: typos, double spaces, "coin de lecture" -> "volet de lecture", "coté" -> "côté", "webmail" -> "interface OWA"

### Roundcube (fr-fr):
- Enrich "Type d'affichage" section with concrete values for each setting (Layout/Columns/Sorting) and add dynamic sort-by-column note
- Expand "Rechercher un e-mail" with search scope and filters info
- Reformulate compose fields "À+/Cc+/Cci+/Transférer à" for clarity
- Sync TOC with section labels (Identité, adresse e-mail, Cas d'usage, Exporter les contacts)
- Fix 15 typos (identifgier, Mailveloppe, flêche, quelque soit, etc.)
- Remove bold from H5 headings, format shortcut list with {.action}
- Fix broken link label (#topwindow was mislabelled "Interface générale")
- Code block ```bash``` -> ```html``` for HTML signature example
