### PR TITLE
[SK-1900] -WEB- Emails - Webmail - OWA- filter management - WAVE 2

### DIFF
--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.de-de.md
@@ -1,235 +1,256 @@
 ---
-title: "E-Mail-Accounts über Outlook Web App (OWA) verwenden"
-excerpt: 'So verwenden Sie Ihre E-Mail-Adressen über OWA Webmail'
-updated: 2026-03-24
+title: 'E-Mail-Adresse über das Webmail Outlook Web App (OWA) verwenden'
+excerpt: 'Erfahren Sie, wie Sie Ihre E-Mail-Adresse über das Webmail OWA verwenden'
+updated: 2026-05-04
 ---
 
 ## Ziel
 
-Mit OVHcloud Hosted Exchange können Sie Ihre E-Mails mit einem Gerät und einem Client Ihrer Wahl senden und empfangen. Um von überall über einen Webbrowser auf ein Konto zuzugreifen, bietet OVHcloud einen Online-E-Mail-Client namens Outlook Web App (OWA). Unsere [Webmail-Anmeldeseite](/links/web/email) ist für alle aktiven E-Mail-Konten in MX Plan, E-Mail Pro und Hosted Exchange der zentrale Zugriffspunkt auf die OWA Benutzeroberfläche.
+Mit den E-Mail-Lösungen von OVHcloud können Sie Ihre E-Mails über ein Gerät und einen Client Ihrer Wahl senden und empfangen. OVHcloud stellt Ihnen einen Online-E-Mail-Dienst namens Outlook Web App (OWA) zur Verfügung, mit dem Sie von überall über einen Webbrowser auf einen Account zugreifen können. Alle aktiven E-Mail-Accounts auf MX Plan, Email Pro und Hosted Exchange teilen sich einen einzigen Zugangspunkt zu ihrer jeweiligen OWA-Oberfläche: unsere [Webmail-Anmeldeseite](/links/web/email).
 
-**Diese Anleitung erläutert, wie Sie Ihre E-Mail-Adresse mit OWA verwenden und erklärt die wichtigsten Funktionen dieser Oberfläche.**
+**Erfahren Sie, wie Sie über die OWA-Oberfläche die gängigen Aktionen mit Ihrer E-Mail-Adresse durchführen.**
 
 ## Voraussetzungen
 
-- Sie haben bereits einen OVHcloud E-Mail-Dienst eingerichtet ([**Exchange**](/links/web/emails), [**E-Mail Pro**](/links/web/email-pro) oder **MX Plan**, aus dem MX Plan Angebot oder als Teil eines [OVHcloud Webhostings](/links/web/hosting)).
-- Sie verfügen über Anmeldeinformationen für die E-Mail-Adresse, die Sie konfigurieren möchten.
+- Sie verfügen über eine bereits eingerichtete OVHcloud E-Mail-Lösung aus den folgenden Angeboten:
+    - [**MX Plan**](/links/web/hosting), verfügbar mit unseren Webhosting-Angeboten, im [100M Free Hosting](/links/web/domains-free-hosting) enthalten oder als eigenständige Lösung bestellt;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange);
+    - [**Email Pro**](/links/web/email-pro).
+- Sie verfügen über die Anmeldedaten für die E-Mail-Adresse, die Sie verwenden möchten.
 
 ## In der praktischen Anwendung
 
+Diese Anleitung hilft Ihnen, die üblichen Aufgaben besser zu verstehen, die in einem E-Mail-Account über OWA verfügbar sind. Da diese Oberfläche jedoch nicht ursprünglich von OVHcloud erstellt wurde, können wir keine spezifischen Anweisungen zu Einstellungen geben, die in dieser Anleitung nicht behandelt werden.
 
-Diese Anleitung vermittelt Ihnen ein besseres Verständnis der üblichen Funktionen eines Mailkontos, die im OWA Webmail verfügbar sind. Da diese Anwendung jedoch ursprünglich nicht von OVHcloud erstellt wurde, können wir keine spezifischen Anweisungen zu Einstellungen geben, die in dieser Anleitung nicht erwähnt werden. In Bezug auf exklusive Exchange-Funktionen stehen gesonderte Anleitungen zur Verfügung, die im Abschnitt **Weiterführende Informationen** am Seitenende verlinkt sind.
-> Nach den ersten beiden Schritten müssen die Anweisungen nicht in einer bestimmten Reihenfolge berücksichtigt werden.
+Für Exchange-spezifische Funktionen finden Sie weitere Anleitungen im Abschnitt [Weiterführende Informationen](./#weiterfuhrende-informationen) am Ende dieser Anleitung.
+
+> [!primary]
 >
+> Nachdem Sie sich angemeldet und mit der Oberfläche vertraut gemacht haben, müssen Sie die Anweisungen nicht in der angegebenen Reihenfolge befolgen.
 
-### 1. Zugriff auf OWA Webmail
+### Anmeldung bei OWA
 
-Um sich mit Ihrer E-Mail-Adresse bei OWA Webmail anzumelden, rufen Sie die allgemeine [Webmail-Anmeldeseite](/links/web/email) auf. Geben Sie Ihre vollständige E-Mail-Adresse und Ihr Passwort ein und klicken Sie danach auf die Schaltfläche `Login`{.action}.
+Um sich mit Ihrer E-Mail-Adresse bei OWA anzumelden, öffnen Sie die [Webmail-Anmeldeseite](/links/web/email). Geben Sie Ihre vollständige E-Mail-Adresse und Ihr Passwort ein. Klicken Sie anschließend auf `Anmelden`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
 > [!warning]
 >
-> Wenn Sie zu einem **Roundcube** Interface weitergeleitet werden, bedeutet dies, dass Sie die Legacy-Version der MX Plan Lösung verwenden. Weitere Informationen zu Ihrem MX Plan finden Sie auf unserer Seite "[Erste Schritte mit MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities)".
+> Wenn Sie auf eine **Roundcube**-Oberfläche weitergeleitet werden, bedeutet dies, dass Sie die Legacy-Version des MX Plan Angebots nutzen. Weitere Informationen zu Ihrem MX Plan Angebot finden Sie auf unserer Seite [Erste Schritte mit dem MX Plan Angebot](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 >
-> Um sich mit dem **Roundcube** Interface vertraut zu machen, lesen Sie unsere Anleitung: [Verwendung Ihres E-Mail-Accounts mit Roundcube Webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+> Um sich mit der **Roundcube**-Oberfläche vertraut zu machen, lesen Sie unsere Anleitung [E-Mail-Adresse über das Webmail Roundcube verwenden](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
 
-Wenn Sie sich zum ersten Mal mit dieser E-Mail-Adresse bei OWA Webmail anmelden, werden Sie aufgefordert, die Sprache und die Zeitzone der Benutzeroberfläche festzulegen. Um fortzufahren, klicken Sie auf `Speichern`{.action}.
+Wenn Sie sich zum ersten Mal mit dieser E-Mail-Adresse bei OWA anmelden, werden Sie aufgefordert, die Sprache der Oberfläche und die Zeitzone festzulegen. Klicken Sie anschließend auf `Speichern`{.action}, um fortzufahren.
 
 > [!primary]
 >
-> Zeitzonen werden nach [UTC (Coordinated Universal Time)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png) und nicht in alphabetischer Reihenfolge der Städte aufgeführt.
+> Die Zeitzonen sind nach [dem Standard UTC (Coordinated Universal Time)](https://de.wikipedia.org/wiki/Koordinierte_Weltzeit) aufgeführt, nicht in alphabetischer Reihenfolge der Städte.
 >
 > **Beispiel**: Für Westeuropa ist dies UTC +1 (Brüssel, Kopenhagen, Madrid, Paris).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-Von nun an wird Ihre Posteingangsansicht nach der Anmeldung standardmäßig angezeigt.
+Ab jetzt wird Ihr Posteingang standardmäßig angezeigt, sobald Sie sich anmelden.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Das OWA Interface
+### Die OWA-Anzeige verstehen
 
-Die OWA Benutzeroberfläche setzt sich aus mehreren Teilsegmenten zusammen. Bitte beziehen Sie sich auf die Tabelle und das nachstehende Bild, um sich damit vertraut zu machen.
+Die OWA-Oberfläche enthält mehrere Bereiche. Anhand der Tabelle und der nachstehenden Abbildung können Sie sich mit ihr vertraut machen.
 
-|Sektion|Beschreibung|  
+|Bereiche|Beschreibung|  
 |---|---|  
-|Oberer Abschnitt (1)|Enthält zwei Leisten: Die erste ermöglicht den Zugriff auf allgemeine Einstellungen (z.B. den [Bereich „Optionen“](./#zugang-zum-bereich-optionen)) und die zweite kann zum Ausführen bestimmter Aktionen mit Ihrer Adresse verwendet werden (z.B. Senden oder Beantworten von E-Mails).|  
-|Linke Seite (2)|Zeigt die Liste der Ordner für Ihre E-Mail-Adresse an. Diese werden als Baumstruktur angezeigt, die Sie erweitern oder ausblenden können.|
-|Mittleres Segment (3)|Zeigt die Liste der Nachrichten (gelesen und ungelesen) aus dem im linken Menü ausgewählten Ordner an. In diesem Abschnitt können auch Suchergebnisse angezeigt werden.|
+|Oberer Bereich (1)|Enthält zwei Registerkartenleisten: Die erste ermöglicht den Zugriff auf allgemeine Einstellungen (etwa den [Bereich Optionen](./#zugriff-auf-den-bereich-optionen)). Die zweite Leiste kann für spezifische Aktionen mit Ihrer Adresse genutzt werden (etwa zum Senden oder Beantworten von E-Mails).|  
+|Linke Seite (2)|Zeigt die Liste der Ordner für Ihre E-Mail-Adresse an. Diese Ordner werden als Baumstruktur dargestellt, die Sie ein- oder ausklappen können.|
+|Mittleres Segment (3)|Zeigt die Liste der Nachrichten (gelesen und ungelesen) aus dem im linken Menü ausgewählten Ordner an. In diesem Bereich können auch Suchergebnisse angezeigt werden.|
 |Rechte Seite (4)|Zeigt den Lesebereich an, wenn eine E-Mail ausgewählt wurde.|
 
 ![useowa](images/use-owa-step4.png){.thumbnail}
 
-Beachten Sie, dass Sie die Größe der vertikalen Abschnitte ändern können, indem Sie auf deren Randlinien klicken und diese verschieben.
+Beachten Sie, dass Sie die Größe der vertikalen Bereiche durch Klicken und Ziehen ihrer Trennlinien ändern können.
 
 ### E-Mails anzeigen
 
-Wählen Sie zum Anzeigen Ihrer E-Mails einen Ordner auf der linken Seite aus. Eingehende E-Mails, für die keine Posteingangsregeln gelten, kommen im Ordner „Posteingang“ an. Um festzustellen, ob Sie neue E-Mails erhalten haben, überprüfen Sie, ob neben dem jeweiligen Ordner eine Nummer angezeigt wird.
+Um Ihre E-Mails anzuzeigen, wählen Sie einen Ordner auf der linken Seite aus. Eingehende E-Mails, die nicht von Posteingangsregeln bearbeitet werden, erscheinen im Ordner "Posteingang". Um zu prüfen, ob Sie neue E-Mails erhalten haben, sehen Sie nach, ob neben dem entsprechenden Ordner eine Zahl angezeigt wird.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-Um eine E-Mail zu lesen, wählen Sie gegebenenfalls ihren Ordner aus. Klicken Sie nun auf die E-Mail, um deren Inhalt im Lesebereich anzuzeigen. Ungelesene Nachrichten werden in einer anderen Farbe angezeigt, um sie von gelesenen Nachrichten zu unterscheiden.
+Um eine E-Mail zu lesen, wählen Sie gegebenenfalls ihren Ordner aus. Klicken Sie dann auf die E-Mail, um deren Inhalt im Lesebereich anzuzeigen. Ungelesene Nachrichten werden in Fettdruck dargestellt, um sie von gelesenen Nachrichten zu unterscheiden.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### E-Mails sortieren und filtern
+
+Oben rechts in der Nachrichtenliste öffnet die Schaltfläche `Filter`{.action} ein Menü, das alle Anzeigeoptionen für den ausgewählten Ordner zusammenfasst.
+
+- **Nach Kategorie filtern**: Wählen Sie einen Eintrag, um nur eine Auswahl von E-Mails anzuzeigen, unter `Alle`{.action}, `Ungelesen`{.action}, `An mich`{.action} (E-Mails, die direkt an Ihre Adresse gerichtet sind), `Gekennzeichnet`{.action} (zur Nachverfolgung markierte E-Mails) oder `Erwähnungen`{.action} (E-Mails, in denen Ihre Adresse erwähnt wird).
+
+- **Sortieren nach**: Bewegen Sie den Mauszeiger über den Eintrag `Sortieren nach`{.action}, um das Sortierkriterium für E-Mails auszuwählen: **Datum**, **Von**, **An**, **Betreff**, **Anlagen**, **Wichtigkeit** oder **Größe**. Der Pfeil links neben dem Kriterium zeigt die aktuelle Reihenfolge an; klicken Sie erneut auf dasselbe Kriterium, um sie umzukehren.
+
+- **Anzeigen als**: Bewegen Sie den Mauszeiger über den Eintrag `Anzeigen als`{.action}, um zwischen der Ansicht **Nachrichten** (eine E-Mail pro Zeile) und der Ansicht **Unterhaltungen** (E-Mails nach Diskussionsverlauf gruppiert) zu wechseln.
+
 ### Senden und Antworten
 
-**Um eine neue E-Mail zu senden**, klicken Sie auf die Schaltfläche `Neu`{.action} oben in der Benutzeroberfläche. Das Bearbeitungsfenster wird auf der rechten Seite angezeigt. Füllen Sie die Felder für Ihre E-Mail aus (Empfänger, Betreff, Nachrichtentext, Anhänge). Sobald Sie bereit sind, die E-Mail zu senden, klicken Sie auf die Schaltfläche `Senden`{.action}.
+Um **eine neue Nachricht zu senden**, klicken Sie auf das Symbol `Neu`{.action} oben in der OWA-Oberfläche. Der Bearbeitungsbereich wird auf der rechten Seite angezeigt. Füllen Sie die Felder Ihrer E-Mail aus (Empfänger, Betreff, Nachrichtentext, Anlagen). Klicken Sie auf `Senden`{.action}, sobald Ihre E-Mail bereit ist.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**Um auf eine E-Mail zu antworten**, [klicken Sie zuerst darauf, um sie](./#emails-anzeigen) anzuzeigen. Danach klicken Sie auf die Schaltfläche `Allen antworten`{.action}. Verwenden Sie stattdessen die Abwärtspfeiltaste, wenn Sie nur dem Absender der E-Mail antworten möchten (ohne die Empfänger in der „Cc“-Zeile einzubeziehen).
+Um **auf eine Nachricht zu antworten**, klicken Sie zunächst darauf, um sie anzuzeigen. Klicken Sie anschließend auf `Allen antworten`{.action}, um allen Empfängern zu antworten. Verwenden Sie die Pfeil-nach-unten-Schaltfläche, wenn Sie nur dem Absender der E-Mail antworten möchten (ohne die Empfänger in Kopie), und klicken Sie dann auf `Antworten`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-Wenn Sie antworten möchten, wird der Schnellantwort-Editor über der E-Mail angezeigt. Verfassen Sie hier Ihre Antwort. Wenn Sie bereit sind, Ihre E-Mail zu senden, klicken Sie auf `Senden`{.action}. Bitte beachten Sie, dass die vollständigen Antwortoptionen (wie das Hinzufügen einer Signatur) nur angezeigt werden, wenn Sie zuerst die Ansicht mit Klick auf das Doppelpfeilsymbol auf den Standard-Bearbeitungsbereich erweitern.
+Wenn Sie sich zum Antworten entscheiden, wird der Schnellantwort-Editor über der E-Mail angezeigt. Verfassen Sie hier Ihre Antwort, und sobald Sie Ihre Nachricht senden möchten, klicken Sie auf `Senden`{.action}. Beachten Sie, dass Sie für jede Antwortoption (etwa das Hinzufügen einer Signatur) zunächst die Ansicht durch Klicken auf das Doppelpfeilsymbol auf den vollständigen Bearbeitungsbereich erweitern müssen.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
 ### Ihren Posteingang organisieren
 
-OWA bietet verschiedene Möglichkeiten, Ihren Posteingang zu organisieren. Sie können
+OWA bietet verschiedene Möglichkeiten, Ihren Posteingang zu organisieren. Sie können:
 
-- [Ordner und Unterordner erstellen](./#einen-ordner-erstellen)
-- [E-Mails verschieben](./#emails-verschieben)
-- [Regeln festlegen](./#posteingangsregeln-erstelllen), damit Aktionen automatisch ausgeführt werden, wenn eine neue E-Mail empfangen wird.
+- [Ordner und Unterordner erstellen](./#einen-ordner-erstellen),
+- [E-Mails verschieben](./#e-mails-verschieben),
+- [Regeln festlegen](./#posteingangsregeln-erstellen), um automatisch Aktionen auszuführen, sobald eine neue E-Mail eingeht,
+- [einen Absender blockieren](./#einen-absender-blockieren), um keine Nachrichten mehr von ihm zu erhalten.
 
 #### Einen Ordner erstellen
 
-Um einen neuen Ordner zu erstellen, klicken Sie mit der rechten Maustaste auf den Namen Ihres E-Mail-Accounts in der Ordnerstruktur und wählen Sie dann `Neuen Ordner erstellen`{.action}. Auf dieselbe Weise können Sie einen Unterordner in bestehenden Ordnern erstellen (`Neuen Unterordner erstellen`{.action}). 
+Um einen neuen Ordner zu erstellen, klicken Sie mit der rechten Maustaste auf den Namen Ihrer E-Mail-Adresse in der Ordnerstruktur und wählen Sie dann `Neuen Ordner erstellen`{.action}. Auf dieselbe Weise können Sie in bestehenden Ordnern einen Unterordner erstellen, indem Sie auf `Neuen Unterordner erstellen`{.action} klicken.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
 #### E-Mails verschieben
 
-**Um eine E-Mail zu verschieben** ziehen Sie sie einfach mittels „Drag-and-Drop“ in den Zielordner oder klicken Sie mit der rechten Maustaste und wählen Sie `Verschieben`{.action}.
-**Um mehrere E-Mails** gleichzeitig zu verschieben, wählen Sie sie aus, indem Sie jeweils die Kontrollkästchen markieren und klicken Sie auf `Verschieben`{.action} auf der rechten Seite oder auf `Verschieben`{.action} im oberen Abschnitt. Danach wählen Sie den Zielordner.
+Um **eine E-Mail zu verschieben**, können Sie sie einfach per Drag-and-Drop in den Zielordner ziehen oder mit der rechten Maustaste darauf klicken und `Verschieben`{.action} auswählen.
+Um **mehrere E-Mails gleichzeitig zu verschieben**, wählen Sie alle über ihre Kontrollkästchen aus. Klicken Sie dann auf `Verschieben`{.action} (auf der rechten Seite) oder auf `Verschieben nach`{.action} (im oberen Bereich). Wählen Sie anschließend den Zielordner aus.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
 #### Posteingangsregeln erstellen
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Zum Verwalten der Regeln klicken Sie oben auf das Zahnradsymbol und danach auf `Optionen`{.action}.
+Um Regeln zu erstellen und zu verwalten, klicken Sie zunächst oben auf das Zahnradsymbol und dann auf `Optionen`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Klicken Sie in der neuen Ansicht auf `Posteingangs- und Aufräumregeln`{.action} links im Menü. In der Baumstruktur der „Optionen“ finden Sie dieses Element unter „E-Mail“ und dann unter „Automatische Verarbeitung“. Von hier aus können Sie Regeln in der Liste erstellen, bearbeiten, löschen und verschieben. 
+Auf der neuen Seite, die sich öffnet, klicken Sie im linken Menü auf `Posteingangs- und Aufräumregeln`{.action}. In der Baumstruktur "Optionen" finden Sie diese Funktion unter "E-Mail" im Bereich "Automatische Verarbeitung". Hier können Sie Regeln in der Liste erstellen, bearbeiten und verschieben.
 
-Um eine neue Regel hinzuzufügen, klicken Sie auf die Schaltfläche `+`{.action}. 
+Um eine neue Regel hinzuzufügen, klicken Sie auf die Schaltfläche `+`{.action}.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Geben Sie die erforderlichen Informationen in Abhängigkeit von der Aktion ein, die von der Regel ausgeführt werden soll. Danach klicken Sie auf `OK`{.action}. 
+Geben Sie die erforderlichen Informationen entsprechend der Aufgabe ein, die diese Regel ausführen soll. Klicken Sie anschließend auf `OK`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-Ausführlichere Anweisungen zum Erstellen von Posteingangsregeln finden Sie in unserer Anleitung: [Posteingangsregeln in OWA erstellen](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+Detailliertere Anweisungen zum Erstellen von Posteingangsregeln finden Sie in unserer Anleitung: [Posteingangsregeln in OWA erstellen](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-##### Einen Absender blockieren
+#### Einen Absender blockieren
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/UeNdpFwdXm0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Klicken Sie oben rechts auf das Zahnrad und dann auf "Optionen". Folgen Sie in der linken Spalte der Ordnerstruktur "E-Mail" unter "Accounts" und "Blockieren oder erlauben".
+Klicken Sie oben rechts auf das Zahnradsymbol und dann auf `Optionen`{.action}. Folgen Sie weiterhin in der linken Spalte der Baumstruktur "E-Mail" unter "Konten" und dann "Blockieren oder zulassen".
 
-Geben Sie im Bereich "**Absender gesperrt**"eine E-Mail-Adresse oder eine zu blockierende Domain ein und klicken Sie auf die Schaltfläche `+`{.action}, um diese in die Liste aufzunehmen.
+Geben Sie im Bereich "**Gesperrte Absender**" eine zu blockierende E-Mail-Adresse oder einen Domainnamen ein und klicken Sie dann auf die Schaltfläche `+`{.action}, um diese in die Liste aufzunehmen.
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Eine Kontaktliste verwalten
+### Ihre Kontakte verwalten
 
-Zum Verwalten Ihrer Kontakte klicken Sie oben auf die „App Launcher“ Schaltfläche und danach auf `Personen`{.action}.
+Um Ihre Kontakte zu verwalten, klicken Sie zunächst oben links auf der Seite auf die blaue App-Launcher-Schaltfläche (die auch Zugriff auf Kalender, Aufgaben und andere Module bietet) und dann auf `Personen`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-Auf dieser Seite können Sie einen neuen Kontakt hinzufügen, eine Kontaktliste erstellen und vorhandene Kontakte entfernen.
+Auf der neuen Seite können Sie einen neuen Kontakt hinzufügen, eine Kontaktliste erstellen und vorhandene Kontakte entfernen.
 
-**Um einen neuen Kontakt hinzuzufügen**, klicken Sie auf `Neu`{.action} und geben Sie die Kontaktdetails ein, die Sie hinzufügen möchten. Sobald Sie diesen Vorgang abgeschlossen haben, klicken Sie auf `Speichern`{.action}.
+#### Einen Kontakt hinzufügen
+
+Klicken Sie auf `Neu`{.action} und geben Sie dann die Daten des Kontakts ein, den Sie hinzufügen möchten. Klicken Sie anschließend auf `Speichern`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**Um eine Kontaktliste zu erstellen**, klicken Sie auf die Pfeiltaste neben „Neu“ und danach auf `Kontaktliste`{.action}. Wählen Sie einen Namen, fügen Sie Kontakte hinzu und klicken Sie danach auf `Speichern`{.action}.
+#### Eine Kontaktliste erstellen
+
+Klicken Sie auf den Pfeil nach unten neben `Neu`{.action} und dann auf `Kontaktliste`{.action}. Geben Sie ihr einen Namen, fügen Sie Kontakte hinzu und klicken Sie anschließend auf `Speichern`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
-### Passwort ändern
+### Ihr Passwort ändern
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Sie können Ihr Kontopasswort ändern, wenn Sie bei OWA angemeldet sind. Hierzu klicken Sie oben auf das Zahnradsymbol und danach auf `Optionen`{.action}.
+Sie können das Passwort Ihres Accounts ändern, während Sie bei OWA angemeldet sind. Klicken Sie hierzu oben auf das Zahnradsymbol und dann auf `Optionen`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Erweitern Sie in der neuen Ansicht den Bereich „Allgemein“ in der Baumstruktur auf der linken Seite und klicken Sie dann auf `Mein Konto`{.action}. Abschließend klicken Sie auf `Ihr Kennwort ändern`{.action}.
+Erweitern Sie auf der neuen Seite den Tab "Allgemein" in der Baumstruktur auf der linken Seite und klicken Sie dann auf `Mein Konto`{.action}. Klicken Sie abschließend auf `Kennwort ändern`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-Geben Sie im neuen Fenster Ihr aktuelles Passwort ein. Danach geben Sie ein neues Passwort ein und wiederholen die Eingabe zum Bestätigen. Klicken Sie auf `Speichern`{.action}, um das neue Passwort zu speichern.
+Geben Sie im neuen Fenster, das sich öffnet, Ihr aktuelles Passwort ein. Geben Sie anschließend ein neues Passwort ein und bestätigen Sie es durch erneute Eingabe. Klicken Sie auf `Speichern`{.action}, um das neue Passwort zu speichern.
 
 > [!primary]
 >
-> Denken Sie daran, Ihr neues Passwort auch auf jedem Gerät anzupassen, das für den Zugriff auf dieses Konto verwendet wird (E-Mail-Clients). Bei Problemen mit Ihrem Passwort wenden Sie sich an Ihren Dienst-Administrator.
+> Denken Sie daran, Ihr neues Passwort auf allen Geräten einzugeben, die für den Zugriff auf diesen Account verwendet werden (zum Beispiel in Ihrer E-Mail-Client-Software). Sollten Sie Schwierigkeiten mit Ihrem Passwort haben, wenden Sie sich an Ihren Dienstadministrator.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
 ### Eine automatische Antwort hinzufügen
 
-In OWA können Sie automatische Antworten für Ihre E-Mail-Adresse erstellen, damit E-Mails während Ihrer Abwesenheit nicht unbeantwortet bleiben. Hierzu klicken Sie oben auf das Zahnradsymbol und danach auf `Automatische Antworten`{.action}.
+In OWA können Sie eine automatische Antwort für Ihren Posteingang erstellen, damit E-Mails während Ihrer Abwesenheit nicht unbeantwortet bleiben. Klicken Sie hierzu oben auf das Zahnradsymbol und dann auf `Automatische Antworten`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-Wählen Sie im angezeigten Fenster die Option „Automatische Antworten senden“. Anschließend können Sie den Auto-Responder so einstellen, dass er verschiedene Kriterien erfüllt:
+Wählen Sie im sich öffnenden Fenster die Option "Automatische Antworten senden". Sie können den Auto-Responder dann so einstellen, dass er verschiedene Kriterien erfüllt:
 
-- E-Mails mit automatischer Antwort für ein festes Zeitintervall oder dauerhaft senden, bis sie manuell deaktiviert werden
-- definieren, welche Absender automatische Antworten auf E-Mails erhalten (nur interne Absender oder externe Absender einschließen).
+- E-Mails mit automatischer Antwort für ein festes Zeitintervall oder dauerhaft senden, bis sie manuell deaktiviert werden,
+- definieren, welche Absender automatische Antworten erhalten (nur interne Absender oder auch externe Absender einschließen).
 
-Geben Sie jetzt die erforderlichen Informationen in Abhängigkeit von der Aktion ein, die ausgeführt werden soll. Sobald Sie diesen Vorgang abgeschlossen haben, klicken Sie auf `OK`{.action}.
+Geben Sie die erforderlichen Informationen entsprechend der Aufgabe ein, die Sie mit dieser Regel ausführen möchten. Klicken Sie anschließend auf `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-Ausführlichere Anweisungen hierzu finden Sie in unserer Anleitung: [Einrichten einer automatischen Antwort in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
+Detailliertere Anweisungen zum Erstellen automatischer Antworten finden Sie in unserer Anleitung: [Automatische Antwort in OWA erstellen](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Eine Signatur hinzufügen
 
-Um eine Signatur hinzuzufügen, klicken Sie oben auf das Zahnradsymbol und danach auf `Optionen`{.action}.
+Um eine E-Mail-Signatur hinzuzufügen, klicken Sie oben auf das Zahnradsymbol und dann auf `Optionen`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Im linken Bereich der neuen Ansicht klicken Sie auf `E-Mail-Signatur`{.action}. In der Baumstruktur der „Optionen“ finden Sie dieses Element unter „E-Mail“ und „Layout“. Von hier aus können Sie die Signatur aktivieren, deaktivieren und bearbeiten.
+Klicken Sie auf der linken Seite der neuen Seite auf `E-Mail-Signatur`{.action}. In der Baumstruktur der Optionen befindet sich dieser Eintrag unter "E-Mail" und "Layout". Von hier aus können Sie die Signatur aktivieren, deaktivieren und bearbeiten.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Verfassen Sie Ihre elektronische Signatur im Editor. Sie können angeben, ob Sie die Signatur standardmäßig nur in neue E-Mails oder auch in Antworten und weitergeleitete E-Mails aufnehmen möchten. Sobald Sie den Vorgang abgeschlossen haben, klicken Sie zum Bestätigen auf `Speichern`{.action}.
+Verfassen Sie Ihre E-Mail-Signatur im Editor-Feld. Sie können angeben, ob Sie die Standardsignatur nur in neuen E-Mails oder auch in Antworten und weitergeleiteten E-Mails einfügen möchten. Sobald Sie fertig sind, klicken Sie zum Bestätigen auf `Speichern`{.action}.
 
-Anweisungen zum Erstellen automatisierter Signaturen mithilfe domainübergreifender Vorlagen finden Sie in unserer Anleitung: [Automatische Signaturen erstellen](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
+Anweisungen zum Erstellen automatischer Signaturen mithilfe domainübergreifender Vorlagen finden Sie in unserer Anleitung: [Automatische Signaturen erstellen](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
 
-### Zugang zum Bereich „Optionen“
+### Zugriff auf den Bereich Optionen
 
-Um auf alle Ihre Einstellungen zuzugreifen, klicken Sie oben auf das Zahnradsymbol und danach auf `Optionen`{.action}.
+Um auf alle Ihre Einstellungen zuzugreifen, klicken Sie oben auf das Zahnradsymbol und dann auf `Optionen`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Sie können dann die Baumstruktur „Optionen“ links auf der Seite durchsuchen. Hier können Sie auch weitere Anpassungen an Layout und Verhalten Ihres E-Mail-Kontos vornehmen. Bitte beachten Sie, dass einige der Accountoptionen aus Sicherheitsgründen von unserer Seite aus deaktiviert sein können.
+Sie können dann die Baumstruktur "Optionen" auf der linken Seite der Seite durchsuchen. Auf dieser Seite können Sie weitere Anpassungen am Layout und Verhalten Ihres E-Mail-Accounts vornehmen. Beachten Sie, dass aus Sicherheitsgründen einige Account-Optionen von OVHcloud deaktiviert sein können.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Cookie-Verwaltung
 
-Das Webmail, das für unsere E-Mail Angebote verwendet wird, basiert auf der Software Microsoft Outlook Web App. Es kann demnach Metadaten mit Microsoft Servern in Form von Cookies (etwa `appsforoffice.microsoft.com`) austauschen.
+Das für unsere E-Mail-Angebote verwendete Webmail basiert auf der Software Microsoft Outlook Web App. Es kann daher Metadaten in Form von Cookies namens `appsforoffice.microsoft.com` mit Microsoft-Servern austauschen.
 
-Wenn Sie diese Datenübertragung deaktivieren möchten, können Sie in Ihrem Browser eine Erweiterung hinzufügen, die Inhalte blockiert, z.B. uBlock Origin oder Ghostery.
-Die Deaktivierung dieser Cookies kann möglicherweise die stabile Funktionalität Ihres Webmail-Accounts beeinträchtigen.
+Wenn Sie diese Datenübertragungen deaktivieren möchten, können Sie eine Erweiterung zur Inhaltsblockierung in Ihrem Browser verwenden (zum Beispiel uBlock Origin oder Ghostery).
+Das Deaktivieren dieser Cookies kann jedoch die Stabilität Ihres Webmails beeinträchtigen.
 
 ## Weiterführende Informationen
 
-[Einrichten einer automatischen Antwort in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
+[Automatische Antworten in OWA erstellen](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
 
-[Ordner in OWA freigeben](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+[Einen Ordner über die OWA-Oberfläche freigeben](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
 
-[Kalender in OWA freigeben](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
+[Kalender über die OWA-Oberfläche freigeben](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
-[Kontaktgruppen erstellen](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
+[Kontaktgruppe erstellen](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
 
 Treten Sie unserer [User Community](/links/community) bei.

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-asia.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-asia.md
@@ -1,57 +1,57 @@
 ---
-title: 'Using the Outlook Web App with an email account'
-excerpt: 'Find out how to manage an email address using OWA webmail'
-updated: 2026-03-24
+title: 'Using your email address from the Outlook Web App (OWA) webmail'
+excerpt: 'Find out how to use your email address from OWA webmail'
+updated: 2026-05-04
 ---
 
 ## Objective
 
-With an OVHcloud Email offer you can send and receive your emails using a device and client of your choice. To access an account from anywhere via web browser, OVHcloud provides an online email client called Outlook Web App (OWA). Our [webmail login page](/links/web/email) is the single point of access to the respective OWA for all active email accounts on your Email offer.
+With OVHcloud email solutions, you can send and receive your emails from a device and client of your choice. OVHcloud provides an online email service called Outlook Web App (OWA) that lets you access an account from anywhere via a web browser. All active email accounts on MX Plan share a single point of access to their respective OWA interface: our [webmail login page](/links/web/email).
 
-**This guide explains how to use your email address with OWA and exemplifies the most important features of this interface.**
+**Find out how to perform common actions with your email address from the OWA interface.**
 
 ## Requirements
 
-- an OVHcloud email solution already set up (**MX Plan**, available as part of our [Web Hosting plans](/links/web/hosting)
-- login credentials for the email address you want to configure
+- An OVHcloud email solution already set up:
+    - [**MX Plan**](/links/web/hosting), available with our Web Hosting plans or ordered as a standalone solution.
+- The login credentials for the email address you want to use.
 
 ## Instructions
 
-This guide will give you a better understanding of the usual email account tasks available in the OWA webmail. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions about any settings not mentioned in this guide.
+This guide will help you better understand the usual tasks available in an email account using OWA. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions for any settings not covered in this guide.
 
 > [!primary]
 >
-> After the first two steps, the instructions don't have to be considered in a particular order.
->
+> After logging in and getting familiar with the interface, you do not need to follow the instructions in the order given.
 
-### 1. Accessing OWA webmail
+### Logging in to OWA
 
-To log in to OWA webmail with your email address, go to the general [webmail login page](/links/web/email). Enter your full email address and password, then click the `Login`{.action} button.
+To log in to OWA with your email address, open the [webmail login page](/links/web/email). Enter your full email address and password. Then click `Sign in`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
-If this is your first time logging in to OWA webmail with this email address, you will be prompted to set the interface language and time zone. Click `Save`{.action} to continue.
+If this is your first time logging in to OWA with this email address, you will be prompted to set the interface language and time zone. Then click `Save`{.action} to continue.
 
 > [!primary]
 >
 > Time zones are listed according to [the UTC (Coordinated Universal Time) standard](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), not in alphabetical order of cities.
 >
-> **Example**: For Western Europe, it is the UTC +1 tranche (Brussels, Copenhagen, Madrid, Paris).
+> **Example**: For Western Europe, this is UTC +1 (Brussels, Copenhagen, Madrid, Paris).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-From now on, your inbox view will appear by default after login.
+From now on, your inbox will appear by default as soon as you log in.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Understanding the OWA display
+### Understanding the OWA display
 
-There are several sections to the OWA interface. Please refer to the table and the image below to familiarise yourself with it.
+The OWA interface contains several sections. Refer to the table and image below to familiarise yourself with it.
 
 |Parts|Description|  
 |---|---|  
-|Top section (1)|Contains two tab bars: the first one allows access to general settings (such as the [options section](./#accessing-the-options-section)), and the second one can be used to perform specific actions with your address (such as sending or replying to emails).|  
-|Left-hand side (2)|Displays the list of folders for your email address. These appear as a tree-view that you can expand or hide.|
+|Top section (1)|Contains two tab bars: the first one provides access to general settings (such as the [Options section](./#accessing-the-options-section)). The second bar can be used for specific actions with your address (such as sending or replying to emails).|  
+|Left-hand side (2)|Displays the list of folders for your email address. These folders appear as a tree-view that you can expand or collapse.|
 |Central segment (3)|Displays the list of messages (read and unread) from the folder selected in the left-hand menu. This section can also display search results.|
 |Right-hand side (4)|Displays the reading pane when an email has been selected.|
 
@@ -61,113 +61,146 @@ Note that you can change the size of the vertical sections by clicking and dragg
 
 ### Viewing emails
 
-To view your emails, select a folder on the left-hand side. Incoming emails that are not treated by inbox rules will arrive in the "Inbox" folder. To see if you have received any new emails, check if a number appears next to the respective folder.
+To view your emails, select a folder on the left-hand side. Incoming emails that are not processed by inbox rules will appear in the "Inbox" folder. To check whether you have received any new emails, see if a number appears next to the corresponding folder.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-To read an email, select its folder if necessary. Now click on the email to show its content in the reading section. Unread messages appear in a different colour to set them apart from messages that have been read.
+To read an email, select its folder if necessary. Then click on the email to display its content in the reading pane. Unread messages appear in bold to distinguish them from read messages.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Sorting and filtering emails
+
+At the top right of the message list, the `Filter`{.action} button opens a menu that gathers all display options for the selected folder.
+
+- **Filter by category**: select an entry to display only a selection of emails among `All`{.action}, `Unread`{.action}, `To me`{.action} (emails addressed directly to your address), `Flagged`{.action} (emails marked for follow-up) or `Mentions`{.action} (emails in which your address is mentioned).
+
+- **Sort by**: hover over the `Sort by`{.action} entry to choose the sort criterion for emails: **Date**, **From**, **To**, **Subject**, **Attachments**, **Importance** or **Size**. The arrow to the left of the criterion indicates the current order; click the same criterion again to reverse it.
+
+- **Show as**: hover over the `Show as`{.action} entry to switch between the **Messages** view (one email per line) and the **Conversations** view (emails grouped by discussion thread).
+
 ### Sending and replying
 
-**To send a new email**, click the `New`{.action} button at the top of the webmail interface. The editing pane will appear on the right-hand side. Fill in the fields for your email (recipients, subject, message body, attachments). Once you are ready to send it, click the `Send`{.action} button.
+To **send a new message**, click the `New`{.action} icon at the top of the OWA interface. The editing pane will appear on the right-hand side. Fill in the fields of your email (recipients, subject, message body, attachments). Click `Send`{.action} once your email is ready.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**To reply to an email**, [click on it first](./#viewing-emails) to display it. Then click on the `Reply all`{.action} button. Use the down-arrow button instead if you only want to reply to the sender of the email (leaving out any recipient who is in copy).
+To **reply to a message**, first click on it to display it. Then click `Reply all`{.action} to reply to all recipients. Use the down-arrow button if you only want to reply to the sender of the email (excluding any recipient in copy), then click `Reply`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-When you choose to reply, the quick-reply editor will appear above the email. Compose your reply here, and once you are ready to send your mail, click `Send`{.action}. Please note that for all reply options (like adding a signature), it must be extended to the full editing pane first by clicking on the double-arrow symbol.
+When you choose to reply, the quick-reply editor will appear above the email. Type your reply there, and once you are ready to send your message, click `Send`{.action}. Note that for each reply option (such as adding a signature), you must first expand it to the full editing pane by clicking the double-arrow symbol.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
 ### Organising your inbox
 
-OWA provides several ways to organise your inbox. You can
+OWA offers several ways to organise your inbox. You can:
 
-- [create folders and subfolders](./#creating-a-folder)
-- [move emails](./#moving-emails)
-- [set rules](./#creating-inbox-rules) so that actions are performed automatically when a new email is received
+- [create folders and subfolders](./#creating-a-folder),
+- [move emails](./#moving-emails),
+- [set rules](./#creating-inbox-rules) to automatically perform actions when a new email is received,
+- [block a sender](./#blocking-a-sender) to stop receiving their messages.
 
 #### Creating a folder
 
-To create a new folder, right-click on the name of your email address in the folder tree and then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way (`Create new subfolder`{.action}). 
+To create a new folder, right-click the name of your email address in the folder tree, then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way by clicking `Create new subfolder`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
 #### Moving emails
 
-**To move an email**, you can simply drag-and-drop it to the target folder or right-click it and select `Move`{.action}.
-**To move multiple emails** at once, select them by checking their tick boxes, and click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
+To **move an email**, you can simply drag-and-drop it into the target folder, or right-click it and select `Move`{.action}.
+To **move multiple emails** at once, select them all using their tick boxes. Then click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
 #### Creating inbox rules
 
-To manage rules, click on the gear icon at the top, then click on `Options`{.action}.
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+To create and manage rules, first click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page that appears, click on `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this item under "Mail", then "Automatic processing". From here, you can create, edit, delete and move rules in the list. 
+On the new page that opens, click `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this feature under "Mail", in "Automatic processing". Here you can create, edit and move rules in the list.
 
-To add a new rule, click the `+`{.action} button. 
+To add a new rule, click the `+`{.action} button.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Fill in the requested information depending on the action you want the rule to carry out. Afterwards, click `OK`{.action}. 
+Fill in the requested information depending on the task you want this rule to perform. Then click `OK`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-### Managing a contact list
+For more detailed instructions on creating inbox rules, please refer to our guide: [Creating inbox rules in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-To manage your contacts, click the blue "app launcher" button at the top, then click on `People`{.action}.
+#### Blocking a sender
+
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+Click the gear icon at the top right, then click `Options`{.action}. Still in the left-hand column, browse the "Mail" tree under "Accounts", then "Block or allow".
+
+In the "**Blocked Senders**" section, type an email address or domain name to block, then click the `+`{.action} button to add it to the list.
+
+![useowa](images/owa_exchange_block.png){.thumbnail}
+
+### Managing your contacts
+
+To manage your contacts, first click the blue app launcher button at the top left of the page (which also gives access to calendar, tasks and other modules), then click `People`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-On the new page, you can add a new contact, create a contact list, and remove existing contacts.
+On the new page, you can add a new contact, create a contact list and remove existing contacts.
 
-**To add a new contact**, click `New`{.action}, and enter the contact details you want to add. Once you have done this, click `Save`{.action}.
+#### Adding a contact
+
+Click `New`{.action}, then enter the details of the contact you want to add. Once done, click `Save`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**To create a contact list**, click the down-arrow button next to "New", then click `Contact List`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
+#### Creating a contact list
+
+Click the down arrow next to `New`{.action}, then click `Contact list`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
-### Changing the password
+### Changing your password
 
-You can change your account password when you are logged in to OWA. To do this, click the gear icon at the top, then click `Options`{.action}.
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+You can change your account password while logged in to OWA. To do so, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page, expand the "General" tab in the tree on the left-hand side, then click `My Account`{.action}. Finally, click `Change Password`{.action}.
+On the new page, expand the "General" tab in the left-hand tree, then click `My account`{.action}. Finally, click `Change your password`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-In the new window that pops up, enter your current password. Then enter a new password, and re-enter to confirm it. Click the `Save`{.action} button to save the new password.
+In the new window that opens, enter your current password. Then enter a new password and confirm it by typing it again. Click `Save`{.action} to save the new password.
 
 > [!primary]
 >
-> Remember to also enter your new password on any device i.e. email client used to access this account. In case of any issues with your password, contact your service administrator.
+> Remember to enter your new password on all devices used to access this account (for example in your email client software). If you have any difficulties with your password, contact your service administrator.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
-### Adding an auto-reply
+### Adding an automatic reply
 
-In OWA, you can create an automatic reply on your email address to not leave emails unanswered during absences. To do this, click the gear icon at the top, then click `Automatic Replies`{.action}.
+In OWA, you can create an automatic reply on your inbox so that emails are not left unanswered while you are away. To do so, click the gear icon at the top, then click `Automatic replies`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-In the window that appears, select the option "Send automatic replies". You can then set the auto-responder to fit several criteria:
+In the window that opens, select the "Send automatic replies" option. You can then configure the auto-responder to match several criteria, such as:
 
-- send auto-reply emails for a fixed time interval, or continuously until it is manually disabled
-- define which senders will receive auto-reply emails (internal senders only, or include external senders)
+- send automatic reply emails for a fixed time interval, or continuously until manually disabled
+- define which senders will receive automatic reply emails (internal senders only, or include external senders)
 
-Now, fill in the requested information depending on the action you want it to carry out. Once you have done so, click `OK`{.action}.
+Fill in the requested information depending on the task you want to perform with this rule. Once done, click `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
+
+For more detailed instructions on creating automatic replies, please refer to our guide: [Creating an automatic reply in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Adding a signature
 
@@ -175,29 +208,35 @@ To add an email signature, click the gear icon at the top, then click `Options`{
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the left-hand side of the new page, click `Email signature`{.action}. In the options tree, this item is under "Mail" and "Layout". From here you can enable, disable and edit the signature.
+On the left-hand side of the new page, click `Email signature`{.action}. In the tree options, this item is located under "Mail" and "Layout". From here, you can enable, disable and edit the signature.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Compose your electronic signature in the editor box. You can specify whether you want to include the signature by default in new emails only or in replies and forwarded emails as well. Once you have finished, click `Save`{.action} to confirm.
+Compose your email signature in the editor box. You can specify whether you want to include the default signature in new emails only, or also in replies and forwarded emails. Once you are done, click `Save`{.action} to confirm.
 
-### Accessing the options section
+### Accessing the Options section
 
 To access all your settings, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be set from here. Please note that some of the account options may be disabled from our side for security reasons.
+You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be made from this page. Note that for security reasons, some account options may be disabled by OVHcloud.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Cookie management
 
-The webmail that is used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies called `appsforoffice.microsoft.com`.
+The webmail used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies named `appsforoffice.microsoft.com`.
 
-If you want to disable these exchanges, you can use a content blocking extension (such as uBlock Origin or Ghostery) on your browser.
+If you want to disable these exchanges, you can use a content blocking extension on your browser (such as uBlock Origin or Ghostery).
 However, disabling these cookies may affect the stability of your webmail.
 
 ## Go further
+
+[Creating automatic replies in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
+
+[Sharing a folder from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+
+[Sharing calendars via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-au.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-au.md
@@ -1,57 +1,56 @@
 ---
-title: 'Using the Outlook Web App with an email account'
-excerpt: 'Find out how to manage an email address using OWA webmail'
-updated: 2026-03-24
+title: 'Using your email address from the Outlook Web App (OWA) webmail'
+excerpt: 'Find out how to use your email address from OWA webmail'
+updated: 2026-05-04
 ---
 
 ## Objective
 
-With an OVHcloud Email offer you can send and receive your emails using a device and client of your choice. To access an account from anywhere via web browser, OVHcloud provides an online email client called Outlook Web App (OWA). Our [webmail login page](/links/web/email) is the single point of access to the respective OWA for all active email accounts on your Email offer.
+With OVHcloud email solutions, you can send and receive your emails from a device and client of your choice. OVHcloud provides an online email service called Outlook Web App (OWA) that lets you access an account from anywhere via a web browser. Active email accounts on MX Plan share a single point of access to the OWA interface: our [webmail login page](/links/web/email).
 
-**This guide explains how to use your email address with OWA and exemplifies the most important features of this interface.**
+**Find out how to perform common actions with your email address from the OWA interface.**
 
 ## Requirements
 
-- an OVHcloud email solution already set up (**MX Plan**, available as part of our [Web Hosting plans](/links/web/hosting)
-- login credentials for the email address you want to configure
+- An OVHcloud [**MX Plan**](/links/web/hosting) email solution already set up, available with our Web Hosting plans or ordered as a standalone solution.
+- The login credentials for the email address you want to use.
 
 ## Instructions
 
-This guide will give you a better understanding of the usual email account tasks available in the OWA webmail. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions about any settings not mentioned in this guide.
+This guide will help you better understand the usual tasks available in an email account using OWA. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions for any settings not covered in this guide.
 
 > [!primary]
 >
-> After the first two steps, the instructions don't have to be considered in a particular order.
->
+> After logging in and getting familiar with the interface, you do not need to follow the instructions in the order given.
 
-### 1. Accessing OWA webmail
+### Logging in to OWA
 
-To log in to OWA webmail with your email address, go to the general [webmail login page](/links/web/email). Enter your full email address and password, then click the `Login`{.action} button.
+To log in to OWA with your email address, open the [webmail login page](/links/web/email). Enter your full email address and password. Then click `Sign in`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
-If this is your first time logging in to OWA webmail with this email address, you will be prompted to set the interface language and time zone. Click `Save`{.action} to continue.
+If this is your first time logging in to OWA with this email address, you will be prompted to set the interface language and time zone. Then click `Save`{.action} to continue.
 
 > [!primary]
 >
 > Time zones are listed according to [the UTC (Coordinated Universal Time) standard](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), not in alphabetical order of cities.
 >
-> **Example**: For Western Europe, it is the UTC +1 tranche (Brussels, Copenhagen, Madrid, Paris).
+> **Example**: For Western Europe, this is UTC +1 (Brussels, Copenhagen, Madrid, Paris).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-From now on, your inbox view will appear by default after login.
+From now on, your inbox will appear by default as soon as you log in.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Understanding the OWA display
+### Understanding the OWA display
 
-There are several sections to the OWA interface. Please refer to the table and the image below to familiarise yourself with it.
+The OWA interface contains several sections. Refer to the table and image below to familiarise yourself with it.
 
 |Parts|Description|  
 |---|---|  
-|Top section (1)|Contains two tab bars: the first one allows access to general settings (such as the [options section](./#accessing-the-options-section)), and the second one can be used to perform specific actions with your address (such as sending or replying to emails).|  
-|Left-hand side (2)|Displays the list of folders for your email address. These appear as a tree-view that you can expand or hide.|
+|Top section (1)|Contains two tab bars: the first one provides access to general settings (such as the [Options section](./#accessing-the-options-section)). The second bar can be used for specific actions with your address (such as sending or replying to emails).|  
+|Left-hand side (2)|Displays the list of folders for your email address. These folders appear as a tree-view that you can expand or collapse.|
 |Central segment (3)|Displays the list of messages (read and unread) from the folder selected in the left-hand menu. This section can also display search results.|
 |Right-hand side (4)|Displays the reading pane when an email has been selected.|
 
@@ -61,113 +60,146 @@ Note that you can change the size of the vertical sections by clicking and dragg
 
 ### Viewing emails
 
-To view your emails, select a folder on the left-hand side. Incoming emails that are not treated by inbox rules will arrive in the "Inbox" folder. To see if you have received any new emails, check if a number appears next to the respective folder.
+To view your emails, select a folder on the left-hand side. Incoming emails that are not processed by inbox rules will appear in the "Inbox" folder. To check whether you have received any new emails, see if a number appears next to the corresponding folder.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-To read an email, select its folder if necessary. Now click on the email to show its content in the reading section. Unread messages appear in a different colour to set them apart from messages that have been read.
+To read an email, select its folder if necessary. Then click on the email to display its content in the reading pane. Unread messages appear in bold to distinguish them from read messages.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Sorting and filtering emails
+
+At the top right of the message list, the `Filter`{.action} button opens a menu that gathers all display options for the selected folder.
+
+- **Filter by category**: select an entry to display only a selection of emails among `All`{.action}, `Unread`{.action}, `To me`{.action} (emails addressed directly to your address), `Flagged`{.action} (emails marked for follow-up) or `Mentions`{.action} (emails in which your address is mentioned).
+
+- **Sort by**: hover over the `Sort by`{.action} entry to choose the sort criterion for emails: **Date**, **From**, **To**, **Subject**, **Attachments**, **Importance** or **Size**. The arrow to the left of the criterion indicates the current order; click the same criterion again to reverse it.
+
+- **Show as**: hover over the `Show as`{.action} entry to switch between the **Messages** view (one email per line) and the **Conversations** view (emails grouped by discussion thread).
+
 ### Sending and replying
 
-**To send a new email**, click the `New`{.action} button at the top of the webmail interface. The editing pane will appear on the right-hand side. Fill in the fields for your email (recipients, subject, message body, attachments). Once you are ready to send it, click the `Send`{.action} button.
+To **send a new message**, click the `New`{.action} icon at the top of the OWA interface. The editing pane will appear on the right-hand side. Fill in the fields of your email (recipients, subject, message body, attachments). Click `Send`{.action} once your email is ready.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**To reply to an email**, [click on it first](./#viewing-emails) to display it. Then click on the `Reply all`{.action} button. Use the down-arrow button instead if you only want to reply to the sender of the email (leaving out any recipient who is in copy).
+To **reply to a message**, first click on it to display it. Then click `Reply all`{.action} to reply to all recipients. Use the down-arrow button if you only want to reply to the sender of the email (excluding any recipient in copy), then click `Reply`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-When you choose to reply, the quick-reply editor will appear above the email. Compose your reply here, and once you are ready to send your mail, click `Send`{.action}. Please note that for all reply options (like adding a signature), it must be extended to the full editing pane first by clicking on the double-arrow symbol.
+When you choose to reply, the quick-reply editor will appear above the email. Type your reply there, and once you are ready to send your message, click `Send`{.action}. Note that for each reply option (such as adding a signature), you must first expand it to the full editing pane by clicking the double-arrow symbol.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
 ### Organising your inbox
 
-OWA provides several ways to organise your inbox. You can
+OWA offers several ways to organise your inbox. You can:
 
-- [create folders and subfolders](./#creating-a-folder)
-- [move emails](./#moving-emails)
-- [set rules](./#creating-inbox-rules) so that actions are performed automatically when a new email is received
+- [create folders and subfolders](./#creating-a-folder),
+- [move emails](./#moving-emails),
+- [set rules](./#creating-inbox-rules) to automatically perform actions when a new email is received,
+- [block a sender](./#blocking-a-sender) to stop receiving their messages.
 
 #### Creating a folder
 
-To create a new folder, right-click on the name of your email address in the folder tree and then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way (`Create new subfolder`{.action}). 
+To create a new folder, right-click the name of your email address in the folder tree, then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way by clicking `Create new subfolder`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
 #### Moving emails
 
-**To move an email**, you can simply drag-and-drop it to the target folder or right-click it and select `Move`{.action}.
-**To move multiple emails** at once, select them by checking their tick boxes, and click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
+To **move an email**, you can simply drag-and-drop it into the target folder, or right-click it and select `Move`{.action}.
+To **move multiple emails** at once, select them all using their tick boxes. Then click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
 #### Creating inbox rules
 
-To manage rules, click on the gear icon at the top, then click on `Options`{.action}.
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+To create and manage rules, first click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page that appears, click on `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this item under "Mail", then "Automatic processing". From here, you can create, edit, delete and move rules in the list.
+On the new page that opens, click `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this feature under "Mail", in "Automatic processing". Here you can create, edit and move rules in the list.
 
 To add a new rule, click the `+`{.action} button.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Fill in the requested information depending on the action you want the rule to carry out. Afterwards, click `OK`{.action}.
+Fill in the requested information depending on the task you want this rule to perform. Then click `OK`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-### Managing a contact list
+For more detailed instructions on creating inbox rules, please refer to our guide: [Creating inbox rules in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-To manage your contacts, click the blue "app launcher" button at the top, then click on `People`{.action}.
+#### Blocking a sender
+
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+Click the gear icon at the top right, then click `Options`{.action}. Still in the left-hand column, browse the "Mail" tree under "Accounts", then "Block or allow".
+
+In the "**Blocked Senders**" section, type an email address or domain name to block, then click the `+`{.action} button to add it to the list.
+
+![useowa](images/owa_exchange_block.png){.thumbnail}
+
+### Managing your contacts
+
+To manage your contacts, first click the blue app launcher button at the top left of the page (which also gives access to calendar, tasks and other modules), then click `People`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-On the new page, you can add a new contact, create a contact list, and remove existing contacts.
+On the new page, you can add a new contact, create a contact list and remove existing contacts.
 
-**To add a new contact**, click `New`{.action}, and enter the contact details you want to add. Once you have done this, click `Save`{.action}.
+#### Adding a contact
+
+Click `New`{.action}, then enter the details of the contact you want to add. Once done, click `Save`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**To create a contact list**, click the down-arrow button next to "New", then click `Contact List`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
+#### Creating a contact list
+
+Click the down arrow next to `New`{.action}, then click `Contact list`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
-### Changing the password
+### Changing your password
 
-You can change your account password when you are logged in to OWA. To do this, click the gear icon at the top, then click `Options`{.action}.
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+You can change your account password while logged in to OWA. To do so, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page, expand the "General" tab in the tree on the left-hand side, then click `My Account`{.action}. Finally, click `Change Password`{.action}.
+On the new page, expand the "General" tab in the left-hand tree, then click `My account`{.action}. Finally, click `Change your password`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-In the new window that pops up, enter your current password. Then enter a new password, and re-enter to confirm it. Click the `Save`{.action} button to save the new password.
+In the new window that opens, enter your current password. Then enter a new password and confirm it by typing it again. Click `Save`{.action} to save the new password.
 
 > [!primary]
 >
-> Remember to also enter your new password on any device i.e. email client used to access this account. In case of any issues with your password, contact your service administrator.
+> Remember to enter your new password on all devices used to access this account (for example in your email client software). If you have any difficulties with your password, contact your service administrator.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
-### Adding an auto-reply
+### Adding an automatic reply
 
-In OWA, you can create an automatic reply on your email address to not leave emails unanswered during absences. To do this, click the gear icon at the top, then click `Automatic Replies`{.action}.
+In OWA, you can create an automatic reply on your inbox so that emails are not left unanswered while you are away. To do so, click the gear icon at the top, then click `Automatic replies`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-In the window that appears, select the option "Send automatic replies". You can then set the auto-responder to fit several criteria:
+In the window that opens, select the "Send automatic replies" option. You can then configure the auto-responder to match several criteria, such as:
 
-- send auto-reply emails for a fixed time interval, or continuously until it is manually disabled
-- define which senders will receive auto-reply emails (internal senders only, or include external senders)
+- send automatic reply emails for a fixed time interval, or continuously until manually disabled
+- define which senders will receive automatic reply emails (internal senders only, or include external senders)
 
-Now, fill in the requested information depending on the action you want it to carry out. Once you have done so, click `OK`{.action}.
+Fill in the requested information depending on the task you want to perform with this rule. Once done, click `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
+
+For more detailed instructions on creating automatic replies, please refer to our guide: [Creating an automatic reply in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Adding a signature
 
@@ -175,29 +207,35 @@ To add an email signature, click the gear icon at the top, then click `Options`{
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the left-hand side of the new page, click `Email signature`{.action}. In the options tree, this item is under "Mail" and "Layout". From here you can enable, disable and edit the signature.
+On the left-hand side of the new page, click `Email signature`{.action}. In the tree options, this item is located under "Mail" and "Layout". From here, you can enable, disable and edit the signature.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Compose your electronic signature in the editor box. You can specify whether you want to include the signature by default in new emails only or in replies and forwarded emails as well. Once you have finished, click `Save`{.action} to confirm.
+Compose your email signature in the editor box. You can specify whether you want to include the default signature in new emails only, or also in replies and forwarded emails. Once you are done, click `Save`{.action} to confirm.
 
-### Accessing the options section
+### Accessing the Options section
 
 To access all your settings, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be set from here. Please note that some of the account options may be disabled from our side for security reasons.
+You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be made from this page. Note that for security reasons, some account options may be disabled by OVHcloud.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Cookie management
 
-The webmail that is used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies called `appsforoffice.microsoft.com`.
+The webmail used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies named `appsforoffice.microsoft.com`.
 
-If you want to disable these exchanges, you can use a content blocking extension (such as uBlock Origin or Ghostery) on your browser.
+If you want to disable these exchanges, you can use a content blocking extension on your browser (such as uBlock Origin or Ghostery).
 However, disabling these cookies may affect the stability of your webmail.
 
 ## Go further
+
+[Creating automatic replies in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
+
+[Sharing a folder from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+
+[Sharing calendars via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-ca.md
@@ -1,57 +1,60 @@
 ---
-title: 'Using the Outlook Web App with an email account'
-excerpt: 'Find out how to manage an email address using OWA webmail'
-updated: 2026-03-24
+title: 'Using your email address from the Outlook Web App (OWA) webmail'
+excerpt: 'Find out how to use your email address from OWA webmail'
+updated: 2026-05-04
 ---
 
 ## Objective
 
-With OVHcloud email solutions you can send and receive your emails using a device and client of your choice. To access an account from anywhere via web browser, OVHcloud provides an online email client called Outlook Web App (OWA). Our [webmail login page](/links/web/email) is the single point of access to the respective OWA for all active email accounts on MX Plan and Hosted Exchange.
+With OVHcloud email solutions, you can send and receive your emails from a device and client of your choice. OVHcloud provides an online email service called Outlook Web App (OWA) that lets you access an account from anywhere via a web browser. All active email accounts on MX Plan and Hosted Exchange share a single point of access to their respective OWA interface: our [webmail login page](/links/web/email).
 
-**This guide explains how to use your email address with OWA and exemplifies the most important features of this interface.**
+**Find out how to perform common actions with your email address from the OWA interface.**
 
 ## Requirements
 
-- an OVHcloud email solution already set up (**MX Plan**, available as part of our [Web Hosting plans](/links/web/hosting) or [**Hosted Exchange**](/links/web/emails-hosted-exchange)
-- login credentials for the email address you want to configure
+- An OVHcloud email solution already set up, from the following offers:
+    - [**MX Plan**](/links/web/hosting), available with our Web Hosting plans, included with [100M free hosting](/links/web/domains-free-hosting) or ordered as a standalone solution;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange).
+- The login credentials for the email address you want to use.
 
 ## Instructions
 
-This guide will give you a better understanding of the usual email account tasks available in the OWA webmail. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions about any settings not mentioned in this guide. Regarding Exchange functionalities, we have prepared some additional guides which you can find in the [**Go further**](./#go-further_1) section below.
+This guide will help you better understand the usual tasks available in an email account using OWA. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions for any settings not covered in this guide.
+
+For Exchange-specific features, you can find some additional guides in the [Go further](./#go-further) section at the bottom of this guide.
 
 > [!primary]
 >
-> After the first two steps, the instructions don't have to be considered in a particular order.
->
+> After logging in and getting familiar with the interface, you do not need to follow the instructions in the order given.
 
-### 1. Accessing OWA webmail
+### Logging in to OWA
 
-To log in to OWA webmail with your email address, go to the general [webmail login page](/links/web/email). Enter your full email address and password, then click the `Login`{.action} button.
+To log in to OWA with your email address, open the [webmail login page](/links/web/email). Enter your full email address and password. Then click `Sign in`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
-If this is your first time logging in to OWA webmail with this email address, you will be prompted to set the interface language and time zone. Click `Save`{.action} to continue.
+If this is your first time logging in to OWA with this email address, you will be prompted to set the interface language and time zone. Then click `Save`{.action} to continue.
 
 > [!primary]
 >
 > Time zones are listed according to [the UTC (Coordinated Universal Time) standard](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), not in alphabetical order of cities.
 >
-> **Example**: For Western Europe, it is the UTC +1 tranche (Brussels, Copenhagen, Madrid, Paris).
+> **Example**: For Western Europe, this is UTC +1 (Brussels, Copenhagen, Madrid, Paris).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-From now on, your inbox view will appear by default after login.
+From now on, your inbox will appear by default as soon as you log in.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Understanding the OWA display
+### Understanding the OWA display
 
-There are several sections to the OWA interface. Please refer to the table and the image below to familiarise yourself with it.
+The OWA interface contains several sections. Refer to the table and image below to familiarise yourself with it.
 
-|Parts|Description|
-|---|---|
-|Top section (1)|Contains two tab bars: the first one allows access to general settings (such as the [options section](./#accessing-the-options-section)), and the second one can be used to perform specific actions with your address (such as sending or replying to emails).|
-|Left-hand side (2)|Displays the list of folders for your email address. These appear as a tree-view that you can expand or hide.|
+|Parts|Description|  
+|---|---|  
+|Top section (1)|Contains two tab bars: the first one provides access to general settings (such as the [Options section](./#accessing-the-options-section)). The second bar can be used for specific actions with your address (such as sending or replying to emails).|  
+|Left-hand side (2)|Displays the list of folders for your email address. These folders appear as a tree-view that you can expand or collapse.|
 |Central segment (3)|Displays the list of messages (read and unread) from the folder selected in the left-hand menu. This section can also display search results.|
 |Right-hand side (4)|Displays the reading pane when an email has been selected.|
 
@@ -61,131 +64,146 @@ Note that you can change the size of the vertical sections by clicking and dragg
 
 ### Viewing emails
 
-To view your emails, select a folder on the left-hand side. Incoming emails that are not treated by inbox rules will arrive in the "Inbox" folder. To see if you have received any new emails, check if a number appears next to the respective folder.
+To view your emails, select a folder on the left-hand side. Incoming emails that are not processed by inbox rules will appear in the "Inbox" folder. To check whether you have received any new emails, see if a number appears next to the corresponding folder.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-To read an email, select its folder if necessary. Now click on the email to show its content in the reading section. Unread messages appear in a different colour to set them apart from messages that have been read.
+To read an email, select its folder if necessary. Then click on the email to display its content in the reading pane. Unread messages appear in bold to distinguish them from read messages.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Sorting and filtering emails
+
+At the top right of the message list, the `Filter`{.action} button opens a menu that gathers all display options for the selected folder.
+
+- **Filter by category**: select an entry to display only a selection of emails among `All`{.action}, `Unread`{.action}, `To me`{.action} (emails addressed directly to your address), `Flagged`{.action} (emails marked for follow-up) or `Mentions`{.action} (emails in which your address is mentioned).
+
+- **Sort by**: hover over the `Sort by`{.action} entry to choose the sort criterion for emails: **Date**, **From**, **To**, **Subject**, **Attachments**, **Importance** or **Size**. The arrow to the left of the criterion indicates the current order; click the same criterion again to reverse it.
+
+- **Show as**: hover over the `Show as`{.action} entry to switch between the **Messages** view (one email per line) and the **Conversations** view (emails grouped by discussion thread).
+
 ### Sending and replying
 
-**To send a new email**, click the `New`{.action} button at the top of the webmail interface. The editing pane will appear on the right-hand side. Fill in the fields for your email (recipients, subject, message body, attachments). Once you are ready to send it, click the `Send`{.action} button.
+To **send a new message**, click the `New`{.action} icon at the top of the OWA interface. The editing pane will appear on the right-hand side. Fill in the fields of your email (recipients, subject, message body, attachments). Click `Send`{.action} once your email is ready.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**To reply to an email**, [click on it first](./#viewing-emails) to display it. Then click on the `Reply all`{.action} button. Use the down-arrow button instead if you only want to reply to the sender of the email (leaving out any recipient who is in copy).
+To **reply to a message**, first click on it to display it. Then click `Reply all`{.action} to reply to all recipients. Use the down-arrow button if you only want to reply to the sender of the email (excluding any recipient in copy), then click `Reply`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-When you choose to reply, the quick-reply editor will appear above the email. Compose your reply here, and once you are ready to send your mail, click `Send`{.action}. Please note that for all reply options (like adding a signature), it must be extended to the full editing pane first by clicking on the double-arrow symbol.
+When you choose to reply, the quick-reply editor will appear above the email. Type your reply there, and once you are ready to send your message, click `Send`{.action}. Note that for each reply option (such as adding a signature), you must first expand it to the full editing pane by clicking the double-arrow symbol.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
 ### Organising your inbox
 
-OWA provides several ways to organise your inbox. You can
+OWA offers several ways to organise your inbox. You can:
 
-- [create folders and subfolders](./#creating-a-folder)
-- [move emails](./#moving-emails)
-- [set rules](./#creating-inbox-rules) so that actions are performed automatically when a new email is received
+- [create folders and subfolders](./#creating-a-folder),
+- [move emails](./#moving-emails),
+- [set rules](./#creating-inbox-rules) to automatically perform actions when a new email is received,
+- [block a sender](./#blocking-a-sender) to stop receiving their messages.
 
 #### Creating a folder
 
-To create a new folder, right-click on the name of your email address in the folder tree and then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way (`Create new subfolder`{.action}).
+To create a new folder, right-click the name of your email address in the folder tree, then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way by clicking `Create new subfolder`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
 #### Moving emails
 
-**To move an email**, you can simply drag-and-drop it to the target folder or right-click it and select `Move`{.action}.
-**To move multiple emails** at once, select them by checking their tick boxes, and click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
+To **move an email**, you can simply drag-and-drop it into the target folder, or right-click it and select `Move`{.action}.
+To **move multiple emails** at once, select them all using their tick boxes. Then click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
 #### Creating inbox rules
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-To manage rules, click on the gear icon at the top, then click on `Options`{.action}.
+To create and manage rules, first click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page that appears, click on `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this item under "Mail", then "Automatic processing". From here, you can create, edit, delete and move rules in the list.
+On the new page that opens, click `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this feature under "Mail", in "Automatic processing". Here you can create, edit and move rules in the list.
 
 To add a new rule, click the `+`{.action} button.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Fill in the requested information depending on the action you want the rule to carry out. Afterwards, click `OK`{.action}.
+Fill in the requested information depending on the task you want this rule to perform. Then click `OK`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-For more detailed instructions about creating inbox rules, please refer to our guide: [Creating inbox rules in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+For more detailed instructions on creating inbox rules, please refer to our guide: [Creating inbox rules in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-#### Block a sender
+#### Blocking a sender
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/UeNdpFwdXm0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Click on the gear icon at the top right-hand corner, then click `Options`{.action}. In the left-hand column, follow the "Mail" tree under "Accounts", then "Block or authorise".
+Click the gear icon at the top right, then click `Options`{.action}. Still in the left-hand column, browse the "Mail" tree under "Accounts", then "Block or allow".
 
-In the "**Blocked Senders**" section, type an email address or domain name to block, and then click the `+`{.action} button to add it to the list.
+In the "**Blocked Senders**" section, type an email address or domain name to block, then click the `+`{.action} button to add it to the list.
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Managing a contact list
+### Managing your contacts
 
-To manage your contacts, click the blue "app launcher" button at the top, then click on `People`{.action}.
+To manage your contacts, first click the blue app launcher button at the top left of the page (which also gives access to calendar, tasks and other modules), then click `People`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-On the new page, you can add a new contact, create a contact list, and remove existing contacts.
+On the new page, you can add a new contact, create a contact list and remove existing contacts.
 
-**To add a new contact**, click `New`{.action}, and enter the contact details you want to add. Once you have done this, click `Save`{.action}.
+#### Adding a contact
+
+Click `New`{.action}, then enter the details of the contact you want to add. Once done, click `Save`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**To create a contact list**, click the down-arrow button next to "New", then click `Contact List`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
+#### Creating a contact list
+
+Click the down arrow next to `New`{.action}, then click `Contact list`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
-### Changing the password
+### Changing your password
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-You can change your account password when you are logged in to OWA. To do this, click the gear icon at the top, then click `Options`{.action}.
+You can change your account password while logged in to OWA. To do so, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page, expand the "General" tab in the tree on the left-hand side, then click `My Account`{.action}. Finally, click `Change Password`{.action}.
+On the new page, expand the "General" tab in the left-hand tree, then click `My account`{.action}. Finally, click `Change your password`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-In the new window that pops up, enter your current password. Then enter a new password, and re-enter to confirm it. Click the `Save`{.action} button to save the new password.
+In the new window that opens, enter your current password. Then enter a new password and confirm it by typing it again. Click `Save`{.action} to save the new password.
 
 > [!primary]
 >
-> Remember to also enter your new password on any device i.e. email client used to access this account. In case of any issues with your password, contact your service administrator.
+> Remember to enter your new password on all devices used to access this account (for example in your email client software). If you have any difficulties with your password, contact your service administrator.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
-### Adding an auto-reply
+### Adding an automatic reply
 
-In OWA, you can create an automatic reply on your email address to not leave emails unanswered during absences. To do this, click the gear icon at the top, then click `Automatic Replies`{.action}.
+In OWA, you can create an automatic reply on your inbox so that emails are not left unanswered while you are away. To do so, click the gear icon at the top, then click `Automatic replies`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-In the window that appears, select the option "Send automatic replies". You can then set the auto-responder to fit several criteria:
+In the window that opens, select the "Send automatic replies" option. You can then configure the auto-responder to match several criteria, such as:
 
-- send auto-reply emails for a fixed time interval, or continuously until it is manually disabled
-- define which senders will receive auto-reply emails (internal senders only, or include external senders)
+- send automatic reply emails for a fixed time interval, or continuously until manually disabled
+- define which senders will receive automatic reply emails (internal senders only, or include external senders)
 
-Now, fill in the requested information depending on the action you want it to carry out. Once you have done so, click `OK`{.action}.
+Fill in the requested information depending on the task you want to perform with this rule. Once done, click `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-For more detailed instructions about creating auto-replies, please refer to our guide: [Creating automatic replies in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
+For more detailed instructions on creating automatic replies, please refer to our guide: [Creating an automatic reply in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Adding a signature
 
@@ -193,39 +211,39 @@ To add an email signature, click the gear icon at the top, then click `Options`{
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the left-hand side of the new page, click `Email signature`{.action}. In the options tree, this item is under "Mail" and "Layout". From here you can enable, disable and edit the signature.
+On the left-hand side of the new page, click `Email signature`{.action}. In the tree options, this item is located under "Mail" and "Layout". From here, you can enable, disable and edit the signature.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Compose your electronic signature in the editor box. You can specify whether you want to include the signature by default in new emails only or in replies and forwarded emails as well. Once you have finished, click `Save`{.action} to confirm.
+Compose your email signature in the editor box. You can specify whether you want to include the default signature in new emails only, or also in replies and forwarded emails. Once you are done, click `Save`{.action} to confirm.
 
-For instructions about creating automated signatures by using domain-wide templates, please refer to our guide: [Creating automatic signatures](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
+For instructions on creating automatic signatures using domain-wide templates, please refer to our guide: [Creating automatic signatures](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
 
-### Accessing the options section
+### Accessing the Options section
 
 To access all your settings, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be set from here. Please note that some of the account options may be disabled from our side for security reasons.
+You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be made from this page. Note that for security reasons, some account options may be disabled by OVHcloud.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Cookie management
 
-The webmail that is used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies called `appsforoffice.microsoft.com`.
+The webmail used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies named `appsforoffice.microsoft.com`.
 
-If you want to disable these exchanges, you can use a content blocking extension (such as uBlock Origin or Ghostery) on your browser.
+If you want to disable these exchanges, you can use a content blocking extension on your browser (such as uBlock Origin or Ghostery).
 However, disabling these cookies may affect the stability of your webmail.
 
 ## Go further
 
 [Creating automatic replies in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
 
-[Sharing folders in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+[Sharing a folder from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
 
-[Sharing calendars in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
+[Sharing calendars via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
-[Creating contact groups](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
+[Creating a contact group](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-gb.md
@@ -1,62 +1,67 @@
 ---
-title: 'Using the Outlook Web App with an email account'
-excerpt: 'Find out how to manage an email address using OWA webmail'
-updated: 2026-03-24
+title: 'Using your email address from the Outlook Web App (OWA) webmail'
+excerpt: 'Find out how to use your email address from OWA webmail'
+updated: 2026-05-04
 ---
 
 ## Objective
 
-With OVHcloud email solutions you can send and receive your emails using a device and client of your choice. To access an account from anywhere via web browser, OVHcloud provides an online email client called Outlook Web App (OWA). Our [webmail login page](/links/web/email) is the single point of access to the respective OWA for all active email accounts on MX Plan, Email Pro and Hosted Exchange.
+With OVHcloud email solutions, you can send and receive your emails from a device and client of your choice. OVHcloud provides an online email service called Outlook Web App (OWA) that lets you access an account from anywhere via a web browser. All active email accounts on MX Plan, Email Pro and Hosted Exchange share a single point of access to their respective OWA interface: our [webmail login page](/links/web/email).
 
-**This guide explains how to use your email address with OWA and exemplifies the most important features of this interface.**
+**Find out how to perform common actions with your email address from the OWA interface.**
 
 ## Requirements
 
-- an OVHcloud email solution already set up (**MX Plan**, available as part of our [Web Hosting plans](/links/web/hosting), included in a [100M free hosting](/links/web/domains-free-hosting) or ordered separately as a standalone solution; [**Hosted Exchange**](/links/web/emails-hosted-exchange) or [**Email Pro**](/links/web/email-pro))
-- login credentials for the email address you want to configure
+- An OVHcloud email solution already set up, from the following offers:
+    - [**MX Plan**](/links/web/hosting), available with our Web Hosting plans, included with [100M free hosting](/links/web/domains-free-hosting) or ordered as a standalone solution;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange);
+    - [**Email Pro**](/links/web/email-pro).
+- The login credentials for the email address you want to use.
 
 ## Instructions
 
-This guide will give you a better understanding of the usual email account tasks available in the OWA webmail. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions about any settings not mentioned in this guide. Regarding Exchange functionalities, we have prepared some additional guides which you can find in the [**Go further**](./#go-further_1) section below.
+This guide will help you better understand the usual tasks available in an email account using OWA. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions for any settings not covered in this guide.
+
+For Exchange-specific features, you can find some additional guides in the [Go further](./#go-further) section at the bottom of this guide.
 
 > [!primary]
 >
-> After the first two steps, the instructions don't have to be considered in a particular order.
+> After logging in and getting familiar with the interface, you do not need to follow the instructions in the order given.
 
-### 1. Accessing OWA webmail
+### Logging in to OWA
 
-To log in to OWA webmail with your email address, go to the general [webmail login page](/links/web/email). Enter your full email address and password, then click the `Login`{.action} button.
+To log in to OWA with your email address, open the [webmail login page](/links/web/email). Enter your full email address and password. Then click `Sign in`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
 > [!warning]
-> 
-> If you are redirected to a **Roundcube** interface, this means that you are using the legacy version of the MX Plan solution. To find out more about your MX Plan solution, go to our guide [Getting started with an MX Plan solution](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 >
-> To familiarise yourself with the **Roundcube** interface, please refer to our guide on [Using your email account via the Roundcube webmail interface](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+> If you are redirected to a **Roundcube** interface, this means you are using the legacy version of the MX Plan offer. For more information about your MX Plan offer, see our [Getting started with the MX Plan offer](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) page.
+>
+> To familiarise yourself with the **Roundcube** interface, see our guide [Using your email address from the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
 
-If this is your first time logging in to OWA webmail with this email address, you will be prompted to set the interface language and time zone. Click `Save`{.action} to continue.
+If this is your first time logging in to OWA with this email address, you will be prompted to set the interface language and time zone. Then click `Save`{.action} to continue.
 
 > [!primary]
 >
 > Time zones are listed according to [the UTC (Coordinated Universal Time) standard](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), not in alphabetical order of cities.
 >
-> **Example**: For Western Europe, it is the UTC +1 tranche (Brussels, Copenhagen, Madrid, Paris).
+> **Example**: For Western Europe, this is UTC +1 (Brussels, Copenhagen, Madrid, Paris).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-From now on, your inbox view will appear by default after login.
+From now on, your inbox will appear by default as soon as you log in.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Understanding the OWA display
+### Understanding the OWA display
 
-There are several sections to the OWA interface. Please refer to the table and the image below to familiarise yourself with it.
+The OWA interface contains several sections. Refer to the table and image below to familiarise yourself with it.
 
-|Parts|Description|
-|---|---|
-|Top section (1)|Contains two tab bars: the first one allows access to general settings (such as the [options section](./#accessing-the-options-section)), and the second one can be used to perform specific actions with your address (such as sending or replying to emails).|
-|Left-hand side (2)|Displays the list of folders for your email address. These appear as a tree-view that you can expand or hide.|
+|Parts|Description|  
+|---|---|  
+|Top section (1)|Contains two tab bars: the first one provides access to general settings (such as the [Options section](./#accessing-the-options-section)). The second bar can be used for specific actions with your address (such as sending or replying to emails).|  
+|Left-hand side (2)|Displays the list of folders for your email address. These folders appear as a tree-view that you can expand or collapse.|
 |Central segment (3)|Displays the list of messages (read and unread) from the folder selected in the left-hand menu. This section can also display search results.|
 |Right-hand side (4)|Displays the reading pane when an email has been selected.|
 
@@ -66,131 +71,146 @@ Note that you can change the size of the vertical sections by clicking and dragg
 
 ### Viewing emails
 
-To view your emails, select a folder on the left-hand side. Incoming emails that are not treated by inbox rules will arrive in the "Inbox" folder. To see if you have received any new emails, check if a number appears next to the respective folder.
+To view your emails, select a folder on the left-hand side. Incoming emails that are not processed by inbox rules will appear in the "Inbox" folder. To check whether you have received any new emails, see if a number appears next to the corresponding folder.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-To read an email, select its folder if necessary. Now click on the email to show its content in the reading section. Unread messages appear in a different colour to set them apart from messages that have been read.
+To read an email, select its folder if necessary. Then click on the email to display its content in the reading pane. Unread messages appear in bold to distinguish them from read messages.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Sorting and filtering emails
+
+At the top right of the message list, the `Filter`{.action} button opens a menu that gathers all display options for the selected folder.
+
+- **Filter by category**: select an entry to display only a selection of emails among `All`{.action}, `Unread`{.action}, `To me`{.action} (emails addressed directly to your address), `Flagged`{.action} (emails marked for follow-up) or `Mentions`{.action} (emails in which your address is mentioned).
+
+- **Sort by**: hover over the `Sort by`{.action} entry to choose the sort criterion for emails: **Date**, **From**, **To**, **Subject**, **Attachments**, **Importance** or **Size**. The arrow to the left of the criterion indicates the current order; click the same criterion again to reverse it.
+
+- **Show as**: hover over the `Show as`{.action} entry to switch between the **Messages** view (one email per line) and the **Conversations** view (emails grouped by discussion thread).
+
 ### Sending and replying
 
-**To send a new email**, click the `New`{.action} button at the top of the webmail interface. The editing pane will appear on the right-hand side. Fill in the fields for your email (recipients, subject, message body, attachments). Once you are ready to send it, click the `Send`{.action} button.
+To **send a new message**, click the `New`{.action} icon at the top of the OWA interface. The editing pane will appear on the right-hand side. Fill in the fields of your email (recipients, subject, message body, attachments). Click `Send`{.action} once your email is ready.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**To reply to an email**, [click on it first](./#viewing-emails) to display it. Then click on the `Reply all`{.action} button. Use the down-arrow button instead if you only want to reply to the sender of the email (leaving out any recipient who is in copy).
+To **reply to a message**, first click on it to display it. Then click `Reply all`{.action} to reply to all recipients. Use the down-arrow button if you only want to reply to the sender of the email (excluding any recipient in copy), then click `Reply`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-When you choose to reply, the quick-reply editor will appear above the email. Compose your reply here, and once you are ready to send your mail, click `Send`{.action}. Please note that for all reply options (like adding a signature), it must be extended to the full editing pane first by clicking on the double-arrow symbol.
+When you choose to reply, the quick-reply editor will appear above the email. Type your reply there, and once you are ready to send your message, click `Send`{.action}. Note that for each reply option (such as adding a signature), you must first expand it to the full editing pane by clicking the double-arrow symbol.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
 ### Organising your inbox
 
-OWA provides several ways to organise your inbox. You can
+OWA offers several ways to organise your inbox. You can:
 
-- [create folders and subfolders](./#creating-a-folder)
-- [move emails](./#moving-emails)
-- [set rules](./#creating-inbox-rules) so that actions are performed automatically when a new email is received
+- [create folders and subfolders](./#creating-a-folder),
+- [move emails](./#moving-emails),
+- [set rules](./#creating-inbox-rules) to automatically perform actions when a new email is received,
+- [block a sender](./#blocking-a-sender) to stop receiving their messages.
 
 #### Creating a folder
 
-To create a new folder, right-click on the name of your email address in the folder tree and then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way (`Create new subfolder`{.action}). 
+To create a new folder, right-click the name of your email address in the folder tree, then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way by clicking `Create new subfolder`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
 #### Moving emails
 
-**To move an email**, you can simply drag-and-drop it to the target folder or right-click it and select `Move`{.action}.
-**To move multiple emails** at once, select them by checking their tick boxes, and click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
+To **move an email**, you can simply drag-and-drop it into the target folder, or right-click it and select `Move`{.action}.
+To **move multiple emails** at once, select them all using their tick boxes. Then click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
 #### Creating inbox rules
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-To manage rules, click on the gear icon at the top, then click on `Options`{.action}.
+To create and manage rules, first click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page that appears, click on `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this item under "Mail", then "Automatic processing". From here, you can create, edit, delete and move rules in the list.
+On the new page that opens, click `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this feature under "Mail", in "Automatic processing". Here you can create, edit and move rules in the list.
 
 To add a new rule, click the `+`{.action} button.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Fill in the requested information depending on the action you want the rule to carry out. Afterwards, click `OK`{.action}.
+Fill in the requested information depending on the task you want this rule to perform. Then click `OK`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-For more detailed instructions about creating inbox rules, please refer to our guide: [Creating inbox rules in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+For more detailed instructions on creating inbox rules, please refer to our guide: [Creating inbox rules in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-#### Block a sender
+#### Blocking a sender
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/UeNdpFwdXm0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Click on the gear icon at the top right-hand corner, then click `Options`{.action}. In the left-hand column, follow the "Mail" tree under "Accounts", then "Block or authorise".
+Click the gear icon at the top right, then click `Options`{.action}. Still in the left-hand column, browse the "Mail" tree under "Accounts", then "Block or allow".
 
-In the "**Blocked Senders**" section, type an email address or domain name to block, and then click the `+`{.action} button to add it to the list.
+In the "**Blocked Senders**" section, type an email address or domain name to block, then click the `+`{.action} button to add it to the list.
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Managing a contact list
+### Managing your contacts
 
-To manage your contacts, click the blue "app launcher" button at the top, then click on `People`{.action}.
+To manage your contacts, first click the blue app launcher button at the top left of the page (which also gives access to calendar, tasks and other modules), then click `People`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-On the new page, you can add a new contact, create a contact list, and remove existing contacts.
+On the new page, you can add a new contact, create a contact list and remove existing contacts.
 
-**To add a new contact**, click `New`{.action}, and enter the contact details you want to add. Once you have done this, click `Save`{.action}.
+#### Adding a contact
+
+Click `New`{.action}, then enter the details of the contact you want to add. Once done, click `Save`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**To create a contact list**, click the down-arrow button next to "New", then click `Contact List`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
+#### Creating a contact list
+
+Click the down arrow next to `New`{.action}, then click `Contact list`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
-### Changing the password
+### Changing your password
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-You can change your account password when you are logged in to OWA. To do this, click the gear icon at the top, then click `Options`{.action}.
+You can change your account password while logged in to OWA. To do so, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page, expand the "General" tab in the tree on the left-hand side, then click `My Account`{.action}. Finally, click `Change Password`{.action}.
+On the new page, expand the "General" tab in the left-hand tree, then click `My account`{.action}. Finally, click `Change your password`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-In the new window that pops up, enter your current password. Then enter a new password, and re-enter to confirm it. Click the `Save`{.action} button to save the new password.
+In the new window that opens, enter your current password. Then enter a new password and confirm it by typing it again. Click `Save`{.action} to save the new password.
 
 > [!primary]
 >
-> Remember to also enter your new password on any device i.e. email client used to access this account. In case of any issues with your password, contact your service administrator.
+> Remember to enter your new password on all devices used to access this account (for example in your email client software). If you have any difficulties with your password, contact your service administrator.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
-### Adding an auto-reply
+### Adding an automatic reply
 
-In OWA, you can create an automatic reply on your email address to not leave emails unanswered during absences. To do this, click the gear icon at the top, then click `Automatic Replies`{.action}.
+In OWA, you can create an automatic reply on your inbox so that emails are not left unanswered while you are away. To do so, click the gear icon at the top, then click `Automatic replies`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-In the window that appears, select the option "Send automatic replies". You can then set the auto-responder to fit several criteria:
+In the window that opens, select the "Send automatic replies" option. You can then configure the auto-responder to match several criteria, such as:
 
-- send auto-reply emails for a fixed time interval, or continuously until it is manually disabled
-- define which senders will receive auto-reply emails (internal senders only, or include external senders)
+- send automatic reply emails for a fixed time interval, or continuously until manually disabled
+- define which senders will receive automatic reply emails (internal senders only, or include external senders)
 
-Now, fill in the requested information depending on the action you want it to carry out. Once you have done so, click `OK`{.action}.
+Fill in the requested information depending on the task you want to perform with this rule. Once done, click `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-For more detailed instructions about creating auto-replies, please refer to our guide: [Creating automatic replies in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
+For more detailed instructions on creating automatic replies, please refer to our guide: [Creating an automatic reply in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Adding a signature
 
@@ -198,39 +218,39 @@ To add an email signature, click the gear icon at the top, then click `Options`{
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the left-hand side of the new page, click `Email signature`{.action}. In the options tree, this item is under "Mail" and "Layout". From here you can enable, disable and edit the signature.
+On the left-hand side of the new page, click `Email signature`{.action}. In the tree options, this item is located under "Mail" and "Layout". From here, you can enable, disable and edit the signature.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Compose your electronic signature in the editor box. You can specify whether you want to include the signature by default in new emails only or in replies and forwarded emails as well. Once you have finished, click `Save`{.action} to confirm.
+Compose your email signature in the editor box. You can specify whether you want to include the default signature in new emails only, or also in replies and forwarded emails. Once you are done, click `Save`{.action} to confirm.
 
-For instructions about creating automated signatures by using domain-wide templates, please refer to our guide: [Creating automatic signatures](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
+For instructions on creating automatic signatures using domain-wide templates, please refer to our guide: [Creating automatic signatures](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
 
-### Accessing the options section
+### Accessing the Options section
 
 To access all your settings, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be set from here. Please note that some of the account options may be disabled from our side for security reasons.
+You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be made from this page. Note that for security reasons, some account options may be disabled by OVHcloud.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Cookie management
 
-The webmail that is used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies called `appsforoffice.microsoft.com`.
+The webmail used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies named `appsforoffice.microsoft.com`.
 
-If you want to disable these exchanges, you can use a content blocking extension (such as uBlock Origin or Ghostery) on your browser.
+If you want to disable these exchanges, you can use a content blocking extension on your browser (such as uBlock Origin or Ghostery).
 However, disabling these cookies may affect the stability of your webmail.
 
 ## Go further
 
 [Creating automatic replies in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
 
-[Sharing folders in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+[Sharing a folder from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
 
-[Sharing calendars in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
+[Sharing calendars via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
-[Creating contact groups](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
+[Creating a contact group](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-ie.md
@@ -1,62 +1,67 @@
 ---
-title: 'Using the Outlook Web App with an email account'
-excerpt: 'Find out how to manage an email address using OWA webmail'
-updated: 2026-03-24
+title: 'Using your email address from the Outlook Web App (OWA) webmail'
+excerpt: 'Find out how to use your email address from OWA webmail'
+updated: 2026-05-04
 ---
 
 ## Objective
 
-With OVHcloud email solutions you can send and receive your emails using a device and client of your choice. To access an account from anywhere via web browser, OVHcloud provides an online email client called Outlook Web App (OWA). Our [webmail login page](/links/web/email) is the single point of access to the respective OWA for all active email accounts on MX Plan, Email Pro and Hosted Exchange.
+With OVHcloud email solutions, you can send and receive your emails from a device and client of your choice. OVHcloud provides an online email service called Outlook Web App (OWA) that lets you access an account from anywhere via a web browser. All active email accounts on MX Plan, Email Pro and Hosted Exchange share a single point of access to their respective OWA interface: our [webmail login page](/links/web/email).
 
-**This guide explains how to use your email address with OWA and exemplifies the most important features of this interface.**
+**Find out how to perform common actions with your email address from the OWA interface.**
 
 ## Requirements
 
-- an OVHcloud email solution already set up (**MX Plan**, available as part of our [Web Hosting plans](/links/web/hosting), included in a [100M free hosting](/links/web/domains-free-hosting) or ordered separately as a standalone solution; [**Hosted Exchange**](/links/web/emails-hosted-exchange) or [**Email Pro**](/links/web/email-pro))
-- login credentials for the email address you want to configure
+- An OVHcloud email solution already set up, from the following offers:
+    - [**MX Plan**](/links/web/hosting), available with our Web Hosting plans, included with [100M free hosting](/links/web/domains-free-hosting) or ordered as a standalone solution;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange);
+    - [**Email Pro**](/links/web/email-pro).
+- The login credentials for the email address you want to use.
 
 ## Instructions
 
-This guide will give you a better understanding of the usual email account tasks available in the OWA webmail. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions about any settings not mentioned in this guide. Regarding Exchange functionalities, we have prepared some additional guides which you can find in the [**Go further**](./#go-further_1) section below.
+This guide will help you better understand the usual tasks available in an email account using OWA. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions for any settings not covered in this guide.
+
+For Exchange-specific features, you can find some additional guides in the [Go further](./#go-further) section at the bottom of this guide.
 
 > [!primary]
 >
-> After the first two steps, the instructions don't have to be considered in a particular order.
+> After logging in and getting familiar with the interface, you do not need to follow the instructions in the order given.
 
-### 1. Accessing OWA webmail
+### Logging in to OWA
 
-To log in to OWA webmail with your email address, go to the general [webmail login page](/links/web/email). Enter your full email address and password, then click the `Login`{.action} button.
+To log in to OWA with your email address, open the [webmail login page](/links/web/email). Enter your full email address and password. Then click `Sign in`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
 > [!warning]
 >
-> If you are redirected to a **Roundcube** interface, this means that you are using the legacy version of the MX Plan solution. To find out more about your MX Plan solution, go to our guide [Getting started with an MX Plan solution](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+> If you are redirected to a **Roundcube** interface, this means you are using the legacy version of the MX Plan offer. For more information about your MX Plan offer, see our [Getting started with the MX Plan offer](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities) page.
 >
-> To familiarise yourself with the **Roundcube** interface, please refer to our guide on [Using your email account via the Roundcube webmail interface](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+> To familiarise yourself with the **Roundcube** interface, see our guide [Using your email address from the Roundcube webmail](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
 
-If this is your first time logging in to OWA webmail with this email address, you will be prompted to set the interface language and time zone. Click `Save`{.action} to continue.
+If this is your first time logging in to OWA with this email address, you will be prompted to set the interface language and time zone. Then click `Save`{.action} to continue.
 
 > [!primary]
 >
 > Time zones are listed according to [the UTC (Coordinated Universal Time) standard](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), not in alphabetical order of cities.
 >
-> **Example**: For Western Europe, it is the UTC +1 tranche (Brussels, Copenhagen, Madrid, Paris).
+> **Example**: For Western Europe, this is UTC +1 (Brussels, Copenhagen, Madrid, Paris).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-From now on, your inbox view will appear by default after login.
+From now on, your inbox will appear by default as soon as you log in.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Understanding the OWA display
+### Understanding the OWA display
 
-There are several sections to the OWA interface. Please refer to the table and the image below to familiarise yourself with it.
+The OWA interface contains several sections. Refer to the table and image below to familiarise yourself with it.
 
 |Parts|Description|  
 |---|---|  
-|Top section (1)|Contains two tab bars: the first one allows access to general settings (such as the [options section](./#accessing-the-options-section)), and the second one can be used to perform specific actions with your address (such as sending or replying to emails).|  
-|Left-hand side (2)|Displays the list of folders for your email address. These appear as a tree-view that you can expand or hide.|
+|Top section (1)|Contains two tab bars: the first one provides access to general settings (such as the [Options section](./#accessing-the-options-section)). The second bar can be used for specific actions with your address (such as sending or replying to emails).|  
+|Left-hand side (2)|Displays the list of folders for your email address. These folders appear as a tree-view that you can expand or collapse.|
 |Central segment (3)|Displays the list of messages (read and unread) from the folder selected in the left-hand menu. This section can also display search results.|
 |Right-hand side (4)|Displays the reading pane when an email has been selected.|
 
@@ -66,131 +71,146 @@ Note that you can change the size of the vertical sections by clicking and dragg
 
 ### Viewing emails
 
-To view your emails, select a folder on the left-hand side. Incoming emails that are not treated by inbox rules will arrive in the "Inbox" folder. To see if you have received any new emails, check if a number appears next to the respective folder.
+To view your emails, select a folder on the left-hand side. Incoming emails that are not processed by inbox rules will appear in the "Inbox" folder. To check whether you have received any new emails, see if a number appears next to the corresponding folder.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-To read an email, select its folder if necessary. Now click on the email to show its content in the reading section. Unread messages appear in a different colour to set them apart from messages that have been read.
+To read an email, select its folder if necessary. Then click on the email to display its content in the reading pane. Unread messages appear in bold to distinguish them from read messages.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Sorting and filtering emails
+
+At the top right of the message list, the `Filter`{.action} button opens a menu that gathers all display options for the selected folder.
+
+- **Filter by category**: select an entry to display only a selection of emails among `All`{.action}, `Unread`{.action}, `To me`{.action} (emails addressed directly to your address), `Flagged`{.action} (emails marked for follow-up) or `Mentions`{.action} (emails in which your address is mentioned).
+
+- **Sort by**: hover over the `Sort by`{.action} entry to choose the sort criterion for emails: **Date**, **From**, **To**, **Subject**, **Attachments**, **Importance** or **Size**. The arrow to the left of the criterion indicates the current order; click the same criterion again to reverse it.
+
+- **Show as**: hover over the `Show as`{.action} entry to switch between the **Messages** view (one email per line) and the **Conversations** view (emails grouped by discussion thread).
+
 ### Sending and replying
 
-**To send a new email**, click the `New`{.action} button at the top of the webmail interface. The editing pane will appear on the right-hand side. Fill in the fields for your email (recipients, subject, message body, attachments). Once you are ready to send it, click the `Send`{.action} button.
+To **send a new message**, click the `New`{.action} icon at the top of the OWA interface. The editing pane will appear on the right-hand side. Fill in the fields of your email (recipients, subject, message body, attachments). Click `Send`{.action} once your email is ready.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**To reply to an email**, [click on it first](./#viewing-emails) to display it. Then click on the `Reply all`{.action} button. Use the down-arrow button instead if you only want to reply to the sender of the email (leaving out any recipient who is in copy).
+To **reply to a message**, first click on it to display it. Then click `Reply all`{.action} to reply to all recipients. Use the down-arrow button if you only want to reply to the sender of the email (excluding any recipient in copy), then click `Reply`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-When you choose to reply, the quick-reply editor will appear above the email. Compose your reply here, and once you are ready to send your mail, click `Send`{.action}. Please note that for all reply options (like adding a signature), it must be extended to the full editing pane first by clicking on the double-arrow symbol.
+When you choose to reply, the quick-reply editor will appear above the email. Type your reply there, and once you are ready to send your message, click `Send`{.action}. Note that for each reply option (such as adding a signature), you must first expand it to the full editing pane by clicking the double-arrow symbol.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
 ### Organising your inbox
 
-OWA provides several ways to organise your inbox. You can
+OWA offers several ways to organise your inbox. You can:
 
-- [create folders and subfolders](./#creating-a-folder)
-- [move emails](./#moving-emails)
-- [set rules](./#creating-inbox-rules) so that actions are performed automatically when a new email is received
+- [create folders and subfolders](./#creating-a-folder),
+- [move emails](./#moving-emails),
+- [set rules](./#creating-inbox-rules) to automatically perform actions when a new email is received,
+- [block a sender](./#blocking-a-sender) to stop receiving their messages.
 
 #### Creating a folder
 
-To create a new folder, right-click on the name of your email address in the folder tree and then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way (`Create new subfolder`{.action}). 
+To create a new folder, right-click the name of your email address in the folder tree, then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way by clicking `Create new subfolder`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
 #### Moving emails
 
-**To move an email**, you can simply drag-and-drop it to the target folder or right-click it and select `Move`{.action}.
-**To move multiple emails** at once, select them by checking their tick boxes, and click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
+To **move an email**, you can simply drag-and-drop it into the target folder, or right-click it and select `Move`{.action}.
+To **move multiple emails** at once, select them all using their tick boxes. Then click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
 #### Creating inbox rules
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-To manage rules, click on the gear icon at the top, then click on `Options`{.action}.
+To create and manage rules, first click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page that appears, click on `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this item under "Mail", then "Automatic processing". From here, you can create, edit, delete and move rules in the list.
+On the new page that opens, click `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this feature under "Mail", in "Automatic processing". Here you can create, edit and move rules in the list.
 
 To add a new rule, click the `+`{.action} button.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Fill in the requested information depending on the action you want the rule to carry out. Afterwards, click `OK`{.action}.
+Fill in the requested information depending on the task you want this rule to perform. Then click `OK`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-For more detailed instructions about creating inbox rules, please refer to our guide: [Creating inbox rules in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+For more detailed instructions on creating inbox rules, please refer to our guide: [Creating inbox rules in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-#### Block a sender
+#### Blocking a sender
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/UeNdpFwdXm0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Click on the gear icon at the top right-hand corner, then click `Options`{.action}. In the left-hand column, follow the "Mail" tree under "Accounts", then "Block or authorise".
+Click the gear icon at the top right, then click `Options`{.action}. Still in the left-hand column, browse the "Mail" tree under "Accounts", then "Block or allow".
 
-In the "**Blocked Senders**" section, type an email address or domain name to block, and then click the `+`{.action} button to add it to the list.
+In the "**Blocked Senders**" section, type an email address or domain name to block, then click the `+`{.action} button to add it to the list.
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Managing a contact list
+### Managing your contacts
 
-To manage your contacts, click the blue "app launcher" button at the top, then click on `People`{.action}.
+To manage your contacts, first click the blue app launcher button at the top left of the page (which also gives access to calendar, tasks and other modules), then click `People`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-On the new page, you can add a new contact, create a contact list, and remove existing contacts.
+On the new page, you can add a new contact, create a contact list and remove existing contacts.
 
-**To add a new contact**, click `New`{.action}, and enter the contact details you want to add. Once you have done this, click `Save`{.action}.
+#### Adding a contact
+
+Click `New`{.action}, then enter the details of the contact you want to add. Once done, click `Save`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**To create a contact list**, click the down-arrow button next to "New", then click `Contact List`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
+#### Creating a contact list
+
+Click the down arrow next to `New`{.action}, then click `Contact list`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
-### Changing the password
+### Changing your password
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-You can change your account password when you are logged in to OWA. To do this, click the gear icon at the top, then click `Options`{.action}.
+You can change your account password while logged in to OWA. To do so, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page, expand the "General" tab in the tree on the left-hand side, then click `My Account`{.action}. Finally, click `Change Password`{.action}.
+On the new page, expand the "General" tab in the left-hand tree, then click `My account`{.action}. Finally, click `Change your password`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-In the new window that pops up, enter your current password. Then enter a new password, and re-enter to confirm it. Click the `Save`{.action} button to save the new password.
+In the new window that opens, enter your current password. Then enter a new password and confirm it by typing it again. Click `Save`{.action} to save the new password.
 
 > [!primary]
 >
-> Remember to also enter your new password on any device i.e. email client used to access this account. In case of any issues with your password, contact your service administrator.
+> Remember to enter your new password on all devices used to access this account (for example in your email client software). If you have any difficulties with your password, contact your service administrator.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
-### Adding an auto-reply
+### Adding an automatic reply
 
-In OWA, you can create an automatic reply on your email address to not leave emails unanswered during absences. To do this, click the gear icon at the top, then click `Automatic Replies`{.action}.
+In OWA, you can create an automatic reply on your inbox so that emails are not left unanswered while you are away. To do so, click the gear icon at the top, then click `Automatic replies`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-In the window that appears, select the option "Send automatic replies". You can then set the auto-responder to fit several criteria:
+In the window that opens, select the "Send automatic replies" option. You can then configure the auto-responder to match several criteria, such as:
 
-- send auto-reply emails for a fixed time interval, or continuously until it is manually disabled
-- define which senders will receive auto-reply emails (internal senders only, or include external senders)
+- send automatic reply emails for a fixed time interval, or continuously until manually disabled
+- define which senders will receive automatic reply emails (internal senders only, or include external senders)
 
-Now, fill in the requested information depending on the action you want it to carry out. Once you have done so, click `OK`{.action}.
+Fill in the requested information depending on the task you want to perform with this rule. Once done, click `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-For more detailed instructions about creating auto-replies, please refer to our guide: [Creating automatic replies in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
+For more detailed instructions on creating automatic replies, please refer to our guide: [Creating an automatic reply in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Adding a signature
 
@@ -198,39 +218,39 @@ To add an email signature, click the gear icon at the top, then click `Options`{
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the left-hand side of the new page, click `Email signature`{.action}. In the options tree, this item is under "Mail" and "Layout". From here you can enable, disable and edit the signature.
+On the left-hand side of the new page, click `Email signature`{.action}. In the tree options, this item is located under "Mail" and "Layout". From here, you can enable, disable and edit the signature.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Compose your electronic signature in the editor box. You can specify whether you want to include the signature by default in new emails only or in replies and forwarded emails as well. Once you have finished, click `Save`{.action} to confirm.
+Compose your email signature in the editor box. You can specify whether you want to include the default signature in new emails only, or also in replies and forwarded emails. Once you are done, click `Save`{.action} to confirm.
 
-For instructions about creating automated signatures by using domain-wide templates, please refer to our guide: [Creating automatic signatures](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
+For instructions on creating automatic signatures using domain-wide templates, please refer to our guide: [Creating automatic signatures](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
 
-### Accessing the options section
+### Accessing the Options section
 
 To access all your settings, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be set from here. Please note that some of the account options may be disabled from our side for security reasons.
+You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be made from this page. Note that for security reasons, some account options may be disabled by OVHcloud.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Cookie management
 
-The webmail that is used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies called `appsforoffice.microsoft.com`.
+The webmail used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies named `appsforoffice.microsoft.com`.
 
-If you want to disable these exchanges, you can use a content blocking extension (such as uBlock Origin or Ghostery) on your browser.
+If you want to disable these exchanges, you can use a content blocking extension on your browser (such as uBlock Origin or Ghostery).
 However, disabling these cookies may affect the stability of your webmail.
 
 ## Go further
 
 [Creating automatic replies in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
 
-[Sharing folders in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+[Sharing a folder from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
 
-[Sharing calendars in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
+[Sharing calendars via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
-[Creating contact groups](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
+[Creating a contact group](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-sg.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-sg.md
@@ -1,56 +1,57 @@
 ---
-title: 'Using the Outlook Web App with an email account'
-excerpt: 'Find out how to manage an email address using OWA webmail'
-updated: 2026-03-24
+title: 'Using your email address from the Outlook Web App (OWA) webmail'
+excerpt: 'Find out how to use your email address from OWA webmail'
+updated: 2026-05-04
 ---
 
 ## Objective
 
-With an OVHcloud email solutions you can send and receive your emails using a device and client of your choice. To access an account from anywhere via web browser, OVHcloud provides an online email client called Outlook Web App (OWA). Our [webmail login page](/links/web/email) is the single point of access to the respective OWA for all active email accounts on your Email offer.
+With OVHcloud email solutions, you can send and receive your emails from a device and client of your choice. OVHcloud provides an online email service called Outlook Web App (OWA) that lets you access an account from anywhere via a web browser. All active email accounts on MX Plan share a single point of access to their respective OWA interface: our [webmail login page](/links/web/email).
 
-**This guide explains how to use your email address with OWA and exemplifies the most important features of this interface.**
+**Find out how to perform common actions with your email address from the OWA interface.**
 
 ## Requirements
 
-- an OVHcloud email solution already set up (**MX Plan**, available as part of our [Web Hosting plans](/links/web/hosting)
-- login credentials for the email address you want to configure
+- An OVHcloud email solution already set up:
+    - [**MX Plan**](/links/web/hosting), available with our Web Hosting plans or ordered as a standalone solution.
+- The login credentials for the email address you want to use.
 
 ## Instructions
 
-This guide will give you a better understanding of the usual email account tasks available in the OWA webmail. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions about any settings not mentioned in this guide.
+This guide will help you better understand the usual tasks available in an email account using OWA. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions for any settings not covered in this guide.
 
 > [!primary]
 >
-> After the first two steps, the instructions don't have to be considered in a particular order.
+> After logging in and getting familiar with the interface, you do not need to follow the instructions in the order given.
 
-### 1. Accessing OWA webmail
+### Logging in to OWA
 
-To log in to OWA webmail with your email address, go to the general [webmail login page](/links/web/email). Enter your full email address and password, then click the `Login`{.action} button.
+To log in to OWA with your email address, open the [webmail login page](/links/web/email). Enter your full email address and password. Then click `Sign in`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
-If this is your first time logging in to OWA webmail with this email address, you will be prompted to set the interface language and time zone. Click `Save`{.action} to continue.
+If this is your first time logging in to OWA with this email address, you will be prompted to set the interface language and time zone. Then click `Save`{.action} to continue.
 
 > [!primary]
 >
 > Time zones are listed according to [the UTC (Coordinated Universal Time) standard](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), not in alphabetical order of cities.
 >
-> **Example**: For Western Europe, it is the UTC +1 tranche (Brussels, Copenhagen, Madrid, Paris).
+> **Example**: For Western Europe, this is UTC +1 (Brussels, Copenhagen, Madrid, Paris).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-From now on, your inbox view will appear by default after login.
+From now on, your inbox will appear by default as soon as you log in.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Understanding the OWA display
+### Understanding the OWA display
 
-There are several sections to the OWA interface. Please refer to the table and the image below to familiarise yourself with it.
+The OWA interface contains several sections. Refer to the table and image below to familiarise yourself with it.
 
 |Parts|Description|  
 |---|---|  
-|Top section (1)|Contains two tab bars: the first one allows access to general settings (such as the [options section](./#accessing-the-options-section)), and the second one can be used to perform specific actions with your address (such as sending or replying to emails).|  
-|Left-hand side (2)|Displays the list of folders for your email address. These appear as a tree-view that you can expand or hide.|
+|Top section (1)|Contains two tab bars: the first one provides access to general settings (such as the [Options section](./#accessing-the-options-section)). The second bar can be used for specific actions with your address (such as sending or replying to emails).|  
+|Left-hand side (2)|Displays the list of folders for your email address. These folders appear as a tree-view that you can expand or collapse.|
 |Central segment (3)|Displays the list of messages (read and unread) from the folder selected in the left-hand menu. This section can also display search results.|
 |Right-hand side (4)|Displays the reading pane when an email has been selected.|
 
@@ -60,113 +61,146 @@ Note that you can change the size of the vertical sections by clicking and dragg
 
 ### Viewing emails
 
-To view your emails, select a folder on the left-hand side. Incoming emails that are not treated by inbox rules will arrive in the "Inbox" folder. To see if you have received any new emails, check if a number appears next to the respective folder.
+To view your emails, select a folder on the left-hand side. Incoming emails that are not processed by inbox rules will appear in the "Inbox" folder. To check whether you have received any new emails, see if a number appears next to the corresponding folder.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-To read an email, select its folder if necessary. Now click on the email to show its content in the reading section. Unread messages appear in a different colour to set them apart from messages that have been read.
+To read an email, select its folder if necessary. Then click on the email to display its content in the reading pane. Unread messages appear in bold to distinguish them from read messages.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Sorting and filtering emails
+
+At the top right of the message list, the `Filter`{.action} button opens a menu that gathers all display options for the selected folder.
+
+- **Filter by category**: select an entry to display only a selection of emails among `All`{.action}, `Unread`{.action}, `To me`{.action} (emails addressed directly to your address), `Flagged`{.action} (emails marked for follow-up) or `Mentions`{.action} (emails in which your address is mentioned).
+
+- **Sort by**: hover over the `Sort by`{.action} entry to choose the sort criterion for emails: **Date**, **From**, **To**, **Subject**, **Attachments**, **Importance** or **Size**. The arrow to the left of the criterion indicates the current order; click the same criterion again to reverse it.
+
+- **Show as**: hover over the `Show as`{.action} entry to switch between the **Messages** view (one email per line) and the **Conversations** view (emails grouped by discussion thread).
+
 ### Sending and replying
 
-**To send a new email**, click the `New`{.action} button at the top of the webmail interface. The editing pane will appear on the right-hand side. Fill in the fields for your email (recipients, subject, message body, attachments). Once you are ready to send it, click the `Send`{.action} button.
+To **send a new message**, click the `New`{.action} icon at the top of the OWA interface. The editing pane will appear on the right-hand side. Fill in the fields of your email (recipients, subject, message body, attachments). Click `Send`{.action} once your email is ready.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**To reply to an email**, [click on it first](./#viewing-emails) to display it. Then click on the `Reply all`{.action} button. Use the down-arrow button instead if you only want to reply to the sender of the email (leaving out any recipient who is in copy).
+To **reply to a message**, first click on it to display it. Then click `Reply all`{.action} to reply to all recipients. Use the down-arrow button if you only want to reply to the sender of the email (excluding any recipient in copy), then click `Reply`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-When you choose to reply, the quick-reply editor will appear above the email. Compose your reply here, and once you are ready to send your mail, click `Send`{.action}. Please note that for all reply options (like adding a signature), it must be extended to the full editing pane first by clicking on the double-arrow symbol.
+When you choose to reply, the quick-reply editor will appear above the email. Type your reply there, and once you are ready to send your message, click `Send`{.action}. Note that for each reply option (such as adding a signature), you must first expand it to the full editing pane by clicking the double-arrow symbol.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
 ### Organising your inbox
 
-OWA provides several ways to organise your inbox. You can
+OWA offers several ways to organise your inbox. You can:
 
-- [create folders and subfolders](./#creating-a-folder)
-- [move emails](./#moving-emails)
-- [set rules](./#creating-inbox-rules) so that actions are performed automatically when a new email is received
+- [create folders and subfolders](./#creating-a-folder),
+- [move emails](./#moving-emails),
+- [set rules](./#creating-inbox-rules) to automatically perform actions when a new email is received,
+- [block a sender](./#blocking-a-sender) to stop receiving their messages.
 
 #### Creating a folder
 
-To create a new folder, right-click on the name of your email address in the folder tree and then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way (`Create new subfolder`{.action}).
+To create a new folder, right-click the name of your email address in the folder tree, then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way by clicking `Create new subfolder`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
 #### Moving emails
 
-**To move an email**, you can simply drag-and-drop it to the target folder or right-click it and select `Move`{.action}.
-**To move multiple emails** at once, select them by checking their tick boxes, and click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
+To **move an email**, you can simply drag-and-drop it into the target folder, or right-click it and select `Move`{.action}.
+To **move multiple emails** at once, select them all using their tick boxes. Then click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
 #### Creating inbox rules
 
-To manage rules, click on the gear icon at the top, then click on `Options`{.action}.
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+To create and manage rules, first click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page that appears, click on `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this item under "Mail", then "Automatic processing". From here, you can create, edit, delete and move rules in the list.
+On the new page that opens, click `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this feature under "Mail", in "Automatic processing". Here you can create, edit and move rules in the list.
 
 To add a new rule, click the `+`{.action} button.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Fill in the requested information depending on the action you want the rule to carry out. Afterwards, click `OK`{.action}.
+Fill in the requested information depending on the task you want this rule to perform. Then click `OK`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-### Managing a contact list
+For more detailed instructions on creating inbox rules, please refer to our guide: [Creating inbox rules in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-To manage your contacts, click the blue "app launcher" button at the top, then click on `People`{.action}.
+#### Blocking a sender
+
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+Click the gear icon at the top right, then click `Options`{.action}. Still in the left-hand column, browse the "Mail" tree under "Accounts", then "Block or allow".
+
+In the "**Blocked Senders**" section, type an email address or domain name to block, then click the `+`{.action} button to add it to the list.
+
+![useowa](images/owa_exchange_block.png){.thumbnail}
+
+### Managing your contacts
+
+To manage your contacts, first click the blue app launcher button at the top left of the page (which also gives access to calendar, tasks and other modules), then click `People`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-On the new page, you can add a new contact, create a contact list, and remove existing contacts.
+On the new page, you can add a new contact, create a contact list and remove existing contacts.
 
-**To add a new contact**, click `New`{.action}, and enter the contact details you want to add. Once you have done this, click `Save`{.action}.
+#### Adding a contact
+
+Click `New`{.action}, then enter the details of the contact you want to add. Once done, click `Save`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**To create a contact list**, click the down-arrow button next to "New", then click `Contact List`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
+#### Creating a contact list
+
+Click the down arrow next to `New`{.action}, then click `Contact list`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
-### Changing the password
+### Changing your password
 
-You can change your account password when you are logged in to OWA. To do this, click the gear icon at the top, then click `Options`{.action}.
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+You can change your account password while logged in to OWA. To do so, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page, expand the "General" tab in the tree on the left-hand side, then click `My Account`{.action}. Finally, click `Change Password`{.action}.
+On the new page, expand the "General" tab in the left-hand tree, then click `My account`{.action}. Finally, click `Change your password`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-In the new window that pops up, enter your current password. Then enter a new password, and re-enter to confirm it. Click the `Save`{.action} button to save the new password.
+In the new window that opens, enter your current password. Then enter a new password and confirm it by typing it again. Click `Save`{.action} to save the new password.
 
 > [!primary]
 >
-> Remember to also enter your new password on any device i.e. email client used to access this account. In case of any issues with your password, contact your service administrator.
+> Remember to enter your new password on all devices used to access this account (for example in your email client software). If you have any difficulties with your password, contact your service administrator.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
-### Adding an auto-reply
+### Adding an automatic reply
 
-In OWA, you can create an automatic reply on your email address to not leave emails unanswered during absences. To do this, click the gear icon at the top, then click `Automatic Replies`{.action}.
+In OWA, you can create an automatic reply on your inbox so that emails are not left unanswered while you are away. To do so, click the gear icon at the top, then click `Automatic replies`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-In the window that appears, select the option "Send automatic replies". You can then set the auto-responder to fit several criteria:
+In the window that opens, select the "Send automatic replies" option. You can then configure the auto-responder to match several criteria, such as:
 
-- send auto-reply emails for a fixed time interval, or continuously until it is manually disabled
-- define which senders will receive auto-reply emails (internal senders only, or include external senders)
+- send automatic reply emails for a fixed time interval, or continuously until manually disabled
+- define which senders will receive automatic reply emails (internal senders only, or include external senders)
 
-Now, fill in the requested information depending on the action you want it to carry out. Once you have done so, click `OK`{.action}.
+Fill in the requested information depending on the task you want to perform with this rule. Once done, click `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
+
+For more detailed instructions on creating automatic replies, please refer to our guide: [Creating an automatic reply in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Adding a signature
 
@@ -174,29 +208,35 @@ To add an email signature, click the gear icon at the top, then click `Options`{
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the left-hand side of the new page, click `Email signature`{.action}. In the options tree, this item is under "Mail" and "Layout". From here you can enable, disable and edit the signature.
+On the left-hand side of the new page, click `Email signature`{.action}. In the tree options, this item is located under "Mail" and "Layout". From here, you can enable, disable and edit the signature.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Compose your electronic signature in the editor box. You can specify whether you want to include the signature by default in new emails only or in replies and forwarded emails as well. Once you have finished, click `Save`{.action} to confirm.
+Compose your email signature in the editor box. You can specify whether you want to include the default signature in new emails only, or also in replies and forwarded emails. Once you are done, click `Save`{.action} to confirm.
 
-### Accessing the options section
+### Accessing the Options section
 
 To access all your settings, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be set from here. Please note that some of the account options may be disabled from our side for security reasons.
+You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be made from this page. Note that for security reasons, some account options may be disabled by OVHcloud.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Cookie management
 
-The webmail that is used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies called `appsforoffice.microsoft.com`.
+The webmail used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies named `appsforoffice.microsoft.com`.
 
-If you want to disable these exchanges, you can use a content blocking extension (such as uBlock Origin or Ghostery) on your browser.
+If you want to disable these exchanges, you can use a content blocking extension on your browser (such as uBlock Origin or Ghostery).
 However, disabling these cookies may affect the stability of your webmail.
 
 ## Go further
+
+[Creating automatic replies in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
+
+[Sharing a folder from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+
+[Sharing calendars via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.en-us.md
@@ -1,57 +1,60 @@
 ---
-title: 'Using the Outlook Web App with an email account'
-excerpt: 'Find out how to manage an email address using OWA webmail'
-updated: 2026-03-24
+title: 'Using your email address from the Outlook Web App (OWA) webmail'
+excerpt: 'Find out how to use your email address from OWA webmail'
+updated: 2026-05-04
 ---
 
 ## Objective
 
-With OVHcloud email solutions you can send and receive your emails using a device and client of your choice. To access an account from anywhere via web browser, OVHcloud provides an online email client called Outlook Web App (OWA). Our [webmail login page](/links/web/email) is the single point of access to the respective OWA for all active email accounts on MX Plan and Hosted Exchange.
+With OVHcloud email solutions, you can send and receive your emails from a device and client of your choice. OVHcloud provides an online email service called Outlook Web App (OWA) that lets you access an account from anywhere via a web browser. All active email accounts on MX Plan and Hosted Exchange share a single point of access to their respective OWA interface: our [webmail login page](/links/web/email).
 
-**This guide explains how to use your email address with OWA and exemplifies the most important features of this interface.**
+**Find out how to perform common actions with your email address from the OWA interface.**
 
 ## Requirements
 
-- an OVHcloud email solution already set up (**MX Plan**, available as part of our [Web Hosting plans](/links/web/hosting) or [**Hosted Exchange**](/links/web/emails-hosted-exchange)
-- login credentials for the email address you want to configure
+- An OVHcloud email solution already set up, from the following offers:
+    - [**MX Plan**](/links/web/hosting), available with our Web Hosting plans, included with [100M free hosting](/links/web/domains-free-hosting) or ordered as a standalone solution;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange).
+- The login credentials for the email address you want to use.
 
 ## Instructions
 
-This guide will give you a better understanding of the usual email account tasks available in the OWA webmail. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions about any settings not mentioned in this guide. Regarding Exchange functionalities, we have prepared some additional guides which you can find in the [**Go further**](./#go-further_1) section below.
+This guide will help you better understand the usual tasks available in an email account using OWA. However, since this interface was not originally created by OVHcloud, we are unable to provide specific instructions for any settings not covered in this guide.
+
+For Exchange-specific features, you can find some additional guides in the [Go further](./#go-further) section at the bottom of this guide.
 
 > [!primary]
 >
-> After the first two steps, the instructions don't have to be considered in a particular order.
->
+> After logging in and getting familiar with the interface, you do not need to follow the instructions in the order given.
 
-### 1. Accessing OWA webmail
+### Logging in to OWA
 
-To log in to OWA webmail with your email address, go to the general [webmail login page](/links/web/email). Enter your full email address and password, then click the `Login`{.action} button.
+To log in to OWA with your email address, open the [webmail login page](/links/web/email). Enter your full email address and password. Then click `Sign in`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
-If this is your first time logging in to OWA webmail with this email address, you will be prompted to set the interface language and time zone. Click `Save`{.action} to continue.
+If this is your first time logging in to OWA with this email address, you will be prompted to set the interface language and time zone. Then click `Save`{.action} to continue.
 
 > [!primary]
 >
 > Time zones are listed according to [the UTC (Coordinated Universal Time) standard](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), not in alphabetical order of cities.
 >
-> **Example**: For Western Europe, it is the UTC +1 tranche (Brussels, Copenhagen, Madrid, Paris).
+> **Example**: For Western Europe, this is UTC +1 (Brussels, Copenhagen, Madrid, Paris).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-From now on, your inbox view will appear by default after login.
+From now on, your inbox will appear by default as soon as you log in.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Understanding the OWA display
+### Understanding the OWA display
 
-There are several sections to the OWA interface. Please refer to the table and the image below to familiarise yourself with it.
+The OWA interface contains several sections. Refer to the table and image below to familiarize yourself with it.
 
-|Parts|Description|
-|---|---|
-|Top section (1)|Contains two tab bars: the first one allows access to general settings (such as the [options section](./#accessing-the-options-section)), and the second one can be used to perform specific actions with your address (such as sending or replying to emails).|
-|Left-hand side (2)|Displays the list of folders for your email address. These appear as a tree-view that you can expand or hide.|
+|Parts|Description|  
+|---|---|  
+|Top section (1)|Contains two tab bars: the first one provides access to general settings (such as the [Options section](./#accessing-the-options-section)). The second bar can be used for specific actions with your address (such as sending or replying to emails).|  
+|Left-hand side (2)|Displays the list of folders for your email address. These folders appear as a tree-view that you can expand or collapse.|
 |Central segment (3)|Displays the list of messages (read and unread) from the folder selected in the left-hand menu. This section can also display search results.|
 |Right-hand side (4)|Displays the reading pane when an email has been selected.|
 
@@ -61,131 +64,146 @@ Note that you can change the size of the vertical sections by clicking and dragg
 
 ### Viewing emails
 
-To view your emails, select a folder on the left-hand side. Incoming emails that are not treated by inbox rules will arrive in the "Inbox" folder. To see if you have received any new emails, check if a number appears next to the respective folder.
+To view your emails, select a folder on the left-hand side. Incoming emails that are not processed by inbox rules will appear in the "Inbox" folder. To check whether you have received any new emails, see if a number appears next to the corresponding folder.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-To read an email, select its folder if necessary. Now click on the email to show its content in the reading section. Unread messages appear in a different colour to set them apart from messages that have been read.
+To read an email, select its folder if necessary. Then click on the email to display its content in the reading pane. Unread messages appear in bold to distinguish them from read messages.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Sorting and filtering emails
+
+At the top right of the message list, the `Filter`{.action} button opens a menu that gathers all display options for the selected folder.
+
+- **Filter by category**: select an entry to display only a selection of emails among `All`{.action}, `Unread`{.action}, `To me`{.action} (emails addressed directly to your address), `Flagged`{.action} (emails marked for follow-up) or `Mentions`{.action} (emails in which your address is mentioned).
+
+- **Sort by**: hover over the `Sort by`{.action} entry to choose the sort criterion for emails: **Date**, **From**, **To**, **Subject**, **Attachments**, **Importance** or **Size**. The arrow to the left of the criterion indicates the current order; click the same criterion again to reverse it.
+
+- **Show as**: hover over the `Show as`{.action} entry to switch between the **Messages** view (one email per line) and the **Conversations** view (emails grouped by discussion thread).
+
 ### Sending and replying
 
-**To send a new email**, click the `New`{.action} button at the top of the webmail interface. The editing pane will appear on the right-hand side. Fill in the fields for your email (recipients, subject, message body, attachments). Once you are ready to send it, click the `Send`{.action} button.
+To **send a new message**, click the `New`{.action} icon at the top of the OWA interface. The editing pane will appear on the right-hand side. Fill in the fields of your email (recipients, subject, message body, attachments). Click `Send`{.action} once your email is ready.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**To reply to an email**, [click on it first](./#viewing-emails) to display it. Then click on the `Reply all`{.action} button. Use the down-arrow button instead if you only want to reply to the sender of the email (leaving out any recipient who is in copy).
+To **reply to a message**, first click on it to display it. Then click `Reply all`{.action} to reply to all recipients. Use the down-arrow button if you only want to reply to the sender of the email (excluding any recipient in copy), then click `Reply`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-When you choose to reply, the quick-reply editor will appear above the email. Compose your reply here, and once you are ready to send your mail, click `Send`{.action}. Please note that for all reply options (like adding a signature), it must be extended to the full editing pane first by clicking on the double-arrow symbol.
+When you choose to reply, the quick-reply editor will appear above the email. Type your reply there, and once you are ready to send your message, click `Send`{.action}. Note that for each reply option (such as adding a signature), you must first expand it to the full editing pane by clicking the double-arrow symbol.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
-### Organising your inbox
+### Organizing your inbox
 
-OWA provides several ways to organise your inbox. You can
+OWA offers several ways to organize your inbox. You can:
 
-- [create folders and subfolders](./#creating-a-folder)
-- [move emails](./#moving-emails)
-- [set rules](./#creating-inbox-rules) so that actions are performed automatically when a new email is received
+- [create folders and subfolders](./#creating-a-folder),
+- [move emails](./#moving-emails),
+- [set rules](./#creating-inbox-rules) to automatically perform actions when a new email is received,
+- [block a sender](./#blocking-a-sender) to stop receiving their messages.
 
 #### Creating a folder
 
-To create a new folder, right-click on the name of your email address in the folder tree and then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way (`Create new subfolder`{.action}).
+To create a new folder, right-click the name of your email address in the folder tree, then choose `Create new folder`{.action}. You can create a subfolder in existing folders in the same way by clicking `Create new subfolder`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
 #### Moving emails
 
-**To move an email**, you can simply drag-and-drop it to the target folder or right-click it and select `Move`{.action}.
-**To move multiple emails** at once, select them by checking their tick boxes, and click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
+To **move an email**, you can simply drag-and-drop it into the target folder, or right-click it and select `Move`{.action}.
+To **move multiple emails** at once, select them all using their tick boxes. Then click `Move`{.action} (on the right-hand side) or `Move to`{.action} (in the top section). Then choose the destination folder.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
 #### Creating inbox rules
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-To manage rules, click on the gear icon at the top, then click on `Options`{.action}.
+To create and manage rules, first click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page that appears, click on `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this item under "Mail", then "Automatic processing". From here, you can create, edit, delete and move rules in the list.
+On the new page that opens, click `Inbox and sweep rules`{.action} in the left-hand menu. In the "Options" tree-view, you can find this feature under "Mail", in "Automatic processing". Here you can create, edit and move rules in the list.
 
 To add a new rule, click the `+`{.action} button.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Fill in the requested information depending on the action you want the rule to carry out. Afterwards, click `OK`{.action}.
+Fill in the requested information depending on the task you want this rule to perform. Then click `OK`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-For more detailed instructions about creating inbox rules, please refer to our guide: [Creating inbox rules in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+For more detailed instructions on creating inbox rules, please refer to our guide: [Creating inbox rules in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-#### Block a sender
+#### Blocking a sender
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/UeNdpFwdXm0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Click on the gear icon at the top right-hand corner, then click `Options`{.action}. In the left-hand column, follow the "Mail" tree under "Accounts", then "Block or authorise".
+Click the gear icon at the top right, then click `Options`{.action}. Still in the left-hand column, browse the "Mail" tree under "Accounts", then "Block or allow".
 
-In the "**Blocked Senders**" section, type an email address or domain name to block, and then click the `+`{.action} button to add it to the list.
+In the "**Blocked Senders**" section, type an email address or domain name to block, then click the `+`{.action} button to add it to the list.
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Managing a contact list
+### Managing your contacts
 
-To manage your contacts, click the blue "app launcher" button at the top, then click on `People`{.action}.
+To manage your contacts, first click the blue app launcher button at the top left of the page (which also gives access to calendar, tasks and other modules), then click `People`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-On the new page, you can add a new contact, create a contact list, and remove existing contacts.
+On the new page, you can add a new contact, create a contact list and remove existing contacts.
 
-**To add a new contact**, click `New`{.action}, and enter the contact details you want to add. Once you have done this, click `Save`{.action}.
+#### Adding a contact
+
+Click `New`{.action}, then enter the details of the contact you want to add. Once done, click `Save`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**To create a contact list**, click the down-arrow button next to "New", then click `Contact List`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
+#### Creating a contact list
+
+Click the down arrow next to `New`{.action}, then click `Contact list`{.action}. Give it a name, add contacts to it, then click `Save`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
-### Changing the password
+### Changing your password
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-You can change your account password when you are logged in to OWA. To do this, click the gear icon at the top, then click `Options`{.action}.
+You can change your account password while logged in to OWA. To do so, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the new page, expand the "General" tab in the tree on the left-hand side, then click `My Account`{.action}. Finally, click `Change Password`{.action}.
+On the new page, expand the "General" tab in the left-hand tree, then click `My account`{.action}. Finally, click `Change your password`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-In the new window that pops up, enter your current password. Then enter a new password, and re-enter to confirm it. Click the `Save`{.action} button to save the new password.
+In the new window that opens, enter your current password. Then enter a new password and confirm it by typing it again. Click `Save`{.action} to save the new password.
 
 > [!primary]
 >
-> Remember to also enter your new password on any device i.e. email client used to access this account. In case of any issues with your password, contact your service administrator.
+> Remember to enter your new password on all devices used to access this account (for example in your email client software). If you have any difficulties with your password, contact your service administrator.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
-### Adding an auto-reply
+### Adding an automatic reply
 
-In OWA, you can create an automatic reply on your email address to not leave emails unanswered during absences. To do this, click the gear icon at the top, then click `Automatic Replies`{.action}.
+In OWA, you can create an automatic reply on your inbox so that emails are not left unanswered while you are away. To do so, click the gear icon at the top, then click `Automatic replies`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-In the window that appears, select the option "Send automatic replies". You can then set the auto-responder to fit several criteria:
+In the window that opens, select the "Send automatic replies" option. You can then configure the auto-responder to match several criteria, such as:
 
-- send auto-reply emails for a fixed time interval, or continuously until it is manually disabled
-- define which senders will receive auto-reply emails (internal senders only, or include external senders)
+- send automatic reply emails for a fixed time interval, or continuously until manually disabled
+- define which senders will receive automatic reply emails (internal senders only, or include external senders)
 
-Now, fill in the requested information depending on the action you want it to carry out. Once you have done so, click `OK`{.action}.
+Fill in the requested information depending on the task you want to perform with this rule. Once done, click `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-For more detailed instructions about creating auto-replies, please refer to our guide: [Creating automatic replies in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
+For more detailed instructions on creating automatic replies, please refer to our guide: [Creating an automatic reply in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Adding a signature
 
@@ -193,39 +211,39 @@ To add an email signature, click the gear icon at the top, then click `Options`{
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-On the left-hand side of the new page, click `Email signature`{.action}. In the options tree, this item is under "Mail" and "Layout". From here you can enable, disable and edit the signature.
+On the left-hand side of the new page, click `Email signature`{.action}. In the tree options, this item is located under "Mail" and "Layout". From here, you can enable, disable and edit the signature.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Compose your electronic signature in the editor box. You can specify whether you want to include the signature by default in new emails only or in replies and forwarded emails as well. Once you have finished, click `Save`{.action} to confirm.
+Compose your email signature in the editor box. You can specify whether you want to include the default signature in new emails only, or also in replies and forwarded emails. Once you are done, click `Save`{.action} to confirm.
 
-For instructions about creating automated signatures by using domain-wide templates, please refer to our guide: [Creating automatic signatures](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
+For instructions on creating automatic signatures using domain-wide templates, please refer to our guide: [Creating automatic signatures](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
 
-### Accessing the options section
+### Accessing the Options section
 
 To access all your settings, click the gear icon at the top, then click `Options`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behaviour of your email account can be set from here. Please note that some of the account options may be disabled from our side for security reasons.
+You can then browse the "Options" tree-view on the left-hand side of the page. Further adjustments to the layout and behavior of your email account can be made from this page. Note that for security reasons, some account options may be disabled by OVHcloud.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Cookie management
 
-The webmail that is used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies called `appsforoffice.microsoft.com`.
+The webmail used for our email offers is based on Microsoft Outlook Web App software. It is therefore likely to exchange metadata with Microsoft servers, in the form of cookies named `appsforoffice.microsoft.com`.
 
-If you want to disable these exchanges, you can use a content blocking extension (such as uBlock Origin or Ghostery) on your browser.
+If you want to disable these exchanges, you can use a content blocking extension on your browser (such as uBlock Origin or Ghostery).
 However, disabling these cookies may affect the stability of your webmail.
 
 ## Go further
 
 [Creating automatic replies in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
 
-[Sharing folders in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+[Sharing a folder from the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
 
-[Sharing calendars in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
+[Sharing calendars via the OWA interface](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
-[Creating contact groups](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
+[Creating a contact group](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
 
 Join our [community of users](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.es-es.md
@@ -1,224 +1,244 @@
 ---
-title: 'Utilizar una dirección de correo desde Outlook en la Web'
-excerpt: 'Cómo utilizar una dirección de correo electrónico desde el webmail Outlook en la Web'
-updated: 2026-03-24
+title: 'Utilizar una dirección de correo desde el webmail Outlook Web App (OWA)'
+excerpt: 'Cómo utilizar una dirección de correo electrónico desde el webmail OWA'
+updated: 2026-05-04
 ---
 
 ## Objetivo
 
-Con las soluciones de correo de OVHcloud puede enviar y recibir correo utilizando el dispositivo y el cliente de correo que usted desee. Para poder iniciar sesión en una cuenta desde cualquier lugar a través de un navegador, OVHcloud ofrece un cliente de correo online llamado Outlook Web App (OWA). Nuestra [página de inicio de sesión de webmail](/links/web/email) es el único punto de acceso al OWA correspondiente para todas las cuentas activas de correo en MX Plan, Email Pro y Hosted Exchange.
+Con las soluciones de correo de OVHcloud, puede enviar y recibir sus correos electrónicos desde el dispositivo y el cliente de correo que prefiera. OVHcloud ofrece un servicio de correo en línea llamado Outlook Web App (OWA) que permite, a través de un navegador web, acceder a una cuenta desde cualquier lugar. Todas las cuentas de correo activas en MX Plan, Email Pro y Hosted Exchange tienen un único punto de acceso a la interfaz OWA correspondiente: nuestra [página de inicio de sesión del webmail](/links/web/email).
 
-**En esta guía aprenderá a realizar las acciones más habituales con su dirección de correo en la interfaz de OWA.**
+**Aprenda a realizar las acciones más habituales con su dirección de correo electrónico desde la interfaz OWA.**
 
 ## Requisitos
 
-- Tener una solución de correo electrónico de OVHcloud configurada (**solución MX Plan**, disponible como parte de nuestros [planes de hospedaje web](/links/web/hosting), incluida en un [Alojamiento gratuito 100M](/links/web/domains-free-hosting) o contratada por separado como una solución independiente; [**Hosted Exchange**](/links/web/emails-hosted-exchange) o [**Email Pro**](/links/web/email-pro))
-- Tener las credenciales de acceso de la dirección de correo electrónico que quiere configurar
+- Disponer de una solución de correo electrónico de OVHcloud previamente configurada, entre las siguientes ofertas:
+    - [**MX Plan**](/links/web/hosting), incluida en nuestros planes de alojamiento web, en el [alojamiento gratuito 100M](/links/web/domains-free-hosting) o contratada como solución independiente;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange);
+    - [**Email Pro**](/links/web/email-pro).
+- Conocer las credenciales de acceso de la dirección de correo electrónico que se desea utilizar.
 
 ## Procedimiento
 
-Esta guía le permitirá comprender mejor las tareas más habituales de la cuenta de correo disponibles en el webmail de OWA. Sin embargo, como esta interfaz no ha sido creada originalmente por OVHcloud, no podemos proporcionarle instrucciones específicas sobre ninguna configuración que no aparezca en esta guía. En cuanto a las funcionalidades de Exchange, hemos preparado unas guías adicionales que podrá encontrar en la sección [**Más información**](./#mas-informacion_1).
+Esta guía le ayudará a comprender mejor las tareas habituales disponibles en una cuenta de correo en OWA. Sin embargo, dado que esta interfaz no ha sido creada originalmente por OVHcloud, no podemos proporcionar instrucciones específicas sobre parámetros que no se aborden en esta guía.
+
+En cuanto a las funcionalidades específicas de Exchange, encontrará algunas guías adicionales en la sección [Más información](./#mas-informacion) al final de esta guía.
 
 > [!primary]
 >
-> Después de los dos primeros pasos, no es necesario seguir las instrucciones en un orden concreto.
+> Después de iniciar sesión y familiarizarse con la interfaz, no es necesario seguir las instrucciones en el orden indicado.
 
-### 1. Acceder a OWA
+### Acceder a OWA
 
-Para acceder al webmail de OWA con su dirección de correo electrónico, diríjase a la [página de inicio de sesión](/links/web/email). Introduzca su dirección de correo electrónico completa y su contraseña, y haga clic en el botón `Iniciar sesión`{.action}.
+Para iniciar sesión en OWA con su dirección de correo electrónico, abra la [página de inicio de sesión del webmail](/links/web/email). Introduzca su dirección de correo electrónico completa y su contraseña. A continuación, haga clic en `Iniciar sesión`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
 > [!warning]
 >
-> Si se le redirige a una interfaz **Roundcube**, significa que se encuentra en la versión antigua del servicio MX Plan. Para más información sobre la solución MX Plan, consulte nuestra página [Primeros pasos con la solución MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+> Si se le redirige a una interfaz **Roundcube**, significa que se encuentra en la versión histórica de la oferta MX Plan. Para más información sobre su oferta MX Plan, consulte nuestra página [Primeros pasos con la oferta MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 >
-> Para familiarizarse con la interfaz **Roundcube**, consulte nuestra guía [Webmail: Guía de uso de Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+> Para familiarizarse con la interfaz **Roundcube**, consulte nuestra guía [Utilizar una dirección de correo electrónico desde el webmail Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
 
-Si es la primera vez que inicia sesión en OWA con esta dirección de correo electrónico, se le pedirá que especifique el idioma de la interfaz y la zona horaria. Haga clic en `Guardar`{.action} para continuar.
+Si es la primera vez que inicia sesión en OWA con esta dirección de correo electrónico, se le pedirá que defina el idioma de la interfaz y la zona horaria. A continuación, haga clic en `Guardar`{.action} para continuar.
 
 > [!primary]
 >
-> Las zonas horarias se enumeran según [el estándar UTC (hora universal coordinada)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), no por orden alfabético de ciudades.
+> Las zonas horarias se enumeran según [el estándar UTC (tiempo universal coordinado)](https://es.wikipedia.org/wiki/Tiempo_universal_coordinado), no por orden alfabético de las ciudades.
 >
-> **Ejemplo** : Para Europa Occidental, se trata de UTC +1 (Bruselas, Copenhague, Madrid, París).
+> **Ejemplo**: Para Europa Occidental, se trata de UTC +1 (Bruselas, Copenhague, Madrid, París).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-De aquí en adelante, tras iniciar sesión, accederá por defecto a su bandeja de entrada.
+A partir de ahora, su bandeja de entrada aparecerá por defecto en cuanto inicie sesión.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Comprender la disposición de OWA
+### Comprender la interfaz de OWA
 
-Existen varias secciones en la interfaz de OWA. Por favor, consulte la tabla y la imagen siguientes para familiarizase con ellas.
+La interfaz de OWA consta de varias secciones. Consulte la siguiente tabla y la imagen para familiarizarse con ella.
 
 |Secciones|Descripción|  
 |---|---|  
-|Parte superior (1)|Contiene dos barras de pestaña: la primera permite acceder a la configuración general (como la [sección de opciones](./#acceder-a-la-seccion-de-opciones)), y la segunda se utiliza para acceder a acciones específicas con su dirección de correo (como enviar o responder correos electrónicos).|  
-|Barra lateral izquierda (2)|Muestra la lista de carpetas de su dirección de correo. Aparecen en un árbol de carpetas que se puede expandir u ocultar.|
-|Parte central (3)|Muestra la lista de mensajes (leídos y no leídos) de la carpeta seleccionada en el menú de la izquierda. En esta sección también se muestran los resultados de una búsqueda.|
-|Barra lateral derecha (4)|Muestra el panel de lectura cuando se ha seleccionado un correo electrónico.|
+|Sección superior (1)|Dispone de dos barras de pestañas: la primera permite acceder a los parámetros generales (como la [sección Opciones](./#acceder-a-la-seccion-opciones)). La segunda barra puede utilizarse para realizar acciones específicas con su dirección (como enviar o responder a correos electrónicos).|  
+|Lado izquierdo (2)|Muestra la lista de carpetas de su dirección de correo electrónico. Estas carpetas se presentan en forma de árbol que puede expandir u ocultar.|
+|Segmento central (3)|Muestra la lista de mensajes (leídos y no leídos) de la carpeta seleccionada en el menú de la izquierda. Esta sección también puede mostrar los resultados de búsqueda.|
+|Lado derecho (4)|Muestra el panel de lectura cuando se ha seleccionado un correo electrónico.|
 
 ![useowa](images/use-owa-step4.png){.thumbnail}
 
-Puede cambiar el tamaño de las secciones verticales haciendo clic en las líneas de los bordes y arrastrándolas.
+Tenga en cuenta que puede modificar el tamaño de las secciones verticales haciendo clic en sus líneas de borde y arrastrándolas.
 
 ### Visualizar los correos electrónicos
 
-Para ver sus correos, seleccione una carpeta de la barra de la izquierda. Los correos entrantes que no sigan ninguna regla de la bandeja de entrada llegarán a la carpeta «Bandeja de entrada». Para ver si ha recibido algún correo nuevo, compruebe si aparece un número junto a la carpeta correspondiente.
+Para consultar sus correos electrónicos, seleccione una carpeta en el lado izquierdo. Los correos entrantes que no estén procesados por las reglas de correo se mostrarán en la carpeta "Bandeja de entrada". Para saber si ha recibido nuevos correos electrónicos, compruebe si aparece un número junto a la carpeta correspondiente.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-Para leer un correo, seleccione la carpeta correspondiente en caso necesario. Haga clic en el correo para mostrar su contenido en la sección de lectura. Los mensajes no leídos aparecen en un color diferente para diferenciarlos de los mensajes leídos.
+Para leer un correo electrónico, seleccione su carpeta si es necesario. A continuación, haga clic en el correo para mostrar su contenido en el panel de lectura. Los mensajes no leídos aparecen en negrita para distinguirlos de los mensajes leídos.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Ordenar y filtrar los correos electrónicos
+
+En la parte superior derecha de la lista de mensajes, el botón `Filtrar`{.action} abre un menú que agrupa todas las opciones de visualización de la carpeta seleccionada.
+
+- **Filtrar por categoría**: seleccione una entrada para mostrar únicamente una selección de correos electrónicos entre `Todos`{.action}, `No leídos`{.action}, `A mí`{.action} (correos dirigidos directamente a su dirección), `Marcado`{.action} (correos marcados para su seguimiento) o `Menciones`{.action} (correos en los que se menciona su dirección).
+
+- **Ordenar por**: pase el cursor sobre la entrada `Ordenar por`{.action} para elegir el criterio de clasificación de los correos electrónicos: **Fecha**, **De**, **Para**, **Asunto**, **Datos adjuntos**, **Importancia** o **Tamaño**. La flecha a la izquierda del criterio indica el orden actual; haga clic de nuevo en el mismo criterio para invertirlo.
+
+- **Mostrar como**: pase el cursor sobre la entrada `Mostrar como`{.action} para alternar entre la vista **Mensajes** (un correo por línea) o **Conversaciones** (correos agrupados por hilo de conversación).
+
 ### Enviar y responder
 
-**Para enviar un correo nuevo**, haga clic en `Nuevo`{.action} en la parte superior de la interfaz del webmail. El panel de edición aparecerá en el lado derecho. Complete los campos del correo (destinatarios, asunto, cuerpo del mensaje, archivos adjuntos). Cuando el correo esté listo, haga clic en el botón `Enviar`{.action}.
+Para **enviar un nuevo mensaje**, haga clic en el icono `Nuevo`{.action} en la parte superior de la interfaz OWA. El panel de edición aparecerá en el lado derecho. Rellene los campos de su correo electrónico (destinatarios, asunto, cuerpo del mensaje, archivos adjuntos). Haga clic en `Enviar`{.action} una vez redactado el correo.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**Para responder a un correo**, [pulse sobre él](./#visualizar-los-correos-electronicos) para visualizarlo. A continuación, haga clic en el botón `Responder a todos`{.action}. Utilice el botón de flecha hacia abajo si solo desea responder al remitente del correo (eliminando a cualquier destinatario que esté en copia).
+Para **responder a un mensaje**, haga clic primero en él para mostrarlo. A continuación, haga clic en `Responder a todos`{.action} para responder al conjunto de destinatarios. Utilice el botón con la flecha hacia abajo si solo desea responder al remitente del correo (excluyendo a los destinatarios en copia) y haga clic en `Responder`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-Cuando elige responder, el editor de respuesta rápida aparece encima del correo. Escriba su respuesta en esta sección y una vez que haya terminado, haga clic en `Enviar`{.action}. Tenga en cuenta que si quiere añadir cualquier opción de respuesta (como, por ejemplo, adjuntar una firma), debe abrir primero el panel de edición al completo haciendo clic en el símbolo de flecha doble.
+Cuando elige responder, el editor de respuesta rápida aparecerá encima del correo electrónico. Escriba allí su respuesta y, en cuanto esté listo para enviar el mensaje, haga clic en `Enviar`{.action}. Tenga en cuenta que, para cada opción de respuesta (como añadir una firma), antes debe ampliarla al panel de edición completo haciendo clic en el símbolo de la doble flecha.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
-### Organizar su bandeja de entrada
+### Organizar su correo
 
-OWA le permite organizar su bandeja de entrada de distintas formas. Puede
+OWA ofrece varias formas de organizar su correo. Puede:
 
-- [crear carpetas y subcarpetas](./#crear-una-carpeta)
-- [mover correos](./#mover-correos)
-- [crear reglas](./#crear-reglas-de-la-bandeja-de-entrada) para determinar las acciones que se realizarán de manera automática cuando llegue un correo nuevo
+- [crear carpetas y subcarpetas](./#crear-una-carpeta),
+- [mover correos electrónicos](./#mover-correos-electronicos),
+- [definir reglas](./#crear-reglas-de-gestion-del-correo) para realizar automáticamente acciones cuando reciba un nuevo correo,
+- [bloquear a un remitente](./#bloquear-a-un-remitente) para no recibir más sus mensajes.
 
 #### Crear una carpeta
 
-Para crear una carpeta nueva, haga clic derecho sobre el nombre de su dirección de correo en el árbol de carpetas y seleccione `Crear carpeta nueva`{.action}. Puede crear subcarpetas en carpetas existentes de la misma formar (`Crear subcarpeta nueva`{.action}).
+Para crear una nueva carpeta, haga clic con el botón derecho sobre el nombre de su dirección de correo electrónico en el árbol de carpetas y seleccione `Crear nueva carpeta`{.action}. Puede crear una subcarpeta dentro de carpetas existentes de la misma forma haciendo clic en `Crear nueva subcarpeta`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
-#### Mover correos
+#### Mover correos electrónicos
 
-**Para mover un correo**, puede simplemente arrastrarlo y soltarlo en la carpeta de destino o hacer clic derecho sobre él y seleccionar `Mover`{.action}.
-**Para mover varios correos** a la vez, selecciónelos marcando sus casillas de verificación, y haga clic en `Mover`{.action} (en la barra lateral derecha) o en `Mover a`{.action}(en la sección superior). A continuación, seleccione la carpeta de destino.
+Para **mover un correo electrónico**, puede simplemente arrastrarlo y soltarlo en la carpeta de destino o hacer clic con el botón derecho y seleccionar `Mover`{.action}.
+Para **mover varios correos electrónicos** simultáneamente, selecciónelos todos mediante su casilla de verificación. A continuación, haga clic en `Mover`{.action} (en el lado derecho) o en `Mover a`{.action} (en la sección superior). Después, elija la carpeta de destino.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
-#### Crear reglas de la bandeja de entrada
+#### Crear reglas de gestión del correo
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/xnq6wvANUFs?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Para gestionar las reglas, haga clic en el símbolo de engranaje en la parte superior, y después en`Opciones`{.action}.
+Para crear y gestionar reglas, haga clic primero en el icono del engranaje en la parte superior y, a continuación, en `Opciones`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-En la página nueva que aparece, seleccione `Reglas de la bandeja de entrada y de limpieza`{.action} del menú de la izquierda. En el árbol de «Opciones» puede encontrar este elemento dentro de «Correo», en «Procesamiento automático». Desde aquí puede crear, editar, eliminar y mover reglas en la lista.
+En la nueva página que se abre, haga clic en `Reglas de bandeja de entrada y de limpieza`{.action} en el menú de la izquierda. En el árbol "Opciones", puede encontrar esta funcionalidad en "Correo", bajo "Procesamiento automático". Aquí puede crear, modificar y mover reglas de la lista.
 
 Para añadir una nueva regla, haga clic en el botón `+`{.action}.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Rellene la información solicitada según la acción que quiere que lleve a cabo la regla. Después, haga clic en `OK`{.action}.
+Rellene la información solicitada en función de la tarea que desee realizar con esta regla. A continuación, haga clic en `Aceptar`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-Para obtener instrucciones más detalladas sobre la creación de reglas de la bandeja de entrada, consulte nuestra guía: [Crear reglas de la bandeja de entrada en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+Para obtener instrucciones más detalladas sobre la creación de reglas de gestión de correo, consulte nuestra guía: [Creación de reglas de gestión de correo en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-#### Bloquear un remitente
+#### Bloquear a un remitente
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/2jia2s1_oIw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Haga clic en el símbolo de engranaje en la esquina superior derecha y seleccione `Opciones`{.action}. En la columna de la izquierda, siga el árbol "Correo" en "Cuentas" > "Bloquear o autorizar".
+Haga clic en el icono del engranaje en la parte superior derecha y, a continuación, en `Opciones`{.action}. Igualmente en la columna de la izquierda, recorra el árbol "Correo" en "Cuentas" y, después, "Bloquear o permitir".
 
-En la sección "**Remitentes bloqueados**", escriba una dirección de correo electrónico o un nombre de dominio que desea bloquear y haga clic en el botón `+`{.action} para añadirlo a la lista.
+En la sección "**Remitentes bloqueados**", escriba una dirección de correo electrónico o un nombre de dominio que desee bloquear y haga clic en el botón `+`{.action} para añadirlo a la lista.
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Gestionar una lista de contactos
+### Gestionar sus contactos
 
-Para gestionar sus contactos, haga clic en el botón azul del «lanzador de aplicaciones» de la parte superior, y haga clic en `Personas`{.action}.
+Para gestionar sus contactos, haga clic primero en el botón azul del iniciador de aplicaciones en la parte superior izquierda de la página (que también da acceso al calendario, las tareas y otros módulos) y, a continuación, en `Contactos`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-En la página que aparece, puede añadir nuevos contactos, crear una lista de contactos o eliminar contactos existentes.
+En la nueva página, puede añadir un nuevo contacto, crear una lista de contactos y eliminar contactos existentes.
 
-**Para añadir un nuevo contacto**, haga clic en `Nuevo`{.action} e introduzca la información del contacto que desea añadir. Una vez hecho esto, haga clic en `Guardar`{.action}.
+#### Añadir un contacto
+
+Haga clic en `Nuevo`{.action} y, a continuación, introduzca los datos del contacto que desea añadir. Una vez hecho esto, haga clic en `Guardar`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**Para crear una lista de contactos**, haga clic en el icono de la flecha desplegable junto a «Nuevo» y haga clic en `Lista de contactos`{.action}. Asígnele un nombre a la lista, añada los contactos y haga clic en `Guardar`{.action}.
+#### Crear una lista de contactos
+
+Haga clic en la flecha hacia abajo junto a `Nuevo`{.action} y, a continuación, en `Lista de contactos`{.action}. Asígnele un nombre, añada contactos y haga clic en `Guardar`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
 ### Cambiar la contraseña
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/xnq6wvANUFs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Puede cambiar la contraseña de su cuenta cuando haya iniciado sesión en OWA. Para ello, haga clic en el símbolo de engranaje en la parte superior, y después en`Opciones`{.action}.
+Puede cambiar la contraseña de su cuenta cuando haya iniciado sesión en OWA. Para ello, haga clic en el icono del engranaje en la parte superior y, a continuación, en `Opciones`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-En la página que aparece, amplíe la pestaña «General» en el árbol de opciones de la barra de la izquierda y haga clic en `Mi cuenta`{.action}. Finalmente, haga clic en `Cambiar contraseña`{.action}.
+En la nueva página, despliegue la pestaña "General" en el árbol de la izquierda y, a continuación, haga clic en `Mi cuenta`{.action}. Por último, haga clic en `Cambiar la contraseña`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-En la nueva ventana emergente, introduzca su contraseña actual. A continuación, introduzca la nueva contraseña, y escríbala de nuevo para confirmarla. Haga clic en el botón `Guardar`{.action} para guardar la nueva contraseña.
+En la nueva ventana que se abre, introduzca su contraseña actual. A continuación, escriba una nueva contraseña y confírmela introduciéndola de nuevo. Haga clic en `Guardar`{.action} para guardar la nueva contraseña.
 
 > [!primary]
 >
-> Recuerde que debe introducir la nueva contraseña en todos los dispositivos que utilice, es decir, en los clientes de correo que utilice para acceder a esta cuenta. Si tiene algún problema con su contraseña, póngase en contacto con el administrador del servicio.
+> No olvide introducir la nueva contraseña en todos sus dispositivos utilizados para acceder a esta cuenta (por ejemplo, en el cliente de correo). Si tiene problemas con su contraseña, póngase en contacto con su administrador de servicios.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
 ### Añadir una respuesta automática
 
-En OWA puede crear una respuesta automática en su dirección de correo para no dejar correos sin responder durante su ausencia. Para ello, haga clic en el símbolo de engranaje en la parte superior, y después en`Respuestas automáticas`{.action}.
+En OWA, puede crear una respuesta automática en su correo para no dejar correos sin responder durante sus ausencias. Para ello, haga clic en el icono del engranaje en la parte superior y, a continuación, en `Respuestas automáticas`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-En la ventana que aparece, seleccione la opción «Enviar respuestas automáticas». Aquí podrá configurar el contestador automático para que se adapte a varios criterios:
+En la ventana que se abre, seleccione la opción "Enviar respuestas automáticas". Puede entonces configurar la respuesta automática para que cumpla varios criterios, como:
 
-- Enviar correos electrónicos de respuesta automática durante un intervalo de tiempo determinado, o de forma continua hasta que se desactive manualmente.
-- Definir los remitentes que recibirán correos de respuesta automática (solo remitentes internos, o incluir remitentes externos).
+- enviar correos de respuesta automática durante un intervalo de tiempo fijo, o de forma continua hasta que se desactive manualmente;
+- definir los remitentes que recibirán los correos de respuesta automática (solo remitentes internos, o incluir a los remitentes externos).
 
-Rellene la información solicitada según la acción que quiere que se lleve a cabo. Una vez hecho esto, haga clic en OK.
+Rellene la información solicitada en función de la tarea que desee realizar con esta regla. Una vez hecho esto, haga clic en `Aceptar`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-Para obtener instrucciones más detalladas sobre la creación de respuestas automáticas, consulte nuestra guía: [Crear respuestas automáticas en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
+Para obtener instrucciones más detalladas sobre la creación de respuestas automáticas, consulte nuestra guía: [Crear una respuesta automática en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Añadir una firma
 
-Para añadir una firma, haga clic en el símbolo de engranaje en la parte superior, y después en`Opciones`{.action}.
+Para añadir una firma electrónica, haga clic en el icono del engranaje en la parte superior y, a continuación, en `Opciones`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-En la barra de la izquierda de la página nueva, haga clic en `Firma de correo electrónico`{.action}. En el árbol de opciones, este elemento se encuentra en «Correo», en «Disposición». En esta sección puede activar, desactivar y editar la firma.
+En el lado izquierdo de la nueva página, haga clic en `Firma de correo electrónico`{.action}. En las opciones del árbol, este elemento se encuentra en "Correo" y "Diseño". Desde ahí, puede activar, desactivar y modificar la firma.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Introduzca su firma electrónica en el cuadro de edición. Puede especificar si quiere incluir la firma por defecto solo en los correos nuevos o también en respuestas o correos reenviados. Una vez haya terminado, haga clic en `Guardar`{.action} para confirmar.
+Componga su firma electrónica en el cuadro del editor. Puede especificar si desea incluir la firma por defecto solo en los correos nuevos o también en las respuestas y los correos reenviados. Una vez haya terminado, haga clic en `Guardar`{.action} para confirmar.
 
-Para obtener instrucciones sobre la creación de firmas automáticas mediante el uso de plantillas para todos los dominios, consulte nuestra guía: [Creación de firmas automáticas](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
+Para obtener instrucciones sobre la creación de firmas automáticas mediante plantillas para todo el dominio, consulte nuestra guía: [Crear firmas automáticas](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
 
-### Acceder a la sección de opciones
+### Acceder a la sección Opciones
 
-Para acceder a todos los ajustes, haga clic en el símbolo de engranaje en la parte superior, y después en `Opciones`{.action}.
+Para acceder a todos sus parámetros, haga clic en el icono del engranaje en la parte superior y, a continuación, en `Opciones`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Puede navegar por el árbol de «Opciones» de la parte izquierda de la página. Desde esta sección podrá realizar más ajustes en cuanto a la disposición y comportamiento de su cuenta de correo electrónico. Tenga en cuenta que algunas de las opciones de la cuenta pueden estar desactivadas por nuestra parte por razones de seguridad.
+Después puede navegar por el árbol "Opciones" en el lado izquierdo de la página. Desde esta página pueden realizarse otros ajustes sobre la presentación y el comportamiento de su cuenta de correo electrónico. Tenga en cuenta que, por motivos de seguridad, OVHcloud puede haber desactivado algunas opciones de la cuenta.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Gestión de cookies
 
-El webmail utilizado para nuestros productos de correo está basado en el programa Microsoft Outlook Web App. por lo que es susceptible de intercambiar metadatos con los servidores de Microsoft, en forma de cookies llamadas `appsforoffice.microsoft.com`.
+El webmail utilizado para nuestras ofertas de correo se basa en el software Microsoft Outlook Web App. Por lo tanto, es susceptible de intercambiar metadatos con los servidores de Microsoft, en forma de cookies denominadas `appsforoffice.microsoft.com`.
 
 Si desea desactivar estos intercambios, puede utilizar en su navegador una extensión de tipo bloqueador de contenidos (como uBlock Origin o Ghostery).
 No obstante, la desactivación de estas cookies puede afectar a la estabilidad de su webmail.
@@ -227,10 +247,10 @@ No obstante, la desactivación de estas cookies puede afectar a la estabilidad d
 
 [Crear respuestas automáticas en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
 
-[Compartir carpetas en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+[Compartir una carpeta desde la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
 
-[Compartir calendarios en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
+[Compartir calendarios a través de la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
-[Crear grupos de contactos](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
+[Crear un grupo de contactos](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.es-us.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.es-us.md
@@ -1,218 +1,237 @@
 ---
-title: 'Utilizar una dirección de correo desde Outlook en la Web'
-excerpt: 'Cómo utilizar una dirección de correo electrónico desde el webmail Outlook en la Web'
-updated: 2026-03-24
+title: 'Utilizar una dirección de correo desde el webmail Outlook Web App (OWA)'
+excerpt: 'Cómo utilizar una dirección de correo electrónico desde el webmail OWA'
+updated: 2026-05-04
 ---
 
 ## Objetivo
 
-Con las soluciones de correo de OVHcloud puede enviar y recibir correo utilizando el dispositivo y el cliente de correo que usted desee. Para poder iniciar sesión en una cuenta desde cualquier lugar a través de un navegador, OVHcloud ofrece un cliente de correo online llamado Outlook Web App (OWA). Nuestra [página de inicio de sesión de webmail](/links/web/email) es el único punto de acceso al OWA correspondiente para todas las cuentas activas de correo en MX Plan y Hosted Exchange.
+Con las soluciones de correo de OVHcloud, puede enviar y recibir sus correos electrónicos desde el dispositivo y el cliente de correo que prefiera. OVHcloud ofrece un servicio de correo en línea llamado Outlook Web App (OWA) que permite, a través de un navegador web, acceder a una cuenta desde cualquier lugar. Todas las cuentas de correo activas en MX Plan y Hosted Exchange tienen un único punto de acceso a la interfaz OWA correspondiente: nuestra [página de inicio de sesión del webmail](/links/web/email).
 
-**En esta guía aprenderá a realizar las acciones más habituales con su dirección de correo en la interfaz de OWA.**
+**Aprenda a realizar las acciones más habituales con su dirección de correo electrónico desde la interfaz OWA.**
 
 ## Requisitos
 
-- Tener una solución de correo electrónico de OVHcloud configurada (**solución MX Plan**, disponible como parte de nuestros [planes de hospedaje web](/links/web/hosting) o [**Hosted Exchange**](/links/web/emails-hosted-exchange))
-- Tener las credenciales de acceso de la dirección de correo electrónico que quiere configurar
+- Disponer de una solución de correo electrónico de OVHcloud previamente configurada, entre las siguientes ofertas:
+    - [**MX Plan**](/links/web/hosting), incluida en nuestros planes de alojamiento web o contratada como solución independiente;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange).
+- Conocer las credenciales de acceso de la dirección de correo electrónico que se desea utilizar.
 
 ## Procedimiento
 
-Esta guía le permitirá comprender mejor las tareas más habituales de la cuenta de correo disponibles en el webmail de OWA. Sin embargo, como esta interfaz no ha sido creada originalmente por OVHcloud, no podemos proporcionarle instrucciones específicas sobre ninguna configuración que no aparezca en esta guía. En cuanto a las funcionalidades de Exchange, hemos preparado unas guías adicionales que podrá encontrar en la sección [**Más información**](./#mas-informacion_1).
+Esta guía le ayudará a comprender mejor las tareas habituales disponibles en una cuenta de correo en OWA. Sin embargo, dado que esta interfaz no ha sido creada originalmente por OVHcloud, no podemos proporcionar instrucciones específicas sobre parámetros que no se aborden en esta guía.
+
+En cuanto a las funcionalidades específicas de Exchange, encontrará algunas guías adicionales en la sección [Más información](./#mas-informacion) al final de esta guía.
 
 > [!primary]
 >
-> Después de los dos primeros pasos, no es necesario seguir las instrucciones en un orden concreto.
+> Después de iniciar sesión y familiarizarse con la interfaz, no es necesario seguir las instrucciones en el orden indicado.
 
-### 1. Acceder a OWA
+### Acceder a OWA
 
-Para acceder al webmail de OWA con su dirección de correo electrónico, diríjase a la [página de inicio de sesión](/links/web/email). Introduzca su dirección de correo electrónico completa y su contraseña, y haga clic en el botón `Iniciar sesión`{.action}.
+Para iniciar sesión en OWA con su dirección de correo electrónico, abra la [página de inicio de sesión del webmail](/links/web/email). Introduzca su dirección de correo electrónico completa y su contraseña. A continuación, haga clic en `Iniciar sesión`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
-Si es la primera vez que inicia sesión en OWA con esta dirección de correo electrónico, se le pedirá que especifique el idioma de la interfaz y la zona horaria. Haga clic en `Guardar`{.action} para continuar.
+Si es la primera vez que inicia sesión en OWA con esta dirección de correo electrónico, se le pedirá que defina el idioma de la interfaz y la zona horaria. A continuación, haga clic en `Guardar`{.action} para continuar.
 
 > [!primary]
 >
-> Las zonas horarias se enumeran según [el estándar UTC (hora universal coordinada)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), no por orden alfabético de ciudades.
+> Las zonas horarias se enumeran según [el estándar UTC (tiempo universal coordinado)](https://es.wikipedia.org/wiki/Tiempo_universal_coordinado), no por orden alfabético de las ciudades.
 >
-> **Ejemplo** : Para Europa Occidental, se trata de UTC +1 (Bruselas, Copenhague, Madrid, París).
+> **Ejemplo**: Para Europa Occidental, se trata de UTC +1 (Bruselas, Copenhague, Madrid, París).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-De aquí en adelante, tras iniciar sesión, accederá por defecto a su bandeja de entrada.
+A partir de ahora, su bandeja de entrada aparecerá por defecto en cuanto inicie sesión.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Comprender la disposición de OWA
+### Comprender la interfaz de OWA
 
-Existen varias secciones en la interfaz de OWA. Por favor, consulte la tabla y la imagen siguientes para familiarizase con ellas.
+La interfaz de OWA consta de varias secciones. Consulte la siguiente tabla y la imagen para familiarizarse con ella.
 
 |Secciones|Descripción|  
 |---|---|  
-|Parte superior (1)|Contiene dos barras de pestaña: la primera permite acceder a la configuración general (como la [sección de opciones](./#acceder-a-la-seccion-de-opciones)), y la segunda se utiliza para acceder a acciones específicas con su dirección de correo (como enviar o responder correos electrónicos).|  
-|Barra lateral izquierda (2)|Muestra la lista de carpetas de su dirección de correo. Aparecen en un árbol de carpetas que se puede expandir u ocultar.|
-|Parte central (3)|Muestra la lista de mensajes (leídos y no leídos) de la carpeta seleccionada en el menú de la izquierda. En esta sección también se muestran los resultados de una búsqueda.|
-|Barra lateral derecha (4)|Muestra el panel de lectura cuando se ha seleccionado un correo electrónico.|
+|Sección superior (1)|Dispone de dos barras de pestañas: la primera permite acceder a los parámetros generales (como la [sección Opciones](./#acceder-a-la-seccion-opciones)). La segunda barra puede utilizarse para realizar acciones específicas con su dirección (como enviar o responder a correos electrónicos).|  
+|Lado izquierdo (2)|Muestra la lista de carpetas de su dirección de correo electrónico. Estas carpetas se presentan en forma de árbol que puede expandir u ocultar.|
+|Segmento central (3)|Muestra la lista de mensajes (leídos y no leídos) de la carpeta seleccionada en el menú de la izquierda. Esta sección también puede mostrar los resultados de búsqueda.|
+|Lado derecho (4)|Muestra el panel de lectura cuando se ha seleccionado un correo electrónico.|
 
 ![useowa](images/use-owa-step4.png){.thumbnail}
 
-Puede cambiar el tamaño de las secciones verticales haciendo clic en las líneas de los bordes y arrastrándolas.
+Tenga en cuenta que puede modificar el tamaño de las secciones verticales haciendo clic en sus líneas de borde y arrastrándolas.
 
 ### Visualizar los correos electrónicos
 
-Para ver sus correos, seleccione una carpeta de la barra de la izquierda. Los correos entrantes que no sigan ninguna regla de la bandeja de entrada llegarán a la carpeta «Bandeja de entrada». Para ver si ha recibido algún correo nuevo, compruebe si aparece un número junto a la carpeta correspondiente.
+Para consultar sus correos electrónicos, seleccione una carpeta en el lado izquierdo. Los correos entrantes que no estén procesados por las reglas de correo se mostrarán en la carpeta "Bandeja de entrada". Para saber si ha recibido nuevos correos electrónicos, compruebe si aparece un número junto a la carpeta correspondiente.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-Para leer un correo, seleccione la carpeta correspondiente en caso necesario. Haga clic en el correo para mostrar su contenido en la sección de lectura. Los mensajes no leídos aparecen en un color diferente para diferenciarlos de los mensajes leídos.
+Para leer un correo electrónico, seleccione su carpeta si es necesario. A continuación, haga clic en el correo para mostrar su contenido en el panel de lectura. Los mensajes no leídos aparecen en negrita para distinguirlos de los mensajes leídos.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Ordenar y filtrar los correos electrónicos
+
+En la parte superior derecha de la lista de mensajes, el botón `Filtrar`{.action} abre un menú que agrupa todas las opciones de visualización de la carpeta seleccionada.
+
+- **Filtrar por categoría**: seleccione una entrada para mostrar únicamente una selección de correos electrónicos entre `Todos`{.action}, `No leídos`{.action}, `A mí`{.action} (correos dirigidos directamente a su dirección), `Marcado`{.action} (correos marcados para su seguimiento) o `Menciones`{.action} (correos en los que se menciona su dirección).
+
+- **Ordenar por**: pase el cursor sobre la entrada `Ordenar por`{.action} para elegir el criterio de clasificación de los correos electrónicos: **Fecha**, **De**, **Para**, **Asunto**, **Datos adjuntos**, **Importancia** o **Tamaño**. La flecha a la izquierda del criterio indica el orden actual; haga clic de nuevo en el mismo criterio para invertirlo.
+
+- **Mostrar como**: pase el cursor sobre la entrada `Mostrar como`{.action} para alternar entre la vista **Mensajes** (un correo por línea) o **Conversaciones** (correos agrupados por hilo de conversación).
+
 ### Enviar y responder
 
-**Para enviar un correo nuevo**, haga clic en `Nuevo`{.action} en la parte superior de la interfaz del webmail. El panel de edición aparecerá en el lado derecho. Complete los campos del correo (destinatarios, asunto, cuerpo del mensaje, archivos adjuntos). Cuando el correo esté listo, haga clic en el botón `Enviar`{.action}.
+Para **enviar un nuevo mensaje**, haga clic en el icono `Nuevo`{.action} en la parte superior de la interfaz OWA. El panel de edición aparecerá en el lado derecho. Rellene los campos de su correo electrónico (destinatarios, asunto, cuerpo del mensaje, archivos adjuntos). Haga clic en `Enviar`{.action} una vez redactado el correo.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**Para responder a un correo**, [pulse sobre él](./#visualizar-los-correos-electronicos) para visualizarlo. A continuación, haga clic en el botón `Responder a todos`{.action}. Utilice el botón de flecha hacia abajo si solo desea responder al remitente del correo (eliminando a cualquier destinatario que esté en copia).
+Para **responder a un mensaje**, haga clic primero en él para mostrarlo. A continuación, haga clic en `Responder a todos`{.action} para responder al conjunto de destinatarios. Utilice el botón con la flecha hacia abajo si solo desea responder al remitente del correo (excluyendo a los destinatarios en copia) y haga clic en `Responder`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-Cuando elige responder, el editor de respuesta rápida aparece encima del correo. Escriba su respuesta en esta sección y una vez que haya terminado, haga clic en `Enviar`{.action}. Tenga en cuenta que si quiere añadir cualquier opción de respuesta (como, por ejemplo, adjuntar una firma), debe abrir primero el panel de edición al completo haciendo clic en el símbolo de flecha doble.
+Cuando elige responder, el editor de respuesta rápida aparecerá encima del correo electrónico. Escriba allí su respuesta y, en cuanto esté listo para enviar el mensaje, haga clic en `Enviar`{.action}. Tenga en cuenta que, para cada opción de respuesta (como añadir una firma), antes debe ampliarla al panel de edición completo haciendo clic en el símbolo de la doble flecha.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
-### Organizar su bandeja de entrada
+### Organizar su correo
 
-OWA le permite organizar su bandeja de entrada de distintas formas. Puede
+OWA ofrece varias formas de organizar su correo. Puede:
 
-- [crear carpetas y subcarpetas](./#crear-una-carpeta)
-- [mover correos](./#mover-correos)
-- [crear reglas](./#crear-reglas-de-la-bandeja-de-entrada) para determinar las acciones que se realizarán de manera automática cuando llegue un correo nuevo
+- [crear carpetas y subcarpetas](./#crear-una-carpeta),
+- [mover correos electrónicos](./#mover-correos-electronicos),
+- [definir reglas](./#crear-reglas-de-gestion-del-correo) para realizar automáticamente acciones cuando reciba un nuevo correo,
+- [bloquear a un remitente](./#bloquear-a-un-remitente) para no recibir más sus mensajes.
 
 #### Crear una carpeta
 
-Para crear una carpeta nueva, haga clic derecho sobre el nombre de su dirección de correo en el árbol de carpetas y seleccione `Crear carpeta nueva`{.action}. Puede crear subcarpetas en carpetas existentes de la misma formar (`Crear subcarpeta nueva`{.action}).
+Para crear una nueva carpeta, haga clic con el botón derecho sobre el nombre de su dirección de correo electrónico en el árbol de carpetas y seleccione `Crear nueva carpeta`{.action}. Puede crear una subcarpeta dentro de carpetas existentes de la misma forma haciendo clic en `Crear nueva subcarpeta`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
-#### Mover correos
+#### Mover correos electrónicos
 
-**Para mover un correo**, puede simplemente arrastrarlo y soltarlo en la carpeta de destino o hacer clic derecho sobre él y seleccionar `Mover`{.action}.
-**Para mover varios correos** a la vez, selecciónelos marcando sus casillas de verificación, y haga clic en `Mover`{.action} (en la barra lateral derecha) o en `Mover a`{.action}(en la sección superior). A continuación, seleccione la carpeta de destino.
+Para **mover un correo electrónico**, puede simplemente arrastrarlo y soltarlo en la carpeta de destino o hacer clic con el botón derecho y seleccionar `Mover`{.action}.
+Para **mover varios correos electrónicos** simultáneamente, selecciónelos todos mediante su casilla de verificación. A continuación, haga clic en `Mover`{.action} (en el lado derecho) o en `Mover a`{.action} (en la sección superior). Después, elija la carpeta de destino.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
-#### Crear reglas de la bandeja de entrada
+#### Crear reglas de gestión del correo
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/xnq6wvANUFs?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Para gestionar las reglas, haga clic en el símbolo de engranaje en la parte superior, y después en`Opciones`{.action}.
+Para crear y gestionar reglas, haga clic primero en el icono del engranaje en la parte superior y, a continuación, en `Opciones`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-En la página nueva que aparece, seleccione `Reglas de la bandeja de entrada y de limpieza`{.action} del menú de la izquierda. En el árbol de «Opciones» puede encontrar este elemento dentro de «Correo», en «Procesamiento automático». Desde aquí puede crear, editar, eliminar y mover reglas en la lista.
+En la nueva página que se abre, haga clic en `Reglas de bandeja de entrada y de limpieza`{.action} en el menú de la izquierda. En el árbol "Opciones", puede encontrar esta funcionalidad en "Correo", bajo "Procesamiento automático". Aquí puede crear, modificar y mover reglas de la lista.
 
 Para añadir una nueva regla, haga clic en el botón `+`{.action}.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Rellene la información solicitada según la acción que quiere que lleve a cabo la regla. Después, haga clic en `OK`{.action}.
+Rellene la información solicitada en función de la tarea que desee realizar con esta regla. A continuación, haga clic en `Aceptar`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-Para obtener instrucciones más detalladas sobre la creación de reglas de la bandeja de entrada, consulte nuestra guía: [Crear reglas de la bandeja de entrada en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+Para obtener instrucciones más detalladas sobre la creación de reglas de gestión de correo, consulte nuestra guía: [Creación de reglas de gestión de correo en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-#### Bloquear un remitente
+#### Bloquear a un remitente
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/2jia2s1_oIw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Haga clic en el símbolo de engranaje en la esquina superior derecha y seleccione `Opciones`{.action}. En la columna de la izquierda, siga el árbol "Correo" en "Cuentas" > "Bloquear o autorizar".
+Haga clic en el icono del engranaje en la parte superior derecha y, a continuación, en `Opciones`{.action}. Igualmente en la columna de la izquierda, recorra el árbol "Correo" en "Cuentas" y, después, "Bloquear o permitir".
 
-En la sección "**Remitentes bloqueados**", escriba una dirección de correo electrónico o un nombre de dominio que desea bloquear y haga clic en el botón `+`{.action} para añadirlo a la lista.
+En la sección "**Remitentes bloqueados**", escriba una dirección de correo electrónico o un nombre de dominio que desee bloquear y haga clic en el botón `+`{.action} para añadirlo a la lista.
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Gestionar una lista de contactos
+### Gestionar sus contactos
 
-Para gestionar sus contactos, haga clic en el botón azul del «lanzador de aplicaciones» de la parte superior, y haga clic en `Personas`{.action}.
+Para gestionar sus contactos, haga clic primero en el botón azul del iniciador de aplicaciones en la parte superior izquierda de la página (que también da acceso al calendario, las tareas y otros módulos) y, a continuación, en `Contactos`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-En la página que aparece, puede añadir nuevos contactos, crear una lista de contactos o eliminar contactos existentes.
+En la nueva página, puede añadir un nuevo contacto, crear una lista de contactos y eliminar contactos existentes.
 
-**Para añadir un nuevo contacto**, haga clic en `Nuevo`{.action} e introduzca la información del contacto que desea añadir. Una vez hecho esto, haga clic en `Guardar`{.action}.
+#### Añadir un contacto
+
+Haga clic en `Nuevo`{.action} y, a continuación, introduzca los datos del contacto que desea añadir. Una vez hecho esto, haga clic en `Guardar`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**Para crear una lista de contactos**, haga clic en el icono de la flecha desplegable junto a «Nuevo» y haga clic en `Lista de contactos`{.action}. Asígnele un nombre a la lista, añada los contactos y haga clic en `Guardar`{.action}.
+#### Crear una lista de contactos
+
+Haga clic en la flecha hacia abajo junto a `Nuevo`{.action} y, a continuación, en `Lista de contactos`{.action}. Asígnele un nombre, añada contactos y haga clic en `Guardar`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
 ### Cambiar la contraseña
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/xnq6wvANUFs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Puede cambiar la contraseña de su cuenta cuando haya iniciado sesión en OWA. Para ello, haga clic en el símbolo de engranaje en la parte superior, y después en`Opciones`{.action}.
+Puede cambiar la contraseña de su cuenta cuando haya iniciado sesión en OWA. Para ello, haga clic en el icono del engranaje en la parte superior y, a continuación, en `Opciones`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-En la página que aparece, amplíe la pestaña «General» en el árbol de opciones de la barra de la izquierda y haga clic en `Mi cuenta`{.action}. Finalmente, haga clic en `Cambiar contraseña`{.action}.
+En la nueva página, despliegue la pestaña "General" en el árbol de la izquierda y, a continuación, haga clic en `Mi cuenta`{.action}. Por último, haga clic en `Cambiar la contraseña`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-En la nueva ventana emergente, introduzca su contraseña actual. A continuación, introduzca la nueva contraseña, y escríbala de nuevo para confirmarla. Haga clic en el botón `Guardar`{.action} para guardar la nueva contraseña.
+En la nueva ventana que se abre, introduzca su contraseña actual. A continuación, escriba una nueva contraseña y confírmela introduciéndola de nuevo. Haga clic en `Guardar`{.action} para guardar la nueva contraseña.
 
 > [!primary]
 >
-> Recuerde que debe introducir la nueva contraseña en todos los dispositivos que utilice, es decir, en los clientes de correo que utilice para acceder a esta cuenta. Si tiene algún problema con su contraseña, póngase en contacto con el administrador del servicio.
+> No olvide introducir la nueva contraseña en todos sus dispositivos utilizados para acceder a esta cuenta (por ejemplo, en el cliente de correo). Si tiene problemas con su contraseña, póngase en contacto con su administrador de servicios.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
 ### Añadir una respuesta automática
 
-En OWA puede crear una respuesta automática en su dirección de correo para no dejar correos sin responder durante su ausencia. Para ello, haga clic en el símbolo de engranaje en la parte superior, y después en`Respuestas automáticas`{.action}.
+En OWA, puede crear una respuesta automática en su correo para no dejar correos sin responder durante sus ausencias. Para ello, haga clic en el icono del engranaje en la parte superior y, a continuación, en `Respuestas automáticas`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-En la ventana que aparece, seleccione la opción «Enviar respuestas automáticas». Aquí podrá configurar el contestador automático para que se adapte a varios criterios:
+En la ventana que se abre, seleccione la opción "Enviar respuestas automáticas". Puede entonces configurar la respuesta automática para que cumpla varios criterios, como:
 
-- Enviar correos electrónicos de respuesta automática durante un intervalo de tiempo determinado, o de forma continua hasta que se desactive manualmente.
-- Definir los remitentes que recibirán correos de respuesta automática (solo remitentes internos, o incluir remitentes externos).
+- enviar correos de respuesta automática durante un intervalo de tiempo fijo, o de forma continua hasta que se desactive manualmente;
+- definir los remitentes que recibirán los correos de respuesta automática (solo remitentes internos, o incluir a los remitentes externos).
 
-Rellene la información solicitada según la acción que quiere que se lleve a cabo. Una vez hecho esto, haga clic en OK.
+Rellene la información solicitada en función de la tarea que desee realizar con esta regla. Una vez hecho esto, haga clic en `Aceptar`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-Para obtener instrucciones más detalladas sobre la creación de respuestas automáticas, consulte nuestra guía: [Crear respuestas automáticas en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
+Para obtener instrucciones más detalladas sobre la creación de respuestas automáticas, consulte nuestra guía: [Crear una respuesta automática en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Añadir una firma
 
-Para añadir una firma, haga clic en el símbolo de engranaje en la parte superior, y después en`Opciones`{.action}.
+Para añadir una firma electrónica, haga clic en el icono del engranaje en la parte superior y, a continuación, en `Opciones`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-En la barra de la izquierda de la página nueva, haga clic en `Firma de correo electrónico`{.action}. En el árbol de opciones, este elemento se encuentra en «Correo», en «Disposición». En esta sección puede activar, desactivar y editar la firma.
+En el lado izquierdo de la nueva página, haga clic en `Firma de correo electrónico`{.action}. En las opciones del árbol, este elemento se encuentra en "Correo" y "Diseño". Desde ahí, puede activar, desactivar y modificar la firma.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Introduzca su firma electrónica en el cuadro de edición. Puede especificar si quiere incluir la firma por defecto solo en los correos nuevos o también en respuestas o correos reenviados. Una vez haya terminado, haga clic en `Guardar`{.action} para confirmar.
+Componga su firma electrónica en el cuadro del editor. Puede especificar si desea incluir la firma por defecto solo en los correos nuevos o también en las respuestas y los correos reenviados. Una vez haya terminado, haga clic en `Guardar`{.action} para confirmar.
 
-Para obtener instrucciones sobre la creación de firmas automáticas mediante el uso de plantillas para todos los dominios, consulte nuestra guía: [Creación de firmas automáticas]/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
+Para obtener instrucciones sobre la creación de firmas automáticas mediante plantillas para todo el dominio, consulte nuestra guía: [Crear firmas automáticas](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
 
-### Acceder a la sección de opciones
+### Acceder a la sección Opciones
 
-Para acceder a todos los ajustes, haga clic en el símbolo de engranaje en la parte superior, y después en`Opciones`{.action}.
+Para acceder a todos sus parámetros, haga clic en el icono del engranaje en la parte superior y, a continuación, en `Opciones`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Puede navegar por el árbol de «Opciones» de la parte izquierda de la página. Desde esta sección podrá realizar más ajustes en cuanto a la disposición y comportamiento de su cuenta de correo electrónico. Tenga en cuenta que algunas de las opciones de la cuenta pueden estar desactivadas por nuestra parte por razones de seguridad.
+Después puede navegar por el árbol "Opciones" en el lado izquierdo de la página. Desde esta página pueden realizarse otros ajustes sobre la presentación y el comportamiento de su cuenta de correo electrónico. Tenga en cuenta que, por motivos de seguridad, OVHcloud puede haber desactivado algunas opciones de la cuenta.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Gestión de cookies
 
-El webmail utilizado para nuestros productos de correo está basado en el programa Microsoft Outlook Web App. por lo que es susceptible de intercambiar metadatos con los servidores de Microsoft, en forma de cookies llamadas `appsforoffice.microsoft.com`.
+El webmail utilizado para nuestras ofertas de correo se basa en el software Microsoft Outlook Web App. Por lo tanto, es susceptible de intercambiar metadatos con los servidores de Microsoft, en forma de cookies denominadas `appsforoffice.microsoft.com`.
 
 Si desea desactivar estos intercambios, puede utilizar en su navegador una extensión de tipo bloqueador de contenidos (como uBlock Origin o Ghostery).
 No obstante, la desactivación de estas cookies puede afectar a la estabilidad de su webmail.
@@ -221,10 +240,10 @@ No obstante, la desactivación de estas cookies puede afectar a la estabilidad d
 
 [Crear respuestas automáticas en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
 
-[Compartir carpetas en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+[Compartir una carpeta desde la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
 
-[Compartir calendarios en OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
+[Compartir calendarios a través de la interfaz OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
-[Crear grupos de contactos](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
+[Crear un grupo de contactos](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
 
 Interactúe con nuestra [comunidad de usuarios](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: 'Utiliser son adresse e-mail depuis le webmail Outlook Web App (OWA)'
 excerpt: 'Découvrez comment utiliser votre adresse e-mail depuis le webmail OWA'
-updated: 2026-03-24
+updated: 2026-05-04
 ---
 
 ## Objectif
@@ -12,20 +12,22 @@ Avec les solutions e-mail OVHcloud, vous pouvez envoyer et recevoir vos e-mails 
 
 ## Prérequis
 
-- Disposer d'une solution e-mail OVHcloud, proposée parmi nos [offres d’hébergement web](/links/web/hosting) ou commandée séparément comme solution autonome telle que [**Hosted Exchange**](/links/web/emails-hosted-exchange)
-- Connaître les identifiants de connexion de l’adresse e-mail que vous souhaitez configurer
+- Disposer d'une solution e-mail OVHcloud configurée au préalable, parmi les offres suivantes :
+    - [**MX Plan**](/links/web/hosting), proposée avec nos offres d'hébergement web ou commandée comme solution autonome ;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange).
+- Connaître les identifiants de connexion de l’adresse e-mail à utiliser.
 
 ## En pratique
 
-Ce guide vous permettra de mieux comprendre les tâches habituelles disponibles dans un compte de messagerie sous OWA. Cependant, comme cette interface n'a pas été créée à l'origine par OVHcloud, nous ne pouvons pas fournir des instructions spécifiques sur les paramètres non abordés dans ce guide.
+Ce guide vous permettra de mieux comprendre les tâches habituelles disponibles dans un compte de messagerie sous OWA. Cependant, comme cette interface n'a pas été créée à l'origine par OVHcloud, nous ne pouvons pas fournir des instructions spécifiques sur des paramètres non abordés dans ce guide.
 
-Concernant les fonctionnalités spécifiques à Exchange, vous pourrez retrouver quelques guides supplémentaires dans la section [Aller plus loin](./#aller-plus-loin_1) en bas de ce guide.
+Concernant les fonctionnalités spécifiques à Exchange, vous pourrez retrouver quelques guides supplémentaires dans la section [Aller plus loin](./#aller-plus-loin) en bas de ce guide.
 
 > [!primary]
 >
-> Après les deux premières étapes, il n'est pas nécessaire de suivre les instructions dans l'ordre donné.
+> Après la connexion et la prise en main de l'interface, il n'est pas nécessaire de suivre les instructions dans l'ordre donné.
 
-### Étape 1 : Se connecter à OWA
+### Se connecter à OWA
 
 Pour vous connecter à OWA avec votre adresse e-mail, ouvrez la page de [connexion au webmail](/links/web/email). Saisissez entièrement votre adresse e-mail et votre mot de passe. Ensuite, cliquez sur `Connexion`{.action}.
 
@@ -35,7 +37,7 @@ Si c'est la première fois que vous vous connectez à OWA avec cette adresse e-m
 
 > [!primary]
 >
-> Les fuseaux horaires sont listés selon [la norme UTC (temps universel coordonné)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), et non par ordre alphabétique des villes.
+> Les fuseaux horaires sont listés selon [la norme UTC (temps universel coordonné)](https://fr.wikipedia.org/wiki/Temps_universel_coordonn%C3%A9), et non par ordre alphabétique des villes.
 >
 > **Exemple** : Pour l'Europe de l'Ouest, il s'agit de UTC +1 (Bruxelles, Copenhague, Madrid, Paris).
 
@@ -45,7 +47,7 @@ Dorénavant, votre boîte de réception apparaîtra par défaut dès que vous se
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### Étape 2 : Comprendre l’affichage d’OWA
+### Comprendre l’affichage d’OWA
 
 L'interface OWA comporte plusieurs sections. Veuillez vous référer au tableau et à l'image ci-dessous pour vous familiariser avec celle-ci.
 
@@ -66,17 +68,27 @@ Pour consulter vos e-mails, sélectionnez un dossier sur le côté gauche. Les e
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-Pour lire un e-mail, sélectionnez son dossier si nécessaire. Cliquez ensuite sur l’e-mail pour afficher son contenu dans le coin de lecture. Une couleur différente est utilisée pour les messages non lus afin de les distinguer de ceux qui ont été lus.
+Pour lire un e-mail, sélectionnez son dossier si nécessaire. Cliquez ensuite sur l’e-mail pour afficher son contenu dans le volet de lecture. Les messages non lus apparaissent en gras pour les distinguer des messages lus.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Trier et filtrer les e-mails
+
+En haut à droite de la liste des messages, le bouton `Filtrer`{.action} ouvre un menu qui regroupe toutes les options d'affichage du dossier sélectionné.
+
+- **Filtrer par catégorie** : sélectionnez une entrée pour n'afficher qu'une sélection d'e-mails parmi `Tout`{.action}, `Non lu`{.action}, `À moi`{.action} (e-mails adressés directement à votre adresse), `Avec indicateur`{.action} (e-mails signalés pour le suivi) ou `Mentions`{.action} (e-mails dans lesquels votre adresse est mentionnée).
+
+- **Trier par** : survolez l'entrée `Trier par`{.action} pour choisir le critère de classement des e-mails : **Date**, **De**, **À**, **Objet**, **Pièces jointes**, **Importance** ou **Taille**. La flèche à gauche du critère indique l'ordre courant ; cliquez à nouveau sur le même critère pour l'inverser.
+
+- **Afficher comme** : survolez l'entrée `Afficher comme`{.action} pour basculer entre l'affichage **Messages** (un e-mail par ligne) ou **Conversations** (e-mails regroupés par fil de discussion).
+
 ### Envoyer et répondre
 
-Pour **envoyer un nouveau message**, cliquez sur l'icône `Nouveau`{.action} en haut de l'interface du webmail. Le volet d’édition apparaîtra sur le côté droit. Remplissez les champs de votre e-mail (destinataires, objet, corps du message, pièces jointes). Dès que vous êtes prêt à l'envoyer, cliquez sur `Envoyer`{.action}.
+Pour **envoyer un nouveau message**, cliquez sur l'icône `Nouveau`{.action} en haut de l'interface OWA. Le volet d’édition apparaîtra sur le côté droit. Remplissez les champs de votre e-mail (destinataires, objet, corps du message, pièces jointes). Cliquez sur `Envoyer`{.action} une fois votre e-mail rédigé.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-Pour **répondre à un message**, [cliquez d'abord](./#afficher-les-e-mails) sur celui-ci pour l'afficher. Cliquez ensuite sur `Répondre à tous`{.action}. Par contre, utilisez le bouton flèche vers le bas si vous souhaitez uniquement répondre à l'expéditeur de l’e-mail (excluant tout destinataire mis en copie).
+Pour **répondre à un message**, cliquez d'abord sur celui-ci pour l'afficher. Cliquez ensuite sur `Répondre à tous`{.action} pour répondre à l'ensemble des destinataires. Utilisez le bouton flèche vers le bas si vous souhaitez uniquement répondre à l'expéditeur de l’e-mail (excluant tout destinataire mis en copie), cliquez sur `Répondre`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
@@ -90,7 +102,8 @@ OWA propose plusieurs façons d'organiser votre messagerie. Vous pouvez :
 
 - [créer des dossiers et des sous-dossiers](./#creer-un-dossier),
 - [déplacer des e-mails](./#deplacer-des-e-mails),
-- [définir des règles](./#creer-des-regles-de-gestion-de-la-messagerie) afin d’effectuer automatiquement des actions dès la réception d'un nouvel e-mail.
+- [définir des règles](./#creer-des-regles-de-gestion-de-la-messagerie) afin d’effectuer automatiquement des actions dès la réception d'un nouvel e-mail,
+- [bloquer un expéditeur](./#bloquer-un-expediteur) pour ne plus recevoir ses messages.
 
 #### Créer un dossier
 
@@ -101,7 +114,7 @@ Pour créer un nouveau dossier, faites un clic droit sur le nom de votre adresse
 #### Déplacer des e-mails
 
 Pour **déplacer un e-mail**, vous pouvez simplement le glisser-déposer dans le dossier cible ou faire un clic droit et sélectionner `Déplacer`{.action}.
-Pour simultanément **déplacer plusieurs e-mails**, sélectionnez les tous grâce à leur case à cocher. Ensuite cliquez sur  `Déplacer`{.action} (sur le coté droit) ou sur `Déplacer vers`{.action} (dans la section supérieure). Choisissez ensuite le dossier de destination.
+Pour simultanément **déplacer plusieurs e-mails**, sélectionnez-les tous grâce à leur case à cocher. Ensuite, cliquez sur `Déplacer`{.action} (sur le côté droit) ou sur `Déplacer vers`{.action} (dans la section supérieure). Choisissez ensuite le dossier de destination.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
@@ -129,25 +142,29 @@ Pour des instructions plus détaillées sur la création des règles de gestion 
 
 <iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Cliquez sur l'icône de l'engrenage en haut à droite, puis cliquez sur `Options`{.action}. Toujours dans la colonne de gauche, parcourez l'arborescence "Courrier" sous "Comptes", puis "Bloquer ou autoriser".
+Cliquez sur l'icône de l'engrenage en haut à droite, puis cliquez sur `Options`{.action}. Toujours dans la colonne de gauche, parcourez l'arborescence « Courrier » sous « Comptes », puis « Bloquer ou autoriser ».
 
 Dans la section « **Expéditeurs bloqués** », tapez une adresse e-mail ou un nom de domaine à bloquer, puis cliquez sur le bouton `+`{.action} pour l'ajouter dans la liste.
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Gérer une liste de contacts
+### Gérer vos contacts
 
-Pour gérer vos contacts, cliquez d’abord sur le bouton bleu du « App launcher » en haut de la page, ensuite sur `Contacts`{.action}.
+Pour gérer vos contacts, cliquez d’abord sur le bouton bleu du lanceur d’applications en haut à gauche de la page (qui donne également accès au calendrier, aux tâches et à d’autres modules), puis sur `Contacts`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
 Dans la nouvelle page, vous pouvez ajouter un nouveau contact, créer une liste de contacts et supprimer des contacts existants.
 
-Pour **ajouter un nouveau contact**, cliquez sur `Nouveau`{.action}, et introduisez les coordonnées du contact à ajouter. Une fois cela fait, cliquez sur `Enregistrer`{.action}.
+#### Ajouter un contact
+
+Cliquez sur `Nouveau`{.action}, puis saisissez les coordonnées du contact à ajouter. Une fois cela fait, cliquez sur `Enregistrer`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-Pour **créer une liste de contacts**, cliquez sur la flèche vers le bas à côté de « Nouveau », puis cliquez sur `Liste de contacts`{.action}. Donnez-lui un nom, ajoutez-y des contacts et cliquez sur `Enregistrer`{.action}.
+#### Créer une liste de contacts
+
+Cliquez sur la flèche vers le bas à côté de `Nouveau`{.action}, puis sur `Liste de contacts`{.action}. Donnez-lui un nom, ajoutez-y des contacts et cliquez sur `Enregistrer`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
@@ -167,8 +184,7 @@ Dans la nouvelle fenêtre qui s'ouvre, entrez votre mot de passe actuel. Saisiss
 
 > [!primary]
 >
-> N'oubliez pas d’enter votre nouveau mot de passe sur tous vos appareils utilisés pour accéder à ce compte (par exemple dans le logiciel client de messagerie). En cas de difficultés avec votre mot de passe, contactez votre administrateur de services.
->
+> N'oubliez pas d’entrer votre nouveau mot de passe sur tous vos appareils utilisés pour accéder à ce compte (par exemple dans le logiciel client de messagerie). En cas de difficultés avec votre mot de passe, contactez votre administrateur de services.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
@@ -183,11 +199,11 @@ Dans la fenêtre qui s’ouvre, sélectionnez l’option « Envoyer des réponse
 - envoyer des e-mails de réponse automatique pendant un intervalle de temps fixe, ou en continu jusqu'à ce qu'il soit désactivé manuellement
 - définir les expéditeurs qui recevront les e-mails de réponse automatique (expéditeurs internes uniquement, ou inclure les expéditeurs externes)
 
-Remplissez les informations demandées en fonction de la tâche que vous voudrez effectuer grâce à cette règle. Une fois cela fait, cliquez sur OK.
+Remplissez les informations demandées en fonction de la tâche que vous voudrez effectuer grâce à cette règle. Une fois cela fait, cliquez sur `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-Pour des instructions plus détaillées sur la création des règles de gestion de messagerie, veuillez vous référer à notre guide : [Créer un répondeur automatique sous OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
+Pour des instructions plus détaillées sur la création de réponses automatiques, veuillez vous référer à notre guide : [Créer un répondeur automatique sous OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Ajouter une signature
 
@@ -227,5 +243,7 @@ La désactivation de ces cookies peut néanmoins affecter la stabilité de votre
 [Partager un dossier depuis l’interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
 
 [Partager des calendriers via l’interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
+
+[Créer un groupe de contacts](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
 
 Échangez avec notre [communauté d'utilisateurs](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: 'Utiliser son adresse e-mail depuis le webmail Outlook Web App (OWA)'
 excerpt: 'Découvrez comment utiliser votre adresse e-mail depuis le webmail OWA'
-updated: 2026-03-24
+updated: 2026-05-04
 ---
 
 ## Objectif
@@ -44,7 +44,7 @@ Si c'est la première fois que vous vous connectez à OWA avec cette adresse e-m
 
 > [!primary]
 >
-> Les fuseaux horaires sont listés selon [la norme UTC (temps universel coordonné)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), et non par ordre alphabétique des villes.
+> Les fuseaux horaires sont listés selon [la norme UTC (temps universel coordonné)](https://fr.wikipedia.org/wiki/Temps_universel_coordonn%C3%A9), et non par ordre alphabétique des villes.
 >
 > **Exemple** : Pour l'Europe de l'Ouest, il s'agit de UTC +1 (Bruxelles, Copenhague, Madrid, Paris).
 

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.it-it.md
@@ -1,236 +1,256 @@
 ---
-title: 'Utilizzare un account di posta da "Outlook on the web"'
-excerpt: 'Come gestire il tuo indirizzo email dalla Webmail "Outlook on the web"'
-updated: 2026-03-24
+title: 'Utilizzare il proprio indirizzo e-mail dalla webmail Outlook Web App (OWA)'
+excerpt: 'Scopri come utilizzare il tuo indirizzo e-mail dalla webmail OWA'
+updated: 2026-05-04
 ---
 
 ## Obiettivo
 
-Con le soluzioni email OVHcloud puoi inviare e ricevere le tue email utilizzando il dispositivo e il client che preferisci. Per accedere a un account da qualsiasi luogo mediante un browser Web, OVHcloud fornisce il client di posta elettronica online Outlook Web App (OWA). La nostra pagina di accesso alla [Webmail](/links/web/email) è l’unico punto di accesso alla relativa OWA per tutti gli account email attivi su MX Plan, Email Pro e Hosted Exchange.
+Con le soluzioni e-mail OVHcloud, puoi inviare e ricevere le tue e-mail da un dispositivo e da un client di tua scelta. OVHcloud fornisce un servizio di posta elettronica online chiamato Outlook Web App (OWA) che consente, tramite un browser web, di accedere a un account da qualsiasi luogo. Tutti gli account di posta attivi su MX Plan, Email Pro e Hosted Exchange dispongono di un unico punto di accesso all'interfaccia OWA corrispondente: la nostra pagina di [accesso alla webmail](/links/web/email).
 
-**Questa guida spiega come eseguire azioni di carattere generale con il tuo indirizzo email nell’interfaccia OWA.**
+**Questa guida illustra come eseguire le azioni più comuni con il tuo indirizzo e-mail dall'interfaccia OWA.**
 
 ## Prerequisiti
 
-- Disporre di una soluzione di posta elettronica OVHcloud attiva (**MX Plan**, disponibile come parte dei nostri piani di [hosting Web](/links/web/hosting), inclusi in un [hosting gratuito 100M](/links/web/domains-free-hosting) oppure ordinato separatamente con una soluzione indipendente; [**Hosted Exchange**](/links/web/emails-hosted-exchange) o ancora [**Email Pro**](/links/web/email-pro))
-- Credenziali di accesso all’account di posta elettronica da configurare
+- Disporre di una soluzione e-mail OVHcloud preconfigurata, tra le seguenti offerte:
+    - [**MX Plan**](/links/web/hosting), proposta con le nostre offerte di hosting web, inclusa nell'[hosting gratuito 100M](/links/web/domains-free-hosting) o ordinata come soluzione autonoma;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange);
+    - [**Email Pro**](/links/web/email-pro).
+- Conoscere le credenziali di accesso dell'indirizzo e-mail da utilizzare.
 
 ## Procedura
 
-Questa guida ti consentirà di comprendere meglio quello che è possibile ottenere con la Webmail OWA. Tuttavia, dal momento che questa interfaccia non è stata originariamente creata da OVHcloud, non siamo in grado di fornire istruzioni specifiche sulle impostazioni non specificate in questa guida. Riguardo alle funzionalità di Exchange, abbiamo preparato alcune guide supplementari che puoi trovare nella sezione [**Per saperne di più**](./#per-saperne-di-piu_1) di seguito.
+Questa guida ti permette di comprendere meglio le attività più comuni disponibili in un account di posta su OWA. Tuttavia, poiché questa interfaccia non è stata creata originariamente da OVHcloud, non possiamo fornire istruzioni specifiche su parametri non trattati in questa guida.
+
+Per quanto riguarda le funzionalità specifiche di Exchange, puoi consultare alcune guide aggiuntive nella sezione [Per saperne di più](./#per-saperne-di-piu) in fondo a questa guida.
 
 > [!primary]
 >
-> Dopo i primi due passaggi la procedura non deve essere seguita con un particolare ordine.
+> Dopo aver effettuato l'accesso e preso confidenza con l'interfaccia, non è necessario seguire le istruzioni nell'ordine indicato.
 
-### 1. Accedere alla Webmail OWA
+### Connettersi a OWA
 
-Per accedere alla Webmail OWA con il tuo indirizzo email, vai alla pagina generale di login [della Webmail](/links/web/email). Digita il tuo indirizzo email e la tua password, quindi clicca sul pulsante `Login`{.action}.
+Per connetterti a OWA con il tuo indirizzo e-mail, apri la pagina di [accesso alla webmail](/links/web/email). Inserisci l'indirizzo e-mail completo e la password. Quindi, clicca su `Connessione`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
 > [!warning]
 >
-> Se vieni reindirizzato su un’interfaccia **Roundcube**, significa che sei sulla versione storica dell’offerta MX Plan. Per maggiori informazioni sulla soluzione MX Plan, consulta la pagina [Iniziare a utilizzare la soluzione MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+> Se vieni reindirizzato su un'interfaccia **Roundcube**, significa che ti trovi sulla versione storica dell'offerta MX Plan. Per maggiori informazioni sulla tua offerta MX Plan, consulta la nostra pagina [Iniziare a utilizzare la soluzione MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 >
-> Per familiarizzare con l'interfaccia **Roundcube**, consulta la nostra guida [Webmail: guida all’utilizzo di Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+> Per familiarizzare con l'interfaccia **Roundcube**, consulta la nostra guida [Utilizzare il proprio indirizzo e-mail dalla webmail Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
 
-Se è la prima volta che ti connetti a OWA con questo indirizzo email, ti verrà chiesto di impostare la lingua dell’interfaccia utente e definire il fuso orario. Clicca su `Salva`{.action} per continuare.
+Se è la prima volta che ti connetti a OWA con questo indirizzo e-mail, ti verrà chiesto di impostare la lingua dell'interfaccia e il fuso orario. Quindi, clicca su `Salva`{.action} per continuare.
 
 > [!primary]
 >
-> I fusi orari sono elencati secondo [la norma UTC (Coordinated Universal Time)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png) e non in ordine alfabetico di città.
+> I fusi orari sono elencati secondo [la norma UTC (tempo coordinato universale)](https://it.wikipedia.org/wiki/Tempo_coordinato_universale), e non in ordine alfabetico delle città.
 >
-> **Esempio** : Per l'Europa occidentale, si tratta di UTC +1 (Bruxelles, Copenaghen, Madrid, Parigi).
+> **Esempio**: per l'Europa occidentale si tratta di UTC +1 (Bruxelles, Copenaghen, Madrid, Parigi).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-Da questo momento, dopo il login apparirà per default la tua casella di posta in arrivo.
+D'ora in poi, la tua casella di posta in arrivo apparirà come impostazione predefinita non appena effettui l'accesso.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. La visualizzazione della Webmail OWA
+### Comprendere la visualizzazione di OWA
 
-L’interfaccia della Webmail OWA ha diverse sezioni. Fai riferimento alla tabella e all’immagine di seguito per approfondirne la conoscenza.
+L'interfaccia OWA è composta da diverse sezioni. Fai riferimento alla tabella e all'immagine seguenti per familiarizzare con essa.
 
-|Parti|Descrizione|
-|---|---|
-|Sezione superiore (1)|Presenta due barre delle schede: la prima consente di accedere alle impostazioni generali (come la [sezione delle opzioni](./#accedere-alla-sezione-delle-opzioni)), mentre la seconda può essere utilizzata per l’esecuzione di azioni specifiche utilizzando il tuo indirizzo (come inviare email o rispondervi).|
-|Lato sinistro (2)|Visualizza l’elenco di cartelle del tuo indirizzo email. Le cartelle appaiono con una visualizzazione ad albero che puoi espandere o ridurre.|
-|Segmento centrale (3)|Visualizza l’elenco dei messaggi (letti e non letti) della cartella selezionata dal menu a sinistra. Questa sezione può anche visualizzare i risultati di una ricerca.|
-|Lato destro (4)|Visualizza il riquadro di lettura della email selezionata.|
+|Sezioni|Descrizione|  
+|---|---|  
+|Sezione superiore (1)|Comprende due barre di schede: la prima consente di accedere alle impostazioni generali (come la [sezione Opzioni](./#accedere-alla-sezione-opzioni)). La seconda barra può essere utilizzata per azioni specifiche con il tuo indirizzo (come l'invio o la risposta alle e-mail).|  
+|Lato sinistro (2)|Visualizza l'elenco delle cartelle del tuo indirizzo e-mail. Queste cartelle si presentano sotto forma di una struttura ad albero che puoi espandere o nascondere.|
+|Sezione centrale (3)|Visualizza l'elenco dei messaggi (letti e non letti) della cartella selezionata nel menu a sinistra. Questa sezione può anche visualizzare i risultati delle ricerche.|
+|Lato destro (4)|Visualizza il riquadro di lettura quando viene selezionata un'e-mail.|
 
 ![useowa](images/use-owa-step4.png){.thumbnail}
 
-Notare che è possibile modificare le dimensioni delle sezioni verticali cliccando e trascinando le loro linee dei bordi.
+Nota che puoi modificare le dimensioni delle sezioni verticali cliccando e trascinando le linee dei loro bordi.
 
-### Visualizzazione delle email
+### Visualizzare le e-mail
 
-Per visualizzare le email, seleziona una cartella sul lato sinistro. Le email in arrivo che non vengono elaborate da regole di posta in arrivo finiscono nella cartella “Posta in arrivo”. Per verificare se hai ricevuto delle nuove email, controlla se appare un numero accanto alla rispettiva cartella.
+Per consultare le tue e-mail, seleziona una cartella sul lato sinistro. Le e-mail in arrivo che non vengono elaborate dalle regole di posta vengono visualizzate nella cartella "Posta in arrivo". Per sapere se hai ricevuto nuove e-mail, controlla se appare un numero accanto alla cartella corrispondente.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-Per leggere una email, seleziona la relativa cartella, se necessario. Ora clicca sulla email per visualizzarne il contenuto nella sezione di lettura. I messaggi non letti appaiono in colore diverso, per distinguerli da quelli già letti.
+Per leggere un'e-mail, seleziona la sua cartella se necessario. Quindi clicca sull'e-mail per visualizzarne il contenuto nel riquadro di lettura. I messaggi non letti appaiono in grassetto per distinguerli da quelli già letti.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
-### Inviare messaggi e risposte
+### Ordinare e filtrare le e-mail
 
-**Per inviare una email**, clicca sul pulsante `Nuovo`{.action} sulla parte superiore dell’interfaccia della Webmail. Sul lato sinistro appare il riquadro di modifica. Compila i campi della tua email (destinatari, oggetto, corpo del messaggio, allegati). Quando sei pronto a inviare, clicca sul pulsante `Invia`{.action}.
+In alto a destra dell'elenco dei messaggi, il pulsante `Filtro`{.action} apre un menu che raggruppa tutte le opzioni di visualizzazione della cartella selezionata.
+
+- **Filtra per categoria**: seleziona una voce per visualizzare solo una selezione di e-mail tra `Tutto`{.action}, `Non letto`{.action}, `A me`{.action} (e-mail indirizzate direttamente al tuo indirizzo), `Con contrassegno`{.action} (e-mail contrassegnate per il completamento) o `Menzioni`{.action} (e-mail in cui è menzionato il tuo indirizzo).
+
+- **Ordina per**: passa il cursore sulla voce `Ordina per`{.action} per scegliere il criterio di ordinamento delle e-mail: **Data**, **Da**, **A**, **Oggetto**, **Allegati**, **Importanza** o **Dimensioni**. La freccia a sinistra del criterio indica l'ordine corrente; clicca nuovamente sullo stesso criterio per invertirlo.
+
+- **Visualizza come**: passa il cursore sulla voce `Visualizza come`{.action} per passare dalla visualizzazione **Messaggi** (un'e-mail per riga) a **Conversazioni** (e-mail raggruppate per conversazione).
+
+### Inviare e rispondere
+
+Per **inviare un nuovo messaggio**, clicca sull'icona `Nuovo`{.action} in alto nell'interfaccia OWA. Il riquadro di composizione apparirà sul lato destro. Compila i campi della tua e-mail (destinatari, oggetto, corpo del messaggio, allegati). Clicca su `Invia`{.action} una volta redatta l'e-mail.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**Per rispondere a una email**, [prima cliccaci sopra](./#visualizzazione-delle-email) per visualizzarla. Quindi clicca sul pulsante `Rispondi a tutti`{.action}. Usa invece il pulsante freccia in giù se desideri solo rispondere al mittente della email (escludendo eventuali destinatari in copia).
+Per **rispondere a un messaggio**, cliccaci prima sopra per visualizzarlo. Quindi clicca su `Rispondi a tutti`{.action} per rispondere a tutti i destinatari. Utilizza il pulsante con la freccia verso il basso se desideri rispondere solo al mittente dell'e-mail (escludendo eventuali destinatari in copia), clicca su `Rispondi`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-Quando scegli di rispondere, al di sopra della email apparirà l’editor per risposta rapida. Componi qui la tua risposta, e al termine invia l’email, cliccando su `Invia`{.action}. Nota che per tutte le opzioni di risposta (ex. l’aggiunta di una firma) è necessario estendere il riquadro a tutte le funzionalità, facendo clic sul simbolo con la doppia freccia.
+Quando scegli di rispondere, l'editor di risposta rapida apparirà sopra l'e-mail. Componi qui la tua risposta e, non appena sei pronto a inviare il messaggio, clicca su `Invia`{.action}. Nota che per ciascuna opzione di risposta (come l'aggiunta di una firma) è necessario prima estenderla all'intero pannello di composizione cliccando sul simbolo della doppia freccia.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
-### Organizzare la casella di posta in arrivo
+### Organizzare la propria casella di posta
 
-La Webmail OWA fornisce diverse modalità per organizzare la tua casella di posta in arrivo. Puoi
+OWA propone diverse modalità per organizzare la tua casella di posta. Puoi:
 
-- [creare cartelle e sottocartelle](./#creare-una-cartella)
-- [spostare email](./#spostare-email)
-- [impostare regole](./#creare-regole-di-posta-in-arrivo) in modo che vengano eseguite automaticamente determinate azioni quando si riceve una email
+- [creare cartelle e sottocartelle](./#creare-una-cartella),
+- [spostare le e-mail](./#spostare-le-e-mail),
+- [definire regole](./#creare-regole-di-gestione-della-posta) per eseguire automaticamente azioni alla ricezione di una nuova e-mail,
+- [bloccare un mittente](./#bloccare-un-mittente) per non ricevere più i suoi messaggi.
 
 #### Creare una cartella
 
-Per creare una nuova cartella, clicca con il tasto destro sul nome del tuo indirizzo email nel menu delle cartelle e quindi scegli `Crea nuova cartella`{.action}. Allo stesso modo puoi creare una sottocartella nelle cartelle esistenti (`Crea nuova sottocartella`{.action}).
+Per creare una nuova cartella, fai clic con il tasto destro sul nome del tuo indirizzo e-mail nella struttura ad albero delle cartelle, quindi scegli `Crea nuova cartella`{.action}. Puoi creare una sottocartella in cartelle esistenti allo stesso modo cliccando su `Crea nuova sottocartella`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
-#### Spostare email
+#### Spostare le e-mail
 
-**Per spostare una email**, puoi semplicemente trascinarla nella cartella di destinazione o cliccare con il tasto destro e selezionare `Sposta`{.action}.
-**Per spostare più email** insieme, selezionale spuntando le apposite caselle, quindi clicca su `Sposta`{.action} (sul lato destro) oppure `Sposta in`{.action} (nella sezione superiore). Quindi scegli la cartella di destinazione.
+Per **spostare un'e-mail**, puoi semplicemente trascinarla nella cartella di destinazione oppure fare clic con il tasto destro e selezionare `Sposta`{.action}.
+Per **spostare più e-mail** contemporaneamente, selezionale tutte tramite la relativa casella di controllo. Quindi clicca su `Sposta`{.action} (sul lato destro) o su `Sposta in`{.action} (nella sezione superiore). Scegli quindi la cartella di destinazione.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
-#### Creare regole di posta in arrivo
+#### Creare regole di gestione della posta
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Per gestire regole, clicca sull’icona con l’ingranaggio, in alto, quindi su `Opzioni`{.action}.
+Per creare e gestire le regole, clicca prima sull'icona a forma di ingranaggio in alto, quindi su `Opzioni`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Sulla nuova pagina che appare, clicca su `Regole di posta in arrivo e di organizzazione`{.action} nel menù a sinistra. Nella visualizzazione ad albero delle "Opzioni", puoi trovare questa voce in "Posta", quindi "Elaborazione automatica". Da qui, puoi creare, modificare, cancellare e spostare regole nell’elenco.
+Nella nuova pagina che si apre, clicca su `Regole della posta in arrivo e di archiviazione`{.action} che si trova nel menu a sinistra. Nella struttura ad albero "Opzioni" puoi trovare questa funzionalità in "Posta", sotto "Elaborazione automatica". Da qui puoi creare, modificare e spostare le regole nell'elenco.
 
 Per aggiungere una nuova regola, clicca sul pulsante `+`{.action}.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Compila con le informazioni richieste a seconda dell’azione che desideri venga compiuta dalla regola. Quindi, clicca su `OK`{.action}.
+Inserisci le informazioni richieste in base all'attività che vuoi eseguire con questa regola. Quindi clicca su `OK`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-Per istruzioni più dettagliate sulla creazione di regole di posta in arrivo, fai riferimento alla nostra guida: [Creare regole di posta in arrivo in OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+Per istruzioni più dettagliate sulla creazione di regole di gestione della posta, consulta la nostra guida: [Creazione di regole di gestione della posta su OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-#### Blocca un mittente
+#### Bloccare un mittente
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/UeNdpFwdXm0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Clicca sull'icona dell'ingranaggio in alto a destra e poi su `Opzioni`{.action}. Sempre nella colonna di sinistra, clicca su "Posta" sotto "Account" e poi "Blocca o autorizza".
+Clicca sull'icona dell'ingranaggio in alto a destra, quindi clicca su `Opzioni`{.action}. Sempre nella colonna di sinistra, sfoglia la struttura ad albero "Posta" sotto "Account", quindi "Blocca o autorizza".
 
-Nella sezione "**Mittenti bloccati**", inserisci un indirizzo email o un dominio da bloccare e clicca sul pulsante `+`{.action} per aggiungerlo nella lista.
+Nella sezione "**Mittenti bloccati**", digita un indirizzo e-mail o un nome di dominio da bloccare, quindi clicca sul pulsante `+`{.action} per aggiungerlo all'elenco.
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Gestire una lista di contatti
+### Gestire i contatti
 
-Per gestire i tuoi contatti, clicca sul pulsante "app launcher" blu in alto, quindi clicca su `Persone`{.action}.
+Per gestire i tuoi contatti, clicca prima sul pulsante blu di avvio applicazioni in alto a sinistra della pagina (che dà accesso anche al calendario, alle attività e ad altri moduli), quindi su `Contatti`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-Sulla nuova pagina, puoi aggiungere un nuovo contatto, creare un elenco di contatti e rimuovere contatti esistenti.
+Nella nuova pagina puoi aggiungere un nuovo contatto, creare un elenco di contatti ed eliminare contatti esistenti.
 
-**Per aggiungere un nuovo contatto**, clicca su `Nuovo`{.action}, e digita i dettagli del contatto che desideri aggiungere. Al termine, clicca su `Salva`{.action}.
+#### Aggiungere un contatto
+
+Clicca su `Nuovo`{.action}, quindi inserisci i dati del contatto da aggiungere. Una volta fatto, clicca su `Salva`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**Per creare un elenco di contatti**, clicca sul pulsante con la freccia in giù accanto a "Nuovo", quindi clicca su `Elenco di contatti`{.action}. Assegna un nome, aggiungi i contatti e quindi clicca su `Salva`{.action}.
+#### Creare un elenco di contatti
+
+Clicca sulla freccia verso il basso accanto a `Nuovo`{.action}, quindi su `Elenco contatti`{.action}. Assegna un nome, aggiungi i contatti e clicca su `Salva`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
 ### Modificare la password
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Puoi modificare la password del tuo account dopo aver effettuato l’accesso a OWA. Per farlo, clicca sull’icona con l’ingranaggio in alto, quindi clicca su `Opzioni`{.action}.
+Puoi modificare la password del tuo account quando sei connesso a OWA. Per farlo, clicca sull'icona a forma di ingranaggio in alto, quindi clicca su `Opzioni`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Sulla nuova pagina, espandi la scheda "Generale" nell’albero sul lato sinistro, quindi clicca su `Il mio account`{.action}. Infine, clicca su `Modifica password`{.action}.
+Nella nuova pagina, espandi la scheda "Generale" nella struttura ad albero a sinistra, quindi clicca su `Il mio account`{.action}. Infine, clicca su `Modifica password`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-Nella nuova finestra popup che appare, digita la tua password attuale. Digita una nuova password, digitala nuovamente e infine conferma. Clicca sul pulsante `Salva`{.action} per salvare la nuova password.
+Nella nuova finestra che si apre, inserisci la tua password attuale. Inserisci poi una nuova password, quindi confermala digitandola di nuovo. Clicca su `Salva`{.action} per salvare la nuova password.
 
 > [!primary]
 >
-> Ricorda di digitare la tua nuova password in ogni dispositivo, cioè ogni client email utilizzato per accedere a questo account. In caso di problemi con la tua password, contatta l’amministratore del servizio.
+> Non dimenticare di inserire la tua nuova password su tutti i dispositivi utilizzati per accedere a questo account (ad esempio nel client di posta). In caso di difficoltà con la tua password, contatta l'amministratore dei servizi.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
-### Aggiungere una risposta automatica
+### Aggiungere la risposta automatica
 
-In OWA, puoi impostare una risposta automatica sul tuo indirizzo email per non lasciare email senza risposta durante lunghe assenze. Per farlo, clicca sull’icona con l’ingranaggio in alto, quindi clicca su `Risposte automatiche`{.action}.
+Su OWA puoi creare un risponditore automatico nella tua casella di posta per non lasciare le e-mail senza risposta durante le tue assenze. Per farlo, clicca sull'icona dell'ingranaggio in alto, quindi clicca su `Risposte automatiche`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-Nella finestra che appare, seleziona l’opzione “Invia risposte automatiche”. Quindi puoi impostare il risponditore automatico in modo che rispetti diversi criteri:
+Nella finestra che si apre, seleziona l'opzione "Invia risposte automatiche". Puoi quindi configurare il risponditore automatico in modo che risponda a diversi criteri, ad esempio:
 
-- inviare email con risposte automatiche per un intervallo di tempo fissato, oppure regolarmente, fino a che non viene disabilitato manualmente
-- definire quali mittenti riceveranno email di risposta automatica (solo mittenti interni, oppure includendo mittenti esterni)
+- inviare e-mail di risposta automatica per un intervallo di tempo prestabilito, oppure in modo continuo finché non viene disattivato manualmente
+- definire i mittenti che riceveranno le e-mail di risposta automatica (solo mittenti interni, oppure includendo i mittenti esterni)
 
-A questo punto, compila con le informazioni richieste a seconda dell’azione che desideri venga compiuta. Al termine clicca su `OK`{.action}.
+Inserisci le informazioni richieste in base all'attività che vuoi eseguire grazie a questa regola. Una volta fatto, clicca su `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-Per istruzioni più dettagliate sull’impostazione di risposte automatiche, fai riferimento alla nostra guida: [Impostare risposte automatiche con OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
+Per istruzioni più dettagliate sulla creazione di risposte automatiche, consulta la nostra guida: [Creare un risponditore automatico su OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Aggiungere una firma
 
-Per aggiungere una firma all’email, clicca sull’icona con l’ingranaggio in alto, quindi clicca su `Opzioni`{.action}.
+Per aggiungere una firma elettronica, clicca sull'icona dell'ingranaggio in alto, quindi clicca su `Opzioni`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Sul lato sinistro della nuova pagina, clicca su `Firma email`{.action}. Nel menu delle opzioni, questa voce si trova sotto "Posta" e "Layout". Da qui puoi abilitare, disabilitare e modificare la firma.
+Sul lato sinistro della nuova pagina, clicca su `Firma di posta elettronica`{.action}. Nelle opzioni della struttura ad albero, questo elemento si trova sotto "Posta" e "Layout". Da qui puoi attivare, disattivare e modificare la firma.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Componi la tua firma elettronica nel riquadro dell’editor. Puoi specificare se preferisci includere la firma solo nelle nuove mail o anche nelle risposte e nelle email inoltrate come impostazione predefinita. Al termine, clicca su `Salva`{.action} per confermare.
+Componi la tua firma elettronica nel riquadro dell'editor. Puoi specificare se desideri includere la firma predefinita solo nelle nuove e-mail oppure anche nelle risposte e nelle e-mail inoltrate. Una volta terminato, clicca su `Salva`{.action} per confermare.
 
-Per scoprire come comporre firme automatiche utilizzando template a livello di dominio, fai riferimento alla nostra guida: [Impostare firme automatiche](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
+Per istruzioni sulla creazione di firme automatiche utilizzando modelli per l'intero dominio, consulta la nostra guida: [Creare firme automatiche](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
 
-### Accedere alla sezione delle opzioni
+### Accedere alla sezione Opzioni
 
-Per accedere a tutte le tue impostazioni, clicca sull’icona con l’ingranaggio in alto, quindi su `Opzioni`{.action}.
+Per accedere a tutte le tue impostazioni, clicca sull'icona a forma di ingranaggio in alto, quindi clicca su `Opzioni`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Puoi quindi consultare la visualizzazione ad albero delle "Opzioni" sul lato sinistro della pagina. Da qui potrai effettuare ulteriori regolazioni della configurazione e del tuo account email. Ricorda che abbiamo la facoltà di disabilitare alcune delle opzioni di account per motivi di sicurezza.
+Puoi quindi navigare nella struttura ad albero "Opzioni" sul lato sinistro della pagina. Da questa pagina è possibile effettuare ulteriori regolazioni alla presentazione e al comportamento del tuo account di posta. Nota che, per motivi di sicurezza, alcune opzioni dell'account possono essere disattivate da OVHcloud.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
-### Gestione dei cookies
+### Gestione dei cookie
 
-La Webmail utilizzata per le nostre soluzioni email è basata sul software Microsoft Outlook Web App. È quindi in grado di scambiare metadati con i server di Microsoft, sotto forma di cookies denominati `appsforoffice.microsoft.com`.
+La webmail utilizzata per le nostre offerte e-mail si basa sul software Microsoft Outlook Web App. È quindi suscettibile di scambiare metadati con i server di Microsoft, sotto forma di cookie denominati `appsforoffice.microsoft.com`.
 
-Per disattivare questi scambi, è possibile utilizzare sul browser un'estensione di tipo "block" di contenuti (ad esempio, uBlock Origin o Ghostery).
-La disattivazione di questi cookies può compromettere la stabilità della webmail.
+Se desideri disattivare questi scambi, puoi utilizzare sul tuo browser un'estensione di tipo bloccatore di contenuti (come uBlock Origin o Ghostery).
+La disattivazione di questi cookie può tuttavia compromettere la stabilità della tua webmail.
 
 ## Per saperne di più
 
-[Impostare risposte automatiche con OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
+[Creare risposte automatiche su OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
 
-[Condividere una cartella con la Webmail OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+[Condividere una cartella dall'interfaccia OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
 
-[Condividere un calendario con la Webmail OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
+[Condividere calendari tramite l'interfaccia OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
-[Creare gruppi di contatti (mailing list)](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
+[Creare un gruppo di contatti](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
 
 Contatta la nostra [Community di utenti](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.pl-pl.md
@@ -1,64 +1,69 @@
 ---
-title: 'Korzystanie z konta e-mail przy użyciu Webmail Outlook Web App (OWA)'
-excerpt: 'Dowiedz się, jak korzystać z konta e-mail przy użyciu Webmail OWA'
-updated: 2026-03-24
+title: 'Korzystanie z konta e-mail w interfejsie Webmail Outlook Web App (OWA)'
+excerpt: 'Dowiedz się, jak korzystać z konta e-mail w interfejsie Webmail OWA'
+updated: 2026-05-04
 ---
 
 ## Wprowadzenie
 
-Dzięki rozwiązaniom poczty elektronicznej OVHcloud można wysyłać oraz odbierać e-maile przy użyciu wybranego urządzenia i klienta poczty. Aby umożliwić dostęp do konta z dowolnego miejsca przy użyciu przeglądarki, OVHcloud udostępnia klient poczty e-mail online o nazwie Outlook Web App (OWA). [Strona logowania do interfejsu webmail](/links/web/email) zapewnia dostęp do odpowiednich interfejsów OWA dla wszystkich aktywnych kont e-mail w ramach usług MX Plan, E-mail Pro i Hosted Exchange.
+Dzięki rozwiązaniom poczty elektronicznej OVHcloud możesz wysyłać i odbierać e-maile na wybranym urządzeniu i z wybranego klienta poczty. OVHcloud udostępnia internetową usługę poczty e-mail o nazwie Outlook Web App (OWA), która umożliwia dostęp do konta z dowolnego miejsca za pośrednictwem przeglądarki. Wszystkie aktywne konta e-mail w usługach MX Plan, E-mail Pro i Hosted Exchange korzystają ze wspólnego punktu dostępu do odpowiedniego interfejsu OWA: naszej [strony logowania do interfejsu webmail](/links/web/email).
 
-**Dowiedz się, jak wykonać typowe działania dotyczące adresu e-mail w interfejsie OWA.**
+**Dowiedz się, jak wykonywać typowe działania na koncie e-mail w interfejsie OWA.**
 
 ## Wymagania początkowe
 
-- skonfigurowane rozwiązanie poczty elektronicznej OVHcloud (**usługa MX Plan** dostępna w ramach [hostingu WWW](/links/web/hosting), zawarta w [Darmowy hosting 100M](/links/web/domains-free-hosting) lub zamówiona oddzielnie jako rozwiązanie autonomiczne; [**Hosted Exchange**](/links/web/emails-hosted-exchange) lub [**E-mail Pro**](/links/web/email-pro))
-- dane do logowania dla adresu e-mail, który chcesz skonfigurować
+- Skonfigurowane rozwiązanie poczty elektronicznej OVHcloud z poniższych ofert:
+    - [**MX Plan**](/links/web/hosting), dostępne w ramach hostingu WWW, zawarte w [darmowym hostingu 100M](/links/web/domains-free-hosting) lub zamówione oddzielnie jako rozwiązanie autonomiczne;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange);
+    - [**E-mail Pro**](/links/web/email-pro).
+- Dane do logowania dla adresu e-mail, którego chcesz używać.
 
 ## W praktyce
 
-Ten przewodnik zawiera informacje o zwykłych zadaniach dotyczących konta e-mail, które są dostępne w interfejsie OWA webmail. Ponieważ interfejs nie został opracowany przez OVHcloud, nie możemy udostępnić konkretnych instrukcji dotyczących ustawień, których nie obejmuje ten przewodnik. Przygotowaliśmy natomiast dodatkowe przewodniki dotyczące funkcji programu Exchange i można je znaleźć w poniższej sekcji [**Sprawdź również**](./#sprawdz-rowniez_1).
+Ten przewodnik pomoże Ci lepiej zrozumieć typowe zadania dostępne na koncie e-mail w interfejsie OWA. Ponieważ jednak interfejs ten nie został pierwotnie utworzony przez OVHcloud, nie możemy udostępnić szczegółowych instrukcji dotyczących ustawień, które nie zostały opisane w tym przewodniku.
+
+Dodatkowe przewodniki dotyczące funkcji specyficznych dla Exchange znajdziesz w sekcji [Sprawdź również](./#sprawdz-rowniez) na końcu tego przewodnika.
 
 > [!primary]
 >
-> Instrukcji przedstawionych po dwóch pierwszych krokach nie trzeba wykonywać w konkretnej kolejności.
+> Po zalogowaniu się i zapoznaniu się z interfejsem nie musisz wykonywać instrukcji w podanej kolejności.
 
-### 1. Dostęp do interfejsu OWA webmail
+### Logowanie do OWA
 
-Aby zalogować się do interfejsu OWA webmail przy użyciu swojego adresu e-mail, przejdź do ogólnej [strony logowania do interfejsu webmail](/links/web/email). Wpisz pełny adres e-mail i hasło, a następnie kliknij przycisk `Zaloguj`{.action}.
+Aby zalogować się do OWA przy użyciu adresu e-mail, otwórz [stronę logowania do interfejsu webmail](/links/web/email). Wpisz pełny adres e-mail i hasło. Następnie kliknij `Zaloguj się`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
 > [!warning]
 >
-> Jeśli zostałeś przekierowany do interfejsu **Roundcube**, oznacza to, że korzystasz z poprzedniej wersji usługi MX Plan. Aby uzyskać więcej informacji na temat oferty MX Plan, sprawdź naszą stronę [Pierwsze kroki z ofertą MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
+> Jeśli zostaniesz przekierowany do interfejsu **Roundcube**, oznacza to, że korzystasz ze starszej wersji oferty MX Plan. Aby uzyskać więcej informacji na temat oferty MX Plan, zapoznaj się z naszą stroną [Pierwsze kroki z ofertą MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 >
-> Aby zapoznać się z interfejsem **Roundcube**, zapoznaj się z naszym przewodnikiem [Korzystanie z konta e-mail w interfejsie Webmail Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+> Aby zapoznać się z interfejsem **Roundcube**, sprawdź nasz przewodnik [Korzystanie z konta e-mail w interfejsie Webmail Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
 
-Jeśli pierwszy raz logujesz się do interfejsu OWA webmail przy użyciu tego adresu e-mail, pojawi się monit o ustawienie języka interfejsu i strefy czasowej. Następnie kliknij przycisk `Zapisz`{.action}, aby kontynuować.
+Jeśli logujesz się do OWA przy użyciu tego adresu e-mail po raz pierwszy, pojawi się monit o ustawienie języka interfejsu i strefy czasowej. Następnie kliknij `Zapisz`{.action}, aby kontynuować.
 
 > [!primary]
 >
-> Strefy czasowe są wymienione zgodnie z [uniwersalnym standardem czasowym (UTC)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), a nie alfabetycznie według miast.
+> Strefy czasowe są wymienione zgodnie ze [standardem UTC (uniwersalny czas koordynowany)](https://pl.wikipedia.org/wiki/Uniwersalny_czas_koordynowany), a nie alfabetycznie według miast.
 >
-> **Przykład** : Dla Europy Zachodniej jest to UTC +1 (Bruksela, Kopenhaga, Madryt, Paryż).
+> **Przykład**: Dla Europy Zachodniej jest to UTC +1 (Bruksela, Kopenhaga, Madryt, Paryż).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-Od tej pory po zalogowaniu domyślnie będzie wyświetlany widok skrzynki odbiorczej.
+Od tej pory po zalogowaniu domyślnie będzie wyświetlana skrzynka odbiorcza.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Zaznajomienie z widokiem interfejsu OWA
+### Zaznajomienie z widokiem interfejsu OWA
 
-Interfejs OWA ma kilka sekcji. W poznaniu ich pomogą poniższa tabela i obrazy.
+Interfejs OWA zawiera kilka sekcji. Aby zapoznać się z nim, zapoznaj się z poniższą tabelą i obrazem.
 
 |Części|Opis|
 |---|---|
-|Sekcja górna (1)|Zawiera dwa paski z kartami: pierwszy umożliwia dostęp do ustawień ogólnych (takich jak [sekcja opcji](./#dostep-do-sekcji-opcji)), a drugi służy do wykonywania konkretnych działań przy użyciu adresu (na przykład wysyłania e-maili lub odpowiadania na nie).|
-|Lewa strona (2)|Tutaj znajduje się lista folderów na potrzeby Twojego adresu e-mail. Jest widoczna w formie drzewa menu, które można rozwinąć lub ukryć.|
-|Część środkowa (3)|Zawiera listę wiadomości (przeczytanych i nieprzeczytanych) z folderu wybranego w lewym menu. W tej sekcji mogą też być widoczne wyniki wyszukiwania.|
-|Prawa strona (4)|Gdy wybrano e-mail, po prawej jest widoczne okienko odczytu.|
+|Sekcja górna (1)|Zawiera dwa paski z kartami: pierwszy umożliwia dostęp do ustawień ogólnych (takich jak [sekcja opcji](./#dostep-do-sekcji-opcji)). Drugi pasek umożliwia wykonywanie konkretnych działań związanych z Twoim adresem (takich jak wysyłanie e-maili lub odpowiadanie na nie).|
+|Lewa strona (2)|Wyświetla listę folderów dla Twojego adresu e-mail. Foldery te są widoczne w formie drzewa menu, które można rozwinąć lub zwinąć.|
+|Część środkowa (3)|Wyświetla listę wiadomości (przeczytanych i nieprzeczytanych) z folderu wybranego w lewym menu. W tej sekcji mogą również być widoczne wyniki wyszukiwania.|
+|Prawa strona (4)|Wyświetla okienko odczytu, gdy wybrano e-mail.|
 
 ![useowa](images/use-owa-step4.png){.thumbnail}
 
@@ -66,171 +71,186 @@ Rozmiar sekcji pionowych można zmienić, klikając i przeciągając ich linie o
 
 ### Wyświetlanie e-maili
 
-Aby wyświetlić e-maile, wybierz folder po lewej stronie. Wiadomości przychodzące, których nie uwzględnią reguły skrzynki odbiorczej, pojawią się w folderze „Skrzynka odbiorcza”. Aby dowiedzieć się, czy masz nowe e-maile, sprawdź liczbę widoczną obok danego folderu.
+Aby wyświetlić e-maile, wybierz folder po lewej stronie. Wiadomości przychodzące, które nie są przetwarzane przez reguły skrzynki odbiorczej, pojawią się w folderze "Skrzynka odbiorcza". Aby sprawdzić, czy otrzymałeś nowe e-maile, sprawdź, czy obok danego folderu pojawia się liczba.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-Aby przeczytać e-mail, wybierz jego folder. Kliknij e-mail, aby wyświetlić jego treść w sekcji odczytu. Wiadomości nieprzeczytane mają inny kolor, co pozwala odróżnić je od przeczytanych.
+Aby przeczytać e-mail, wybierz w razie potrzeby jego folder. Następnie kliknij e-mail, aby wyświetlić jego treść w okienku odczytu. Wiadomości nieprzeczytane są pogrubione, co pozwala odróżnić je od przeczytanych.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Sortowanie i filtrowanie e-maili
+
+W prawym górnym rogu listy wiadomości przycisk `Filtr`{.action} otwiera menu zawierające wszystkie opcje wyświetlania dla wybranego folderu.
+
+- **Filtruj według kategorii**: wybierz pozycję, aby wyświetlić tylko wybrane e-maile spośród `Wszystkie`{.action}, `Nieprzeczytane`{.action}, `Do mnie`{.action} (e-maile zaadresowane bezpośrednio do Twojego adresu), `Oflagowane`{.action} (e-maile oznaczone do dalszego przetwarzania) lub `Wzmianki`{.action} (e-maile, w których wymieniono Twój adres).
+
+- **Sortuj według**: najedź kursorem na pozycję `Sortuj według`{.action}, aby wybrać kryterium sortowania e-maili: **Data**, **Od**, **Do**, **Temat**, **Załączniki**, **Ważność** lub **Rozmiar**. Strzałka po lewej stronie kryterium wskazuje aktualny porządek; kliknij to samo kryterium ponownie, aby go odwrócić.
+
+- **Pokaż jako**: najedź kursorem na pozycję `Pokaż jako`{.action}, aby przełączać między widokiem **Wiadomości** (jeden e-mail w wierszu) a widokiem **Konwersacje** (e-maile pogrupowane według wątku dyskusji).
+
 ### Wysyłanie i odpowiadanie
 
-**Aby wysłać nowy e-mail**, kliknij przycisk `Nowy`{.action} w górnej części interfejsu webmail. Po prawej stronie pojawi się okienko edycji. Wypełnij pola e-maila (odbiorcy, temat, treść, załączniki). Gdy wiadomość będzie gotowa do wysłania, kliknij przycisk `Wyślij`{.action}.
+**Aby wysłać nową wiadomość**, kliknij ikonę `Nowy`{.action} w górnej części interfejsu OWA. Po prawej stronie pojawi się okienko edycji. Wypełnij pola e-maila (odbiorcy, temat, treść wiadomości, załączniki). Gdy wiadomość będzie gotowa, kliknij `Wyślij`{.action}.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**Aby odpowiedzieć na e-mail**, [najpierw kliknij go](./#wyswietlanie-e-maili) w celu wyświetlenia. Następnie kliknij przycisk `Odpowiedz wszystkim`{.action}. Jeśli natomiast chcesz odpowiedzieć tylko nadawcy e-maila (pomijając odbiorców kopii), kliknij przycisk strzałki w dół.
+**Aby odpowiedzieć na wiadomość**, najpierw kliknij ją, aby ją wyświetlić. Następnie kliknij `Odpowiedz wszystkim`{.action}, aby odpowiedzieć wszystkim odbiorcom. Użyj przycisku strzałki w dół, jeśli chcesz odpowiedzieć tylko nadawcy e-maila (z pominięciem odbiorców kopii), a następnie kliknij `Odpowiedz`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-Gdy wybierzesz działanie odpowiedzi, nad e-mailem pojawi się edytor szybkiej odpowiedzi. Ułóż odpowiedź, a kiedy e-mail będzie gotowy do wysłania, kliknij przycisk `Wyślij`{.action}. Aby wyświetlić wszystkie opcje odpowiedzi (takie jak dodanie podpisu), najpierw trzeba w pełni rozwinąć okienko edycji, klikając symbol dwóch strzałek.
+Gdy wybierzesz opcję odpowiedzi, nad e-mailem pojawi się edytor szybkiej odpowiedzi. Wpisz tam swoją odpowiedź, a kiedy będziesz gotowy do wysłania wiadomości, kliknij `Wyślij`{.action}. Pamiętaj, że dla każdej opcji odpowiedzi (takiej jak dodanie podpisu) musisz najpierw rozwinąć ją do pełnego okienka edycji, klikając symbol podwójnej strzałki.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
 ### Porządkowanie skrzynki odbiorczej
 
-Interfejs OWA umożliwia porządkowanie skrzynki odbiorczej. Możesz
+OWA oferuje kilka sposobów porządkowania skrzynki odbiorczej. Możesz:
 
-- [tworzyć foldery i podfoldery](./#tworzenie-folderu)
-- [przenosić e-maile](./#przenoszenie-e-maili)
-- [ustawiać reguły](./#tworzenie-regul-skrzynki-odbiorczej), aby po odebraniu nowego e-maila automatycznie były wykonywane konkretne działania
+- [tworzyć foldery i podfoldery](./#tworzenie-folderu),
+- [przenosić e-maile](./#przenoszenie-e-maili),
+- [ustawiać reguły](./#tworzenie-regul-skrzynki-odbiorczej), aby po odebraniu nowego e-maila automatycznie były wykonywane konkretne działania,
+- [zablokować nadawcę](./#blokowanie-nadawcy), aby nie otrzymywać już jego wiadomości.
 
 #### Tworzenie folderu
 
-Aby utworzyć nowy folder, kliknij prawym przyciskiem myszy nazwę adresu e-mail w drzewie folderów i wybierz pozycję `Utwórz nowy folder`{.action}. W taki sam sposób możesz utworzyć podfolder w istniejących folderach (`Utwórz nowy podfolder`{.action}).
+Aby utworzyć nowy folder, kliknij prawym przyciskiem myszy nazwę adresu e-mail w drzewie folderów, a następnie wybierz `Utwórz nowy folder`{.action}. W taki sam sposób możesz utworzyć podfolder w istniejących folderach, klikając `Utwórz nowy podfolder`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
 #### Przenoszenie e-maili
 
-**Aby przenieść e-mail**, po prostu przeciągnij go i upuść w folderze docelowym lub kliknij go prawym przyciskiem myszy i wybierz pozycję `Przenieś`{.action}.
-**Aby przenieść wiele e-maili** jednocześnie, wybierz je przez zaznaczenie pól wyboru i kliknij pozycję `Przenieś`{.action} (po prawej stronie) lub `Przenieś do`{.action} (w górnej sekcji). Następnie wybierz folder docelowy.
+**Aby przenieść e-mail**, możesz po prostu przeciągnąć go i upuścić w folderze docelowym lub kliknąć go prawym przyciskiem myszy i wybrać `Przenieś`{.action}.
+**Aby przenieść wiele e-maili** jednocześnie, zaznacz je wszystkie za pomocą pól wyboru. Następnie kliknij `Przenieś`{.action} (po prawej stronie) lub `Przenieś do`{.action} (w górnej sekcji). Następnie wybierz folder docelowy.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
 #### Tworzenie reguł skrzynki odbiorczej
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Aby zarządzać regułami, kliknij ikonę koła zębatego u góry, a następnie kliknij pozycję `Opcje`{.action}.
+Aby tworzyć reguły i nimi zarządzać, najpierw kliknij ikonę koła zębatego u góry, a następnie kliknij `Opcje`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Zostanie wyświetlona nowa strona, na której kliknij pozycję `Skrzynka odbiorcza i reguły oczyszczania`{.action} w lewym menu. W widoku drzewa „Opcje” ten element jest widoczny po rozwinięciu kolejno pozycji „Poczta” i „Automatyczne przetwarzanie”. W tym obszarze można tworzyć, edytować i usuwać reguły oraz przenosić je na liście.
+Na nowej stronie, która zostanie otwarta, kliknij `Reguły skrzynki odbiorczej i oczyszczania`{.action} w lewym menu. W widoku drzewa "Opcje" znajdziesz tę funkcję pod pozycją "Poczta", w sekcji "Automatyczne przetwarzanie". W tym obszarze możesz tworzyć, edytować i przenosić reguły na liście.
 
 Aby dodać nową regułę, kliknij przycisk `+`{.action}.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Podaj wymagane informacje w zależności od działania, które ma wykonywać reguła. Na koniec kliknij `OK`{.action}.
+Wypełnij wymagane informacje w zależności od zadania, które ma wykonywać reguła. Następnie kliknij `OK`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-Szczegółowe instrukcje tworzenia reguł skrzynki odbiorczej zawiera przewodnik: [Tworzenie reguł skrzynki odbiorczej w aplikacji OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+Aby uzyskać bardziej szczegółowe instrukcje dotyczące tworzenia reguł skrzynki odbiorczej, zapoznaj się z naszym przewodnikiem: [Tworzenie reguł skrzynki odbiorczej w OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
-#### Zablokuj nadawcę
+#### Blokowanie nadawcy
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/UeNdpFwdXm0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Kliknij ikonę koła zębatego w prawym górnym rogu, a następnie kliknij przycisk `Opcje`{.action}. W lewej kolumnie, po drzewie "Mail" w "Konta", a następnie "Zablokuj lub autoryzuj".
+Kliknij ikonę koła zębatego w prawym górnym rogu, a następnie kliknij `Opcje`{.action}. Nadal w lewej kolumnie przejdź drzewem "Poczta" w sekcji "Konta", a następnie "Blokuj lub zezwalaj".
 
-W sekcji "**Nadawcy zablokowani**" wpisz adres e-mail lub nazwę domeny, którą chcesz zablokować, następnie kliknij przycisk `+`{.action}, aby dodać ją do listy.
+W sekcji "**Zablokowani nadawcy**" wpisz adres e-mail lub nazwę domeny do zablokowania, a następnie kliknij przycisk `+`{.action}, aby dodać go do listy.
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Zarządzanie listą kontaktów
+### Zarządzanie kontaktami
 
-Aby zarządzać listą kontaktów, kliknij niebieski przycisk „uruchamiania” w lewym górnym rogu, a następnie kliknij ikonę `Kontakty`{.action}.
+Aby zarządzać kontaktami, kliknij najpierw niebieski przycisk uruchamiania aplikacji w lewym górnym rogu strony (który zapewnia również dostęp do kalendarza, zadań i innych modułów), a następnie kliknij `Osoby`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-Zostanie wyświetlona nowa strona, na której można dodać nowy kontakt, utworzyć listę kontaktów lub usunąć istniejące kontakty.
+Na nowej stronie możesz dodać nowy kontakt, utworzyć listę kontaktów i usunąć istniejące kontakty.
 
-**Aby dodać nowy kontakt**, kliknij przycisk `Nowy`{.action} i wpisz informacje o kontakcie do dodania. Po ich wprowadzeniu kliknij przycisk `Zapisz`{.action}.
+#### Dodawanie kontaktu
+
+Kliknij `Nowy`{.action}, a następnie wpisz dane kontaktu, który chcesz dodać. Po wprowadzeniu danych kliknij `Zapisz`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**Aby utworzyć listę kontaktów**, kliknij przycisk strzałki w dół obok przycisku „Nowy”, a następnie kliknij pozycję `Lista kontaktów`{.action}. Nadaj liście nazwę, dodaj do niej kontakty, a następnie kliknij przycisk `Zapisz`{.action}.
+#### Tworzenie listy kontaktów
+
+Kliknij strzałkę w dół obok przycisku `Nowy`{.action}, a następnie kliknij `Lista kontaktów`{.action}. Nadaj jej nazwę, dodaj do niej kontakty, a następnie kliknij `Zapisz`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
 ### Zmiana hasła
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Po zalogowaniu do interfejsu OWA możesz zmienić hasło do konta. W tym celu kliknij ikonę koła zębatego u góry, a następnie kliknij pozycję `Opcje`{.action}.
+Po zalogowaniu się do OWA możesz zmienić hasło do konta. W tym celu kliknij ikonę koła zębatego u góry, a następnie kliknij `Opcje`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Na nowej stronie rozwiń kartę „Ogólne” w drzewie po lewej, a następnie kliknij pozycję `Moje konto`{.action}. Na koniec kliknij przycisk `Zmień hasło`{.action}.
+Na nowej stronie rozwiń kartę "Ogólne" w drzewie po lewej stronie, a następnie kliknij `Moje konto`{.action}. Na koniec kliknij `Zmień hasło`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-Zostanie wyświetlone nowe okno. Wpisz w nim bieżące hasło. Następnie wpisz nowe hasło i podaj je ponownie, aby potwierdzić. Kliknij przycisk `Zapisz`{.action}, aby zapisać nowe hasło.
+W nowym oknie, które zostanie otwarte, wpisz aktualne hasło. Następnie wpisz nowe hasło i potwierdź je, wpisując je ponownie. Kliknij `Zapisz`{.action}, aby zapisać nowe hasło.
 
 > [!primary]
 >
-> Wprowadź nowe hasło na każdym urządzeniu (na przykład kliencie poczty e-mail), z którego uzyskujesz dostęp do tego konta. W przypadku problemów z hasłem skontaktuj się z administratorem usługi.
+> Pamiętaj, aby wprowadzić nowe hasło na wszystkich urządzeniach używanych do dostępu do tego konta (na przykład w oprogramowaniu klienta poczty e-mail). W przypadku problemów z hasłem skontaktuj się z administratorem usługi.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
 ### Dodawanie odpowiedzi automatycznej
 
-W interfejsie OWA możesz utworzyć odpowiedź automatyczną z Twojego adresu e-mail, aby podczas nieobecności nie pozostawiać e-maili bez odpowiedzi. W tym celu kliknij ikonę koła zębatego u góry, a następnie kliknij pozycję `Odpowiedzi automatyczne`{.action}.
+W OWA możesz utworzyć odpowiedź automatyczną dla swojej skrzynki odbiorczej, aby e-maile nie pozostawały bez odpowiedzi podczas Twojej nieobecności. W tym celu kliknij ikonę koła zębatego u góry, a następnie kliknij `Odpowiedzi automatyczne`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-W wyświetlonym oknie zaznacz opcję „Wysyłaj odpowiedzi automatyczne”. Możesz też ustawić różne kryteria automatycznych odpowiedzi:
+W oknie, które zostanie otwarte, wybierz opcję "Wysyłaj odpowiedzi automatyczne". Następnie możesz skonfigurować autoresponder zgodnie z różnymi kryteriami, takimi jak:
 
-- wysyłanie e-maili z automatyczną odpowiedzią w stałych przedziałach czasu lub ciągle, aż do ręcznego wyłączenia,
-- którzy nadawcy będą otrzymywać e-maile z automatyczną odpowiedzią (tylko nadawcy wewnętrzni lub również nadawcy zewnętrzni).
+- wysyłanie e-maili z odpowiedzią automatyczną przez ustalony przedział czasu lub w sposób ciągły, aż do ręcznego wyłączenia,
+- określenie, którzy nadawcy będą otrzymywać e-maile z odpowiedzią automatyczną (tylko nadawcy wewnętrzni lub również nadawcy zewnętrzni).
 
-Podaj wymagane informacje w zależności od działania, które ma być wykonywane. Po ich wprowadzeniu kliknij przycisk `OK`{.action}.
+Wypełnij wymagane informacje w zależności od zadania, które chcesz wykonać przy użyciu tej reguły. Po wprowadzeniu danych kliknij `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-Szczegółowe instrukcje tworzenia odpowiedzi automatycznych zawiera przewodnik: [Tworzenie odpowiedzi automatycznych w interfejsie OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
+Aby uzyskać bardziej szczegółowe instrukcje dotyczące tworzenia odpowiedzi automatycznych, zapoznaj się z naszym przewodnikiem: [Tworzenie odpowiedzi automatycznej w OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
 ### Dodawanie podpisu
 
-Aby dodać podpis e-maila, kliknij ikonę koła zębatego u góry, a następnie kliknij pozycję `Opcje`{.action}.
+Aby dodać podpis e-mail, kliknij ikonę koła zębatego u góry, a następnie kliknij `Opcje`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Na nowej stronie (po lewej) kliknij pozycję `Podpis wiadomości e-mail`{.action}. W drzewie opcji ten element znajduje się pod pozycjami „Poczta” i „Układ”. W tym obszarze można włączyć, wyłączyć i edytować podpis.
+Po lewej stronie nowej strony kliknij `Podpis e-mail`{.action}. W opcjach drzewa pozycja ta znajduje się pod "Poczta" i "Układ". W tym obszarze możesz włączyć, wyłączyć i edytować podpis.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Przygotuj podpis elektroniczny w polu edytora. Możesz określić, czy podpis ma być dołączany domyślnie tylko do nowych e-maili, czy też do odpowiedzi i wiadomości przesłanych dalej. Na koniec kliknij przycisk `Zapisz`{.action}, aby potwierdzić.
+Skomponuj swój podpis e-mail w polu edytora. Możesz określić, czy chcesz dołączać domyślny podpis tylko do nowych e-maili, czy również do odpowiedzi i wiadomości przesyłanych dalej. Po zakończeniu kliknij `Zapisz`{.action}, aby potwierdzić.
 
-Instrukcje dotyczące tworzenia automatycznych podpisów przy użyciu szablonów dla domeny zawiera przewodnik: [Automatyczny podpis](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
+Aby uzyskać instrukcje dotyczące tworzenia automatycznych podpisów przy użyciu szablonów dla całej domeny, zapoznaj się z naszym przewodnikiem: [Tworzenie automatycznych podpisów](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
 
 ### Dostęp do sekcji opcji
 
-Aby uzyskać dostęp do wszystkich ustawień, kliknij ikonę koła zębatego u góry, a następnie kliknij pozycję `Opcje`{.action}.
+Aby uzyskać dostęp do wszystkich ustawień, kliknij ikonę koła zębatego u góry, a następnie kliknij `Opcje`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Po lewej stronie pojawi się drzewo menu „Opcje”. W tym widoku można dostosować układ i zachowanie konta e-mail. Niektóre opcje konta mogą być wyłączone po stronie OVHcloud ze względów bezpieczeństwa.
+Po lewej stronie strony możesz następnie przeglądać widok drzewa "Opcje". Z tej strony można dostosowywać układ i zachowanie konta e-mail. Pamiętaj, że ze względów bezpieczeństwa niektóre opcje konta mogą być wyłączone przez OVHcloud.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Zarządzanie plikami cookie
 
-Aplikacja webmail, która jest używana w naszych ofertach e-mail, jest oparta na oprogramowaniu Microsoft Outlook Web App. Może więc wymieniać metadane z serwerami Microsoft w postaci plików cookie nazywanych `appsforoffice.microsoft.com`.
+Webmail używany w naszych ofertach e-mail jest oparty na oprogramowaniu Microsoft Outlook Web App. Może więc wymieniać metadane z serwerami Microsoft w postaci plików cookie nazywanych `appsforoffice.microsoft.com`.
 
-Jeśli chcesz wyłączyć tę wymianę, możesz w przeglądarce używać rozszerzenia typu bloker treści (takiego jak uBlock Origin lub Ghostery).
-Wyłączenie tych plików cookie może mieć wpływ na stabilność usługi webmail.
+Jeśli chcesz wyłączyć tę wymianę, możesz w przeglądarce używać rozszerzenia blokującego treści (takiego jak uBlock Origin lub Ghostery).
+Wyłączenie tych plików cookie może jednak wpłynąć na stabilność usługi webmail.
 
 ## Sprawdź również
 
-[Tworzenie odpowiedzi automatycznych w interfejsie OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
+[Tworzenie odpowiedzi automatycznych w OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
 
-[Współdzielenie katalogu w interfejsie OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+[Współdzielenie folderu w interfejsie OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
 
-[Współdzielenie kalendarza w interfejsie OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
+[Współdzielenie kalendarzy w interfejsie OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
-[Korzystanie z grup (mailing listy) dostępnych z kontem Exchange](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
+[Tworzenie grupy kontaktów](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
 
 Dołącz do [grona naszych użytkowników](/links/community).

--- a/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/email_owa/guide.pt-pt.md
@@ -1,236 +1,256 @@
 ---
 title: 'Utilizar o endereço de e-mail a partir do webmail Outlook Web App (OWA)'
 excerpt: 'Saiba como utilizar o seu endereço de e-mail a partir do webmail OWA'
-updated: 2026-03-24
+updated: 2026-05-04
 ---
 
-## Sumário
+## Objetivo
 
-Com as soluções de e-mail OVHcloud pode enviar e receber e-mails utilizando um dispositivo e um cliente à sua escolha. Para aceder a uma conta a partir de qualquer local através do seu browser, a OVHcloud disponibiliza-lhe um cliente de e-mail online denominado Outlook Web App (OWA). A nossa [página de login](/links/web/email) é o único ponto de acesso à interface OWA para todas as contas de e-mail ativas no MX Plan, E-mail Pro e Hosted Exchange.
+Com as soluções de e-mail OVHcloud, pode enviar e receber os seus e-mails a partir de um dispositivo e de um cliente à sua escolha. A OVHcloud disponibiliza um serviço de mensagens online denominado Outlook Web App (OWA) que permite, através de um browser, aceder a uma conta a partir de qualquer local. Todas as contas de e-mail ativas no MX Plan, E-mail Pro e Hosted Exchange têm um único ponto de acesso à interface OWA correspondente: a nossa página de [acesso ao webmail](/links/web/email).
 
-**Este guia explica-lhe como desempenhar ações comuns com o seu endereço de e-mail na interface OWA.**
+**Saiba como executar ações comuns com o seu endereço de e-mail a partir da interface OWA.**
 
 ## Requisitos
 
-- uma solução de e-mail OVHcloud já configurada (**MX Plan**, disponível como parte dos nossos [planos Web Hosting](/links/web/hosting), incluída num [Alojamento gratuito 100M](/links/web/domains-free-hosting) ou encomendada separadamente como solução autónoma; [**Hosted Exchange**](/links/web/emails-hosted-exchange) ou [**E-mail Pro**](/links/web/email-pro))
-- credenciais de login para o endereço de e-mail que deseja configurar
+- Dispor de uma solução de e-mail OVHcloud previamente configurada, entre as ofertas seguintes:
+    - [**MX Plan**](/links/web/hosting), proposto com as nossas ofertas de alojamento web, incluído no [alojamento gratuito 100M](/links/web/domains-free-hosting) ou encomendado como solução autónoma;
+    - [**Hosted Exchange**](/links/web/emails-hosted-exchange);
+    - [**E-mail Pro**](/links/web/email-pro).
+- Conhecer as credenciais de acesso do endereço de e-mail a utilizar.
 
 ## Instruções
 
-Este guia fornece-lhe informações mais detalhadas sobre as habituais tarefas associadas à sua conta de e-mail disponível no webmail OWA. No entanto, uma vez que esta interface não foi criada pela OVHcloud, não temos capacidade de disponibilizar instruções específicas sobre quaisquer configurações não mencionadas neste guia. Relativamente às funcionalidades Exchange, preparámos alguns guias adicionais que pode encontrar mais abaixo, na secção [**Vá mais longe**](./#saiba-mais_1).
+Este guia permite-lhe compreender melhor as tarefas habituais disponíveis numa conta de e-mail no OWA. No entanto, dado que esta interface não foi originalmente criada pela OVHcloud, não podemos disponibilizar instruções específicas sobre parâmetros não abordados neste guia.
+
+Relativamente às funcionalidades específicas do Exchange, encontrará alguns guias adicionais na secção [Quer saber mais?](./#quer-saber-mais) no final deste guia.
 
 > [!primary]
 >
-> Após as duas primeiras etapas, as instruções não têm de ser consideradas de acordo com uma ordem particular
+> Após o acesso e a familiarização com a interface, não é necessário seguir as instruções pela ordem indicada.
 
-### 1. Aceder ao webmail OWA
+### Aceder ao OWA
 
-Para entrar no webmail OWA através do seu endereço de e-mail, aceda à [página de login](/links/web/email) geral. Introduza o seu endereço de e-mail e palavra-passe e clique no botão `Login`{.action}.
+Para aceder ao OWA com o seu endereço de e-mail, abra a página de [acesso ao webmail](/links/web/email). Introduza por completo o seu endereço de e-mail e a sua palavra-passe. Em seguida, clique em `Iniciar sessão`{.action}.
 
 ![useowa](images/use-owa-step1.png){.thumbnail}
 
 > [!warning]
-> 
+>
 > Se for redirecionado para uma interface **Roundcube**, isso significa que está na versão antiga da oferta MX Plan. Para mais informações sobre a sua oferta MX Plan, consulte a nossa página [Primeiros passos com a oferta MX Plan](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_generalities).
 >
-> Para se familiarizar com a interface **Roundcube**, consulte o nosso guia [Webmail: Guia de utilização do Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
+> Para se familiarizar com a interface **Roundcube**, consulte o nosso guia [Utilizar o endereço de e-mail a partir do webmail Roundcube](/pages/web_cloud/email_and_collaborative_solutions/mx_plan/email_roundcube).
 
-Se for a primeira vez que acede ao OWA com este endereço de e-mail, ser-lhe-á pedido que defina o idioma da interface e o fuso horário. Em seguida, clique em `Guardar`{.action} para continuar.
+Se for a primeira vez que acede ao OWA com este endereço de e-mail, ser-lhe-á pedido que defina o idioma da interface, bem como o fuso horário. Em seguida, clique em `Guardar`{.action} para continuar.
 
 > [!primary]
 >
-> Os fusos horários estão listados de acordo com [a norma UTC (tempo universal coordenado)](https://en.wikipedia.org/wiki/Coordinated_Universal_Time#/media/File:World_Time_Zones_Map.png), e não por ordem alfabética das cidades.
+> Os fusos horários estão listados de acordo com [a norma UTC (tempo universal coordenado)](https://pt.wikipedia.org/wiki/Tempo_Universal_Coordenado), e não por ordem alfabética das cidades.
 >
-> **Exemplo** : Para a Europa Ocidental, trata-se de UTC +1 (Bruxelas, Copenhaga, Madrid, Paris).
+> **Exemplo**: Para a Europa Ocidental, trata-se de UTC +1 (Bruxelas, Copenhaga, Madrid, Paris).
 
 ![useowa](images/use-owa-step2.png){.thumbnail}
 
-A partir de agora, a sua caixa de correio irá aparecer por defeito sempre que iniciar a sessão.
+A partir de agora, a sua caixa de entrada será apresentada por defeito sempre que iniciar sessão.
 
 ![useowa](images/use-owa-step3.png){.thumbnail}
 
-### 2. Compreender a estrutura OWA
+### Compreender a apresentação do OWA
 
-Existem várias secções na interface OWA. Para as conhecer melhor, consulte o quadro e a imagem que se seguem.
+A interface OWA contém várias secções. Consulte o quadro e a imagem abaixo para se familiarizar com a mesma.
 
 |Componentes|Descrição|
 |---|---|
-|Secção superior (1)|Contém duas barras de separadores: a primeira permite o acesso às configurações gerais (tais como [a secção de opções](./#aceder-a-seccao-de-opcoes)), e a segunda pode ser utilizada para realizar ações específicas com o seu endereço (como enviar ou responder a e-mails).|
-|Lado esquerdo (2)|Exibe a lista de pastas relativas ao seu endereço de e-mail. Estas são visualizadas numa estrutura em árvore que se pode expandir ou ocultar.|
-|Segmento central (3)|Exibe a lista de mensagens (lidas e não lidas) da pasta selecionada no menu à esquerda. Esta secção pode igualmente exibir os resultados de pesquisa.|
-|Lado direito (4)|Exibe o painel de leitura quando um e-mail foi selecionado.|
+|Secção superior (1)|Dispõe de duas barras de separadores: a primeira permite aceder aos parâmetros gerais (tais como a [secção Opções](./#aceder-a-seccao-opcoes)). A segunda barra pode ser utilizada para ações específicas com o seu endereço (tais como o envio ou a resposta a e-mails).|
+|Lado esquerdo (2)|Apresenta a lista de pastas do seu endereço de e-mail. Estas pastas apresentam-se sob a forma de uma árvore que pode expandir ou ocultar.|
+|Segmento central (3)|Apresenta a lista de mensagens (lidas e não lidas) da pasta selecionada no menu da esquerda. Esta secção pode também apresentar os resultados de pesquisa.|
+|Lado direito (4)|Apresenta o painel de leitura quando um e-mail foi selecionado.|
 
 ![useowa](images/use-owa-step4.png){.thumbnail}
 
 Tenha em atenção que pode alterar o tamanho das secções verticais clicando e arrastando as suas linhas de contorno.
 
-### Visualizar e-mails
+### Visualizar os e-mails
 
-Para visualizar os seus e-mails, selecione uma pasta do lado esquerdo. Os e-mails que chegarem à sua caixa de correio e não forem tratados pelas regras inbox entrarão na pasta “inbox”. Para ver se recebeu novos e-mails, verifique se aparece um número junto à respetiva pasta.
+Para consultar os seus e-mails, selecione uma pasta no lado esquerdo. Os e-mails recebidos que não sejam tratados pelas regras de mensagens serão apresentados na pasta "Caixa de entrada". Para saber se recebeu novos e-mails, verifique se aparece um número junto à pasta correspondente.
 
 ![useowa](images/use-owa-step5.png){.thumbnail}
 
-Para ler um e-mail, selecione a sua pasta se necessário. De seguida, clique no e-mail para abrir o seu conteúdo na secção de leitura. As mensagens não lidas aparecerão com outra cor para as diferenciar das que já foram lidas.
+Para ler um e-mail, selecione a respetiva pasta se necessário. Em seguida, clique no e-mail para apresentar o seu conteúdo no painel de leitura. As mensagens não lidas aparecem a negrito para as distinguir das mensagens lidas.
 
 ![useowa](images/use-owa-step6.png){.thumbnail}
 
+### Ordenar e filtrar os e-mails
+
+Na parte superior direita da lista de mensagens, o botão `Filtro`{.action} abre um menu que reúne todas as opções de apresentação da pasta selecionada.
+
+- **Filtrar por categoria**: selecione uma entrada para apresentar apenas uma seleção de e-mails entre `Tudo`{.action}, `Não lidas`{.action}, `Para mim`{.action} (e-mails enviados diretamente para o seu endereço), `Com sinalizador`{.action} (e-mails sinalizados para acompanhamento) ou `Menções`{.action} (e-mails nos quais o seu endereço é mencionado).
+
+- **Ordenar por**: passe o cursor sobre a entrada `Ordenar por`{.action} para escolher o critério de ordenação dos e-mails: **Data**, **De**, **Para**, **Assunto**, **Anexos**, **Importância** ou **Tamanho**. A seta à esquerda do critério indica a ordem atual; clique novamente no mesmo critério para a inverter.
+
+- **Apresentar como**: passe o cursor sobre a entrada `Apresentar como`{.action} para alternar entre a visualização **Mensagens** (um e-mail por linha) ou **Conversações** (e-mails agrupados por fio de discussão).
+
 ### Enviar e responder
 
-**Para enviar um novo e-mail**, clique no botão `Novo`{.action} situado na parte superior da interface de webmail. O painel de edição irá surgir no lado direito. Preencha os campos necessários (destinatários, assunto, corpo da mensagem, anexos). Quando terminar, clique no botão `Enviar`{.action}.
+Para **enviar uma nova mensagem**, clique no ícone `Novo`{.action} na parte superior da interface OWA. O painel de edição será apresentado no lado direito. Preencha os campos do seu e-mail (destinatários, assunto, corpo da mensagem, anexos). Clique em `Enviar`{.action} quando o seu e-mail estiver redigido.
 
 ![useowa](images/use-owa-step7.png){.thumbnail}
 
-**Para responder a um e-mail**, [clique nele primeiro](./#visualizar-e-mails) para exibir o respetivo conteúdo. De seguida, clique no botão `Responder a todos`{.action}. Use a seta para baixo se quiser apenas responder ao remetente do e-mail (deixando de fora qualquer outro destinatário incluído).
+Para **responder a uma mensagem**, clique primeiro nela para a apresentar. Em seguida, clique em `Responder a todos`{.action} para responder ao conjunto dos destinatários. Utilize o botão de seta para baixo se pretender apenas responder ao remetente do e-mail (excluindo qualquer destinatário em cópia) e clique em `Responder`{.action}.
 
 ![useowa](images/use-owa-step8.png){.thumbnail}
 
-Ao escolher responder, aparecerá um editor de resposta rápida sobre o e-mail. Escreva a sua mensagem e, quando estiver pronto para enviar o seu e-mail, clique em `Enviar`{.action}. Note que, para aceder a todas as opções de resposta (como adicionar uma assinatura), o editor deve ser primeiro alargado, clicando no símbolo de seta dupla.
+Quando opta por responder, o editor de resposta rápida aparece por cima do e-mail. Introduza aí a sua resposta e, assim que estiver pronto para enviar a mensagem, clique em `Enviar`{.action}. Tenha em atenção que, para cada opção de resposta (como adicionar uma assinatura), deve primeiro alargá-la a todo o painel de edição clicando no símbolo de seta dupla.
 
 ![useowa](images/use-owa-step9.png){.thumbnail}
 
-### Organizar a sua caixa de entrada
+### Organizar a sua caixa de correio
 
-O OWA disponibiliza várias formas de organizar a sua caixa de entrada (inbox). Pode:
+O OWA propõe várias formas de organizar a sua caixa de correio. Pode:
 
-- [criar pastas e subpastas](./#criar-uma-pasta)
-- [mover e-mails](./#mover-e-mails)
-- [configurar regras](./#criar-regras-inbox) para que algumas ações sejam realizadas automaticamente quando um novo e-mail é recebido
+- [criar pastas e subpastas](./#criar-uma-pasta),
+- [mover e-mails](./#mover-e-mails),
+- [definir regras](./#criar-regras-de-gestao-da-caixa-de-correio) para executar automaticamente ações ao receber um novo e-mail,
+- [bloquear um remetente](./#bloquear-um-remetente) para deixar de receber as suas mensagens.
 
 #### Criar uma pasta
 
-Para criar uma pasta, clique com o botão direito do rato no seu endereço de e-mail na árvore de pastas e, de seguida, selecione `Criar nova pasta`{.action}. Pode ainda criar subpastas dentro das pastas existentes selecionando (`Criar nova subpasta`{.action}). 
+Para criar uma nova pasta, clique com o botão direito do rato sobre o nome do seu endereço de e-mail na árvore de pastas e, em seguida, escolha `Criar nova pasta`{.action}. Pode criar uma subpasta dentro de pastas existentes da mesma forma, clicando em `Criar nova subpasta`{.action}.
 
 ![useowa](images/use-owa-step10.png){.thumbnail}
 
 #### Mover e-mails
 
-**Para mover um e-mail**, basta arrastá-lo e largá-lo na pasta pretendida ou clicar nele com o botão direito do rato e selecionar `Mover`{.action}.
-**Para mover vários e-mails** de uma vez, selecione-os e clique em `Mover`{.action} (do lado direito) ou em `Mover para`{.action} (na secção superior). Por fim, escolha a pasta de destino.
+Para **mover um e-mail**, basta arrastá-lo e largá-lo na pasta de destino ou clicar com o botão direito do rato e selecionar `Mover`{.action}.
+Para **mover vários e-mails** simultaneamente, selecione-os todos através da respetiva caixa de seleção. Em seguida, clique em `Mover`{.action} (no lado direito) ou em `Mover para`{.action} (na secção superior). Escolha depois a pasta de destino.
 
 ![useowa](images/use-owa-step11.png){.thumbnail}
 
-#### Criar regras inbox
+#### Criar regras de gestão da caixa de correio
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4?start=48" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Para gerir as regras, clique no ícone de engrenagem na parte superior e, de seguida, em `Opções`{.action}.
+Para criar e gerir regras, clique primeiro no ícone de engrenagem na parte superior e, em seguida, em `Opções`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Na nova página exibida, clique em `Regras inbox e varrimento`{.action} no menu situado à esquerda. Na vista de árvore do menu “Opções”, pode encontrá-lo clicando em “Mail” e, de seguida, em “Processamento automático”. A partir daqui, pode criar, editar, apagar e mover regras da lista.
+Na nova página apresentada, clique em `Regras de caixa de entrada e de organização`{.action} no menu da esquerda. Na árvore "Opções", pode encontrar esta funcionalidade em "Mail", em "Processamento automático". Aqui, pode criar, modificar e deslocar regras da lista.
 
 Para adicionar uma nova regra, clique no botão `+`{.action}.
 
 ![useowa](images/use-owa-step13.png){.thumbnail}
 
-Preencha a informação solicitada consoante a regra que pretende que seja executada. De seguida, clique em `OK`{.action}.
+Preencha as informações solicitadas em função da tarefa que pretende executar com esta regra. Em seguida, clique em `OK`{.action}.
 
 ![useowa](images/use-owa-step14.png){.thumbnail}
 
-Para instruções mais detalhadas sobre como criar regras inbox, consulte o nosso guia: [Criar regras inbox no OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
+Para instruções mais detalhadas sobre a criação de regras de gestão da caixa de correio, consulte o nosso guia: [Criação de regras de gestão da caixa de correio no OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/creating-inbox-rules-in-owa-mx-plan).
 
 #### Bloquear um remetente
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/UeNdpFwdXm0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/Ivad4FgJ2No" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Clique no ícone de engrenagem no canto superior direito e depois em `Opções`{.action}. Na coluna da esquerda, siga a árvore "Mail" em "Contas" e, a seguir, "Bloquear ou autorizar".
+Clique no ícone de engrenagem no canto superior direito e, em seguida, clique em `Opções`{.action}. Sempre na coluna da esquerda, percorra a árvore "Mail" em "Contas" e, em seguida, "Bloquear ou autorizar".
 
-Na secção "**Remetentes bloqueados**", introduza um endereço de e-mail ou um domínio a bloquear e clique no botão `+`{.action} para o adicionar na lista.
+Na secção "**Remetentes bloqueados**", introduza um endereço de e-mail ou um nome de domínio a bloquear e clique no botão `+`{.action} para o adicionar à lista.
 
 ![useowa](images/owa_exchange_block.png){.thumbnail}
 
-### Gerir uma lista de contactos
+### Gerir os seus contactos
 
-Para gerir os seus contactos, clique no botão azul “iniciador de aplicações” situado na parte superior e, de seguida, em `Contactos`{.action}.
+Para gerir os seus contactos, clique primeiro no botão azul do iniciador de aplicações no canto superior esquerdo da página (que dá igualmente acesso ao calendário, às tarefas e a outros módulos) e, em seguida, em `Contactos`{.action}.
 
 ![useowa](images/use-owa-step15.png){.thumbnail}
 
-Nesta nova página, pode adicionar um novo contacto, criar uma lista de contactos e remover os contactos existentes.
+Na nova página, pode adicionar um novo contacto, criar uma lista de contactos e eliminar contactos existentes.
 
-**Para adicionar um novo contacto**, clique em `Novo`{.action} e introduza os detalhes do contacto que deseja adicionar. Quando terminar, clique em `Guardar`{.action}.
+#### Adicionar um contacto
+
+Clique em `Novo`{.action} e introduza os dados do contacto a adicionar. Quando terminar, clique em `Guardar`{.action}.
 
 ![useowa](images/use-owa-step16.png){.thumbnail}
 
-**Para criar uma lista de contactos**, clique no botão com a seta para baixo, situado junto a “Novo” e, de seguida, em `Lista de contactos`{.action}. Dê um nome à lista, adicione os contactos e, por fim, clique em `Guardar`{.action}.
+#### Criar uma lista de contactos
+
+Clique na seta para baixo junto a `Novo`{.action} e, em seguida, em `Lista de contactos`{.action}. Atribua-lhe um nome, adicione contactos e clique em `Guardar`{.action}.
 
 ![useowa](images/use-owa-step17.png){.thumbnail}
 
 ### Alterar a palavra-passe
 
-<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/msmUN7cLSNI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<iframe class="video" width="560" height="315" src="https://www.youtube-nocookie.com/embed/z1D2wc7XWX4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Pode alterar a palavra-passe da sua conta quando tiver iniciado uma sessão no OWA. Para o fazer, clique no ícone de engrenagem situado na parte superior e, de seguida, em `Opções`{.action}.
+Pode alterar a palavra-passe da sua conta quando tiver iniciado sessão no OWA. Para o fazer, clique no ícone de engrenagem na parte superior e, em seguida, clique em `Opções`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Na nova página, expanda o separador “Geral” na árvore situada do lado esquerdo e, de seguida, clique em `A minha conta`{.action}. Por fim, clique em `Alterar palavra-passe`{.action}.
+Na nova página, expanda o separador "Geral" na árvore da esquerda e, em seguida, clique em `A minha conta`{.action}. Por fim, clique em `Alterar a sua palavra-passe`{.action}.
 
 ![useowa](images/use-owa-step18.png){.thumbnail}
 
-Na janela seguinte, introduza a sua palavra-passe atual. De seguida, introduza a sua nova palavra-passe, voltando a reintroduzi-la para confirmar. Clique no botão `Guardar`{.action} para guardar a nova palavra-passe.
+Na nova janela apresentada, introduza a sua palavra-passe atual. Em seguida, introduza uma nova palavra-passe e confirme-a, voltando a introduzi-la. Clique em `Guardar`{.action} para guardar a nova palavra-passe.
 
 > [!primary]
 >
-> Lembre-se também de voltar a introduzir a sua nova palavra-passe em qualquer dispositivo que use para aceder a esta conta. Caso tenha algum problema com a sua palavra-passe, contacte o administrador responsável pelo seu serviço.
+> Não se esqueça de introduzir a sua nova palavra-passe em todos os dispositivos utilizados para aceder a esta conta (por exemplo, no software de cliente de e-mail). Em caso de dificuldades com a sua palavra-passe, contacte o administrador de serviços.
 
 ![useowa](images/use-owa-step19.png){.thumbnail}
 
-### Adicionar uma resposta automática
+### Adicionar resposta automática
 
-Na interface OWA, pode criar uma resposta automática para o seu endereço de e-mail, de forma a não deixar qualquer e-mail sem resposta durante a sua ausência. Para o fazer, clique no ícone de engrenagem situado na parte superior e, de seguida, em `Resposta automática`{.action}.
+No OWA, pode criar um sistema de resposta automática na sua caixa de correio para não deixar e-mails sem resposta durante as suas ausências. Para o fazer, clique no ícone de engrenagem na parte superior e, em seguida, clique em `Respostas automáticas`{.action}.
 
 ![useowa](images/use-owa-step20.png){.thumbnail}
 
-Na janela exibida, selecione a opção "Enviar respostas automáticas". Pode então configurar o sistema de resposta automática para obedecer a alguns critérios:
+Na janela apresentada, selecione a opção "Enviar respostas automáticas". Pode então configurar a resposta automática para responder a vários critérios, tais como:
 
-- enviar e-mails de resposta automática durante um período de tempo predefinido, ou de uma forma contínua até que seja manualmente desativado
-- definir que remetentes irão receber os e-mails de resposta automática (apenas os remetentes internos ou incluir os remetentes externos)
+- enviar e-mails de resposta automática durante um intervalo de tempo fixo, ou continuamente até ser desativada manualmente
+- definir os remetentes que receberão os e-mails de resposta automática (apenas remetentes internos, ou incluir os remetentes externos)
 
-Preencha a informação solicitada dependendo da ação que deseja ver concluída. Quando terminar, clique em `OK`{.action}.
+Preencha as informações solicitadas em função da tarefa que pretende executar com esta regra. Quando terminar, clique em `OK`{.action}.
 
 ![useowa](images/use-owa-step21.png){.thumbnail}
 
-Para instruções mais detalhadas sobre como criar respostas automáticas, consulte o nosso guia: [Criar respostas automáticas no OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
+Para instruções mais detalhadas sobre a criação de respostas automáticas, consulte o nosso guia: [Criar respostas automáticas no OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies).
 
-### Adicionar assinatura
+### Adicionar uma assinatura
 
-Para adicionar uma assinatura ao seu e-mail, clique no ícone de engrenagem situado na parte superior e, de seguida, em `Opções`{.action}.
+Para adicionar uma assinatura eletrónica, clique no ícone de engrenagem na parte superior e, em seguida, clique em `Opções`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-No lado esquerdo da nova página, clique em `Assinatura e-mail`{.action}. Na árvore de opções, encontrará esta opção selecionando “Mail” e depois “Estrutura”. A partir daqui, pode gerir, desativar e editar a assinatura.
+No lado esquerdo da nova página, clique em `Assinatura de e-mail`{.action}. Nas opções da árvore, este elemento encontra-se em "Mail" e "Esquema". A partir daqui, pode ativar, desativar e modificar a assinatura.
 
 ![useowa](images/use-owa-step22.png){.thumbnail}
 
-Componha a sua assinatura eletrónica no editor de texto. Pode especificar se deseja incluir a assinatura por defeito apenas nos novos e-mails ou também nas respostas e reencaminhamentos efetuados. Quando terminar, clique em `Guardar`{.action} para confirmar.
+Componha a sua assinatura eletrónica na caixa de edição. Pode especificar se pretende incluir a assinatura por defeito apenas nos novos e-mails ou também nas respostas e nos e-mails reencaminhados. Quando terminar, clique em `Guardar`{.action} para confirmar.
 
-Para mais instruções sobre como criar assinaturas automáticas através da utilização de modelos padronizados, consulte o nosso guia: [Criar assinaturas automáticas](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
+Para obter instruções sobre a criação de assinaturas automáticas utilizando modelos para todo o domínio, consulte o nosso guia: [Criar assinaturas automáticas](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_footers).
 
-### Aceder à secção de opções
+### Aceder à secção Opções
 
-Para aceder a todas as suas configurações, clique no ícone de engrenagem situado na parte superior e, de seguida, em `Opções`{.action}.
+Para aceder a todos os seus parâmetros, clique no ícone de engrenagem na parte superior e, em seguida, clique em `Opções`{.action}.
 
 ![useowa](images/use-owa-step12.png){.thumbnail}
 
-Depois aceda à vista de árvore do menu “Opções” situado do lado esquerdo da página. Aqui poderá fazer mais ajustes à estrutura e ao comportamento da sua conta de e-mail. Tenha em atenção que algumas opções da conta podem ser desativadas por nós por razões de segurança.
+Pode em seguida navegar na árvore "Opções" no lado esquerdo da página. Outros ajustes da apresentação e do comportamento da sua conta de e-mail podem ser efetuados a partir desta página. Tenha em atenção que, por motivos de segurança, algumas opções da conta podem ser desativadas pela OVHcloud.
 
 ![useowa](images/use-owa-step23.png){.thumbnail}
 
 ### Gestão dos cookies
 
-O webmail que é utilizado para as nossas ofertas de e-mail está baseado no software Microsoft Outlook Web App. Portanto, é suscetível de trocar metadados com os servidores da Microsoft, sob a forma de cookies designados `appsforoffice.microsoft.com`.
+O webmail utilizado para as nossas ofertas de e-mail baseia-se no software Microsoft Outlook Web App. É, portanto, suscetível de trocar metadados com os servidores da Microsoft, sob a forma de cookies denominados `appsforoffice.microsoft.com`.
 
-Se pretender desativar esta troca de informações, pode utilizar no seu browser uma extensão do tipo de bloqueador de conteúdos (como o uBlock Origin ou Ghostery).
-A desativação destes cookies pode afetar a estabilidade do webmail.
+Se pretender desativar estas trocas, pode utilizar no seu browser uma extensão do tipo bloqueador de conteúdos (como o uBlock Origin ou o Ghostery).
+A desativação destes cookies pode, no entanto, afetar a estabilidade do seu webmail.
 
-## Saiba mais
+## Quer saber mais?
 
-[Criar respostas automáticas no OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
+[Criação de respostas automáticas no OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_automatic_replies)
 
-[Partilhar uma pasta através do webmail OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
+[Partilhar uma pasta a partir da interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_directory_sharing)
 
-[Partilhar calendários em OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
+[Partilhar calendários através da interface OWA](/pages/web_cloud/email_and_collaborative_solutions/using_the_outlook_web_app_webmail/owa_calendar_sharing)
 
-[Utilização de grupos de difusão (mailing lists)](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
+[Criar um grupo de contactos](/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/feature_groups)
 
-Fale com nossa [comunidade de utilizadores](/links/community).
+Fale com a nossa [comunidade de utilizadores](/links/community).


### PR DESCRIPTION

## What type of Pull Request is this?

- Update of existing guide
- Optimization

## Description

Sync all locales (8 EU + 4 CA + 3 APAC) with the recent fr-fr update that introduced the new "Sorting and filtering emails" section, reordered "Viewing emails" before "Sorting and filtering", added Contacts H4 subsections (Adding a contact / Creating a contact list), and refined the compose-field wording.

EU (8 locales)
- Retranslate en-gb from fr-fr (source of truth), then propagate: EN -> de-de, pl-pl  |  FR -> es-es, it-it, pt-pt
- Mirror en-gb to en-ie
- Localize the Wikipedia UTC link in fr/de/es/it/pl/pt locales (native articles, dropping the en.wikipedia /media fragment)
- Refresh updated date to 2026-05-04 on all 8 locales

CA region (en-ca, en-us, fr-ca, es-us)
- Apply CA-specific trimming on top of the new EU content:
  - Drop Email Pro from prerequisites (CA catalog: MX Plan + Hosted Exchange only)
  - Remove the Roundcube redirect callout (CA MX Plan uses OWA only)
  - Keep Hosted Exchange references and "Go further" Exchange links
- en-us: apply US English spelling (familiarize, organize, behavior)
- es-us: drop the 100M free hosting parenthetical (not offered in US)

APAC region (en-au, en-asia, en-sg)
- Apply APAC-specific trimming on top of the new EU content:
  - Drop Email Pro and Hosted Exchange from prerequisites (APAC catalog: MX Plan only)
  - Remove the "For Exchange-specific features" sentence and the Exchange-specific guides (feature_footers, feature_groups) from "Go further"
  - Remove the Roundcube redirect callout

Cross-cutting
- Verified images (24 used, 24 present), hash anchors resolve in each file, /pages cross-refs exist (8 targets), external links return 200
