### PR TITLE
CP-STEPS integrations - fixes on broken tabs

### DIFF
--- a/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup/guide.en-gb.md
+++ b/pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup/guide.en-gb.md
@@ -47,7 +47,7 @@ You can make use of these instance backups for two basic purposes:
 
 > [!tabs]
 > Via the OVHcloud Control Panel
-<!-- CP-STEPS-START:creating-instance-from-backup-cp -->
+>> <!-- CP-STEPS-START:creating-instance-from-backup-cp -->
 >> Click [this link](/links/control-panel/publiccloud-projects) to access the `Public Cloud`{.action} section, then click `Instance backup`{.action} in the left-hand navigation bar under **Compute**.
 >>
 >> ![public-cloud-instance-backup](images/restorebackup01.png){.thumbnail}
@@ -75,7 +75,7 @@ You can make use of these instance backups for two basic purposes:
 >> > In order to create the instance in a different data centre, you will first need to transfer the backup to the appropriate region. Please refer to our guide to [transferring an instance backup](/pages/public_cloud/compute/transfer_instance_backup_from_one_datacentre_to_another).
 >> >
 >>
-<!-- CP-STEPS-END:creating-instance-from-backup-cp -->
+>> <!-- CP-STEPS-END:creating-instance-from-backup-cp -->
 > Via the OpenStack CLI
 >>
 >> To create an instance from your backup, use the backup ID as the image with this command:
@@ -148,7 +148,7 @@ You can make use of these instance backups for two basic purposes:
 
 > [!tabs]
 > Via the OVHcloud Control Panel
-<!-- CP-STEPS-START:restoring-instance-from-backup-cp -->
+>> <!-- CP-STEPS-START:restoring-instance-from-backup-cp -->
 >> Click [this link](/links/control-panel/publiccloud-projects) to access the `Public Cloud`{.action} section, then click `Instances`{.action} in the left-hand navigation bar under **Compute**.
 >>
 >> ![public-cloud-instance-backup](images/restorebackup04.png){.thumbnail}
@@ -175,7 +175,7 @@ You can make use of these instance backups for two basic purposes:
 >> > As stated in the warning message, any data added after the backup creation will be lost.
 >> >
 >>
-<!-- CP-STEPS-END:restoring-instance-from-backup-cp -->
+>> <!-- CP-STEPS-END:restoring-instance-from-backup-cp -->
 > Via the OVHcloud API
 >> > [!api]
 >> >

--- a/pages/public_cloud/compute/switch_volume_type/guide.en-gb.md
+++ b/pages/public_cloud/compute/switch_volume_type/guide.en-gb.md
@@ -42,8 +42,8 @@ This modification can be made via Horizon or the OpenStack CLI.
 >
 
 > [!tabs]
-<!-- CP-STEPS-START:change-volume-type-cp -->
 > Via the OVHcloud Control Panel
+>> <!-- CP-STEPS-START:change-volume-type-cp -->
 >>
 >> Click on `Block Storage`{.action} in the left-hand menu under **Storage & Backup**.
 >>
@@ -56,7 +56,7 @@ This modification can be made via Horizon or the OpenStack CLI.
 >> > Changing the volume type (retyping) may take a few minutes.
 >> >
 >>
-<!-- CP-STEPS-END:change-volume-type-cp -->
+>> <!-- CP-STEPS-END:change-volume-type-cp -->
 > Via the Horizon Interface
 >>
 >> Log in to the [Horizon interface](https://horizon.cloud.ovh.net/auth/login/) and make sure you are in the correct region. You can verify this in the top left corner. 

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/guide.en-gb.md
@@ -101,7 +101,7 @@ This is why we invite you to consult the chapter corresponding to the interface 
 >>
 >> ![exchange](images/config-outlook-legacy-exchange03.png){.thumbnail}
 >>
-<!-- CP-STEPS-START:exchange-diagnostic-check -->
+>> <!-- CP-STEPS-START:exchange-diagnostic-check -->
 >> > [!primary]
 >> >
 >> > If you get a message saying that Outlook was unable to configure your account, this may mean that the OVHcloud SRV record is not correctly configured in your domain name’s DNS zone.
@@ -109,7 +109,7 @@ This is why we invite you to consult the chapter corresponding to the interface 
 >> > ![exchange](images/config-outlook-legacy-exchange04.png){.thumbnail}
 >> >
 >> > We recommend that you check the configuration of the domain name associated with your Exchange service. In your [OVHcloud Control Panel](/links/manager), go to the `Associated domains`{.action} tab and check the `Diagnostic`{.action} column of the table.
-<!-- CP-STEPS-END:exchange-diagnostic-check -->
+>> <!-- CP-STEPS-END:exchange-diagnostic-check -->
 >>
 >> - If your domain name’s configuration is valid, you may receive a login authorisation message for your OVHcloud servers. Accept this to allow your Exchange account to be configured automatically.
 >> - Then determine the retention period of the items in your Exchange account to keep them stored **locally on your computer**. Click `Next`{.action}, and then click `Done`{.action}.

--- a/pages/web_cloud/internet/internet_access/end_of_copper_migration_ftth/guide.fr-fr.md
+++ b/pages/web_cloud/internet/internet_access/end_of_copper_migration_ftth/guide.fr-fr.md
@@ -149,7 +149,7 @@ Dans ce cas de figure, nous vous recommandons de suivre les étapes ci-dessous *
 >> - En cas de divergence d'adresse, contactez le support OVHcloud via un [ticket](https://help.ovhcloud.com/csm?id=csm_get_help) en précisant la référence de votre accès xDSL et l'**Identifiant immeuble IPE** de votre adresse.
 >>
 > Étape 3
-<!-- CP-STEPS-START:migrate-fiber-cas2-step3 -->
+>> <!-- CP-STEPS-START:migrate-fiber-cas2-step3 -->
 >> **Effectuez un déménagement de votre accès à Internet :**
 >>
 >> Maintenant que vous avez récupéré et confirmé les bonnes informations de raccordement à la fibre, il est nécessaire de déménager techniquement votre accès depuis l'adresse actuelle (celle qui correspond au réseau cuivre) vers la nouvelle adresse (correspondant au réseau fibre).
@@ -166,7 +166,7 @@ Dans ce cas de figure, nous vous recommandons de suivre les étapes ci-dessous *
 >> - L'**Identifiant immeuble IPE** de votre adresse.
 >>
 >> Les équipes du support OVHcloud vous aideront alors à finaliser votre migration vers la fibre.
-<!-- CP-STEPS-END:migrate-fiber-cas2-step3 -->
+>> <!-- CP-STEPS-END:migrate-fiber-cas2-step3 -->
 
 ### Si vous ne souhaitez pas migrer vers la fibre <a name="cancel"></a>
 

--- a/pages/web_cloud/phone_and_fax/voip/configuration_basique_dun_sip_trunk_ovh_sur_3cx_phone_system/guide.fr-fr.md
+++ b/pages/web_cloud/phone_and_fax/voip/configuration_basique_dun_sip_trunk_ovh_sur_3cx_phone_system/guide.fr-fr.md
@@ -85,7 +85,7 @@ Obtenez gratuitement 3CX en accédant à la [page de téléchargement 3CX](https
 >>
 >> ![3CX Phone System](images/3cx_phone_system-trunk03.png){.thumbnail}
 >>
-<!-- CP-STEPS-START:sip-trunk-credentials-in-cp -->
+>> <!-- CP-STEPS-START:sip-trunk-credentials-in-cp -->
 >> > [!primary]
 >> > Pour retrouver vos informations de connexion depuis votre espace client :
 >> >
@@ -93,7 +93,7 @@ Obtenez gratuitement 3CX en accédant à la [page de téléchargement 3CX](https
 >> >
 >> > Vous retrouvez alors, dans la partie « Informations SIP », le **Login**, **Domain** et **Proxy sortant** de votre ligne SIP Trunk.
 >>
-<!-- CP-STEPS-END:sip-trunk-credentials-in-cp -->
+>> <!-- CP-STEPS-END:sip-trunk-credentials-in-cp -->
 >> Saisissez les informations d'authentification du trunk dans le formulaire en complétant les champs suivants :
 >>
 >> - **Nom d'hôte** : Renseignez le **Domain** de votre trunk.


### PR DESCRIPTION
## What type of Pull Request is this?

- Fix

## Description

Fix 5 guides where CP-STEPS markers were placed without the proper blockquote
prefix, breaking the surrounding [!tabs] alert rendering. Markers sat on bare
lines (no `>` or `>>` prefix) between blockquoted content, which prematurely
closed the [!tabs] block and split it into two separate blockquotes — leaving
tabs broken at runtime.

Markers are now consistently placed at `>>` (tab content level), aligned with
the convention already used in deployed guides such as
analytics_getting_started.

Affected guides:
- pages/public_cloud/compute/switch_volume_type/guide.en-gb.md
- pages/public_cloud/compute/create_restore_a_virtual_server_with_a_backup/guide.en-gb.md
- pages/web_cloud/email_and_collaborative_solutions/microsoft_exchange/how_to_configure_outlook_2016/guide.en-gb.md
- pages/web_cloud/phone_and_fax/voip/configuration_basique_dun_sip_trunk_ovh_sur_3cx_phone_system/guide.fr-fr.md
- pages/web_cloud/internet/internet_access/end_of_copper_migration_ftth/guide.fr-fr.md

## Mandatory information

The translations in this Pull Request have been done using:
- [ ] OVHcloud integrated translation LLM <!-- If you're interested in this new option, contact the Guides team -->
- [ ] Systran
- [ ] Other tool (specify which tool was used)
- [x] This Pull Request didn't require any translation.

- This Pull Request can be merged as soon as possible.

- This Pull Request content should be replicated for the US OVHcloud documentation : NO