### PR TITLE
fixes on account creation link

### DIFF
--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp1/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp1/guide.en-gb.md
@@ -25,7 +25,7 @@ Here is the list of software included in the suite:
 
 ## Requirements
 
-- An [OVHcloud customer account](/links/manager)
+- An [OVHcloud customer account](/pages/account_and_service_management/account_information/ovhcloud-account-creation)
 
 <!-- CP-NAV-START:web-microsoft-365 -->
 ---

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp1/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp1/guide.en-ie.md
@@ -25,7 +25,7 @@ Here is the list of software included in the suite:
 
 ## Requirements
 
-- An [OVHcloud customer account](/links/manager)
+- An [OVHcloud customer account](/pages/account_and_service_management/account_information/ovhcloud-account-creation)
 
 <!-- CP-NAV-START:web-microsoft-365 -->
 ---

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp1/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp1/guide.fr-fr.md
@@ -25,7 +25,7 @@ Voici la liste des logiciels compris dans la suite :
 
 ## Prérequis
 
-- Disposer d'un [compte client OVHcloud](/links/manager).
+- Disposer d'un [compte client OVHcloud](/pages/account_and_service_management/account_information/ovhcloud-account-creation).
 
 <!-- CP-NAV-START:web-microsoft-365 -->
 ---

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp2/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp2/guide.en-gb.md
@@ -12,7 +12,7 @@ Office 365 for Resellers (CSP2) is a service that allows you to purchase differe
 
 ## Requirements
 
-- An [OVHcloud customer account](/links/manager)
+- An [OVHcloud customer account](/pages/account_and_service_management/account_information/ovhcloud-account-creation)
 - An [MPN ID](https://learn.microsoft.com/partner-center/mpn-create-a-partner-center-account) (Microsoft Partner Network IDentifier)
 - Registration with the Microsoft Cloud Solution Provider (CSP) program as an "indirect reseller" in the region where you operate (for example: “EU” for Europe)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp2/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp2/guide.en-ie.md
@@ -12,7 +12,7 @@ Office 365 for Resellers (CSP2) is a service that allows you to purchase differe
 
 ## Requirements
 
-- An [OVHcloud customer account](/links/manager)
+- An [OVHcloud customer account](/pages/account_and_service_management/account_information/ovhcloud-account-creation)
 - An [MPN ID](https://learn.microsoft.com/partner-center/mpn-create-a-partner-center-account) (Microsoft Partner Network IDentifier)
 - Registration with the Microsoft Cloud Solution Provider (CSP) program as an "indirect reseller" in the region where you operate (for example: “EU” for Europe)
 

--- a/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp2/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/microsoft_office/office_csp2/guide.fr-fr.md
@@ -12,7 +12,7 @@ Office 365 Revendeurs (CSP2) est un service vous permettant de bénéficier de p
 
 ## Prérequis
 
-- Disposer d’un [compte client OVHcloud](/links/manager).
+- Disposer d’un [compte client OVHcloud](/pages/account_and_service_management/account_information/ovhcloud-account-creation).
 - Disposer d’un [MPN ID](https://learn.microsoft.com/partner-center/mpn-create-a-partner-center-account) (Microsoft Partner Network IDentifiant).
 - Être inscrit au programme CSP (Cloud Solution Provider) de Microsoft en tant que revendeur indirect dans la région où vous exercez (par exemple : « UE » pour l’Europe)
 


### PR DESCRIPTION
## What type of Pull Request is this?

- Fix

## Description

Following #9370

Replacing /links/manager with /pages/account_and_service_management/account_information/ovhcloud-account-creation

## Mandatory information

The translations in this Pull Request have been done using:
- [ ] OVHcloud integrated translation LLM <!-- If you're interested in this new option, contact the Guides team -->
- [ ] Systran
- [ ] Other tool (specify which tool was used)
- [x] This Pull Request didn't require any translation.

- This Pull Request can be merged as soon as possible.

- This Pull Request content should be replicated for the US OVHcloud documentation : NO