### PR TITLE
VPS - fix Nextcloud connectivity, pull errors, and persistence

### DIFF
--- a/pages/bare_metal_cloud/virtual_private_servers/install_nextcloud_on_vps_advanced/guide.en-gb.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_nextcloud_on_vps_advanced/guide.en-gb.md
@@ -156,11 +156,15 @@ services:
       MYSQL_PASSWORD: ${DB_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
     volumes:
-      - db_data:/var/lib/MySQL
+      - db_data:/var/lib/mysql
+    networks:
+      - internal
 
   Redis:
-    image: Redis:7-alpine
+    image: redis:7-alpine
     restart: unless-stopped
+    networks:
+      - internal
 
   app:
     image: nextcloud:apache
@@ -179,11 +183,14 @@ services:
       NEXTCLOUD_TRUSTED_DOMAINS: ${NC_DOMAIN}
     volumes:
       - nextcloud_html:/var/www/html
+      - config:/var/www/html/config
       - nextcloud_data:/var/www/html/data
     networks:
+      - internal
       - proxy
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.nextcloud.rule=Host(`${NC_DOMAIN}`)
       - traefik.http.routers.nextcloud.entrypoints=websecure
       - traefik.http.routers.nextcloud.tls.certresolver=letsencrypt
@@ -192,8 +199,10 @@ volumes:
   db_data:
   nextcloud_html:
   nextcloud_data:
+  config:
 
 networks:
+  internal:
   proxy:
     external: true
 ```

--- a/pages/bare_metal_cloud/virtual_private_servers/install_nextcloud_on_vps_advanced/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/virtual_private_servers/install_nextcloud_on_vps_advanced/guide.fr-fr.md
@@ -157,10 +157,14 @@ services:
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
     volumes:
       - db_data:/var/lib/mysql
+    networks:
+      - internal
 
   redis:
     image: redis:7-alpine
     restart: unless-stopped
+    networks:
+      - internal
 
   app:
     image: nextcloud:apache
@@ -179,11 +183,14 @@ services:
       NEXTCLOUD_TRUSTED_DOMAINS: ${NC_DOMAIN}
     volumes:
       - nextcloud_html:/var/www/html
+      - config:/var/www/html/config
       - nextcloud_data:/var/www/html/data
     networks:
+      - internal
       - proxy
     labels:
       - traefik.enable=true
+      - traefik.docker.network=proxy
       - traefik.http.routers.nextcloud.rule=Host(`${NC_DOMAIN}`)
       - traefik.http.routers.nextcloud.entrypoints=websecure
       - traefik.http.routers.nextcloud.tls.certresolver=letsencrypt
@@ -192,8 +199,10 @@ volumes:
   db_data:
   nextcloud_html:
   nextcloud_data:
+  config:
 
 networks:
+  internal:
   proxy:
     external: true
 ```


### PR DESCRIPTION
## What type of Pull Request is this?

- Update of existing guide

## Description

**1. Networking & DNS Resolution**
* **Fix**: Introduced a dedicated `internal` network for the `db`, `redis`, and `app` services.
* **Reasons**: Resolved the error: `php_network_getaddresses: getaddrinfo for db failed`. Relying solely on the `external` proxy network caused Docker's internal service discovery to fail. A private bridge network ensures reliable communication between the application and its dependencies.

**2. Image Pull & Registry Compliance**
* **Fix**: Standardized the Redis image name to lowercase (`redis:7-alpine`).
* **Reasons**: Corrected the error: `invalid reference format: repository name must be lowercase`. Docker registry protocols require lowercase repository names; the previous uppercase "Redis" caused pull failures on standard Docker engines.

**3. Data Persistence & Integrity**
* **Fix**: Corrected the MariaDB volume path to `/var/lib/mysql` and added a persistent volume for the Nextcloud `/config` directory.
* **Reasons**: 
    * **MariaDB**: Linux filesystems are case-sensitive. 
    * **Config**: Without a volume for `/var/www/html/config`, users lose their `config.php` (and thus their entire setup) whenever the container is updated or recreated.

**4. Traefik Routing Optimization**
* **Fix**: Added the `traefik.docker.network=proxy` label to the `app` service.
* **Reasons**: Since the `app` container is now attached to two networks (`internal` and `proxy`), this label is required to explicitly tell Traefik which network to use for routing public web traffic, preventing potential 502 Gateway Errors.

## Mandatory information

The translations in this Pull Request have been done using:
- This Pull Request didn't require any translation.

- This Pull Request can be merged as soon as possible.