### PR TITLE
Public Cloud Databases - Removing MongoDB Entreprise mentions

### DIFF
--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.de-de.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-asia.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-au.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-ca.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-gb.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-ie.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-sg.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-us.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.es-es.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.es-us.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.fr-ca.md
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.fr-ca.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: Sauvegardes automatiques des bases de données Public Cloud (EN)
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.fr-fr.md
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.fr-fr.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: Sauvegardes automatiques des bases de données Public Cloud (EN)
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.it-it.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.pl-pl.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes

--- a/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.pt-pt.md
+++ b/pages/public_cloud/public_cloud_databases/databases_05_automated_backups/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
 title: Automated Backups for Public Cloud Databases
 excerpt: Discover the automated backup methods for each engine
-updated: 2026-02-17
+updated: 2026-04-30
 ---
 
 ## Objective
@@ -25,7 +25,6 @@ Either you run into a problem or you just want to see what your data looked like
 Engine | Backup Method(s) | Location(s) | Frequency | RPO | Encrypted
 :--- | :--- | :---: | :---: | :---: | :---:
 MongoDB | Backup on object storage | Off-Site | Daily | 24h | Yes
-MongoDB Enterprise | PITR on object storage | Off-site | Continuous | Few minutes | Yes
 PostgreSQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 MySQL | PITR on object storage | On-Site, Off-Site | Continuous | Few minutes | Yes
 Valkey | Backup on object storage | On-Site, Off-Site | 2 times a day | 12h | Yes


### PR DESCRIPTION
MongoDB Entreprise was sunset in September/October 2025 but one mention was still there in the backups.