### PR TITLE
Hosted Private Cloud / Bare Metal Pod - adding snc_iam_manage guide

### DIFF
--- a/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.en-gb.md
+++ b/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.en-gb.md
@@ -19,7 +19,6 @@ All authentication is centralised in **Keycloak**, which acts as the single entr
 - A **Bare Metal Pod SecNumCloud** delivered and operational
 - Access to the Keycloak interface with an account holding the `pod_operator` role or higher
 - Having read the [Getting started with your Bare Metal Pod SecNumCloud](/pages/hosted_private_cloud/baremetal_pod/snc_getting_started) guide
-- Having `jq` installed on your workstation (required for the Keycloak API script)
 
 ## Instructions
 

--- a/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.en-gb.md
+++ b/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.en-gb.md
@@ -103,7 +103,6 @@ Available OpenStack roles are:
 
 | OpenStack role | Description |
 |----------------|-------------|
-| `admin` | Full administration of the project |
 | `member` | Edit rights on the project |
 | `reader` | Read-only access to the project |
 
@@ -127,7 +126,7 @@ Example for a user accessing two projects:
 **Attribute 2** (key: `project`):
 
 ```json
-{"domain": {"name": "Default"}, "name": "staging-project", "roles": [{"name": "admin"}, {"name": "reader"}]}
+{"domain": {"name": "Default"}, "name": "staging-project", "roles": [{"name": "member"}, {"name": "reader"}]}
 ```
 
 #### Configuring attributes on a group

--- a/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.en-gb.md
+++ b/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "IAM Rights Management - Bare Metal Pod SecNumCloud"
-excerpt: "Learn how to manage users and their access rights on your Bare Metal Pod SecNumCloud using Keycloak"
-updated: 2026-04-27
+excerpt: "Find out how to manage users, configure their access rights, and assign OpenStack roles on your Bare Metal Pod SecNumCloud via Keycloak."
+updated: 2026-04-28
 ---
 
 ## Objective
@@ -48,7 +48,7 @@ The `pod_operator` role is assigned by OVHcloud to the first platform access acc
 
 It provides the following additional capabilities:
 
-- Manage users, groups and roles within the pod realm (create accounts, assign OpenStack rights via project attributes)
+- Manage users, groups, and roles within the pod realm (create accounts, assign OpenStack rights via project attributes)
 - Request node delegation from OVHcloud support (required for specific configurations such as LACP or software RAID)
 
 ### Access matrix
@@ -89,12 +89,18 @@ Add a new attribute with the following values:
 
 ```json
 {
-  "domain": {"name": "Default"},
-  "name": "project-name",
-  "roles": [
-    {"name": "member"},
-    {"name": "reader"}
-  ]
+    "domain": {
+        "name": "Default"
+    },
+    "name": "project-name",
+    "roles": [
+        {
+            "name": "member"
+        },
+        {
+            "name": "reader"
+        }
+    ]
 }
 ```
 
@@ -112,25 +118,48 @@ Available OpenStack roles are:
 
 #### Assigning multiple projects to a user
 
-Multiple `project` attributes can be added to the same user or group. They will automatically be merged into a single `projects` attribute in the token passed to Keystone.
+You can add multiple `project` attributes to the same user or group. Keycloak automatically merges them into a single `projects` attribute in the token passed to Keystone.
 
 Example for a user accessing two projects:
 
 **Attribute 1** (key: `project`):
 
 ```json
-{"domain": {"name": "Default"}, "name": "production-project", "roles": [{"name": "member"}]}
+{
+    "domain": {
+        "name": "Default"
+    },
+    "name": "production-project",
+    "roles": [
+        {
+            "name": "member"
+        }
+    ]
+}
 ```
 
 **Attribute 2** (key: `project`):
 
 ```json
-{"domain": {"name": "Default"}, "name": "staging-project", "roles": [{"name": "member"}, {"name": "reader"}]}
+{
+    "domain": {
+        "name": "Default"
+    },
+    "name": "staging-project",
+    "roles": [
+        {
+            "name": "member"
+        },
+        {
+            "name": "reader"
+        }
+    ]
+}
 ```
 
 #### Configuring attributes on a group
 
-The same configuration can be applied to a **Keycloak group**. All members of the group will automatically inherit the project attributes defined on that group.
+You can apply the same configuration to a **Keycloak group** — all members automatically inherit the project attributes defined on it.
 
 In Keycloak, navigate to **Groups**, select the target group, and fill in the `project` attributes in the same way as for an individual user.
 
@@ -162,7 +191,7 @@ openstack role list
 
 #### Via the Keycloak API (complete view)
 
-To obtain an exhaustive view of rights, including users who have never logged into OpenStack, you need to query the Keycloak API directly and consolidate project attributes manually.
+For an exhaustive view of rights — including Keycloak users who have never logged into OpenStack — query the Keycloak API directly and consolidate project attributes manually.
 
 The script uses a **service account** in Keycloak, which avoids any dependency on user credentials or OTP. Follow the steps below to set it up before running the script.
 
@@ -212,9 +241,13 @@ pip install python-keycloak requests
 
 ##### Rights retrieval script
 
-A user's OpenStack rights can come from multiple sources: attributes defined directly on their account, inherited from groups, parent groups, or roles. This combination can make it difficult to read effective permissions from the administration interface. To check the rights of a specific user, you can use the Keycloak web interface directly: **Clients** > select the `keystone` client > **Client scopes** > **Evaluate** > select the user > **Generate access token**. The script below is an example of using the Keycloak API to retrieve this same information programmatically. By querying Keycloak the same way Keystone would, it provides a **clear and consolidated view of effective permissions** across all active users in the realm in a single run.
+A user's OpenStack rights can come from multiple sources: attributes defined directly on their account, inherited from groups, parent groups, or roles. This combination can make it difficult to read effective permissions from the administration interface.
 
-This script uses the same mechanism as the **Generate access token** button in the Keycloak interface, via the scope evaluation endpoint. This is the ground truth: groups, subgroups and user attributes are all merged by Keycloak itself.
+To check the rights of a specific user, you can use the Keycloak web interface directly: **Clients** > select the `keystone` client (OpenStack client) > **Client scopes** > **Evaluate** > select the user > **Generate access token**.
+
+The script below is an example of using the Keycloak API to retrieve this same information programmatically. By querying Keycloak the same way Keystone would, it provides a **clear and consolidated view of effective permissions** across all active users in the realm in a single run.
+
+This script uses the same mechanism as the **Generate access token** button in the Keycloak interface, via the scope evaluation endpoint. This is the ground truth: groups, subgroups, and user attributes are all merged by Keycloak itself.
 
 ```python
 import json
@@ -276,15 +309,15 @@ for user in kc.get_users():
         print(f"[!] {user['username']}: {e}")
 ```
 
-This script displays for each user the `projects` claim **exactly as Keystone will receive it**, including own attributes, inherited from direct groups and all parent groups.
+This script displays for each user the `projects` claim **exactly as Keystone will receive it**, including own attributes, inherited from direct groups, and all parent groups.
 
 > [!primary]
 >
-> A no-script alternative is available directly in the Keycloak interface: **Clients** > select the OpenStack client > **Client scopes** > **Evaluate** > select a user > **Generate access token**. This shows the exact token that will be sent to Keystone for that user.
+> A no-script alternative is available directly in the Keycloak interface: **Clients** > select the `keystone` client (OpenStack client) > **Client scopes** > **Evaluate** > select a user > **Generate access token**. This shows the exact token that will be sent to Keystone for that user.
 >
 
 ## Go further
 
-If you need training or technical assistance with the implementation of our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+For training or technical assistance with implementing our solutions, contact your sales representative or visit our [Professional Services](/links/professional-services) page to request a quote and a custom project analysis from our experts.
 
 Join our [community of users](/links/community).

--- a/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.en-gb.md
+++ b/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.en-gb.md
@@ -1,0 +1,292 @@
+---
+title: "IAM Rights Management - Bare Metal Pod SecNumCloud"
+excerpt: "Learn how to manage users and their access rights on your Bare Metal Pod SecNumCloud using Keycloak"
+updated: 2026-04-27
+---
+
+## Objective
+
+This guide explains how to manage Identity and Access Management (IAM) on your **Bare Metal Pod SecNumCloud**.
+
+All authentication is centralised in **Keycloak**, which acts as the single entry point for:
+
+- Access to the **Dashboard** (unified service portal)
+- Access to the **OpenStack Horizon** graphical interface
+- Access to the **OpenStack APIs** (Keystone, Nova, Neutron, Glance, Ironic...)
+
+## Requirements
+
+- A **Bare Metal Pod SecNumCloud** delivered and operational
+- Access to the Keycloak interface with an account holding the `pod_operator` role or higher
+- Having read the [Getting started with your Bare Metal Pod SecNumCloud](/pages/hosted_private_cloud/baremetal_pod/snc_getting_started) guide
+- Having `jq` installed on your workstation (required for the Keycloak API script)
+
+## Instructions
+
+### Authentication architecture
+
+All **Bare Metal Pod** authentication is centralised in **Keycloak**. A single Keycloak user account grants access to all pod services: dashboard, OpenStack Horizon, and OpenStack APIs.
+
+### Role hierarchy
+
+The IAM model of the **Bare Metal Pod SecNumCloud** is based on two access levels.
+
+#### Default access
+
+Any user registered in Keycloak, without a specific role assigned, has default access allowing them to:
+
+- Log in to the **Dashboard** and manage their own Keycloak account settings
+- Access **OpenStack** and the projects for which a `pod_operator` has granted them rights via project attributes
+
+> [!primary]
+>
+> A user without any project attribute configured will be able to log in to the dashboard but will have no access to any OpenStack project until a `pod_operator` assigns them rights.
+>
+
+#### `pod_operator` role
+
+The `pod_operator` role is assigned by OVHcloud to the first platform access account upon service delivery. This initial account can then freely assign the role to any other users within the pod realm.
+
+It provides the following additional capabilities:
+
+- Manage users, groups and roles within the pod realm (create accounts, assign OpenStack rights via project attributes)
+- Request node delegation from OVHcloud support (required for specific configurations such as LACP or software RAID)
+
+### Access matrix
+
+The table below summarises the access each level has across integrated applications.
+
+**Legend**: ✅ Allowed | ❌ Not allowed | 🟡 Partial (depends on project attributes)
+
+| Application | Permission | Default | `pod_operator` |
+|-------------|------------|:-------:|:--------------:|
+| **Keycloak** | View account settings | ✅ | ✅ |
+| **Keycloak** | Manage Keycloak users | ❌ | ✅ |
+| **OpenStack** | view | 🟡 | 🟡 |
+| **OpenStack** | member (edit) | 🟡 | 🟡 |
+| **Dashboard** | OpenStack iframe | ✅ | ✅ |
+| **Grafana** | view | ❌ | ✅ |
+| **Prometheus** | view | ❌ | ✅ |
+| **Dashboard** | Grafana iframe | ❌ | ✅ |
+| **Dashboard** | Prometheus iframe | ❌ | ✅ |
+
+> [!primary]
+>
+> OpenStack accesses marked 🟡 require **project attributes** to be configured on the user or their group in Keycloak. Without a project attribute, the user will not be able to access OpenStack resources.
+>
+
+### Configuring OpenStack rights via Keycloak attributes
+
+OpenStack project access rights are defined directly as **user attributes** (or group attributes) in Keycloak. This allows you to specify which OpenStack project(s) a user can operate on and with which role(s).
+
+#### Adding a project attribute to a user
+
+In the Keycloak interface, navigate to the relevant user and open the **Attributes** tab.
+
+Add a new attribute with the following values:
+
+- **Key**: `project`
+- **Value**: a JSON object describing the project and the roles to assign
+
+```json
+{
+  "domain": {"name": "Default"},
+  "name": "project-name",
+  "roles": [
+    {"name": "member"},
+    {"name": "reader"}
+  ]
+}
+```
+
+Available OpenStack roles are:
+
+| OpenStack role | Description |
+|----------------|-------------|
+| `admin` | Full administration of the project |
+| `member` | Edit rights on the project |
+| `reader` | Read-only access to the project |
+
+> [!primary]
+>
+> If an OpenStack project with the specified name does not yet exist, it will be **created automatically** when the user first logs in.
+>
+
+#### Assigning multiple projects to a user
+
+Multiple `project` attributes can be added to the same user or group. They will automatically be merged into a single `projects` attribute in the token passed to Keystone.
+
+Example for a user accessing two projects:
+
+**Attribute 1** (key: `project`):
+
+```json
+{"domain": {"name": "Default"}, "name": "production-project", "roles": [{"name": "member"}]}
+```
+
+**Attribute 2** (key: `project`):
+
+```json
+{"domain": {"name": "Default"}, "name": "staging-project", "roles": [{"name": "admin"}, {"name": "reader"}]}
+```
+
+#### Configuring attributes on a group
+
+The same configuration can be applied to a **Keycloak group**. All members of the group will automatically inherit the project attributes defined on that group.
+
+In Keycloak, navigate to **Groups**, select the target group, and fill in the `project` attributes in the same way as for an individual user.
+
+> [!primary]
+>
+> Attributes defined on a group and those defined directly on a user are merged. A user can therefore benefit from projects coming from multiple groups in addition to their own attributes.
+>
+
+### Listing all access rights
+
+#### Via the OpenStack CLI
+
+To list active role assignments in OpenStack:
+
+```bash
+openstack role assignment list --names
+```
+
+To list roles available on the platform:
+
+```bash
+openstack role list
+```
+
+> [!warning]
+>
+> These commands only return users who have **already authenticated** at least once through OpenStack. Users present in Keycloak but who have never logged into OpenStack will not appear in these results.
+>
+
+#### Via the Keycloak API (complete view)
+
+To obtain an exhaustive view of rights, including users who have never logged into OpenStack, you need to query the Keycloak API directly and consolidate project attributes manually.
+
+The script uses a **service account** in Keycloak, which avoids any dependency on user credentials or OTP. Follow the steps below to set it up before running the script.
+
+##### Creating the service account in Keycloak
+
+**1. Create a new client**
+
+In the Keycloak interface, select your pod realm and navigate to **Clients** > **Create client**.
+
+Fill in the following fields:
+
+- **Client type**: `OpenID Connect`
+- **Client ID**: choose a descriptive name, for example `iam-audit`
+
+Click **Next**.
+
+**2. Enable the Service Account**
+
+On the **Capability config** screen, enable only:
+
+- **Service accounts roles**: `On`
+
+Disable **Standard flow** and **Direct access grants** if they are enabled. Click **Save**.
+
+**3. Retrieve the Client Secret**
+
+In your newly created client, open the **Credentials** tab. Copy the value of the **Client secret** field — this is the value to use for `CLIENT_SECRET` in the script.
+
+**4. Assign the `view-users` role**
+
+Open the **Service accounts roles** tab of your client, then click **Assign role**.
+
+In the filter, select **Filter by clients** and search for `realm-management`. Assign the **view-users** role.
+
+> [!primary]
+>
+> The `view-users` role from the `realm-management` client allows the service account to list realm users without granting any modification rights.
+>
+
+##### Prerequisite: install the required libraries
+
+Make sure Python 3 is installed, then install the required libraries:
+
+```bash
+pip install python-keycloak requests
+```
+
+##### Rights retrieval script
+
+A user's OpenStack rights can come from multiple sources: attributes defined directly on their account, inherited from groups, parent groups, or roles. This combination can make it difficult to read effective permissions from the administration interface. To check the rights of a specific user, you can use the Keycloak web interface directly: **Clients** > select the `keystone` client > **Client scopes** > **Evaluate** > select the user > **Generate access token**. The script below is an example of using the Keycloak API to retrieve this same information programmatically. By querying Keycloak the same way Keystone would, it provides a **clear and consolidated view of effective permissions** across all active users in the realm in a single run.
+
+This script uses the same mechanism as the **Generate access token** button in the Keycloak interface, via the scope evaluation endpoint. This is the ground truth: groups, subgroups and user attributes are all merged by Keycloak itself.
+
+```python
+import json
+import requests
+from keycloak import KeycloakAdmin
+
+KEYCLOAK_URL = "https://<your-keycloak>"
+REALM = "pod"
+CLIENT_ID = "<client-id>"
+CLIENT_SECRET = "<client-secret>"
+
+kc = KeycloakAdmin(
+    server_url=KEYCLOAK_URL,
+    realm_name=REALM,
+    client_id=CLIENT_ID,
+    client_secret_key=CLIENT_SECRET
+)
+
+# Obtain the service account token
+admin_token = requests.post(
+    f"{KEYCLOAK_URL}/realms/{REALM}/protocol/openid-connect/token",
+    data={
+        "grant_type": "client_credentials",
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+    }
+).json()['access_token']
+
+# Retrieve the keystone client UUID
+keystone_uuid = kc.get_client_id("keystone")
+
+# For each active user, evaluate the token and display effective projects
+for user in kc.get_users():
+    if not user.get('enabled'):
+        continue
+    try:
+        resp = requests.get(
+            f"{KEYCLOAK_URL}/admin/realms/{REALM}/clients/{keystone_uuid}"
+            f"/evaluate-scopes/generate-example-access-token",
+            params={"userId": user['id'], "scope": "openid"},
+            headers={"Authorization": f"Bearer {admin_token}"}
+        )
+        if not resp.ok:
+            print(f"[DEBUG] status={resp.status_code} body={resp.text}")
+            resp.raise_for_status()
+        claims = resp.json()
+        # projects can be a JSON string or a list depending on the Keycloak version
+        projects_raw = (
+            claims.get('projects')
+            or claims.get('otherClaims', {}).get('projects', [])
+        )
+        if isinstance(projects_raw, str):
+            projects_raw = json.loads(projects_raw)
+        print(json.dumps({
+            "username": user['username'],
+            "effective_projects": projects_raw
+        }, indent=2))
+    except Exception as e:
+        print(f"[!] {user['username']}: {e}")
+```
+
+This script displays for each user the `projects` claim **exactly as Keystone will receive it**, including own attributes, inherited from direct groups and all parent groups.
+
+> [!primary]
+>
+> A no-script alternative is available directly in the Keycloak interface: **Clients** > select the OpenStack client > **Client scopes** > **Evaluate** > select a user > **Generate access token**. This shows the exact token that will be sent to Keystone for that user.
+>
+
+## Go further
+
+If you need training or technical assistance with the implementation of our solutions, contact your sales representative or click on [this link](/links/professional-services) to get a quote and request a custom analysis of your project from our Professional Services team experts.
+
+Join our [community of users](/links/community).

--- a/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.en-gb.md
+++ b/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.en-gb.md
@@ -1,6 +1,6 @@
 ---
 title: "IAM Rights Management - Bare Metal Pod SecNumCloud"
-excerpt: "Find out how to manage users, configure their access rights, and assign OpenStack roles on your Bare Metal Pod SecNumCloud via Keycloak."
+excerpt: "Find out how to manage users, configure their access rights, and assign OpenStack roles on your Bare Metal Pod SecNumCloud via Keycloak"
 updated: 2026-04-28
 ---
 

--- a/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.fr-fr.md
@@ -108,11 +108,10 @@ Ajoutez un nouvel attribut avec les valeurs suivantes :
 
 Les rôles OpenStack disponibles sont :
 
-| Rôle OpenStack | Description                       |
-|----------------|-----------------------------------|
-| `admin`        | Administration complète du projet |
-| `member`       | Droits d'édition sur le projet    |
-| `reader`       | Lecture seule sur le projet       |
+| Rôle OpenStack | Description                    |
+|----------------|--------------------------------|
+| `member`       | Droits d'édition sur le projet |
+| `reader`       | Lecture seule sur le projet    |
 
 > [!primary]
 >
@@ -153,7 +152,7 @@ Exemple pour un utilisateur accédant à deux projets :
     "name": "projet-staging",
     "roles": [
         {
-            "name": "admin"
+            "name": "member"
         },
         {
             "name": "reader"

--- a/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.fr-fr.md
@@ -1,15 +1,14 @@
 ---
 title: "Gestion des droits IAM - Bare Metal Pod SecNumCloud"
-excerpt: "Découvrez comment gérer les utilisateurs et leurs droits d'accès sur votre Bare Metal Pod SecNumCloud via Keycloak"
-updated: 2026-04-27
+excerpt: "Découvrez comment gérer les utilisateurs, configurer leurs droits et attribuer les rôles OpenStack sur votre Bare Metal Pod SecNumCloud via Keycloak."
+updated: 2026-04-28
 ---
 
 ## Objectif
 
-Ce guide explique comment gérer les droits et les accès (IAM - Identity and Access Management) de votre **Bare Metal Pod
-SecNumCloud**.
+Ce guide explique comment gérer les droits et les accès (IAM - Identity and Access Management) de votre **Bare Metal Pod SecNumCloud**.
 
-L'ensemble de l'authentification est centralisé dans **Keycloak**, qui sert de point d'entrée unique pour :
+L'ensemble de l'authentification est centralisé dans **Keycloak**, qui sert de point d'entrée unique pour :
 
 - L'accès au **Dashboard** (tableau de bord unifié du service)
 - L'accès à l'interface graphique **OpenStack Horizon**
@@ -19,15 +18,13 @@ L'ensemble de l'authentification est centralisé dans **Keycloak**, qui sert de 
 
 - Disposer d'un **Bare Metal Pod SecNumCloud** livré et opérationnel
 - Avoir accès à l'interface Keycloak avec un compte disposant du rôle `pod_operator` ou supérieur
-- Avoir pris connaissance du
-  guide [Mise en route de votre Bare Metal Pod SecNumCloud](/pages/hosted_private_cloud/baremetal_pod/snc_getting_started)
+- Avoir pris connaissance du guide [Mise en route de votre Bare Metal Pod SecNumCloud](/pages/hosted_private_cloud/baremetal_pod/snc_getting_started)
 
 ## En pratique
 
 ### Architecture d'authentification
 
-Toute l'authentification du **Bare Metal Pod** est centralisée dans **Keycloak**. Un seul et même compte utilisateur
-Keycloak donne accès à l'ensemble des services du pod : dashboard, OpenStack Horizon et APIs OpenStack.
+Toute l'authentification du **Bare Metal Pod** est centralisée dans **Keycloak**. Un seul et même compte utilisateur Keycloak donne accès à l'ensemble des services du pod : dashboard, OpenStack Horizon et APIs OpenStack.
 
 ### Hiérarchie des rôles
 
@@ -35,7 +32,7 @@ Le modèle IAM du **Bare Metal Pod SecNumCloud** repose sur deux niveaux d'accè
 
 #### Accès par défaut
 
-Tout utilisateur enregistré dans Keycloak, sans rôle spécifique attribué, dispose d'un accès par défaut lui permettant de :
+Tout utilisateur enregistré dans Keycloak, sans rôle spécifique attribué, dispose d'un accès par défaut lui permettant de :
 
 - Se connecter au **Dashboard** et gérer ses propres paramètres de compte Keycloak
 - Accéder à l'interface **OpenStack** et aux projets pour lesquels un `pod_operator` lui a attribué des droits via des attributs de projet
@@ -49,7 +46,7 @@ Tout utilisateur enregistré dans Keycloak, sans rôle spécifique attribué, di
 
 Le rôle `pod_operator` est attribué par OVHcloud au premier compte d'accès à la plateforme lors de la livraison du service. Ce compte initial peut ensuite assigner librement ce rôle à d'autres utilisateurs du realm pod.
 
-Il donne les capacités supplémentaires suivantes :
+Il donne les capacités supplémentaires suivantes :
 
 - Gérer les utilisateurs, groupes et rôles au sein du realm pod (créer des comptes, attribuer des droits OpenStack via les attributs de projet)
 - Faire une demande de délégation de nœuds auprès du support OVHcloud (nécessaire pour certaines configurations spécifiques comme le LACP ou le RAID logiciel)
@@ -58,36 +55,37 @@ Il donne les capacités supplémentaires suivantes :
 
 Le tableau ci-dessous récapitule les accès de chaque rôle sur les applications intégrées.
 
-**Légende** : ✅ Autorisé | ❌ Non autorisé | 🟡 Partiel (conditionné par les attributs de projet)
+**Légende** : ✅ Autorisé | ❌ Non autorisé | 🟡 Partiel (conditionné par les attributs de projet)
 
-| Application   | Permission                      | `default` | `pod_operator` |
+| Application   | Permission                      | Default   | `pod_operator` |
 |---------------|---------------------------------|:---------:|:--------------:|
 | **Keycloak**  | Voir ses paramètres de compte   |     ✅     |       ✅        |
-| **Keycloak**  | Gérer les utilisateurs keycloak |     ❌     |       ✅        |
+| **Keycloak**  | Gérer les utilisateurs Keycloak |     ❌     |       ✅        |
 | **OpenStack** | view                            |    🟡     |       🟡       |
 | **OpenStack** | member (édition)                |    🟡     |       🟡       |
 | **Dashboard** | Iframe OpenStack                |     ✅     |       ✅        |
+| **Grafana**   | view                            |     ❌     |       ✅        |
+| **Prometheus**| view                            |     ❌     |       ✅        |
+| **Dashboard** | Iframe Grafana                  |     ❌     |       ✅        |
+| **Dashboard** | Iframe Prometheus               |     ❌     |       ✅        |
 
 > [!primary]
 >
-> Les accès OpenStack marqués 🟡 sont conditionnés par la présence d'**attributs de projet** sur l'utilisateur ou son
-> groupe dans Keycloak. Sans attribut de projet configuré, l'utilisateur ne pourra pas accéder aux ressources OpenStack.
+> Les accès OpenStack marqués 🟡 sont conditionnés par la présence d'**attributs de projet** sur l'utilisateur ou son groupe dans Keycloak. Sans attribut de projet configuré, l'utilisateur ne pourra pas accéder aux ressources OpenStack.
 >
 
 ### Configurer les droits OpenStack via les attributs Keycloak
 
-Les droits d'accès aux projets OpenStack se définissent directement dans les **attributs de l'utilisateur** (ou du
-groupe) dans Keycloak. Cela permet de spécifier sur quel(s) projet(s) OpenStack un utilisateur peut opérer, et avec
-quel(s) rôle(s).
+Les droits d'accès aux projets OpenStack se définissent directement dans les **attributs de l'utilisateur** (ou du groupe) dans Keycloak. Cela permet de spécifier sur quel(s) projet(s) OpenStack un utilisateur peut opérer, et avec quel(s) rôle(s).
 
 #### Ajouter un attribut de projet sur un utilisateur
 
 Dans l'interface Keycloak, accédez à l'utilisateur concerné, puis ouvrez l'onglet **Attributes**.
 
-Ajoutez un nouvel attribut avec les valeurs suivantes :
+Ajoutez un nouvel attribut avec les valeurs suivantes :
 
-- **Clé** : `project`
-- **Valeur** : un objet JSON décrivant le projet et les rôles à attribuer
+- **Clé** : `project`
+- **Valeur** : un objet JSON décrivant le projet et les rôles à attribuer
 
 ```json
 {
@@ -106,7 +104,7 @@ Ajoutez un nouvel attribut avec les valeurs suivantes :
 }
 ```
 
-Les rôles OpenStack disponibles sont :
+Les rôles OpenStack disponibles sont :
 
 | Rôle OpenStack | Description                    |
 |----------------|--------------------------------|
@@ -115,18 +113,16 @@ Les rôles OpenStack disponibles sont :
 
 > [!primary]
 >
-> Si le projet OpenStack portant le nom indiqué n'existe pas encore, il sera **créé automatiquement** lors de la
-> première connexion de l'utilisateur.
+> Si le projet OpenStack portant le nom indiqué n'existe pas encore, il sera **créé automatiquement** lors de la première connexion de l'utilisateur.
 >
 
 #### Attribuer plusieurs projets à un utilisateur
 
-Il est possible d'ajouter **plusieurs attributs `project`** pour un même utilisateur ou groupe. Ils seront
-automatiquement fusionnés en un attribut `projects` dans le token transmis à Keystone.
+Vous pouvez ajouter **plusieurs attributs `project`** pour un même utilisateur ou groupe. Keycloak les fusionne automatiquement en un attribut `projects` dans le token transmis à Keystone.
 
-Exemple pour un utilisateur accédant à deux projets :
+Exemple pour un utilisateur accédant à deux projets :
 
-**Attribut 1** (clé : `project`) :
+**Attribut 1** (clé : `project`) :
 
 ```json
 {
@@ -142,7 +138,7 @@ Exemple pour un utilisateur accédant à deux projets :
 }
 ```
 
-**Attribut 2** (clé : `project`) :
+**Attribut 2** (clé : `project`) :
 
 ```json
 {
@@ -163,29 +159,26 @@ Exemple pour un utilisateur accédant à deux projets :
 
 #### Configurer les attributs sur un groupe
 
-La même configuration peut être appliquée à un **groupe Keycloak**. Tous les membres du groupe hériteront
-automatiquement des attributs de projet définis sur ce groupe.
+Vous pouvez appliquer la même configuration à un **groupe Keycloak** : tous les membres héritent automatiquement des attributs de projet qui y sont définis.
 
-Dans Keycloak, accédez à **Groups**, sélectionnez le groupe souhaité, puis renseignez les attributs `project` de la même
-manière que pour un utilisateur individuel.
+Dans Keycloak, accédez à **Groups**, sélectionnez le groupe souhaité, puis renseignez les attributs `project` de la même manière que pour un utilisateur individuel.
 
 > [!primary]
 >
-> Les attributs définis sur un groupe et ceux définis directement sur l'utilisateur sont fusionnés. Un utilisateur peut
-> ainsi bénéficier de projets issus de plusieurs groupes en plus de ses propres attributs.
+> Les attributs définis sur un groupe et ceux définis directement sur l'utilisateur sont fusionnés. Un utilisateur peut ainsi bénéficier de projets issus de plusieurs groupes en plus de ses propres attributs.
 >
 
 ### Lister l'ensemble des droits
 
 #### Via la CLI OpenStack
 
-Pour lister les assignations de rôles actives dans OpenStack :
+Pour lister les assignations de rôles actives dans OpenStack :
 
 ```bash
 openstack role assignment list --names
 ```
 
-Pour lister les rôles disponibles sur la plateforme :
+Pour lister les rôles disponibles sur la plateforme :
 
 ```bash
 openstack role list
@@ -193,15 +186,12 @@ openstack role list
 
 > [!warning]
 >
-> Ces commandes ne retournent que les utilisateurs qui se sont **déjà authentifiés** au moins une fois via OpenStack.
-> Les utilisateurs présents dans Keycloak mais n'ayant jamais effectué de connexion OpenStack n'apparaîtront pas dans
-> ces
-> résultats.
+> Ces commandes ne retournent que les utilisateurs qui se sont **déjà authentifiés** au moins une fois via OpenStack. Les utilisateurs présents dans Keycloak mais ne s'étant jamais connectés à OpenStack n'apparaîtront pas dans ces résultats.
 >
 
 #### Via l'API Keycloak (vue complète)
 
-Pour obtenir une vue exhaustive des droits, y compris pour les utilisateurs Keycloak n'ayant jamais effectué de connexion OpenStack, il est nécessaire d'interroger directement l'API Keycloak et de consolider manuellement les attributs de projet.
+Pour obtenir une vue exhaustive des droits, y compris pour les utilisateurs Keycloak ne s'étant jamais connectés à OpenStack, interrogez directement l'API Keycloak et consolidez manuellement les attributs de projet.
 
 Le script utilise un **service account** Keycloak, ce qui évite toute dépendance aux credentials utilisateur et aux OTP. Suivez les étapes ci-dessous pour le créer avant d'exécuter le script.
 
@@ -211,18 +201,18 @@ Le script utilise un **service account** Keycloak, ce qui évite toute dépendan
 
 Dans l'interface Keycloak, sélectionnez votre realm pod puis accédez à **Clients** > **Create client**.
 
-Renseignez les champs suivants :
+Renseignez les champs suivants :
 
-- **Client type** : `OpenID Connect`
-- **Client ID** : choisissez un nom explicite, par exemple `iam-audit`
+- **Client type** : `OpenID Connect`
+- **Client ID** : choisissez un nom explicite, par exemple `iam-audit`
 
 Cliquez sur **Next**.
 
 **2. Activer le Service Account**
 
-Sur l'écran **Capability config**, activez uniquement :
+Sur l'écran **Capability config**, activez uniquement :
 
-- **Service accounts roles** : `On`
+- **Service accounts roles** : `On`
 
 Désactivez **Standard flow** et **Direct access grants** s'ils sont activés. Cliquez sur **Save**.
 
@@ -241,9 +231,9 @@ Dans le filtre, sélectionnez **Filter by clients** et recherchez `realm-managem
 > Le rôle `view-users` du client `realm-management` permet au service account de lister les utilisateurs du realm sans lui donner aucun droit de modification.
 >
 
-##### Prérequis : installer les librairies nécessaires
+##### Prérequis : installer les librairies nécessaires
 
-Assurez-vous d'avoir Python 3 installé, puis installez les librairies requises :
+Assurez-vous d'avoir Python 3 installé, puis installez les librairies requises :
 
 ```bash
 pip install python-keycloak requests
@@ -251,9 +241,13 @@ pip install python-keycloak requests
 
 ##### Script de récupération des droits
 
-Les droits OpenStack d'un utilisateur peuvent provenir de plusieurs sources : attributs définis directement sur son compte, hérités de groupes, de groupes parents ou encore de rôles. Cette combinaison peut rendre difficile la lecture des permissions effectives depuis l'interface d'administration. Pour vérifier les droits d'un utilisateur en particulier, il est tout à fait possible de passer par l'interface web Keycloak : **Clients** > sélectionner le client `keystone` > **Client scopes** > **Evaluate** > sélectionner l'utilisateur > **Generate access token**. Le script ci-dessous est un exemple d'utilisation de l'API Keycloak pour récupérer ces mêmes informations de manière programmatique. En interrogeant Keycloak comme le ferait Keystone, il permet d'obtenir une **vue claire et consolidée des permissions effectives** de l'ensemble des utilisateurs actifs du realm en une seule exécution.
+Les droits OpenStack d'un utilisateur peuvent provenir de plusieurs sources : attributs définis directement sur son compte, hérités de groupes, de groupes parents ou encore de rôles. Cette combinaison peut rendre difficile la lecture des permissions effectives depuis l'interface d'administration.
 
-Ce script utilise le même mécanisme que le bouton **Generate access token** de l'interface Keycloak, via l'endpoint d'évaluation des scopes. C'est la source de vérité : groupes, sous-groupes et attributs utilisateur sont tous fusionnés par Keycloak lui-même.
+Pour vérifier les droits d'un utilisateur en particulier, vous pouvez utiliser l'interface web Keycloak : **Clients** > sélectionner le client `keystone` (client OpenStack) > **Client scopes** > **Evaluate** > sélectionner l'utilisateur > **Generate access token**.
+
+Le script ci-dessous est un exemple d'utilisation de l'API Keycloak pour récupérer ces mêmes informations de manière programmatique. En interrogeant Keycloak comme le ferait Keystone, il permet d'obtenir une **vue claire et consolidée des permissions effectives** de l'ensemble des utilisateurs actifs du realm en une seule exécution.
+
+Ce script utilise le même mécanisme que le bouton **Generate access token** de l'interface Keycloak, via l'endpoint d'évaluation des scopes. C'est la source de vérité : groupes, sous-groupes et attributs utilisateur sont tous fusionnés par Keycloak lui-même.
 
 ```python
 import json
@@ -319,13 +313,11 @@ Ce script affiche pour chaque utilisateur le claim `projects` **tel que Keystone
 
 > [!primary]
 >
-> Une alternative sans script est disponible directement dans l'interface Keycloak : **Clients** > sélectionner le client OpenStack > **Client scopes** > **Evaluate** > sélectionner un utilisateur > **Generate access token**. Cela affiche le token exact qui sera transmis à Keystone pour cet utilisateur.
+> Une alternative sans script est disponible directement dans l'interface Keycloak : **Clients** > sélectionner le client `keystone` (client OpenStack) > **Client scopes** > **Evaluate** > sélectionner un utilisateur > **Generate access token**. Cela affiche le token exact qui sera transmis à Keystone pour cet utilisateur.
 >
 
 ## Aller plus loin
 
-Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez
-votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse
-personnalisée de votre projet à nos experts de l'équipe Professional Services.
+Pour une formation ou une assistance technique sur la mise en œuvre de nos solutions, contactez votre commercial ou rendez-vous sur la page [Professional Services](/links/professional-services) afin d'obtenir un devis et une analyse personnalisée de votre projet par nos experts.
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.fr-fr.md
@@ -1,0 +1,332 @@
+---
+title: "Gestion des droits IAM - Bare Metal Pod SecNumCloud"
+excerpt: "Découvrez comment gérer les utilisateurs et leurs droits d'accès sur votre Bare Metal Pod SecNumCloud via Keycloak"
+updated: 2026-04-27
+---
+
+## Objectif
+
+Ce guide explique comment gérer les droits et les accès (IAM - Identity and Access Management) de votre **Bare Metal Pod
+SecNumCloud**.
+
+L'ensemble de l'authentification est centralisé dans **Keycloak**, qui sert de point d'entrée unique pour :
+
+- L'accès au **Dashboard** (tableau de bord unifié du service)
+- L'accès à l'interface graphique **OpenStack Horizon**
+- L'accès aux **APIs OpenStack** (Keystone, Nova, Neutron, Glance, Ironic...)
+
+## Prérequis
+
+- Disposer d'un **Bare Metal Pod SecNumCloud** livré et opérationnel
+- Avoir accès à l'interface Keycloak avec un compte disposant du rôle `pod_operator` ou supérieur
+- Avoir pris connaissance du
+  guide [Mise en route de votre Bare Metal Pod SecNumCloud](/pages/hosted_private_cloud/baremetal_pod/snc_getting_started)
+
+## En pratique
+
+### Architecture d'authentification
+
+Toute l'authentification du **Bare Metal Pod** est centralisée dans **Keycloak**. Un seul et même compte utilisateur
+Keycloak donne accès à l'ensemble des services du pod : dashboard, OpenStack Horizon et APIs OpenStack.
+
+### Hiérarchie des rôles
+
+Le modèle IAM du **Bare Metal Pod SecNumCloud** repose sur deux niveaux d'accès.
+
+#### Accès par défaut
+
+Tout utilisateur enregistré dans Keycloak, sans rôle spécifique attribué, dispose d'un accès par défaut lui permettant de :
+
+- Se connecter au **Dashboard** et gérer ses propres paramètres de compte Keycloak
+- Accéder à l'interface **OpenStack** et aux projets pour lesquels un `pod_operator` lui a attribué des droits via des attributs de projet
+
+> [!primary]
+>
+> Un utilisateur sans attribut de projet configuré pourra se connecter au dashboard mais n'aura accès à aucun projet OpenStack tant qu'un `pod_operator` ne lui aura pas assigné des droits.
+>
+
+#### Rôle `pod_operator`
+
+Le rôle `pod_operator` est attribué par OVHcloud au premier compte d'accès à la plateforme lors de la livraison du service. Ce compte initial peut ensuite assigner librement ce rôle à d'autres utilisateurs du realm pod.
+
+Il donne les capacités supplémentaires suivantes :
+
+- Gérer les utilisateurs, groupes et rôles au sein du realm pod (créer des comptes, attribuer des droits OpenStack via les attributs de projet)
+- Faire une demande de délégation de nœuds auprès du support OVHcloud (nécessaire pour certaines configurations spécifiques comme le LACP ou le RAID logiciel)
+
+### Matrice des droits
+
+Le tableau ci-dessous récapitule les accès de chaque rôle sur les applications intégrées.
+
+**Légende** : ✅ Autorisé | ❌ Non autorisé | 🟡 Partiel (conditionné par les attributs de projet)
+
+| Application   | Permission                      | `default` | `pod_operator` |
+|---------------|---------------------------------|:---------:|:--------------:|
+| **Keycloak**  | Voir ses paramètres de compte   |     ✅     |       ✅        |
+| **Keycloak**  | Gérer les utilisateurs keycloak |     ❌     |       ✅        |
+| **OpenStack** | view                            |    🟡     |       🟡       |
+| **OpenStack** | member (édition)                |    🟡     |       🟡       |
+| **Dashboard** | Iframe OpenStack                |     ✅     |       ✅        |
+
+> [!primary]
+>
+> Les accès OpenStack marqués 🟡 sont conditionnés par la présence d'**attributs de projet** sur l'utilisateur ou son
+> groupe dans Keycloak. Sans attribut de projet configuré, l'utilisateur ne pourra pas accéder aux ressources OpenStack.
+>
+
+### Configurer les droits OpenStack via les attributs Keycloak
+
+Les droits d'accès aux projets OpenStack se définissent directement dans les **attributs de l'utilisateur** (ou du
+groupe) dans Keycloak. Cela permet de spécifier sur quel(s) projet(s) OpenStack un utilisateur peut opérer, et avec
+quel(s) rôle(s).
+
+#### Ajouter un attribut de projet sur un utilisateur
+
+Dans l'interface Keycloak, accédez à l'utilisateur concerné, puis ouvrez l'onglet **Attributes**.
+
+Ajoutez un nouvel attribut avec les valeurs suivantes :
+
+- **Clé** : `project`
+- **Valeur** : un objet JSON décrivant le projet et les rôles à attribuer
+
+```json
+{
+    "domain": {
+        "name": "Default"
+    },
+    "name": "nom-du-projet",
+    "roles": [
+        {
+            "name": "member"
+        },
+        {
+            "name": "reader"
+        }
+    ]
+}
+```
+
+Les rôles OpenStack disponibles sont :
+
+| Rôle OpenStack | Description                       |
+|----------------|-----------------------------------|
+| `admin`        | Administration complète du projet |
+| `member`       | Droits d'édition sur le projet    |
+| `reader`       | Lecture seule sur le projet       |
+
+> [!primary]
+>
+> Si le projet OpenStack portant le nom indiqué n'existe pas encore, il sera **créé automatiquement** lors de la
+> première connexion de l'utilisateur.
+>
+
+#### Attribuer plusieurs projets à un utilisateur
+
+Il est possible d'ajouter **plusieurs attributs `project`** pour un même utilisateur ou groupe. Ils seront
+automatiquement fusionnés en un attribut `projects` dans le token transmis à Keystone.
+
+Exemple pour un utilisateur accédant à deux projets :
+
+**Attribut 1** (clé : `project`) :
+
+```json
+{
+    "domain": {
+        "name": "Default"
+    },
+    "name": "projet-production",
+    "roles": [
+        {
+            "name": "member"
+        }
+    ]
+}
+```
+
+**Attribut 2** (clé : `project`) :
+
+```json
+{
+    "domain": {
+        "name": "Default"
+    },
+    "name": "projet-staging",
+    "roles": [
+        {
+            "name": "admin"
+        },
+        {
+            "name": "reader"
+        }
+    ]
+}
+```
+
+#### Configurer les attributs sur un groupe
+
+La même configuration peut être appliquée à un **groupe Keycloak**. Tous les membres du groupe hériteront
+automatiquement des attributs de projet définis sur ce groupe.
+
+Dans Keycloak, accédez à **Groups**, sélectionnez le groupe souhaité, puis renseignez les attributs `project` de la même
+manière que pour un utilisateur individuel.
+
+> [!primary]
+>
+> Les attributs définis sur un groupe et ceux définis directement sur l'utilisateur sont fusionnés. Un utilisateur peut
+> ainsi bénéficier de projets issus de plusieurs groupes en plus de ses propres attributs.
+>
+
+### Lister l'ensemble des droits
+
+#### Via la CLI OpenStack
+
+Pour lister les assignations de rôles actives dans OpenStack :
+
+```bash
+openstack role assignment list --names
+```
+
+Pour lister les rôles disponibles sur la plateforme :
+
+```bash
+openstack role list
+```
+
+> [!warning]
+>
+> Ces commandes ne retournent que les utilisateurs qui se sont **déjà authentifiés** au moins une fois via OpenStack.
+> Les utilisateurs présents dans Keycloak mais n'ayant jamais effectué de connexion OpenStack n'apparaîtront pas dans
+> ces
+> résultats.
+>
+
+#### Via l'API Keycloak (vue complète)
+
+Pour obtenir une vue exhaustive des droits, y compris pour les utilisateurs Keycloak n'ayant jamais effectué de connexion OpenStack, il est nécessaire d'interroger directement l'API Keycloak et de consolider manuellement les attributs de projet.
+
+Le script utilise un **service account** Keycloak, ce qui évite toute dépendance aux credentials utilisateur et aux OTP. Suivez les étapes ci-dessous pour le créer avant d'exécuter le script.
+
+##### Créer le service account dans Keycloak
+
+**1. Créer un nouveau client**
+
+Dans l'interface Keycloak, sélectionnez votre realm pod puis accédez à **Clients** > **Create client**.
+
+Renseignez les champs suivants :
+
+- **Client type** : `OpenID Connect`
+- **Client ID** : choisissez un nom explicite, par exemple `iam-audit`
+
+Cliquez sur **Next**.
+
+**2. Activer le Service Account**
+
+Sur l'écran **Capability config**, activez uniquement :
+
+- **Service accounts roles** : `On`
+
+Désactivez **Standard flow** et **Direct access grants** s'ils sont activés. Cliquez sur **Save**.
+
+**3. Récupérer le Client Secret**
+
+Dans votre client nouvellement créé, ouvrez l'onglet **Credentials**. Copiez la valeur du champ **Client secret** — c'est la valeur à utiliser pour `CLIENT_SECRET` dans le script.
+
+**4. Assigner le rôle `view-users`**
+
+Ouvrez l'onglet **Service accounts roles** de votre client, puis cliquez sur **Assign role**.
+
+Dans le filtre, sélectionnez **Filter by clients** et recherchez `realm-management`. Assignez le rôle **view-users**.
+
+> [!primary]
+>
+> Le rôle `view-users` du client `realm-management` permet au service account de lister les utilisateurs du realm sans lui donner aucun droit de modification.
+>
+
+##### Prérequis : installer les librairies nécessaires
+
+Assurez-vous d'avoir Python 3 installé, puis installez les librairies requises :
+
+```bash
+pip install python-keycloak requests
+```
+
+##### Script de récupération des droits
+
+Les droits OpenStack d'un utilisateur peuvent provenir de plusieurs sources : attributs définis directement sur son compte, hérités de groupes, de groupes parents ou encore de rôles. Cette combinaison peut rendre difficile la lecture des permissions effectives depuis l'interface d'administration. Pour vérifier les droits d'un utilisateur en particulier, il est tout à fait possible de passer par l'interface web Keycloak : **Clients** > sélectionner le client `keystone` > **Client scopes** > **Evaluate** > sélectionner l'utilisateur > **Generate access token**. Le script ci-dessous est un exemple d'utilisation de l'API Keycloak pour récupérer ces mêmes informations de manière programmatique. En interrogeant Keycloak comme le ferait Keystone, il permet d'obtenir une **vue claire et consolidée des permissions effectives** de l'ensemble des utilisateurs actifs du realm en une seule exécution.
+
+Ce script utilise le même mécanisme que le bouton **Generate access token** de l'interface Keycloak, via l'endpoint d'évaluation des scopes. C'est la source de vérité : groupes, sous-groupes et attributs utilisateur sont tous fusionnés par Keycloak lui-même.
+
+```python
+import json
+import requests
+from keycloak import KeycloakAdmin
+
+KEYCLOAK_URL = "https://<votre-keycloak>"
+REALM = "pod"
+CLIENT_ID = "<client-id>"
+CLIENT_SECRET = "<client-secret>"
+
+kc = KeycloakAdmin(
+    server_url=KEYCLOAK_URL,
+    realm_name=REALM,
+    client_id=CLIENT_ID,
+    client_secret_key=CLIENT_SECRET
+)
+
+# Obtenir le token du service account
+admin_token = requests.post(
+    f"{KEYCLOAK_URL}/realms/{REALM}/protocol/openid-connect/token",
+    data={
+        "grant_type": "client_credentials",
+        "client_id": CLIENT_ID,
+        "client_secret": CLIENT_SECRET,
+    }
+).json()['access_token']
+
+# Récupérer l'UUID du client keystone
+keystone_uuid = kc.get_client_id("keystone")
+
+# Pour chaque utilisateur actif, évaluer le token et afficher les projets effectifs
+for user in kc.get_users():
+    if not user.get('enabled'):
+        continue
+    try:
+        resp = requests.get(
+            f"{KEYCLOAK_URL}/admin/realms/{REALM}/clients/{keystone_uuid}"
+            f"/evaluate-scopes/generate-example-access-token",
+            params={"userId": user['id'], "scope": "openid"},
+            headers={"Authorization": f"Bearer {admin_token}"}
+        )
+        if not resp.ok:
+            print(f"[DEBUG] status={resp.status_code} body={resp.text}")
+            resp.raise_for_status()
+        claims = resp.json()
+        # projects peut être une chaîne JSON ou une liste selon la version de Keycloak
+        projects_raw = (
+            claims.get('projects')
+            or claims.get('otherClaims', {}).get('projects', [])
+        )
+        if isinstance(projects_raw, str):
+            projects_raw = json.loads(projects_raw)
+        print(json.dumps({
+            "username": user['username'],
+            "effective_projects": projects_raw
+        }, indent=2))
+    except Exception as e:
+        print(f"[!] {user['username']}: {e}")
+```
+
+Ce script affiche pour chaque utilisateur le claim `projects` **tel que Keystone le recevra**, incluant les attributs propres, hérités des groupes directs et de tous les groupes parents.
+
+> [!primary]
+>
+> Une alternative sans script est disponible directement dans l'interface Keycloak : **Clients** > sélectionner le client OpenStack > **Client scopes** > **Evaluate** > sélectionner un utilisateur > **Generate access token**. Cela affiche le token exact qui sera transmis à Keystone pour cet utilisateur.
+>
+
+## Aller plus loin
+
+Si vous avez besoin d'une formation ou d'une assistance technique pour la mise en œuvre de nos solutions, contactez
+votre commercial ou cliquez sur [ce lien](/links/professional-services) pour obtenir un devis et demander une analyse
+personnalisée de votre projet à nos experts de l'équipe Professional Services.
+
+Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/guide.fr-fr.md
@@ -1,6 +1,6 @@
 ---
 title: "Gestion des droits IAM - Bare Metal Pod SecNumCloud"
-excerpt: "Découvrez comment gérer les utilisateurs, configurer leurs droits et attribuer les rôles OpenStack sur votre Bare Metal Pod SecNumCloud via Keycloak."
+excerpt: "Découvrez comment gérer les utilisateurs, configurer leurs droits et attribuer les rôles OpenStack sur votre Bare Metal Pod SecNumCloud via Keycloak"
 updated: 2026-04-28
 ---
 

--- a/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/meta.yaml
+++ b/pages/hosted_private_cloud/baremetal_pod/snc_iam_manage/meta.yaml
@@ -1,0 +1,2 @@
+id: c4e9b823-7f12-4a5d-8e31-9d6c2a0f5b74
+full_slug: bmpod-secnumcloud-iam-manage

--- a/pages/index-translations.de.yaml
+++ b/pages/index-translations.de.yaml
@@ -110,6 +110,7 @@ hosted-private-cloud-snc-cloud-platform: SNC Cloud Platform
 hosted-private-cloud-snc-cloud-platform-getting-started: Erste Schritte
 hosted-private-cloud-baremetal-pod: Bare Metal Pod
 hosted-private-cloud-baremetal-pod-getting-started: Erste Schritte
+hosted-private-cloud-baremetal-pod-security: Sicherheit
 hosted-private-cloud-sap-ovhcloud: SAP on OVHcloud
 hosted-private-cloud-sap-ovhcloud-concepts: Konzepte
 hosted-private-cloud-sap-ovhcloud-getting-started: Erste Schritte

--- a/pages/index-translations.es.yaml
+++ b/pages/index-translations.es.yaml
@@ -110,6 +110,7 @@ hosted-private-cloud-snc-cloud-platform: SNC Cloud Platform
 hosted-private-cloud-snc-cloud-platform-getting-started: Primeros pasos
 hosted-private-cloud-baremetal-pod: Bare Metal Pod
 hosted-private-cloud-baremetal-pod-getting-started: Primeros pasos
+hosted-private-cloud-baremetal-pod-security: Seguridad
 hosted-private-cloud-sap-ovhcloud: SAP on OVHcloud
 hosted-private-cloud-sap-ovhcloud-concepts: Conceptos
 hosted-private-cloud-sap-ovhcloud-getting-started: Primeros pasos

--- a/pages/index-translations.fq.yaml
+++ b/pages/index-translations.fq.yaml
@@ -110,6 +110,7 @@ hosted-private-cloud-snc-cloud-platform: SNC Cloud Platform
 hosted-private-cloud-snc-cloud-platform-getting-started: Premiers pas
 hosted-private-cloud-baremetal-pod: Bare Metal Pod
 hosted-private-cloud-baremetal-pod-getting-started: Premiers pas
+hosted-private-cloud-baremetal-pod-security: Sécurité
 hosted-private-cloud-sap-ovhcloud: SAP on OVHcloud
 hosted-private-cloud-sap-ovhcloud-concepts: Concepts
 hosted-private-cloud-sap-ovhcloud-getting-started: Premiers pas

--- a/pages/index-translations.fr.yaml
+++ b/pages/index-translations.fr.yaml
@@ -110,6 +110,7 @@ hosted-private-cloud-snc-cloud-platform: SNC Cloud Platform
 hosted-private-cloud-snc-cloud-platform-getting-started: Premiers pas
 hosted-private-cloud-baremetal-pod: Bare Metal Pod
 hosted-private-cloud-baremetal-pod-getting-started: Premiers pas
+hosted-private-cloud-baremetal-pod-security: Sécurité
 hosted-private-cloud-sap-ovhcloud: SAP on OVHcloud
 hosted-private-cloud-sap-ovhcloud-concepts: Concepts
 hosted-private-cloud-sap-ovhcloud-getting-started: Premiers pas

--- a/pages/index-translations.it.yaml
+++ b/pages/index-translations.it.yaml
@@ -100,6 +100,7 @@ hosted-private-cloud-snc-cloud-platform: SNC Cloud Platform
 hosted-private-cloud-snc-cloud-platform-getting-started: Per iniziare
 hosted-private-cloud-baremetal-pod: Bare Metal Pod
 hosted-private-cloud-baremetal-pod-getting-started: Per iniziare
+hosted-private-cloud-baremetal-pod-security: Sicurezza
 hosted-private-cloud-sap-ovhcloud: SAP on OVHcloud
 hosted-private-cloud-sap-ovhcloud-concepts: Concetti
 hosted-private-cloud-sap-ovhcloud-getting-started: Per iniziare

--- a/pages/index-translations.pl.yaml
+++ b/pages/index-translations.pl.yaml
@@ -110,6 +110,7 @@ hosted-private-cloud-snc-cloud-platform: SNC Cloud Platform
 hosted-private-cloud-snc-cloud-platform-getting-started: Pierwsze kroki
 hosted-private-cloud-baremetal-pod: Bare Metal Pod
 hosted-private-cloud-baremetal-pod-getting-started: Pierwsze kroki
+hosted-private-cloud-baremetal-pod-security: Bezpieczeństwo
 hosted-private-cloud-sap-ovhcloud: SAP on OVHcloud
 hosted-private-cloud-sap-ovhcloud-concepts: Koncepcje
 hosted-private-cloud-sap-ovhcloud-getting-started: Pierwsze kroki

--- a/pages/index-translations.pt.yaml
+++ b/pages/index-translations.pt.yaml
@@ -110,6 +110,7 @@ hosted-private-cloud-snc-cloud-platform: SNC Cloud Platform
 hosted-private-cloud-snc-cloud-platform-getting-started: Primeiros passos
 hosted-private-cloud-baremetal-pod: Bare Metal Pod
 hosted-private-cloud-baremetal-pod-getting-started: Primeiros passos
+hosted-private-cloud-baremetal-pod-security: Segurança
 hosted-private-cloud-sap-ovhcloud: SAP on OVHcloud
 hosted-private-cloud-sap-ovhcloud-concepts: Conceitos
 hosted-private-cloud-sap-ovhcloud-getting-started: Primeiros passos

--- a/pages/index.md
+++ b/pages/index.md
@@ -589,6 +589,8 @@
     + [Bare Metal Pod](hosted-private-cloud-baremetal-pod)
         + [Getting started](hosted-private-cloud-baremetal-pod-getting-started)
             + [Mise en route de votre Bare Metal POD SecNumCloud](hosted_private_cloud/baremetal_pod/snc_getting_started)
+        + [Users and access management](hosted-private-cloud-baremetal-pod-users-and-access-management)
+            + [IAM Rights Management - Bare Metal Pod SecNumCloud](hosted_private_cloud/baremetal_pod/snc_iam_manage)
     + [On-Prem Cloud Platform](products/hosted-private-cloud-hosted-private-cloud-opcp)
         + [Getting started](hosted-private-cloud-hosted-private-cloud-opcp-getting-started)
             + [Getting started with your OPCP](hosted_private_cloud/opcp/opcp-getting-started)

--- a/pages/index.md
+++ b/pages/index.md
@@ -589,7 +589,7 @@
     + [Bare Metal Pod](hosted-private-cloud-baremetal-pod)
         + [Getting started](hosted-private-cloud-baremetal-pod-getting-started)
             + [Mise en route de votre Bare Metal POD SecNumCloud](hosted_private_cloud/baremetal_pod/snc_getting_started)
-        + [Users and access management](hosted-private-cloud-baremetal-pod-users-and-access-management)
+        + [Security](hosted-private-cloud-baremetal-pod-security)
             + [IAM Rights Management - Bare Metal Pod SecNumCloud](hosted_private_cloud/baremetal_pod/snc_iam_manage)
     + [On-Prem Cloud Platform](products/hosted-private-cloud-hosted-private-cloud-opcp)
         + [Getting started](hosted-private-cloud-hosted-private-cloud-opcp-getting-started)


### PR DESCRIPTION
## What type of Pull Request is this?

- New guide(s)

## Description

New guide explaining how to manage IAM (Identity and Access Management) 
on the Bare Metal Pod SecNumCloud platform via Keycloak.

Covers:
- Centralized authentication architecture (Keycloak as single entry point for Dashboard, Horizon and OpenStack APIs)
- Role hierarchy: default access vs `pod_operator` role (assigned initially by OVHcloud)
- Access matrix per integrated application
- OpenStack project attribute configuration on users and groups (including group inheritance)
- Step-by-step service account setup in Keycloak for API access
- Python script using the Keycloak evaluate-scopes API to audit effective OpenStack permissions across all active users

## Mandatory information

The translations in this Pull Request have been done using:
- [ ] OVHcloud integrated translation LLM
- [ ] Systran
- [x] Other tool (Claude AI)
- [ ] This Pull Request didn't require any translation.

- This Pull Request can be merged as soon as possible.

- This Pull Request content should be replicated for the US OVHcloud documentation: NO