### PR TITLE
[SK-2445] - WEB - Emails - Zimbra - General Email configuration on heavy client

### DIFF
--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.de-de.md
@@ -1,43 +1,94 @@
 ---
-title: Zimbra-E-Mail-Adresse auf einem E-Mail-Client konfigurieren
-excerpt: Erfahren Sie hier, wie Sie Ihren E-Mail-Client konfigurieren, um die E-Mails Ihres Zimbra-Kontos zu verwalten
-updated: 2025-02-12
+title: "Zimbra - E-Mail-Account auf einem E-Mail-Client konfigurieren"
+excerpt: "Wählen Sie die passende Konfigurationsmethode für Ihr Zimbra Starter- oder Pro-Angebot und Ihren E-Mail-Client"
+updated: 2026-05-04
 ---
-
-<style>
-.w-400 {
-max-width:400px!important;
-}
-</style>
 
 ## Ziel
 
-Mit dem Zimbra Dienst bietet Ihnen OVHcloud eine kollaborative Open Source Messaging Plattform mit allen für eine professionelle Nutzung notwendigen Funktionen.  
-Auf dieser Seite finden Sie Informationen, die Sie benötigen, um Ihre Zimbra E-Mail-Accounts auf Ihrem bevorzugten E-Mail-Client einzurichten.
+Mit der Lösung Zimbra bietet Ihnen OVHcloud eine kollaborative Open-Source-Messaging-Plattform mit allen für eine professionelle Nutzung notwendigen Funktionen. Diese Anleitung hilft Ihnen, die passende Konfigurationsmethode für Ihr Zimbra-Angebot und Ihren E-Mail-Client auszuwählen.
 
-**Diese Anleitung erklärt, wie Sie Ihren E-Mail-Client konfigurieren, um E-Mails von Ihrem Zimbra-Konto abzurufen.**
+**Erfahren Sie, welche Methode Sie wählen müssen, um Ihren Zimbra-E-Mail-Account auf dem E-Mail-Client Ihrer Wahl zu konfigurieren.**
 
 ## Voraussetzungen
 
-- Sie haben einen E-Mail-Account auf der OVHcloud Zimbra E-Mail-Lösung abonniert.
-- Sie haben ein E-Mail-Programm auf dem Gerät Ihrer Wahl installiert.
+- Sie verfügen über ein Abonnement für einen E-Mail-Account auf einer unserer [Zimbra-Lösungen](/links/web/emails-zimbra) (**Zimbra Starter** oder **Zimbra Pro**).
+- Sie haben einen E-Mail-Client auf dem Gerät Ihrer Wahl installiert.
+- Sie verfügen über die Zugangsdaten für die zu konfigurierende E-Mail-Adresse.
+
+<!-- CP-NAV-START:web-zimbra -->
+---
+
+### Auf Ihr OVHcloud Kundencenter zugreifen
+
+- **Direktzugriff:** [Zimbra](/links/control-panel/web-zimbra)
+- **So greifen Sie auf Ihre Dienste zu:** `Web Cloud`{.action} > `Zimbra Mail`{.action}
+
+---
+<!-- CP-NAV-END:web-zimbra -->
 
 ## In der praktischen Anwendung
 
-### Konfiguration Ihres E-Mail-Accounts <a name="mail-config"></a>
+### Ihr Zimbra-Angebot identifizieren <a name="identifier-offre"></a>
 
-Die Konfiguration Ihres Zimbra E-Mail-Accounts verwendet die gleichen Einstellungen wie unser E-Mail-Dienst MX Plan, der auch bei OVHcloud Webhostings inklusive ist. Aus diesem Grund beziehen sich die nachfolgend verlinkten Anleitungen auf "MX Plan".
+Die zu verwendende Konfigurationsmethode hängt von Ihrem Zimbra-Angebot ab. Die beiden Angebote unterstützen nicht dieselben Protokolle.
 
-Klicken Sie auf den Tab für Ihren zutreffenden Gerätetyp:
+| Angebot | Unterstützte Protokolle | Synchronisierte Funktionen |
+|---|---|---|
+| **Zimbra Starter** | IMAP, POP, SMTP | Nur E-Mails |
+| **Zimbra Pro** | IMAP, POP, SMTP, **ActiveSync**, **EWS** | E-Mails, Kalender, Kontakte, Aufgaben |
+
+> [!primary]
+>
+> Um Ihr Angebot zu identifizieren, melden Sie sich in Ihrem [OVHcloud Kundencenter](/links/manager) an und gehen Sie zu `Web Cloud`{.action} und dann zu `Zimbra Mail`{.action}. Im Tab `E-Mail-Accounts`{.action} ist das Angebot in der Spalte **Angebot** für jeden Account angegeben.
+
+### Einen Zimbra Pro-Account konfigurieren <a name="config-zimbra-pro"></a>
+
+> [!success]
+>
+> Um die kollaborativen Funktionen von Zimbra Pro (Synchronisation von Kalender, Kontakten und Aufgaben) voll auszuschöpfen, verwenden Sie die Protokolle **ActiveSync** oder **EWS** über die unten aufgeführten Anleitungen. Eine IMAP/POP-Konfiguration ist weiterhin möglich, synchronisiert jedoch nur die E-Mails.
+
+Klicken Sie auf den Tab für den von Ihnen verwendeten Gerätetyp:
 
 > [!tabs]
-> **Windows**
+> **Windows-PC**
+>>
+>> - [Klassisches Outlook über ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_windows)
+>>
+> **Apple Mac-Computer**
+>>
+>> - [Mail über EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_macos)
+>> - [Outlook über EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_macos)
+>>
+> **iPhone oder iPad**
+>>
+>> - [Mail über ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_app_ios)
+>> - [Outlook über ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_ios)
+>>
+> **Android-Smartphone oder -Tablet**
+>>
+>> - [Gmail über ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_gmail_app_android)
+>> - [Outlook über ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_android)
+>>
+
+### Einen Zimbra Starter-Account konfigurieren (oder einen Zimbra Pro-Account in IMAP/POP) <a name="mail-config"></a>
+
+Verwenden Sie für das **Zimbra Starter**-Angebot oder bei Bevorzugung einer IMAP/POP-Konfiguration für Ihren **Zimbra Pro**-Account die nachfolgenden Anleitungen.
+
+> [!primary]
+>
+> Die nachfolgenden Anleitungen werden mit dem MX Plan-Angebot geteilt, da die IMAP/POP/SMTP-Einstellungen für die beiden Angebote strikt identisch sind. Aus diesem Grund tragen die Links den Vermerk "MX Plan" im Titel.
+
+Klicken Sie auf den Tab für den von Ihnen verwendeten Gerätetyp:
+
+> [!tabs]
+> **Windows-PC**
 >>
 >> - [Outlook für Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016)
 >> - [Thunderbird für Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_thunderbird_windows)
->> - [Mail for Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
+>> - [Mail für Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
 >>
-> **Apple Mac Computer**
+> **Apple Mac-Computer**
 >>
 >> - [Outlook für macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016_mac)
 >> - [Mail für macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
@@ -47,63 +98,71 @@ Klicken Sie auf den Tab für Ihren zutreffenden Gerätetyp:
 >>
 >> - [Mail für iPhone und iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
 >>
-> **Android Smartphone oder Tablet**
+> **Android-Smartphone oder -Tablet**
 >>
->> - [Google Mail für Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android)
+>> - [Gmail für Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android)
 >>
 > **Webinterface**
 >>
 >> - [Gmail-Webinterface](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_gmail)
 >>
 
-### POP-, IMAP- und SMTP-Einstellungen <a name="popimap-settings"></a>
+### Die mobile Zimbra-App verwenden <a name="config-zimbra-app"></a>
 
-Für den Empfang von E-Mails empfehlen wir bei der Auswahl des Kontotyps die Verwendung von **IMAP**. Sie können sich aber auch für **POP** entscheiden.
+Die mobile Zimbra-App (Android und iOS) ist sowohl mit dem **Zimbra Starter**- als auch mit dem **Zimbra Pro**-Angebot kompatibel und ermöglicht den Zugriff auf Ihren Account über das native Zimbra-Protokoll.
 
-- **POP-Konfiguration**
+- [Mobile Zimbra-App konfigurieren](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
 
-|Information|Beschreibung|
-|---|---|
-|Benutzername|Geben Sie die **vollständige** E-Mail-Adresse ein.|
-|Passwort|Geben Sie das Passwort des E-Mail-Accounts ein.|
-|Server **EUROPA** (eingehend)|pop.mail.ovh.net **oder** ssl0.ovh.net|
-|Server **AMERIKA / ASIEN-PAZIFIK** (eingehend)|pop.mail.ovh.ca|
-|Port|995|
-|Sicherheitstyp|SSL/TLS|
+### Referenzeinstellungen für IMAP, POP und SMTP <a name="popimap-settings"></a>
 
-- **IMAP-Konfiguration**
+Falls Ihr E-Mail-Client eine manuelle Konfiguration erfordert, verwenden Sie die folgenden Einstellungen.
 
-|Information|Beschreibung|
-|---|---|
-|Benutzername|Geben Sie die **vollständige** E-Mail-Adresse ein.|
-|Passwort|Geben Sie das Passwort des E-Mail-Accounts ein.|
-|Server **EUROPA** (eingehend)|imap.mail.ovh.net **oder** ssl0.ovh.net|
-|Server **AMERIKA / ASIEN-PAZIFIK** (eingehend)|imap.mail.ovh.ca|
-|Port|993|
-|Sicherheitstyp|SSL/TLS|
+#### Eingangsserver
 
-Wenn Sie zum Senden von E-Mails die **SMTP**-Einstellungen in den Kontoeinstellungen manuell eingeben müssen, verwenden Sie die folgenden Einstellungen:
+Für den Empfang von E-Mails empfehlen wir das Protokoll **IMAP**. Das Protokoll **POP** steht weiterhin zur Verfügung. Klicken Sie auf den Tab für das Protokoll Ihrer Wahl:
 
-- **SMTP-Konfiguration**
+> [!tabs]
+> **IMAP (empfohlen)**
+>>
+>> - **Benutzername**: **vollständige** E-Mail-Adresse
+>> - **Passwort**: Passwort der E-Mail-Adresse
+>> - **EUROPA-Server (eingehend)**: `imap.mail.ovh.net` **oder** `ssl0.ovh.net`
+>> - **AMERIKA/ASIEN-PAZIFIK-Server (eingehend)**: `imap.mail.ovh.ca`
+>> - **Port**: 993
+>> - **Sicherheitstyp**: SSL/TLS
+>>
+> **POP**
+>>
+>> - **Benutzername**: **vollständige** E-Mail-Adresse
+>> - **Passwort**: Passwort der E-Mail-Adresse
+>> - **EUROPA-Server (eingehend)**: `pop.mail.ovh.net` **oder** `ssl0.ovh.net`
+>> - **AMERIKA/ASIEN-PAZIFIK-Server (eingehend)**: `pop.mail.ovh.ca`
+>> - **Port**: 995
+>> - **Sicherheitstyp**: SSL/TLS
+>>
 
-|Information|Beschreibung|
-|---|---|
-|Benutzername|Geben Sie die **vollständige** E-Mail-Adresse ein.|
-|Passwort|Geben Sie das Passwort des E-Mail-Accounts ein.|
-|Server **EUROPA** (eingehend)|smtp.mail.ovh.net **oder** ssl0.ovh.net|
-|Server **AMERIKA / ASIEN-PAZIFIK** (eingehend)|smtp.mail.ovh.ca|
-|Port|465|
-|Sicherheitstyp|SSL/TLS|
+#### Ausgangsserver
+
+Verwenden Sie zum Senden von E-Mails die folgenden **SMTP**-Einstellungen:
+
+- **Benutzername**: **vollständige** E-Mail-Adresse
+- **Passwort**: Passwort der E-Mail-Adresse
+- **EUROPA-Server (ausgehend)**: `smtp.mail.ovh.net` **oder** `ssl0.ovh.net`
+- **AMERIKA/ASIEN-PAZIFIK-Server (ausgehend)**: `smtp.mail.ovh.ca`
+- **Port**: 465
+- **Sicherheitstyp**: SSL/TLS
 
 ## Weiterführende Informationen <a name="go-further"></a>
 
 [Erste Schritte mit Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
 
+[Mobile Zimbra-App konfigurieren](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
+
 [Zimbra Webmail verwenden](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
-[OVHcloud Zimbra FAQ](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-zimbra)
+[FAQ zur OVHcloud Zimbra-Lösung](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-zimbra)
 
-Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Web-Entwicklung etc.) die [OVHcloud Partner](/links/partner).
+Kontaktieren Sie für spezialisierte Dienstleistungen (SEO, Webentwicklung etc.) die [OVHcloud Partner](/links/partner).
 
 Wenn Sie Hilfe bei der Nutzung und Konfiguration Ihrer OVHcloud Lösungen benötigen, beachten Sie unsere [Support-Angebote](/links/support).
 

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.en-gb.md
@@ -1,33 +1,85 @@
 ---
-title: "How to configure a Zimbra email address on an email client"
-excerpt: "Find out how to configure your email software to view emails from your Zimbra account"
-updated: 2025-02-12
+title: "Zimbra - Configuring your email account on an email client"
+excerpt: "Choose the configuration method suited to your Zimbra Starter or Pro plan and your email client"
+updated: 2026-05-04
 ---
-
-<style>
-.w-400 {
-max-width:400px!important;
-}
-</style>
 
 ## Objective
 
-With the Zimbra solution, OVHcloud offers an open-source collaborative messaging platform, with all the features you need for professional use. On this page, you can find the information you need to configure your Zimbra email accounts on your preferred email client.
+With the Zimbra solution, OVHcloud offers an open-source collaborative messaging platform with all the features you need for professional use. This guide helps you choose the configuration method suited to your Zimbra plan and your email client.
 
-**Find out how to configure your email software to manage emails from your Zimbra account.**
+**Find out which method to choose to configure your Zimbra email account on the email client of your choice.**
 
 ## Requirements
 
-- An email account on our Zimbra OVHcloud email solution
-- An email client installed on the device of your choice
+- A subscription to an email account on one of our [Zimbra solutions](/links/web/emails-zimbra) (**Zimbra Starter** or **Zimbra Pro**).
+- An email client installed on the device of your choice.
+- The login credentials for the email address to configure.
+
+<!-- CP-NAV-START:web-zimbra -->
+---
+
+### Access your OVHcloud Control Panel
+
+- **Direct link:** [Zimbra](/links/control-panel/web-zimbra)
+- **To access your services:** `Web Cloud`{.action} > `Zimbra Mail`{.action}
+
+---
+<!-- CP-NAV-END:web-zimbra -->
 
 ## Instructions
 
-### Configuring your email account <a name="mail-config"></a>
+### Identifying your Zimbra plan <a name="identifier-offre"></a>
 
-Your Zimbra email account configuration uses the same settings as the MX Plan email solution, which is included with OVHcloud Web Hosting plans as well. For this reason, the documentation pages linked below refer to "MX Plan".
+The configuration method to use depends on your Zimbra plan. The two plans do not support the same protocols.
 
-Click the tab for the type of device you are using:
+| Plan | Supported protocols | Synchronised features |
+|---|---|---|
+| **Zimbra Starter** | IMAP, POP, SMTP | Emails only |
+| **Zimbra Pro** | IMAP, POP, SMTP, **ActiveSync**, **EWS** | Emails, calendar, contacts, tasks |
+
+> [!primary]
+>
+> To identify your plan, log in to your [OVHcloud Control Panel](/links/manager) and go to `Web Cloud`{.action} then `Zimbra Mail`{.action}. In the `Email accounts`{.action} tab, the plan is indicated in the **Service plan** column for each account.
+
+### Configuring a Zimbra Pro account <a name="config-zimbra-pro"></a>
+
+> [!success]
+>
+> To take full advantage of the collaborative features of Zimbra Pro (calendar, contact and task synchronisation), use the **ActiveSync** or **EWS** protocols via the dedicated guides below. IMAP/POP configuration is still possible, but it only synchronises emails.
+
+Click the tab corresponding to the type of device you are using:
+
+> [!tabs]
+> **Windows PC**
+>>
+>> - [Classic Outlook via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_windows)
+>>
+> **Apple Mac computer**
+>>
+>> - [Mail via EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_macos)
+>> - [Outlook via EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_macos)
+>>
+> **iPhone or iPad**
+>>
+>> - [Mail via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_app_ios)
+>> - [Outlook via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_ios)
+>>
+> **Android smartphone or tablet**
+>>
+>> - [Gmail via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_gmail_app_android)
+>> - [Outlook via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_android)
+>>
+
+### Configuring a Zimbra Starter account (or a Zimbra Pro account in IMAP/POP) <a name="mail-config"></a>
+
+For the **Zimbra Starter** plan, or if you prefer an IMAP/POP configuration for your **Zimbra Pro** account, use the guides below.
+
+> [!primary]
+>
+> The guides below are shared with the MX Plan offer because the IMAP/POP/SMTP settings are strictly identical for the two plans. This is why the links have an "MX Plan" mention in their title.
+
+Click the tab corresponding to the type of device you are using:
 
 > [!tabs]
 > **Windows PC**
@@ -36,7 +88,7 @@ Click the tab for the type of device you are using:
 >> - [Thunderbird for Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_thunderbird_windows)
 >> - [Mail for Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
 >>
-> **Apple mac computer**
+> **Apple Mac computer**
 >>
 >> - [Outlook for macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016_mac)
 >> - [Mail for macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
@@ -46,64 +98,72 @@ Click the tab for the type of device you are using:
 >>
 >> - [Mail for iPhone and iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
 >>
-> **Android Smartphone or Tablet**
+> **Android smartphone or tablet**
 >>
 >> - [Gmail for Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android)
 >>
-> **Web Interface**
+> **Web interface**
 >>
 >> - [Gmail online interface](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_gmail)
 >>
 
-### POP, IMAP and SMTP settings <a name="popimap-settings"></a>
+### Using the Zimbra mobile app <a name="config-zimbra-app"></a>
 
-When you choose your account type, we recommend using **IMAP** to receive emails. However, you can decide to use **POP**.
+Compatible with both the **Zimbra Starter** and **Zimbra Pro** plans, the Zimbra mobile app (Android and iOS) lets you access your account using the native Zimbra protocol.
 
-- **POP configuration**
+- [Configuring the Zimbra mobile app](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
 
-|Information|Description|
-|---|---|
-|Username|Enter the **full** email address.|
-|Password|Enter the password for the email account|
-|Server **EUROPE** (incoming)|pop.mail.ovh.net **ou** ssl0.ovh.net|
-|Server **AMERICA / ASIA-PACIFIC** (incoming)|pop.mail.ovh.ca|
-|Port|995|
-|Security type|SSL/TLS|
+### Reference IMAP, POP and SMTP settings <a name="popimap-settings"></a>
 
-- **IMAP configuration**
+If your email client requires manual configuration, use the following settings.
 
-|Information|Description|
-|---|---|
-|Username|Enter the **full** email address.|
-|Password|Enter the password for the email account|
-|Server **EUROPE** (incoming)|imap.mail.ovh.net **ou** ssl0.ovh.net|
-|Server **AMERICA / ASIA-PACIFIC** (incoming)|imap.mail.ovh.ca|
-|Port|993|
-|Security type|SSL/TLS|
+#### Incoming servers
 
-For sending emails, if you need to enter the **SMTP** settings manually in your account preferences, you will find the settings below:
+To receive emails, we recommend the **IMAP** protocol. The **POP** protocol is still available. Click the tab corresponding to the protocol of your choice:
 
-- **SMTP configuration**
+> [!tabs]
+> **IMAP (recommended)**
+>>
+>> - **Username**: **full** email address
+>> - **Password**: password for the email address
+>> - **EUROPE server (incoming)**: `imap.mail.ovh.net` **or** `ssl0.ovh.net`
+>> - **AMERICA/ASIA-PACIFIC server (incoming)**: `imap.mail.ovh.ca`
+>> - **Port**: 993
+>> - **Security type**: SSL/TLS
+>>
+> **POP**
+>>
+>> - **Username**: **full** email address
+>> - **Password**: password for the email address
+>> - **EUROPE server (incoming)**: `pop.mail.ovh.net` **or** `ssl0.ovh.net`
+>> - **AMERICA/ASIA-PACIFIC server (incoming)**: `pop.mail.ovh.ca`
+>> - **Port**: 995
+>> - **Security type**: SSL/TLS
+>>
 
-|Information|Description|
-|---|---|
-|Username|Enter the **full** email address.|
-|Password|Enter the password for the email account|
-|Server **EUROPE** (incoming)|smtp.mail.ovh.net **ou** ssl0.ovh.net|
-|Server **AMERICA / ASIA-PACIFIC** (incoming)|smtp.mail.ovh.ca|
-|Port|465|
-|Security type|SSL/TLS|
+#### Outgoing server
+
+To send emails, use the following **SMTP** settings:
+
+- **Username**: **full** email address
+- **Password**: password for the email address
+- **EUROPE server (outgoing)**: `smtp.mail.ovh.net` **or** `ssl0.ovh.net`
+- **AMERICA/ASIA-PACIFIC server (outgoing)**: `smtp.mail.ovh.ca`
+- **Port**: 465
+- **Security type**: SSL/TLS
 
 ## Go further <a name="go-further"></a>
 
 [Getting started with Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
 
-[Use Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
+[Configuring the Zimbra mobile app](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
 
-[OVHcloud Zimbra FAQ](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-zimbra)
+[Using Zimbra webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
-For specialized services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+[FAQ on the OVHcloud Zimbra solution](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-zimbra)
 
-If you would like assistance with using and configuring your OVHcloud solutions, we recommend referring to our range of [support solutions](/links/support).
+For specialised services (SEO, development, etc.), contact the [OVHcloud partners](/links/partner).
+
+If you would like assistance with using and configuring your OVHcloud solutions, we recommend our range of [support solutions](/links/support).
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.es-es.md
@@ -1,109 +1,169 @@
 ---
-title: "Configurar una dirección de correo electrónico de Zimbra en un cliente de correo"
-excerpt: "Cómo configurar su cliente de correo para consultar el correo de su cuenta de Zimbra"
-updated: 2025-02-12
+title: "Zimbra - Configurar la cuenta de correo electrónico en un cliente de correo"
+excerpt: "Elija el método de configuración adaptado a su plan Zimbra Starter o Pro y a su cliente de correo"
+updated: 2026-05-04
 ---
-
-<style>
-.w-400 {
-max-width:400px!important;
-}
-</style>
 
 ## Objetivo
 
-Con el servicio Zimbra, OVHcloud le ofrece una plataforma de mensajería en colaboración open source que ofrece todas las funcionalidades necesarias para un uso profesional. Esta página contiene la información necesaria para configurar sus cuentas de correo electrónico de Zimbra en su cliente de correo preferido.
+Con su plan Zimbra, OVHcloud le ofrece una plataforma de mensajería colaborativa open source con todas las funcionalidades necesarias para un uso profesional. Esta guía le ayuda a elegir el método de configuración adaptado a su plan Zimbra y a su cliente de correo.
 
-**Descubra cómo configurar su cliente de correo para consultar los mensajes de su cuenta Zimbra**
+**Descubra qué método elegir para configurar su cuenta de correo electrónico Zimbra en el cliente de correo de su elección.**
 
 ## Requisitos
 
-- Tener una cuenta de correo en nuestra solución de correo Zimbra OVHcloud.
-- Haber instalado un programa de correo en el dispositivo que usted elija.
+- Haber contratado una cuenta de correo electrónico en una de nuestras [soluciones Zimbra](/links/web/emails-zimbra) (**Zimbra Starter** o **Zimbra Pro**).
+- Haber instalado un cliente de correo en el dispositivo de su elección.
+- Disponer de las credenciales de la dirección de correo electrónico que desea configurar.
+
+<!-- CP-NAV-START:web-zimbra -->
+---
+
+### Acceso al área de cliente de OVHcloud
+
+- **Enlace directo:** [Zimbra](/links/control-panel/web-zimbra)
+- **Para acceder a sus servicios:** `Web Cloud`{.action} > `Zimbra Mail`{.action}
+
+---
+<!-- CP-NAV-END:web-zimbra -->
 
 ## Procedimiento
 
-### Configurar una cuenta de correo <a name="mail-config"></a>
+### Identificar su plan Zimbra <a name="identifier-offre"></a>
 
-La configuración de su cuenta de correo electrónico Zimbra utiliza los mismos parámetros que la solución MX Plan, incluida con los planes de hosting de OVHcloud o como solución de alojamiento individual. Por ese motivo, los enlaces de configuración que aparecen a continuación tienen la mención «MX Plan» en su título.
+El método de configuración que debe utilizar depende de su plan Zimbra. Los dos planes no admiten los mismos protocolos.
 
-Haga clic en la ficha correspondiente al tipo de dispositivo que utilice:
+| Plan | Protocolos admitidos | Funcionalidades sincronizadas |
+|---|---|---|
+| **Zimbra Starter** | IMAP, POP, SMTP | Solo correos electrónicos |
+| **Zimbra Pro** | IMAP, POP, SMTP, **ActiveSync**, **EWS** | Correos electrónicos, calendario, contactos, tareas |
+
+> [!primary]
+>
+> Para identificar su plan, conéctese a su [área de cliente de OVHcloud](/links/manager) y acceda a `Web Cloud`{.action} y, a continuación, a `Zimbra Mail`{.action}. En la pestaña `Cuentas de correo`{.action}, el plan se indica en la columna **Plan** de cada cuenta.
+
+### Configurar una cuenta Zimbra Pro <a name="config-zimbra-pro"></a>
+
+> [!success]
+>
+> Para aprovechar al máximo las funcionalidades colaborativas de Zimbra Pro (sincronización del calendario, los contactos y las tareas), utilice los protocolos **ActiveSync** o **EWS** mediante las guías dedicadas que aparecen a continuación. La configuración IMAP/POP sigue siendo posible, pero solo sincroniza los correos electrónicos.
+
+Haga clic en la pestaña correspondiente al tipo de dispositivo que utiliza:
+
+> [!tabs]
+> **Ordenador Windows**
+>>
+>> - [Outlook clásico mediante ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_windows)
+>>
+> **Ordenador Apple Mac**
+>>
+>> - [Mail mediante EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_macos)
+>> - [Outlook mediante EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_macos)
+>>
+> **iPhone o iPad**
+>>
+>> - [Mail mediante ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_app_ios)
+>> - [Outlook mediante ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_ios)
+>>
+> **Smartphone o tableta Android**
+>>
+>> - [Gmail mediante ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_gmail_app_android)
+>> - [Outlook mediante ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_android)
+>>
+
+### Configurar una cuenta Zimbra Starter (o una cuenta Zimbra Pro en IMAP/POP) <a name="mail-config"></a>
+
+Para el plan **Zimbra Starter**, o si prefiere una configuración IMAP/POP para su cuenta **Zimbra Pro**, utilice las guías que aparecen a continuación.
+
+> [!primary]
+>
+> Las guías que aparecen a continuación se comparten con el plan MX Plan, ya que los parámetros IMAP/POP/SMTP son estrictamente idénticos para ambos planes. Por ese motivo, los enlaces tienen la mención "MX Plan" en su título.
+
+Haga clic en la pestaña correspondiente al tipo de dispositivo que utiliza:
 
 > [!tabs]
 > **Ordenador Windows**
 >>
 >> - [Outlook para Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016)
 >> - [Thunderbird para Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_thunderbird_windows)
->> - [Correo de Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
+>> - [Correo para Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
 >>
-> **Ordenador Apple mac**
+> **Ordenador Apple Mac**
 >>
 >> - [Outlook para macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016_mac)
->> - [Mail for macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
+>> - [Mail para macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
 >> - [Thunderbird para macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_thunderbird_mac)
 >>
 > **iPhone o iPad**
 >>
->> - [Correo para iPhone e iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
+>> - [Mail para iPhone e iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
 >>
 > **Smartphone o tableta Android**
 >>
 >> - [Gmail para Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android)
 >>
-> **Interfaz Web**
+> **Interfaz web**
 >>
 >> - [Interfaz online de Gmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_gmail)
 >>
 
-### Aviso de los parámetros POP, IMAP y SMTP <a name="popimap-settings"></a>
+### Utilizar la aplicación móvil Zimbra <a name="config-zimbra-app"></a>
 
-Para la recepción de mensajes de correo, al elegir el tipo de cuenta, le recomendamos que utilice **IMAP**. Sin embargo, puede seleccionar **POP**.
+Compatible con los planes **Zimbra Starter** y **Zimbra Pro**, la aplicación móvil Zimbra (Android e iOS) permite acceder a su cuenta mediante el protocolo nativo de Zimbra.
 
-- **Para una configuración en POP**
+- [Configurar la aplicación móvil Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
 
-|Información|Descripción|
-|---|---|
-|Nombre de usuario|Introduzca la dirección de correo electrónico **completa**|
-|Contraseña|Introduzca la contraseña de la dirección de correo|
-|Servidor **EUROPA** (entrante)|pop.mail.ovh.net **o** ssl0.ovh.net|
-|Servidor **AMÉRICA / ASIA-PACÍFICO** (entrante)|pop.mail.ovh.ca|
-|Puerto|995|
-|Tipo de seguridad|SSL/TLS|
+### Parámetros IMAP, POP y SMTP de referencia <a name="popimap-settings"></a>
 
-- **Para una configuración en IMAP**
+Si su cliente de correo requiere una configuración manual, utilice los siguientes parámetros.
 
-|Información|Descripción|
-|---|---|
-|Nombre de usuario|Introduzca la dirección de correo electrónico **completa**|
-|Contraseña|Introduzca la contraseña de la dirección de correo|
-|Servidor **EUROPA** (entrante)|imap.mail.ovh.net **o** ssl0.ovh.net|
-|Servidor **AMÉRICA / ASIA-PACÍFICO** (entrante)|imap.mail.ovh.ca|
-|Puerto|993|
-|Tipo de seguridad|SSL/TLS|
+#### Servidores de recepción
 
-Para el envío de mensajes de correo electrónico, si debe introducir manualmente los parámetros **SMTP** en las preferencias de la cuenta, encontrará a continuación los parámetros que debe utilizar:
+Para la recepción de los correos electrónicos, recomendamos el protocolo **IMAP**. El protocolo **POP** sigue estando disponible. Haga clic en la pestaña correspondiente al protocolo de su elección:
 
-- **Configuración SMTP**
+> [!tabs]
+> **IMAP (recomendado)**
+>>
+>> - **Nombre de usuario**: dirección de correo electrónico **completa**
+>> - **Contraseña**: contraseña de la dirección de correo electrónico
+>> - **Servidor EUROPA (entrante)**: `imap.mail.ovh.net` **o** `ssl0.ovh.net`
+>> - **Servidor AMÉRICA/ASIA-PACÍFICO (entrante)**: `imap.mail.ovh.ca`
+>> - **Puerto**: 993
+>> - **Tipo de seguridad**: SSL/TLS
+>>
+> **POP**
+>>
+>> - **Nombre de usuario**: dirección de correo electrónico **completa**
+>> - **Contraseña**: contraseña de la dirección de correo electrónico
+>> - **Servidor EUROPA (entrante)**: `pop.mail.ovh.net` **o** `ssl0.ovh.net`
+>> - **Servidor AMÉRICA/ASIA-PACÍFICO (entrante)**: `pop.mail.ovh.ca`
+>> - **Puerto**: 995
+>> - **Tipo de seguridad**: SSL/TLS
+>>
 
-|Información|Descripción|
-|---|---|
-|Nombre de usuario|Introduzca la dirección de correo electrónico **completa**|
-|Contraseña|Introduzca la contraseña de la dirección de correo|
-|Servidor **EUROPA** (entrante)|smtp.mail.ovh.net **o** ssl0.ovh.net|
-|Servidor **AMÉRICA / ASIA-PACÍFICO** (entrante)|smtp.mail.ovh.ca|
-|Puerto|465|
-|Tipo de seguridad|SSL/TLS|
+#### Servidor de envío
+
+Para el envío de los correos electrónicos, utilice los siguientes parámetros **SMTP**:
+
+- **Nombre de usuario**: dirección de correo electrónico **completa**
+- **Contraseña**: contraseña de la dirección de correo electrónico
+- **Servidor EUROPA (saliente)**: `smtp.mail.ovh.net` **o** `ssl0.ovh.net`
+- **Servidor AMÉRICA/ASIA-PACÍFICO (saliente)**: `smtp.mail.ovh.ca`
+- **Puerto**: 465
+- **Tipo de seguridad**: SSL/TLS
 
 ## Más información <a name="go-further"></a>
 
-[Primeros pasos con Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
+[Primeros pasos con el plan Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
+
+[Configurar la aplicación móvil Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
 
 [Utilizar el webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
 [FAQ sobre la solución Zimbra OVHcloud](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-zimbra)
 
-Para servicios especializados (posicionamiento web, desarrollo...), póngase en contacto con los [partners de OVHcloud](/links/partner).
+Para servicios especializados (posicionamiento web, desarrollo, etc.), póngase en contacto con los [partners de OVHcloud](/links/partner).
 
-Si necesita ayuda para el uso y la configuración de sus soluciones de OVHcloud, puede consultar nuestras distintas [ofertas de soporte](/links/support).
+Si necesita ayuda para el uso y la configuración de sus soluciones de OVHcloud, puede consultar nuestras [ofertas de soporte](/links/support).
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Zimbra - Configurer son compte e-mail sur un logiciel de messagerie"
 excerpt: "Choisissez la méthode de configuration adaptée à votre offre Zimbra Starter ou Pro et à votre logiciel de messagerie"
-updated: 2026-04-22
+updated: 2026-05-04
 ---
 
 ## Objectif

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.fr-fr.md
@@ -6,7 +6,7 @@ updated: 2026-04-22
 
 ## Objectif
 
-Avec l'offre Zimbra, OVHcloud vous propose une plateforme de messagerie collaborative open source offrant toutes les fonctionnalités nécessaires à une utilisation professionnelle. Ce guide vous aide à choisir la méthode de configuration adaptée à votre offre Zimbra et à votre logiciel de messagerie.
+Avec l'offre Zimbra, OVHcloud vous propose une plateforme de messagerie collaborative open source avec toutes les fonctionnalités nécessaires à un usage professionnel. Ce guide vous aide à choisir la méthode de configuration adaptée à votre offre Zimbra et à votre logiciel de messagerie.
 
 **Découvrez quelle méthode choisir pour configurer votre compte e-mail Zimbra sur le logiciel de messagerie de votre choix.**
 
@@ -31,22 +31,22 @@ Avec l'offre Zimbra, OVHcloud vous propose une plateforme de messagerie collabor
 
 ### Identifier votre offre Zimbra <a name="identifier-offre"></a>
 
-La méthode de configuration à utiliser dépend de votre offre Zimbra. Les deux offres ne supportent pas les mêmes protocoles.
+La méthode de configuration à utiliser dépend de votre offre Zimbra. Les deux offres ne prennent pas en charge les mêmes protocoles.
 
-| Offre | Protocoles supportés | Fonctionnalités synchronisées |
+| Offre | Protocoles pris en charge | Fonctionnalités synchronisées |
 |---|---|---|
 | **Zimbra Starter** | IMAP, POP, SMTP | E-mails uniquement |
 | **Zimbra Pro** | IMAP, POP, SMTP, **ActiveSync**, **EWS** | E-mails, calendrier, contacts, tâches |
 
 > [!primary]
 >
-> Pour identifier votre offre, connectez-vous à votre [espace client OVHcloud](/links/manager), rendez-vous dans la partie `Web Cloud`{.action} puis `Emails`{.action}, et sélectionnez votre service Zimbra. L'offre est indiquée dans les informations du service.
+> Pour identifier votre offre, connectez-vous à votre [espace client OVHcloud](/links/manager), rendez-vous dans la partie `Web Cloud`{.action} puis `Zimbra Mail`{.action}. Dans l'onglet `Compte email`{.action}, l'offre est indiquée dans la colonne **Offre** de chaque compte.
 
 ### Configurer un compte Zimbra Pro <a name="config-zimbra-pro"></a>
 
 > [!success]
 >
-> Pour tirer pleinement parti des fonctionnalités collaboratives de Zimbra Pro (synchronisation du calendrier, des contacts et des tâches), utilisez les protocoles **ActiveSync** ou **EWS** via les guides dédiés ci-dessous. La configuration IMAP/POP reste possible mais ne synchronisera que les e-mails.
+> Pour tirer pleinement parti des fonctionnalités collaboratives de Zimbra Pro (synchronisation du calendrier, des contacts et des tâches), utilisez les protocoles **ActiveSync** ou **EWS** via les guides dédiés ci-dessous. La configuration IMAP/POP reste possible, mais ne synchronise que les e-mails.
 
 Cliquez sur l'onglet correspondant au type d'appareil que vous utilisez :
 
@@ -71,9 +71,9 @@ Cliquez sur l'onglet correspondant au type d'appareil que vous utilisez :
 >> - [Outlook via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_android)
 >>
 
-### Configurer un compte Zimbra Starter (ou en IMAP/POP) <a name="mail-config"></a>
+### Configurer un compte Zimbra Starter (ou un compte Zimbra Pro en IMAP/POP) <a name="mail-config"></a>
 
-Pour l'offre **Zimbra Starter**, ou si vous préférez une configuration IMAP/POP avec votre compte **Zimbra Pro**, utilisez les guides ci-dessous.
+Pour l'offre **Zimbra Starter**, ou si vous préférez une configuration IMAP/POP pour votre compte **Zimbra Pro**, utilisez les guides ci-dessous.
 
 > [!primary]
 >
@@ -109,7 +109,7 @@ Cliquez sur l'onglet correspondant au type d'appareil que vous utilisez :
 
 ### Utiliser l'application mobile Zimbra <a name="config-zimbra-app"></a>
 
-Compatible avec les offres **Zimbra Starter** et **Zimbra Pro**, l'application mobile Zimbra (Android et iOS) permet d'accéder à votre compte en utilisant le protocole natif de Zimbra.
+Compatible avec les offres **Zimbra Starter** et **Zimbra Pro**, l'application mobile Zimbra (Android et iOS) permet d'accéder à votre compte via le protocole natif de Zimbra.
 
 - [Configurer l'application mobile Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
 
@@ -119,7 +119,7 @@ Si votre logiciel de messagerie nécessite une configuration manuelle, utilisez 
 
 #### Serveurs de réception
 
-Pour la réception des e-mails, nous vous recommandons l'usage du protocole **IMAP**. Le protocole **POP** reste disponible. Cliquez sur l'onglet correspondant au protocole de votre choix :
+Pour la réception des e-mails, nous recommandons le protocole **IMAP**. Le protocole **POP** reste disponible. Cliquez sur l'onglet correspondant au protocole de votre choix :
 
 > [!tabs]
 > **IMAP (recommandé)**
@@ -127,7 +127,7 @@ Pour la réception des e-mails, nous vous recommandons l'usage du protocole **IM
 >> - **Nom d'utilisateur** : adresse e-mail **complète**
 >> - **Mot de passe** : mot de passe de l'adresse e-mail
 >> - **Serveur EUROPE (entrant)** : `imap.mail.ovh.net` **ou** `ssl0.ovh.net`
->> - **Serveur AMERIQUE/ASIE-PACIFIQUE (entrant)** : `imap.mail.ovh.ca`
+>> - **Serveur AMÉRIQUE/ASIE-PACIFIQUE (entrant)** : `imap.mail.ovh.ca`
 >> - **Port** : 993
 >> - **Type de sécurité** : SSL/TLS
 >>
@@ -136,7 +136,7 @@ Pour la réception des e-mails, nous vous recommandons l'usage du protocole **IM
 >> - **Nom d'utilisateur** : adresse e-mail **complète**
 >> - **Mot de passe** : mot de passe de l'adresse e-mail
 >> - **Serveur EUROPE (entrant)** : `pop.mail.ovh.net` **ou** `ssl0.ovh.net`
->> - **Serveur AMERIQUE/ASIE-PACIFIQUE (entrant)** : `pop.mail.ovh.ca`
+>> - **Serveur AMÉRIQUE/ASIE-PACIFIQUE (entrant)** : `pop.mail.ovh.ca`
 >> - **Port** : 995
 >> - **Type de sécurité** : SSL/TLS
 >>
@@ -148,7 +148,7 @@ Pour l'envoi des e-mails, utilisez les paramètres **SMTP** suivants :
 - **Nom d'utilisateur** : adresse e-mail **complète**
 - **Mot de passe** : mot de passe de l'adresse e-mail
 - **Serveur EUROPE (sortant)** : `smtp.mail.ovh.net` **ou** `ssl0.ovh.net`
-- **Serveur AMERIQUE/ASIE-PACIFIQUE (sortant)** : `smtp.mail.ovh.ca`
+- **Serveur AMÉRIQUE/ASIE-PACIFIQUE (sortant)** : `smtp.mail.ovh.ca`
 - **Port** : 465
 - **Type de sécurité** : SSL/TLS
 

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.fr-fr.md
@@ -1,31 +1,83 @@
 ---
-title: "Configurer une adresse e-mail Zimbra sur un logiciel de messagerie"
-excerpt: "Découvrez comment configurer votre logiciel de messagerie pour consulter les e-mails de votre compte Zimbra"
-updated: 2025-02-12
+title: "Zimbra - Configurer son compte e-mail sur un logiciel de messagerie"
+excerpt: "Choisissez la méthode de configuration adaptée à votre offre Zimbra Starter ou Pro et à votre logiciel de messagerie"
+updated: 2026-04-22
 ---
-
-<style>
-.w-400 {
-max-width:400px!important;
-}
-</style>
 
 ## Objectif
 
-Avec l'offre Zimbra, OVHcloud vous propose une plateforme de messagerie collaborative open source offrant toutes les fonctionnalités nécessaires à une utilisation professionnelle. Retrouvez sur cette page les informations nécessaires à la configuration de vos comptes e-mail Zimbra sur votre logiciel de messagerie préféré.
+Avec l'offre Zimbra, OVHcloud vous propose une plateforme de messagerie collaborative open source offrant toutes les fonctionnalités nécessaires à une utilisation professionnelle. Ce guide vous aide à choisir la méthode de configuration adaptée à votre offre Zimbra et à votre logiciel de messagerie.
 
-**Découvrez comment configurer votre logiciel de messagerie pour consulter les e-mails de votre compte Zimbra**
+**Découvrez quelle méthode choisir pour configurer votre compte e-mail Zimbra sur le logiciel de messagerie de votre choix.**
 
 ## Prérequis
 
-- Avoir souscrit à un compte e-mail sur notre solution e-mail Zimbra OVHcloud.
+- Avoir souscrit à un compte e-mail sur l'une de nos [solutions Zimbra](/links/web/emails-zimbra) (**Zimbra Starter** ou **Zimbra Pro**).
 - Avoir installé un logiciel de messagerie sur l'appareil de votre choix.
+- Posséder les identifiants de connexion de l'adresse e-mail à configurer.
+
+<!-- CP-NAV-START:web-zimbra -->
+---
+
+### Accès à l'espace client OVHcloud
+
+- **Lien direct :** [Zimbra](/links/control-panel/web-zimbra)
+- **Pour accéder à vos services :** `Web Cloud`{.action} > `Zimbra Mail`{.action}
+
+---
+<!-- CP-NAV-END:web-zimbra -->
 
 ## En pratique
 
-### Configurer son compte e-mail <a name="mail-config"></a>
+### Identifier votre offre Zimbra <a name="identifier-offre"></a>
 
-La configuration de votre compte e-mail Zimbra utilise les mêmes paramètres que l'offre MX Plan, incluse avec les hébergements Web OVHcloud ou en offre seule. C'est pourquoi les liens de configuration ci-dessous ont une mention « MX Plan » dans leur titre.
+La méthode de configuration à utiliser dépend de votre offre Zimbra. Les deux offres ne supportent pas les mêmes protocoles.
+
+| Offre | Protocoles supportés | Fonctionnalités synchronisées |
+|---|---|---|
+| **Zimbra Starter** | IMAP, POP, SMTP | E-mails uniquement |
+| **Zimbra Pro** | IMAP, POP, SMTP, **ActiveSync**, **EWS** | E-mails, calendrier, contacts, tâches |
+
+> [!primary]
+>
+> Pour identifier votre offre, connectez-vous à votre [espace client OVHcloud](/links/manager), rendez-vous dans la partie `Web Cloud`{.action} puis `Emails`{.action}, et sélectionnez votre service Zimbra. L'offre est indiquée dans les informations du service.
+
+### Configurer un compte Zimbra Pro <a name="config-zimbra-pro"></a>
+
+> [!success]
+>
+> Pour tirer pleinement parti des fonctionnalités collaboratives de Zimbra Pro (synchronisation du calendrier, des contacts et des tâches), utilisez les protocoles **ActiveSync** ou **EWS** via les guides dédiés ci-dessous. La configuration IMAP/POP reste possible mais ne synchronisera que les e-mails.
+
+Cliquez sur l'onglet correspondant au type d'appareil que vous utilisez :
+
+> [!tabs]
+> **Ordinateur Windows**
+>>
+>> - [Outlook classique via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_windows)
+>>
+> **Ordinateur Apple Mac**
+>>
+>> - [Mail via EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_macos)
+>> - [Outlook via EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_macos)
+>>
+> **iPhone ou iPad**
+>>
+>> - [Mail via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_app_ios)
+>> - [Outlook via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_ios)
+>>
+> **Smartphone ou tablette Android**
+>>
+>> - [Gmail via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_gmail_app_android)
+>> - [Outlook via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_android)
+>>
+
+### Configurer un compte Zimbra Starter (ou en IMAP/POP) <a name="mail-config"></a>
+
+Pour l'offre **Zimbra Starter**, ou si vous préférez une configuration IMAP/POP avec votre compte **Zimbra Pro**, utilisez les guides ci-dessous.
+
+> [!primary]
+>
+> Les guides ci-dessous sont partagés avec l'offre MX Plan car les paramètres IMAP/POP/SMTP sont strictement identiques pour les deux offres. C'est pourquoi les liens ont une mention « MX Plan » dans leur titre.
 
 Cliquez sur l'onglet correspondant au type d'appareil que vous utilisez :
 
@@ -36,7 +88,7 @@ Cliquez sur l'onglet correspondant au type d'appareil que vous utilisez :
 >> - [Thunderbird pour Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_thunderbird_windows)
 >> - [Courrier pour Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
 >>
-> **Ordinateur Apple mac**
+> **Ordinateur Apple Mac**
 >>
 >> - [Outlook pour macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016_mac)
 >> - [Mail pour macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
@@ -46,63 +98,71 @@ Cliquez sur l'onglet correspondant au type d'appareil que vous utilisez :
 >>
 >> - [Mail pour iPhone et iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
 >>
-> **Smartphone ou Tablette Android**
+> **Smartphone ou tablette Android**
 >>
 >> - [Gmail pour Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android)
 >>
-> **Interface Web**
+> **Interface web**
 >>
 >> - [Interface en ligne de Gmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_gmail)
 >>
 
-### Rappel des paramètres POP, IMAP et SMTP <a name="popimap-settings"></a>
+### Utiliser l'application mobile Zimbra <a name="config-zimbra-app"></a>
 
-Pour la réception des e-mails, lors du choix du type de compte, nous vous conseillons une utilisation en **IMAP**. Vous pouvez cependant sélectionner **POP**.
+Compatible avec les offres **Zimbra Starter** et **Zimbra Pro**, l'application mobile Zimbra (Android et iOS) permet d'accéder à votre compte en utilisant le protocole natif de Zimbra.
 
-- **Pour une configuration en POP**
+- [Configurer l'application mobile Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
 
-|Information|Description|
-|---|---|
-|Nom d'utilisateur|Renseignez l'adresse e-mail **complète**|
-|Mot de passe|Renseignez le mot de passe de l'adresse e-mail|
-|Serveur **EUROPE** (entrant)|pop.mail.ovh.net **ou** ssl0.ovh.net|
-|Serveur **AMERIQUE / ASIE-PACIFIQUE** (entrant)|pop.mail.ovh.ca|
-|Port|995|
-|Type de sécurité|SSL/TLS|
+### Paramètres IMAP, POP et SMTP de référence <a name="popimap-settings"></a>
 
-- **Pour une configuration en IMAP**
+Si votre logiciel de messagerie nécessite une configuration manuelle, utilisez les paramètres suivants.
 
-|Information|Description|
-|---|---|
-|Nom d'utilisateur|Renseignez l'adresse e-mail **complète**|
-|Mot de passe|Renseignez le mot de passe de l'adresse e-mail|
-|Serveur **EUROPE** (entrant)|imap.mail.ovh.net **ou** ssl0.ovh.net|
-|Serveur **AMERIQUE / ASIE-PACIFIQUE** (entrant)|imap.mail.ovh.ca|
-|Port|993|
-|Type de sécurité|SSL/TLS|
+#### Serveurs de réception
 
-Pour l'envoi des e-mails, si vous devez renseigner manuellement les paramètres **SMTP** dans les préférences du compte, vous trouverez ci-dessous les paramètres à utiliser :
+Pour la réception des e-mails, nous vous recommandons l'usage du protocole **IMAP**. Le protocole **POP** reste disponible. Cliquez sur l'onglet correspondant au protocole de votre choix :
 
-- **Configuration SMTP**
+> [!tabs]
+> **IMAP (recommandé)**
+>>
+>> - **Nom d'utilisateur** : adresse e-mail **complète**
+>> - **Mot de passe** : mot de passe de l'adresse e-mail
+>> - **Serveur EUROPE (entrant)** : `imap.mail.ovh.net` **ou** `ssl0.ovh.net`
+>> - **Serveur AMERIQUE/ASIE-PACIFIQUE (entrant)** : `imap.mail.ovh.ca`
+>> - **Port** : 993
+>> - **Type de sécurité** : SSL/TLS
+>>
+> **POP**
+>>
+>> - **Nom d'utilisateur** : adresse e-mail **complète**
+>> - **Mot de passe** : mot de passe de l'adresse e-mail
+>> - **Serveur EUROPE (entrant)** : `pop.mail.ovh.net` **ou** `ssl0.ovh.net`
+>> - **Serveur AMERIQUE/ASIE-PACIFIQUE (entrant)** : `pop.mail.ovh.ca`
+>> - **Port** : 995
+>> - **Type de sécurité** : SSL/TLS
+>>
 
-|Information|Description|
-|---|---|
-|Nom d'utilisateur|Renseignez l'adresse e-mail **complète**|
-|Mot de passe|Renseignez le mot de passe de l'adresse e-mail|
-|Serveur **EUROPE** (entrant)|smtp.mail.ovh.net **ou** ssl0.ovh.net|
-|Serveur **AMERIQUE / ASIE-PACIFIQUE** (entrant)|smtp.mail.ovh.ca|
-|Port|465|
-|Type de sécurité|SSL/TLS|
+#### Serveur d'envoi
+
+Pour l'envoi des e-mails, utilisez les paramètres **SMTP** suivants :
+
+- **Nom d'utilisateur** : adresse e-mail **complète**
+- **Mot de passe** : mot de passe de l'adresse e-mail
+- **Serveur EUROPE (sortant)** : `smtp.mail.ovh.net` **ou** `ssl0.ovh.net`
+- **Serveur AMERIQUE/ASIE-PACIFIQUE (sortant)** : `smtp.mail.ovh.ca`
+- **Port** : 465
+- **Type de sécurité** : SSL/TLS
 
 ## Aller plus loin <a name="go-further"></a>
 
 [Premiers pas avec l'offre Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
 
+[Configurer l'application mobile Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
+
 [Utiliser le webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
 [FAQ sur la solution Zimbra OVHcloud](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-zimbra)
 
-Pour des prestations spécialisées (référencement, développement, etc), contactez les [partenaires OVHcloud](/links/partner).
+Pour des prestations spécialisées (référencement, développement, etc.), contactez les [partenaires OVHcloud](/links/partner).
 
 Si vous souhaitez bénéficier d'une assistance à l'usage et à la configuration de vos solutions OVHcloud, nous vous proposons de consulter nos différentes [offres de support](/links/support).
 

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.it-it.md
@@ -1,33 +1,85 @@
 ---
-title: "Configurare un indirizzo email Zimbra su un client di posta"
-excerpt: "Scopri come configurare il tuo client di posta per consultare le email del tuo account Zimbra"
-updated: 2025-02-12
+title: "Zimbra - Configurare il proprio account e-mail su un client di posta"
+excerpt: "Scopri come scegliere il metodo di configurazione adatto alla tua offerta Zimbra Starter o Pro e al tuo client di posta"
+updated: 2026-05-04
 ---
-
-<style>
-.w-400 {
-max-width:400px!important;
-}
-</style>
 
 ## Obiettivo
 
-Con l'offerta Zimbra, OVHcloud ti propone una piattaforma di messaggeria collaborativa open source che offre tutte le funzionalità necessarie ad un utilizzo professionale. In questa pagina trovi le informazioni necessarie per configurare i tuoi account email Zimbra sul tuo client di posta preferito.
+Con l'offerta Zimbra, OVHcloud ti propone una piattaforma di messaggeria collaborativa open source che offre tutte le funzionalità necessarie per un utilizzo professionale. Questa guida ti aiuta a scegliere il metodo di configurazione adatto alla tua offerta Zimbra e al tuo client di posta.
 
-**Questa guida ti mostra come configurare il client di posta per consultare le email del tuo account Zimbra**
+**Scopri quale metodo scegliere per configurare il tuo account e-mail Zimbra sul client di posta che preferisci.**
 
 ## Prerequisiti
 
-- Aver sottoscritto un account email sulla soluzione email Zimbra OVHcloud.
-- Aver installato un client di posta elettronica sul dispositivo scelto.
+- Aver sottoscritto un account e-mail su una delle nostre [soluzioni Zimbra](/links/web/emails-zimbra) (**Zimbra Starter** o **Zimbra Pro**).
+- Aver installato un client di posta sul dispositivo scelto.
+- Possedere le credenziali di accesso dell'indirizzo e-mail da configurare.
+
+<!-- CP-NAV-START:web-zimbra -->
+---
+
+### Accesso allo Spazio Cliente OVHcloud
+
+- **Link diretto:** [Zimbra](/links/control-panel/web-zimbra)
+- **Per accedere ai tuoi servizi:** `Web Cloud`{.action} > `Zimbra Mail`{.action}
+
+---
+<!-- CP-NAV-END:web-zimbra -->
 
 ## Procedura
 
-### Configurare un account email <a name="mail-config"></a>
+### Identificare la tua offerta Zimbra <a name="identifier-offre"></a>
 
-La configurazione dell’account email Zimbra utilizza gli stessi parametri della soluzione MX Plan, inclusa con gli hosting Web OVHcloud o disponibile solo in. Ecco perché i link di configurazione qui sotto hanno una dicitura "MX Plan" nel loro titolo.
+Il metodo di configurazione da utilizzare dipende dalla tua offerta Zimbra. Le due offerte non supportano gli stessi protocolli.
 
-Fare clic sulla scheda relativa al tipo di dispositivo in uso:
+| Offerta | Protocolli supportati | Funzionalità sincronizzate |
+|---|---|---|
+| **Zimbra Starter** | IMAP, POP, SMTP | Solo e-mail |
+| **Zimbra Pro** | IMAP, POP, SMTP, **ActiveSync**, **EWS** | E-mail, calendario, contatti, attività |
+
+> [!primary]
+>
+> Per identificare la tua offerta, accedi al tuo [Spazio Cliente OVHcloud](/links/manager), vai nella sezione `Web Cloud`{.action} e poi `Zimbra Mail`{.action}. Nella scheda `Account email`{.action}, l'offerta è indicata nella colonna **Piano** di ogni account.
+
+### Configurare un account Zimbra Pro <a name="config-zimbra-pro"></a>
+
+> [!success]
+>
+> Per sfruttare pienamente le funzionalità collaborative di Zimbra Pro (sincronizzazione di calendario, contatti e attività), utilizza i protocolli **ActiveSync** o **EWS** tramite le guide dedicate qui sotto. La configurazione IMAP/POP resta possibile, ma sincronizza solo le e-mail.
+
+Fai clic sulla scheda corrispondente al tipo di dispositivo in uso:
+
+> [!tabs]
+> **Computer Windows**
+>>
+>> - [Outlook classico tramite ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_windows)
+>>
+> **Computer Apple Mac**
+>>
+>> - [Mail tramite EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_macos)
+>> - [Outlook tramite EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_macos)
+>>
+> **iPhone o iPad**
+>>
+>> - [Mail tramite ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_app_ios)
+>> - [Outlook tramite ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_ios)
+>>
+> **Smartphone o tablet Android**
+>>
+>> - [Gmail tramite ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_gmail_app_android)
+>> - [Outlook tramite ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_android)
+>>
+
+### Configurare un account Zimbra Starter (o un account Zimbra Pro in IMAP/POP) <a name="mail-config"></a>
+
+Per l'offerta **Zimbra Starter**, o se preferisci una configurazione IMAP/POP per il tuo account **Zimbra Pro**, utilizza le guide qui sotto.
+
+> [!primary]
+>
+> Le guide qui sotto sono condivise con l'offerta MX Plan poiché i parametri IMAP/POP/SMTP sono assolutamente identici per le due offerte. È per questo che i link riportano la dicitura "MX Plan" nel loro titolo.
+
+Fai clic sulla scheda corrispondente al tipo di dispositivo in uso:
 
 > [!tabs]
 > **Computer Windows**
@@ -36,7 +88,7 @@ Fare clic sulla scheda relativa al tipo di dispositivo in uso:
 >> - [Thunderbird per Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_thunderbird_windows)
 >> - [Posta per Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
 >>
-> **Computer Apple mac**
+> **Computer Apple Mac**
 >>
 >> - [Outlook per macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016_mac)
 >> - [Mail per macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
@@ -46,64 +98,72 @@ Fare clic sulla scheda relativa al tipo di dispositivo in uso:
 >>
 >> - [Mail per iPhone e iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
 >>
-> **Smartphone o Tablet Android**
+> **Smartphone o tablet Android**
 >>
 >> - [Gmail per Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android)
 >>
-> **Interfaccia Web**
+> **Interfaccia web**
 >>
->> - [Gmail Online Interface](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_gmail)
+>> - [Interfaccia online di Gmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_gmail)
 >>
 
-### Richiamo dei parametri POP, IMAP e SMTP <a name="popimap-settings"></a>
+### Utilizzare l'applicazione mobile Zimbra <a name="config-zimbra-app"></a>
 
-Per la ricezione delle email, durante la scelta del tipo di account, ti consigliamo di utilizzare il **IMAP**. Tuttavia, è possibile selezionare **POP**.
+Compatibile con le offerte **Zimbra Starter** e **Zimbra Pro**, l'applicazione mobile Zimbra (Android e iOS) consente di accedere al tuo account tramite il protocollo nativo di Zimbra.
 
-- **Per una configurazione in POP**
+- [Configurare l'applicazione mobile Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
 
-|Informazione|Descrizione|
-|---|---|
-|Nome utente|Inserisci l'indirizzo email **completo**|
-|Password|Inserisci la password dell’indirizzo email|
-|Server **EUROPA** (in entrata)|pop.mail.ovh.net **o** ssl0.ovh.net|
-|Server **AMERICA/ASIA PACIFICA** (in entrata)|pop.mail.ovh.ca|
-|Porta|995|
-|Tipo di sicurezza|SSL/TLS|
+### Parametri IMAP, POP e SMTP di riferimento <a name="popimap-settings"></a>
 
-- **Per una configurazione in IMAP**
+Se il tuo client di posta richiede una configurazione manuale, utilizza i parametri seguenti.
 
-|Informazione|Descrizione|
-|---|---|
-|Nome utente|Inserisci l'indirizzo email **completo**|
-|Password|Inserisci la password dell’indirizzo email|
-|Server **EUROPA** (in entrata)|imap.mail.ovh.net **o** ssl0.ovh.net|
-|Server **AMERICA/ASIA PACIFICA** (in entrata)|imap.mail.ovh.ca|
-|Porta|993|
-|Tipo di sicurezza|SSL/TLS|
+#### Server di ricezione
 
-Per l’invio delle email, se hai necessità di inserire manualmente le impostazioni **SMTP** nelle preferenze dell’account, ecco i parametri da utilizzare:
+Per la ricezione delle e-mail, consigliamo il protocollo **IMAP**. Il protocollo **POP** resta disponibile. Fai clic sulla scheda corrispondente al protocollo che preferisci:
 
-- **Configurazione SMTP**
+> [!tabs]
+> **IMAP (consigliato)**
+>>
+>> - **Nome utente**: indirizzo e-mail **completo**
+>> - **Password**: password dell'indirizzo e-mail
+>> - **Server EUROPA (in entrata)**: `imap.mail.ovh.net` **o** `ssl0.ovh.net`
+>> - **Server AMERICA/ASIA-PACIFICO (in entrata)**: `imap.mail.ovh.ca`
+>> - **Porta**: 993
+>> - **Tipo di sicurezza**: SSL/TLS
+>>
+> **POP**
+>>
+>> - **Nome utente**: indirizzo e-mail **completo**
+>> - **Password**: password dell'indirizzo e-mail
+>> - **Server EUROPA (in entrata)**: `pop.mail.ovh.net` **o** `ssl0.ovh.net`
+>> - **Server AMERICA/ASIA-PACIFICO (in entrata)**: `pop.mail.ovh.ca`
+>> - **Porta**: 995
+>> - **Tipo di sicurezza**: SSL/TLS
+>>
 
-|Informazione|Descrizione|
-|---|---|
-|Nome utente|Inserisci l'indirizzo email **completo**|
-|Password|Inserisci la password dell’indirizzo email|
-|Server **EUROPA** (in entrata)|smtp.mail.ovh.net **o** ssl0.ovh.net|
-|Server **AMERICA/ASIA PACIFICA** (in entrata)|smtp.mail.ovh.ca|
-|Porta|465|
-|Tipo di sicurezza|SSL/TLS|
+#### Server di invio
+
+Per l'invio delle e-mail, utilizza i seguenti parametri **SMTP**:
+
+- **Nome utente**: indirizzo e-mail **completo**
+- **Password**: password dell'indirizzo e-mail
+- **Server EUROPA (in uscita)**: `smtp.mail.ovh.net` **o** `ssl0.ovh.net`
+- **Server AMERICA/ASIA-PACIFICO (in uscita)**: `smtp.mail.ovh.ca`
+- **Porta**: 465
+- **Tipo di sicurezza**: SSL/TLS
 
 ## Per saperne di più <a name="go-further"></a>
 
-[Iniziare a utilizzare il servizio Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
+[Iniziare a utilizzare l'offerta Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
 
-[Webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
+[Configurare l'applicazione mobile Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
 
-[FAQ soluzione Zimbra OVHcloud](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-zimbra)
+[Utilizzare il webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
+
+[FAQ sulla soluzione Zimbra OVHcloud](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-zimbra)
 
 Per prestazioni specializzate (referenziazione, sviluppo, etc.), contatta i [partner OVHcloud](/links/partner).
 
-Per usufruire di un'assistenza per l'utilizzo e la configurazione delle soluzioni OVHcloud, consulta le nostre [offerte di supporto](/links/support).
+Per usufruire di un'assistenza all'utilizzo e alla configurazione delle tue soluzioni OVHcloud, ti proponiamo di consultare le nostre diverse [offerte di supporto](/links/support).
 
 Contatta la nostra [Community di utenti](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.pl-pl.md
@@ -1,31 +1,83 @@
 ---
-title: "Konfiguracja konta e-mail Zimbra w programie pocztowym"
-excerpt: "Dowiedz się, jak skonfigurować program pocztowy, aby sprawdzać e-maile dotyczące Twojego konta Zimbra"
-updated: 2025-02-12
+title: "Zimbra - Konfiguracja konta e-mail w programie pocztowym"
+excerpt: "Wybierz metodę konfiguracji odpowiednią dla Twojej oferty Zimbra Starter lub Pro oraz Twojego programu pocztowego"
+updated: 2026-05-04
 ---
-
-<style>
-.w-400 {
-max-width:400px!important;
-}
-</style>
 
 ## Wprowadzenie
 
-Z ofertą Zimbra OVHcloud oferuje platformę open source do przesyłania wiadomości e-mail z wszystkimi niezbędnymi funkcjami do profesjonalnego użytku. Na tej stronie znajdziesz informacje niezbędne do skonfigurowania kont e-mail Zimbra w Twoim ulubionym programie pocztowym.
+Z ofertą Zimbra OVHcloud oferuje platformę open source do pracy zespołowej z wszystkimi funkcjami niezbędnymi do profesjonalnego użytku. Niniejszy przewodnik pomoże Ci wybrać metodę konfiguracji odpowiednią dla Twojej oferty Zimbra oraz Twojego programu pocztowego.
 
-**Dowiedz się, jak skonfigurować program pocztowy do sprawdzania wiadomości e-mail na swoim koncie Zimbra**
+**Dowiedz się, jaką metodę wybrać, aby skonfigurować Twoje konto e-mail Zimbra w wybranym programie pocztowym.**
 
 ## Wymagania początkowe
 
-- Zakup konta e-mail w ramach naszego rozwiązania e-mail Zimbra OVHcloud.
-- Instalacja programu pocztowego na wybranym urządzeniu.
+- Posiadasz subskrypcję konta e-mail w jednym z naszych [rozwiązań Zimbra](/links/web/emails-zimbra) (**Zimbra Starter** lub **Zimbra Pro**).
+- Masz program pocztowy zainstalowany na wybranym urządzeniu.
+- Posiadasz dane logowania do konfigurowanego adresu e-mail.
+
+<!-- CP-NAV-START:web-zimbra -->
+---
+
+### Dostęp do Panelu klienta OVHcloud
+
+- **Bezpośredni link:** [Zimbra](/links/control-panel/web-zimbra)
+- **Aby uzyskać dostęp do usług:** `Web Cloud`{.action} > `Zimbra Mail`{.action}
+
+---
+<!-- CP-NAV-END:web-zimbra -->
 
 ## W praktyce
 
-### Konfiguracja konta e-mail <a name="mail-config"></a>
+### Identyfikacja Twojej oferty Zimbra <a name="identifier-offre"></a>
 
-Konfiguracja Twojego konta e-mail Zimbra korzysta z tych samych ustawień, co oferta MX Plan zawarta w pakiecie hostingowym OVHcloud lub oferowana samodzielnie. Z tego powodu poniższe linki konfiguracyjne zawierają w tytule adnotację "MX Plan".
+Stosowana metoda konfiguracji zależy od posiadanej oferty Zimbra. Obie oferty nie obsługują tych samych protokołów.
+
+| Oferta | Obsługiwane protokoły | Synchronizowane funkcje |
+|---|---|---|
+| **Zimbra Starter** | IMAP, POP, SMTP | Wyłącznie e-maile |
+| **Zimbra Pro** | IMAP, POP, SMTP, **ActiveSync**, **EWS** | E-maile, kalendarz, kontakty, zadania |
+
+> [!primary]
+>
+> Aby zidentyfikować Twoją ofertę, zaloguj się do [Panelu klienta OVHcloud](/links/manager) i przejdź do `Web Cloud`{.action}, a następnie `Zimbra Mail`{.action}. W zakładce `Konta e-mail`{.action} oferta jest wskazana w kolumnie **Pakiet** dla każdego konta.
+
+### Konfiguracja konta Zimbra Pro <a name="config-zimbra-pro"></a>
+
+> [!success]
+>
+> Aby w pełni korzystać z funkcji pracy zespołowej Zimbra Pro (synchronizacja kalendarza, kontaktów i zadań), używaj protokołów **ActiveSync** lub **EWS** za pomocą poniższych dedykowanych przewodników. Konfiguracja IMAP/POP jest nadal możliwa, ale synchronizuje wyłącznie e-maile.
+
+Kliknij kartę odpowiadającą typowi używanego urządzenia:
+
+> [!tabs]
+> **Komputer z systemem Windows**
+>>
+>> - [Klasyczny Outlook przez ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_windows)
+>>
+> **Komputer Apple Mac**
+>>
+>> - [Mail przez EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_macos)
+>> - [Outlook przez EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_macos)
+>>
+> **iPhone lub iPad**
+>>
+>> - [Mail przez ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_app_ios)
+>> - [Outlook przez ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_ios)
+>>
+> **Smartfon lub tablet z systemem Android**
+>>
+>> - [Gmail przez ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_gmail_app_android)
+>> - [Outlook przez ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_android)
+>>
+
+### Konfiguracja konta Zimbra Starter (lub konta Zimbra Pro w IMAP/POP) <a name="mail-config"></a>
+
+Dla oferty **Zimbra Starter** lub jeśli wolisz konfigurację IMAP/POP dla Twojego konta **Zimbra Pro**, użyj poniższych przewodników.
+
+> [!primary]
+>
+> Poniższe przewodniki są wspólne z ofertą MX Plan, ponieważ ustawienia IMAP/POP/SMTP są ściśle identyczne dla obu ofert. Z tego powodu linki zawierają w tytule adnotację "MX Plan".
 
 Kliknij kartę odpowiadającą typowi używanego urządzenia:
 
@@ -34,71 +86,79 @@ Kliknij kartę odpowiadającą typowi używanego urządzenia:
 >>
 >> - [Outlook dla Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016)
 >> - [Thunderbird dla Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_thunderbird_windows)
->> - [Poczta elektroniczna systemu Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
+>> - [Mail dla Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
 >>
-> **Komputer Apple mac**
+> **Komputer Apple Mac**
 >>
->> - [Outlook for macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016_mac)
->> - [Mail na macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
+>> - [Outlook dla macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016_mac)
+>> - [Mail dla macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
 >> - [Thunderbird dla macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_thunderbird_mac)
 >>
 > **iPhone lub iPad**
 >>
->> - [Mail na iPhone'a i iPada](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
+>> - [Mail dla iPhone'a i iPada](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
 >>
-> **Smartphone lub tablet z systemem Android**
+> **Smartfon lub tablet z systemem Android**
 >>
->> - [Gmail na Androida](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android)
+>> - [Gmail dla Androida](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android)
 >>
 > **Interfejs WWW**
 >>
 >> - [Interfejs online programu Gmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_gmail)
 >>
 
-### Przypomnienie parametrów POP, IMAP i SMTP <a name="popimap-settings"></a>
+### Korzystanie z aplikacji mobilnej Zimbra <a name="config-zimbra-app"></a>
 
-Jeśli chcesz otrzymywać e-maile, wybierz rodzaj konta. Zalecamy użycie **IMAP**. Możesz jednak wybrać **POP**.
+Kompatybilna z ofertami **Zimbra Starter** i **Zimbra Pro** aplikacja mobilna Zimbra (Android i iOS) umożliwia dostęp do Twojego konta przy użyciu natywnego protokołu Zimbra.
 
-- **Konfiguracja POP**
+- [Konfiguracja aplikacji mobilnej Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
 
-|Informacje|Opis|
-|---|---|
-|Nazwa użytkownika|Wpisz pełny adres e-mail **complete**|
-|Hasło|Wpisz hasło wybrane dla tego konta e-mail|
-|Serwer **EUROPE** (ruch przychodzący)|pop.mail.ovh.net **lub** ssl0.ovh.net|
-|Serwer **AMERYKA / AZJA-PACYFIK** (ruch przychodzący)|pop.mail.ovh.ca|
-|Port|995|
-|Typ zabezpieczeń|SSL/TLS|
+### Referencyjne ustawienia IMAP, POP i SMTP <a name="popimap-settings"></a>
 
-- **Konfiguracja IMAP**
+Jeśli Twój program pocztowy wymaga ręcznej konfiguracji, użyj następujących ustawień.
 
-|Informacje|Opis|
-|---|---|
-|Nazwa użytkownika|Wpisz pełny adres e-mail **complete**|
-|Hasło|Wpisz hasło wybrane dla tego konta e-mail|
-|Serwer **EUROPE** (ruch przychodzący)|imap.mail.ovh.net **lub** ssl0.ovh.net|
-|Serwer **AMERYKA / AZJA-PACYFIK** (ruch przychodzący)|imap.mail.ovh.ca|
-|Port|993|
-|Typ zabezpieczeń|SSL/TLS|
+#### Serwery przychodzące
 
-Do wysyłki e-maili, jeśli wprowadzasz ręcznie ustawienia **SMTP** w ustawieniach konta poniżej znajdziesz parametry, których należy użyć:
+Aby otrzymywać e-maile, zalecamy protokół **IMAP**. Protokół **POP** jest nadal dostępny. Kliknij kartę odpowiadającą wybranemu protokołowi:
 
-- **Konfiguracja SMTP**
+> [!tabs]
+> **IMAP (zalecany)**
+>>
+>> - **Nazwa użytkownika**: **pełny** adres e-mail
+>> - **Hasło**: hasło do adresu e-mail
+>> - **Serwer EUROPA (przychodzący)**: `imap.mail.ovh.net` **lub** `ssl0.ovh.net`
+>> - **Serwer AMERYKA/AZJA-PACYFIK (przychodzący)**: `imap.mail.ovh.ca`
+>> - **Port**: 993
+>> - **Typ zabezpieczeń**: SSL/TLS
+>>
+> **POP**
+>>
+>> - **Nazwa użytkownika**: **pełny** adres e-mail
+>> - **Hasło**: hasło do adresu e-mail
+>> - **Serwer EUROPA (przychodzący)**: `pop.mail.ovh.net` **lub** `ssl0.ovh.net`
+>> - **Serwer AMERYKA/AZJA-PACYFIK (przychodzący)**: `pop.mail.ovh.ca`
+>> - **Port**: 995
+>> - **Typ zabezpieczeń**: SSL/TLS
+>>
 
-|Informacje|Opis|
-|---|---|
-|Nazwa użytkownika|Wpisz pełny adres e-mail **complete**|
-|Hasło|Wpisz hasło wybrane dla tego konta e-mail|
-|Serwer **EUROPE** (ruch przychodzący)|smtp.mail.ovh.net **lub** ssl0.ovh.net|
-|Serwer **AMERYKA / AZJA-PACYFIK** (przychodzący)|smtp.mail.ovh.ca|
-|Port|465|
-|Typ zabezpieczeń|SSL/TLS|
+#### Serwer wychodzący
+
+Aby wysyłać e-maile, użyj następujących ustawień **SMTP**:
+
+- **Nazwa użytkownika**: **pełny** adres e-mail
+- **Hasło**: hasło do adresu e-mail
+- **Serwer EUROPA (wychodzący)**: `smtp.mail.ovh.net` **lub** `ssl0.ovh.net`
+- **Serwer AMERYKA/AZJA-PACYFIK (wychodzący)**: `smtp.mail.ovh.ca`
+- **Port**: 465
+- **Typ zabezpieczeń**: SSL/TLS
 
 ## Sprawdź również <a name="go-further"></a>
 
 [Pierwsze kroki z ofertą Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
 
-[Skorzystaj z poczty Zimbra Webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
+[Konfiguracja aplikacji mobilnej Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
+
+[Korzystanie z poczty Zimbra Webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
 [FAQ dotyczący rozwiązania Zimbra OVHcloud](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-zimbra)
 
@@ -106,4 +166,4 @@ W przypadku specjalistycznych usług (SEO, programowanie, itp.) skontaktuj się 
 
 Jeśli chcesz uzyskać wsparcie w zakresie użytkowania i konfiguracji Twoich rozwiązań OVHcloud, zapoznaj się z naszymi [ofertami wsparcia](/links/support).
 
-Przyłącz się do [społeczności użytkowników](/links/community).
+Dołącz do [grona naszych użytkowników](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_apps/guide.pt-pt.md
@@ -1,42 +1,94 @@
 ---
-title: "Configurar um endereço de e-mail Zimbra num software de mensagens"
-excerpt: "Descubra como configurar o seu software de e-mail para consultar os e-mails da sua conta Zimbra"
-updated: 2025-02-12
+title: "Zimbra - Configurar a sua conta de e-mail num software de mensagens"
+excerpt: "Escolha o método de configuração adequado à sua oferta Zimbra Starter ou Pro e ao seu software de mensagens"
+updated: 2026-05-04
 ---
-
-<style>
-.w-400 {
-max-width:400px!important;
-}
-</style>
 
 ## Objetivo
 
-Com a oferta Zimbra, a OVHcloud propõe-lhe uma plataforma de mensagens colaborativa open source que oferece todas as funcionalidades necessárias a uma utilização profissional. Encontre nesta página as informações necessárias para configurar as suas contas de e-mail Zimbra no seu programa de mensagens preferido.
+Com a oferta Zimbra, a OVHcloud propõe-lhe uma plataforma de mensagens colaborativa open source com todas as funcionalidades necessárias para uma utilização profissional. Este guia ajuda-o a escolher o método de configuração adequado à sua oferta Zimbra e ao seu software de mensagens.
 
-**Saiba como configurar o software de e-mail para consultar os e-mails da sua conta Zimbra**
+**Descubra qual o método a escolher para configurar a sua conta de e-mail Zimbra no software de mensagens da sua preferência.**
 
 ## Requisitos
 
-- Ter subscrito uma conta de e-mail na nossa solução de e-mail Zimbra OVHcloud.
+- Ter subscrito uma conta de e-mail numa das nossas [soluções Zimbra](/links/web/emails-zimbra) (**Zimbra Starter** ou **Zimbra Pro**).
 - Ter instalado um software de mensagens no dispositivo da sua escolha.
+- Possuir os dados de acesso do endereço de e-mail a configurar.
+
+<!-- CP-NAV-START:web-zimbra -->
+---
+
+### Acesso à área de cliente OVHcloud
+
+- **Link direto:** [Zimbra](/links/control-panel/web-zimbra)
+- **Para aceder aos seus serviços:** `Web Cloud`{.action} > `Zimbra Mail`{.action}
+
+---
+<!-- CP-NAV-END:web-zimbra -->
 
 ## Instruções
 
-### Configurar a conta de e-mail <a name="mail-config"></a>
+### Identificar a sua oferta Zimbra <a name="identifier-offre"></a>
 
-A configuração da sua conta de e-mail Zimbra utiliza os mesmos parâmetros que a oferta MX Plan, incluída com os alojamentos Web da OVHcloud ou com uma oferta só. É por isso que os links de configuração abaixo têm uma menção « MX Plan » no título.
+O método de configuração a utilizar depende da sua oferta Zimbra. As duas ofertas não suportam os mesmos protocolos.
 
-Clique na guia correspondente ao tipo de dispositivo que você está usando:
+| Oferta | Protocolos suportados | Funcionalidades sincronizadas |
+|---|---|---|
+| **Zimbra Starter** | IMAP, POP, SMTP | Apenas e-mails |
+| **Zimbra Pro** | IMAP, POP, SMTP, **ActiveSync**, **EWS** | E-mails, calendário, contactos, tarefas |
+
+> [!primary]
+>
+> Para identificar a sua oferta, inicie sessão na sua [área de cliente OVHcloud](/links/manager) e aceda à secção `Web Cloud`{.action} e, em seguida, a `Zimbra Mail`{.action}. No separador `Contas de email`{.action}, a oferta é indicada na coluna **Plano** de cada conta.
+
+### Configurar uma conta Zimbra Pro <a name="config-zimbra-pro"></a>
+
+> [!success]
+>
+> Para tirar pleno partido das funcionalidades colaborativas do Zimbra Pro (sincronização do calendário, dos contactos e das tarefas), utilize os protocolos **ActiveSync** ou **EWS** através dos guias dedicados abaixo. A configuração IMAP/POP continua disponível, mas apenas sincroniza os e-mails.
+
+Clique no separador correspondente ao tipo de dispositivo que utiliza:
 
 > [!tabs]
-> **Computador com Windows**
+> **Computador Windows**
+>>
+>> - [Outlook clássico via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_windows)
+>>
+> **Computador Apple Mac**
+>>
+>> - [Mail via EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_macos)
+>> - [Outlook via EWS](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_macos)
+>>
+> **iPhone ou iPad**
+>>
+>> - [Mail via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_mail_app_ios)
+>> - [Outlook via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_ios)
+>>
+> **Smartphone ou tablet Android**
+>>
+>> - [Gmail via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_gmail_app_android)
+>> - [Outlook via ActiveSync](/pages/web_cloud/email_and_collaborative_solutions/zimbra/zimbra_outlook_app_android)
+>>
+
+### Configurar uma conta Zimbra Starter (ou uma conta Zimbra Pro em IMAP/POP) <a name="mail-config"></a>
+
+Para a oferta **Zimbra Starter**, ou caso prefira uma configuração IMAP/POP para a sua conta **Zimbra Pro**, utilize os guias abaixo.
+
+> [!primary]
+>
+> Os guias abaixo são partilhados com a oferta MX Plan, uma vez que os parâmetros IMAP/POP/SMTP são estritamente idênticos para as duas ofertas. É por essa razão que os links incluem a menção "MX Plan" no respetivo título.
+
+Clique no separador correspondente ao tipo de dispositivo que utiliza:
+
+> [!tabs]
+> **Computador Windows**
 >>
 >> - [Outlook para Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016)
 >> - [Thunderbird para Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_thunderbird_windows)
 >> - [Correio para Windows](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_windows_10)
 >>
-> **Computador Apple mac**
+> **Computador Apple Mac**
 >>
 >> - [Outlook para macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_outlook_2016_mac)
 >> - [Mail para macOS](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_mail_macos)
@@ -44,66 +96,74 @@ Clique na guia correspondente ao tipo de dispositivo que você está usando:
 >>
 > **iPhone ou iPad**
 >>
->> - [Mail para o iPhone e o iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
+>> - [Mail para iPhone e iPad](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_ios)
 >>
-> **Smartphone ou Tablet Android**
+> **Smartphone ou tablet Android**
 >>
 >> - [Gmail para Android](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_android)
 >>
-> **Interface Web**
+> **Interface web**
 >>
 >> - [Interface online do Gmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/how_to_configure_gmail)
 >>
 
-### Lembrete dos parâmetros POP, IMAP e SMTP <a name="popimap-settings"></a>
+### Utilizar a aplicação móvel Zimbra <a name="config-zimbra-app"></a>
 
-Para a receção dos e-mails, ao escolher o tipo de conta, recomendamos uma utilização em **IMAP**. No entanto, pode selecionar **POP**.
+Compatível com as ofertas **Zimbra Starter** e **Zimbra Pro**, a aplicação móvel Zimbra (Android e iOS) permite aceder à sua conta através do protocolo nativo do Zimbra.
 
-- **Para uma configuração em POP**
+- [Configurar a aplicação móvel Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
 
-|Informação|Descrição|
-|---|---|
-|Nome de utilizador|Introduza o endereço de e-mail **completo**|
-|Palavra-passe|Introduza a palavra-passe do endereço de e-mail|
-|Servidor **EUROPE** (entrada)|pop.mail.ovh.net **ou** ssl0.ovh.net|
-|Servidor **AMÉRICA/ÁSIA-PACÍFICO** (entrada)|pop.mail.ovh.ca|
-|Porta|995|
-|Tipo de segurança|SSL/TLS|
+### Parâmetros IMAP, POP e SMTP de referência <a name="popimap-settings"></a>
 
-- **Para uma configuração em IMAP**
+Se o seu software de mensagens necessitar de uma configuração manual, utilize os parâmetros seguintes.
 
-|Informação|Descrição|
-|---|---|
-|Nome de utilizador|Introduza o endereço de e-mail **completo**|
-|Palavra-passe|Introduza a palavra-passe do endereço de e-mail|
-|Servidor **EUROPA** (entrada)|imap.mail.ovh.net **ou** ssl0.ovh.net|
-|Servidor **AMÉRICA/ÁSIA-PACÍFICO** (entrada)|imap.mail.ovh.ca|
-|Porta|993|
-|Tipo de segurança|SSL/TLS|
+#### Servidores de receção
 
-Se necessitar de inserir manualmente as definições **SMTP** nas preferências da conta para enviar uma mensagem de correio eletrónico, poderá encontrar abaixo as definições que deve utilizar:
+Para a receção dos e-mails, recomendamos o protocolo **IMAP**. O protocolo **POP** continua disponível. Clique no separador correspondente ao protocolo da sua escolha:
 
-- **Configuração SMTP**
+> [!tabs]
+> **IMAP (recomendado)**
+>>
+>> - **Nome de utilizador**: endereço de e-mail **completo**
+>> - **Palavra-passe**: palavra-passe do endereço de e-mail
+>> - **Servidor EUROPA (entrada)**: `imap.mail.ovh.net` **ou** `ssl0.ovh.net`
+>> - **Servidor AMÉRICA/ÁSIA-PACÍFICO (entrada)**: `imap.mail.ovh.ca`
+>> - **Porta**: 993
+>> - **Tipo de segurança**: SSL/TLS
+>>
+> **POP**
+>>
+>> - **Nome de utilizador**: endereço de e-mail **completo**
+>> - **Palavra-passe**: palavra-passe do endereço de e-mail
+>> - **Servidor EUROPA (entrada)**: `pop.mail.ovh.net` **ou** `ssl0.ovh.net`
+>> - **Servidor AMÉRICA/ÁSIA-PACÍFICO (entrada)**: `pop.mail.ovh.ca`
+>> - **Porta**: 995
+>> - **Tipo de segurança**: SSL/TLS
+>>
 
-|Informação|Descrição|
-|---|---|
-|Nome de utilizador|Introduza o endereço de e-mail **completo**|
-|Palavra-passe|Introduza a palavra-passe do endereço de e-mail|
-|Servidor **EUROPA** (entrada)|smtp.mail.ovh.net **ou** ssl0.ovh.net|
-|Servidor **AMÉRICA/ÁSIA-PACÍFICO** (entrada)|smtp.mail.ovh.ca|
-|Porta|465|
-|Tipo de segurança|SSL/TLS|
+#### Servidor de envio
+
+Para o envio dos e-mails, utilize os parâmetros **SMTP** seguintes:
+
+- **Nome de utilizador**: endereço de e-mail **completo**
+- **Palavra-passe**: palavra-passe do endereço de e-mail
+- **Servidor EUROPA (saída)**: `smtp.mail.ovh.net` **ou** `ssl0.ovh.net`
+- **Servidor AMÉRICA/ÁSIA-PACÍFICO (saída)**: `smtp.mail.ovh.ca`
+- **Porta**: 465
+- **Tipo de segurança**: SSL/TLS
 
 ## Quer saber mais? <a name="go-further"></a>
 
 [Primeiros passos com a oferta Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/getting_started_zimbra)
 
+[Configurar a aplicação móvel Zimbra](/pages/web_cloud/email_and_collaborative_solutions/zimbra/mail_app_zimbra_for_android_ios)
+
 [Utilizar o webmail Zimbra](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_zimbra)
 
 [FAQ sobre a solução Zimbra OVHcloud](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/faq-zimbra)
 
-Para serviços especializados (referenciamento, desenvolvimento, etc), contacte os [parceiros OVHcloud](/links/partner).
+Para serviços especializados (referenciamento, desenvolvimento, etc.), contacte os [parceiros OVHcloud](/links/partner).
 
-Se deseja beneficiar de uma assistência ao uso e à configuração das suas soluções OVHcloud, sugerimos que consulte as nossas diferentes [ofertas de suporte](/links/support).
+Caso pretenda beneficiar de assistência na utilização e configuração das suas soluções OVHcloud, sugerimos que consulte as nossas diferentes [ofertas de suporte](/links/support).
 
 Fale com a nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION
## What type of Pull Request is this?

- Update of existing guide
- Optimization

## Description

The guide was ambiguous about which Zimbra offer it covered, leading clients to follow IMAP/POP instructions on Zimbra Pro accounts and miss the collaborative features (calendar, contacts, tasks sync).

Changes (fr-fr):
- New section "Identifier votre offre Zimbra" with comparison table (Starter: IMAP/POP/SMTP only vs Pro: + ActiveSync/EWS)
- New section "Configurer un compte Zimbra Pro" linking to the 7 dedicated ActiveSync/EWS guides (Windows/macOS/iOS/Android)
- Existing MX Plan redirects kept under "Configurer un compte Zimbra Starter (ou en IMAP/POP)" with explanation of why MX Plan guides apply
- New section "Utiliser l'application mobile Zimbra" (transverse to both offers, previously misplaced under Pro only)
- Server settings restructured: tables converted to lists, IMAP/POP wrapped in tabs under "Serveurs de reception" H4, SMTP under "Serveur d'envoi" H4; fixed "(entrant)" -> "(sortant)" for SMTP
- Added <!-- CP-NAV-START:web-zimbra --> template block (standard OVHcloud pattern, consistent with other Zimbra guides)
- Added link to the Zimbra mobile app guide in "Aller plus loin"
- Link to Zimbra offer added on "solutions Zimbra" in prerequisites
