### PR TITLE
fix(bring-your-own-{image,linux}): clarify config drive options and cloud-init expectation

### DIFF
--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
+title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -64,19 +69,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnImage Control Panel 01](images/byoi-controlpanel01.png){.thumbnail}
+![Bring Your Own Image Control Panel install button](images/byoi-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Image - byoi`, and click `Next`{.action}.
 
-![BringYourOwnImage Control Panel 03](images/byoi-controlpanel03.png){.thumbnail}
+![Bring Your Own Image Control Panel custom image selection](images/byoi-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnImage Control Panel 04](images/byoi-controlpanel04.png){.thumbnail}
+![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -74,8 +79,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -74,8 +79,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -74,8 +79,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
@@ -156,7 +156,7 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | customizations/imageCheckSum | Your image's checksum | ❌ |
 | customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
 | customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
@@ -179,6 +179,8 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Alma | `\\efi\\almalinux\\shimx64.efi` |
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
+
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
@@ -155,13 +155,13 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | customizations/imageType | Your image format (qcow2, raw) | ✅ |
 | customizations/imageCheckSum | Your image's checksum | ❌ |
 | customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
+| customizations/configDriveUserData | Your cloud-init user-data¹ | ❌ |
 | customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script. Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
+
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
 
@@ -75,8 +80,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 <!-- CP-STEPS-END:deploy-via-control-panel -->
 
@@ -115,13 +118,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -161,7 +164,7 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script. Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -184,7 +187,7 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data on top.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -158,7 +158,7 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | customizations/imageType | Image format (qcow2, raw) | ✅ |
 | customizations/imageCheckSum | Image checksum | ❌ |
 | customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Cloud-init user-data¹ | ❌ |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
 | customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
@@ -187,7 +187,7 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 
 > [!primary]
 >
-> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data on top.
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-gb.md
@@ -151,11 +151,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your cloud-init user-data¹ | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | Cloud-init user-data¹ | ❌ |
 | customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -74,8 +79,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -74,8 +79,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -74,8 +79,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
+title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -64,19 +69,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnImage Control Panel 01](images/byoi-controlpanel01.png){.thumbnail}
+![Bring Your Own Image Control Panel install button](images/byoi-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Image - byoi`, and click `Next`{.action}.
 
-![BringYourOwnImage Control Panel 03](images/byoi-controlpanel03.png){.thumbnail}
+![Bring Your Own Image Control Panel custom image selection](images/byoi-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnImage Control Panel 04](images/byoi-controlpanel04.png){.thumbnail}
+![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying Custom Images using Bring Your Own Image (BYOI) on Dedicated Servers"
+title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -64,19 +69,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnImage Control Panel 01](images/byoi-controlpanel01.png){.thumbnail}
+![Bring Your Own Image Control Panel install button](images/byoi-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Image - byoi`, and click `Next`{.action}.
 
-![BringYourOwnImage Control Panel 03](images/byoi-controlpanel03.png){.thumbnail}
+![Bring Your Own Image Control Panel custom image selection](images/byoi-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnImage Control Panel 04](images/byoi-controlpanel04.png){.thumbnail}
+![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Déployer des images personnalisées avec le service Bring Your Own Image (BYOI) sur un serveur dédié"
 excerpt: "Déployez vos propres images OS personnalisées sur un serveur dédié OVHcloud grâce à la fonctionnalité Bring Your Own Image (BYOI)"
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objectif
@@ -20,6 +20,11 @@ En plus des prérequis et limitations mentionnés ci-dessous, vous devez vous as
 - Un [serveur dédié](/links/bare-metal/bare-metal) dans votre compte OVHcloud
 - Avoir accès à l'[API OVHcloud](/pages/manage_and_operate/api/first-steps) (pour la méthode de [déploiement via l'API](#viaapi) de ce guide)
 - Votre image doit être inférieure à la RAM du serveur moins 3 Gio
+
+> [!primary]
+>
+> Pour appliquer les personnalisations OVHcloud au premier démarrage, votre image doit inclure [cloud-init](https://cloud-init.io/) ou une alternative compatible (par exemple [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/) sur FreeBSD).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -74,8 +79,6 @@ Vous allez être redirigé vers la page de configuration. Assurez-vous que l'URL
 
 Vous trouverez plus de détails sur les options dans la section « [options de déploiement](#options) » ci-dessous.
 
-Pour plus d'informations et des exemples sur ConfigDrive de Cloud-Init, consultez la documentation officielle sur [cette page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Page de configuration Bring Your Own Image dans l'espace client](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Déploiement de votre image via l'API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ Le contenu de la requête API de Bring Your Own Image (BYOI) doit être similair
 }
 ```
 
-Même si le configDrive user data peut être envoyé à l'API en clair directement en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
+Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Voici le configDrive user data en clair avec l'exemple ci-dessus :
+Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 |-|-|-|
 | customizations/hostname | Le hostname | ❌ |
 | customizations/sshKey | La clé publique SSH | ❌ |
-| customizations/imageURL | L'URL de votre image | ✅ |
-| customizations/imageType | Le type/format de votre image (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Checksum de votre image | ❌ |
-| customizations/imageCheckSumType | Type de checksum de votre image. (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
-| customizations/configDriveUserData | Contenu de votre fichier configDrive¹ | ❌ |
-| customizations/configDriveMetadata | Métadonnées Cloud-Init personnalisées | ❌ |
+| customizations/imageURL | L'URL de l'image | ✅ |
+| customizations/imageType | Le type/format de l'image (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Checksum de l'image | ❌ |
+| customizations/imageCheckSumType | Type de checksum de l'image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
+| customizations/configDriveUserData | Données utilisateur (user-data) cloud-init¹ | ❌ |
+| customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
 | userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
 
-¹ Il peut s'agir d'un `#cloud-config` ou d'un script. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
+¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script (voir les [exemples officiels de cloud-init](https://docs.cloud-init.io/en/latest/reference/examples.html)). Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
 ² À utiliser uniquement si vous avez besoin d'en-têtes HTTP, tels que `Basic Auth`<br />
 ³ Le chemin du bootloader EFI est utilisé par iPXE pour démarrer votre système d'exploitation. Pour plus d'informations, consultez notre guide « [Comprendre le processus de démarrage des serveurs dédiés](/pages/bare_metal_cloud/dedicated_servers/boot-process) ». Exemples :
 
@@ -178,9 +181,11 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property clé=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
+
 > [!primary]
 >
-> La partition ConfigDrive est utilisée par cloud-init lors du premier démarrage du serveur afin d'appliquer vos configurations. Vous pouvez choisir d'utiliser la partition par défaut ou une partition personnalisée (en utilisant `configDriveUserData`).
+> Lorsque vous renseignez l'une des personnalisations de cette page, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) lors de l'installation ; sinon, aucun config drive n'est créé. Cloud-init la lit au premier démarrage. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init.
 >
 
 #### Les erreurs clients fréquentes <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
@@ -154,7 +154,7 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | customizations/imageCheckSum | Checksum de votre image | ❌ |
 | customizations/imageCheckSumType | Type de checksum de votre image. (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
 | customizations/configDriveUserData | Contenu de votre fichier configDrive¹ | ❌ |
-| customizations/configDriveMetadata | Métadonnées Cloud-Init personnalisées | ❌ |
+| customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
 | userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
@@ -177,6 +177,8 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | Alma | `\\efi\\almalinux\\shimx64.efi` |
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
+
+⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property cle=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
@@ -149,11 +149,11 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 |-|-|-|
 | customizations/hostname | Le hostname | ❌ |
 | customizations/sshKey | La clé publique SSH | ❌ |
-| customizations/imageURL | L'URL de votre image | ✅ |
-| customizations/imageType | Le type/format de votre image (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Checksum de votre image | ❌ |
-| customizations/imageCheckSumType | Type de checksum de votre image. (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
-| customizations/configDriveUserData | Vos données utilisateur (user-data) cloud-init¹ | ❌ |
+| customizations/imageURL | L'URL de l'image | ✅ |
+| customizations/imageType | Le type/format de l'image (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Checksum de l'image | ❌ |
+| customizations/imageCheckSumType | Type de checksum de l'image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
+| customizations/configDriveUserData | Données utilisateur (user-data) cloud-init¹ | ❌ |
 | customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
@@ -153,13 +153,13 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | customizations/imageType | Le type/format de votre image (qcow2, raw) | ✅ |
 | customizations/imageCheckSum | Checksum de votre image | ❌ |
 | customizations/imageCheckSumType | Type de checksum de votre image. (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
-| customizations/configDriveUserData | Contenu de votre fichier configDrive¹ | ❌ |
+| customizations/configDriveUserData | Vos données utilisateur (user-data) cloud-init¹ | ❌ |
 | customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
 | userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
 
-¹ Il peut s'agir d'un `#cloud-config` ou d'un script. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
+¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script. Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
 ² À utiliser uniquement si vous avez besoin d'en-têtes HTTP, tels que `Basic Auth`<br />
 ³ Le chemin du bootloader EFI est utilisé par iPXE pour démarrer votre système d'exploitation. Pour plus d'informations, consultez notre guide « [Comprendre le processus de démarrage des serveurs dédiés](/pages/bare_metal_cloud/dedicated_servers/boot-process) ». Exemples :
 

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Déployer des images personnalisées avec le service Bring Your Own Image (BYOI) sur un serveur dédié"
 excerpt: "Déployez vos propres images OS personnalisées sur un serveur dédié OVHcloud grâce à la fonctionnalité Bring Your Own Image (BYOI)"
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objectif
@@ -116,13 +116,13 @@ Le contenu de la requête API de Bring Your Own Image (BYOI) doit être similair
 }
 ```
 
-Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
+Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
+Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
 
 ```yaml
 #cloud-config
@@ -181,11 +181,11 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
-⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property cle=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
+⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property clé=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
 
 > [!primary]
 >
-> Lorsque vous renseignez l'une des personnalisations de cette page, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) lors de l'installation ; sinon, aucun config drive n'est créé. Cloud-init la lit au premier démarrage. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init par-dessus.
+> Lorsque vous renseignez l'une des personnalisations de cette page, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) lors de l'installation ; sinon, aucun config drive n'est créé. Cloud-init la lit au premier démarrage. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init.
 >
 
 #### Les erreurs clients fréquentes <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.fr-fr.md
@@ -21,6 +21,11 @@ En plus des prérequis et limitations mentionnés ci-dessous, vous devez vous as
 - Avoir accès à l'[API OVHcloud](/pages/manage_and_operate/api/first-steps) (pour la méthode de [déploiement via l'API](#viaapi) de ce guide)
 - Votre image doit être inférieure à la RAM du serveur moins 3 Gio
 
+> [!primary]
+>
+> Pour appliquer les personnalisations OVHcloud au premier démarrage, votre image doit inclure [cloud-init](https://cloud-init.io/) ou une alternative compatible (par exemple [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/) sur FreeBSD).
+>
+
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
 
@@ -74,8 +79,6 @@ Vous allez être redirigé vers la page de configuration. Assurez-vous que l'URL
 
 Vous trouverez plus de détails sur les options dans la section « [options de déploiement](#options) » ci-dessous.
 
-Pour plus d'informations et des exemples sur ConfigDrive de Cloud-Init, consultez la documentation officielle sur [cette page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Page de configuration Bring Your Own Image dans l'espace client](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Déploiement de votre image via l'API <a name="viaapi"></a>
@@ -113,13 +116,13 @@ Le contenu de la requête API de Bring Your Own Image (BYOI) doit être similair
 }
 ```
 
-Même si le configDrive user data peut être envoyé à l'API en clair directement en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
+Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Voici le configDrive user data en clair avec l'exemple ci-dessus :
+Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
 
 ```yaml
 #cloud-config
@@ -159,7 +162,7 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
 | userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
 
-¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script. Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
+¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script (voir les [exemples officiels de cloud-init](https://docs.cloud-init.io/en/latest/reference/examples.html)). Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
 ² À utiliser uniquement si vous avez besoin d'en-têtes HTTP, tels que `Basic Auth`<br />
 ³ Le chemin du bootloader EFI est utilisé par iPXE pour démarrer votre système d'exploitation. Pour plus d'informations, consultez notre guide « [Comprendre le processus de démarrage des serveurs dédiés](/pages/bare_metal_cloud/dedicated_servers/boot-process) ». Exemples :
 
@@ -182,7 +185,7 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 
 > [!primary]
 >
-> La partition ConfigDrive est utilisée par cloud-init lors du premier démarrage du serveur afin d'appliquer vos configurations. Vous pouvez choisir d'utiliser la partition par défaut ou une partition personnalisée (en utilisant `configDriveUserData`).
+> Lorsque vous renseignez l'une des personnalisations de cette page, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) lors de l'installation ; sinon, aucun config drive n'est créé. Cloud-init la lit au premier démarrage. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init par-dessus.
 >
 
 #### Les erreurs clients fréquentes <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
+title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -64,19 +69,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnImage Control Panel 01](images/byoi-controlpanel01.png){.thumbnail}
+![Bring Your Own Image Control Panel install button](images/byoi-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Image - byoi`, and click `Next`{.action}.
 
-![BringYourOwnImage Control Panel 03](images/byoi-controlpanel03.png){.thumbnail}
+![Bring Your Own Image Control Panel custom image selection](images/byoi-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnImage Control Panel 04](images/byoi-controlpanel04.png){.thumbnail}
+![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
+title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -64,19 +69,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnImage Control Panel 01](images/byoi-controlpanel01.png){.thumbnail}
+![Bring Your Own Image Control Panel install button](images/byoi-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Image - byoi`, and click `Next`{.action}.
 
-![BringYourOwnImage Control Panel 03](images/byoi-controlpanel03.png){.thumbnail}
+![Bring Your Own Image Control Panel custom image selection](images/byoi-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnImage Control Panel 04](images/byoi-controlpanel04.png){.thumbnail}
+![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-image/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
+title: "Deploy custom images using Bring Your Own Image (BYOI) on Dedicated Servers"
 excerpt: "Deploy your own custom OS images on OVHcloud dedicated servers using the Bring Your Own Image (BYOI) feature."
-updated: 2026-02-10
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -20,6 +20,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - A [dedicated server](/links/bare-metal/bare-metal) in your OVHcloud account
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -64,19 +69,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnImage Control Panel 01](images/byoi-controlpanel01.png){.thumbnail}
+![Bring Your Own Image Control Panel install button](images/byoi-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Image - byoi`, and click `Next`{.action}.
 
-![BringYourOwnImage Control Panel 03](images/byoi-controlpanel03.png){.thumbnail}
+![Bring Your Own Image Control Panel custom image selection](images/byoi-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnImage Control Panel 04](images/byoi-controlpanel04.png){.thumbnail}
+![Bring Your Own Image Control Panel configuration page](images/byoi-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -113,13 +116,13 @@ The Bring Your Own Image (BYOI) payload should be similar to the following:
 }
 ```
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -149,17 +152,17 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your image URL | ✅ |
-| customizations/imageType | Your image format (qcow2, raw) | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Image URL | ✅ |
+| customizations/imageType | Image format (qcow2, raw) | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> When you set any customization on this page, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition during installation; otherwise no config drive is created. Cloud-init reads it at first boot. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 #### Common customer errors <a name="errors"></a>

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.de-de.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.de-de.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
+title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -58,19 +63,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnLinux Control Panel 01](images/byolinux-controlpanel01.png){.thumbnail}
+![Bring Your Own Linux Control Panel install button](images/byolinux-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Linux - byolinux`, and click `Next`{.action}.
 
-![BringYourOwnLinux Control Panel 03](images/byolinux-controlpanel03.png){.thumbnail}
+![Bring Your Own Linux Control Panel custom image selection](images/byolinux-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnLinux Control Panel 04](images/byolinux-controlpanel04.png){.thumbnail}
+![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-asia.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-asia.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -68,8 +73,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-au.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-au.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -68,8 +73,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -68,8 +73,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-gb.md
@@ -22,6 +22,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
 
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
+
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
 
@@ -69,8 +74,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 <!-- CP-STEPS-END:deploy-via-control-panel -->
 
@@ -112,13 +115,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -161,7 +164,7 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script. Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -184,7 +187,7 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data on top.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-gb.md
@@ -156,7 +156,7 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | customizations/imageCheckSum | Your image's checksum | ❌ |
 | customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
 | customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
@@ -179,6 +179,8 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Alma | `\\efi\\almalinux\\shimx64.efi` |
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
+
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-gb.md
@@ -152,10 +152,10 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your cloud-init user-data¹ | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | Cloud-init user-data¹ | ❌ |
 | customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-gb.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -158,7 +158,7 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | customizations/imageURL | Linux image URL | ✅ |
 | customizations/imageCheckSum | Image checksum | ❌ |
 | customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Cloud-init user-data¹ | ❌ |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
 | customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
@@ -187,7 +187,7 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 
 > [!primary]
 >
-> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data on top.
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-gb.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-gb.md
@@ -155,13 +155,13 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | customizations/imageURL | Your Linux image URL | ✅ |
 | customizations/imageCheckSum | Your image's checksum | ❌ |
 | customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
+| customizations/configDriveUserData | Your cloud-init user-data¹ | ❌ |
 | customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script. Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-ie.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-ie.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -68,8 +73,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-sg.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-sg.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -68,8 +73,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.en-us.md
@@ -1,7 +1,7 @@
 ---
 title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -68,8 +73,6 @@ You will be redirected to the configuration page. Make sure your image URL is in
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.es-es.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.es-es.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
+title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -58,19 +63,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnLinux Control Panel 01](images/byolinux-controlpanel01.png){.thumbnail}
+![Bring Your Own Linux Control Panel install button](images/byolinux-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Linux - byolinux`, and click `Next`{.action}.
 
-![BringYourOwnLinux Control Panel 03](images/byolinux-controlpanel03.png){.thumbnail}
+![Bring Your Own Linux Control Panel custom image selection](images/byolinux-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnLinux Control Panel 04](images/byolinux-controlpanel04.png){.thumbnail}
+![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.es-us.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.es-us.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying Custom Linux image using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
+title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -58,19 +63,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnLinux Control Panel 01](images/byolinux-controlpanel01.png){.thumbnail}
+![Bring Your Own Linux Control Panel install button](images/byolinux-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Linux - byolinux`, and click `Next`{.action}.
 
-![BringYourOwnLinux Control Panel 03](images/byolinux-controlpanel03.png){.thumbnail}
+![Bring Your Own Linux Control Panel custom image selection](images/byolinux-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnLinux Control Panel 04](images/byolinux-controlpanel04.png){.thumbnail}
+![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-ca.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-ca.md
@@ -1,7 +1,7 @@
 ---
 title: "Déployer des images Linux personnalisées via Bring Your Own Linux (BYOLinux) sur un serveur dédié"
 excerpt: "Déployez vos propres images Linux personnalisées sur un serveur dédié OVHcloud grâce à la fonctionnalité Bring Your Own Linux (BYOLinux)"
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objectif
@@ -21,6 +21,11 @@ En plus des prérequis et limitations mentionnés ci-dessous, vous devez vous as
 - Avoir accès à l'[API OVHcloud](/pages/manage_and_operate/api/first-steps) (pour la méthode de [déploiement via l'API](#viaapi) de ce guide)
 - Votre image doit être inférieure à la RAM du serveur moins 3 Gio
 - Un script `/root/.ovh/make_image_bootable.sh` exécutable, qui installera ou configurera le bootloader, [par exemple GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). Ce script ne doit pas modifier l'ordre de boot NVRAM (par exemple, utilisez `grub-install --no-nvram`). Pour plus d'informations, consultez notre guide « [Comprendre le processus de démarrage des serveurs dédiés](/pages/bare_metal_cloud/dedicated_servers/boot-process) ».
+
+> [!primary]
+>
+> Pour appliquer les personnalisations OVHcloud au premier démarrage, votre image doit inclure [cloud-init](https://cloud-init.io/) ou une alternative compatible (par exemple [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/) sur FreeBSD).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -68,8 +73,6 @@ Vous allez être redirigé vers la page de configuration. Assurez-vous que l'URL
 
 Vous trouverez plus de détails sur les options dans la section « [options de déploiement](#options) » ci-dessous.
 
-Pour plus d'informations et des exemples sur ConfigDrive de Cloud-Init, consultez la documentation officielle sur [cette page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Page de configuration Bring Your Own Linux dans l'espace client](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Déploiement de votre image via l'API <a name="viaapi"></a>
@@ -110,13 +113,13 @@ Le contenu de la requête API de Bring Your Own Linux (BYOLinux) doit être simi
 > Dans l'exemple ci-dessus, la valeur de `imageCheckSum` a été masquée, car elle change régulièrement à chaque reconstruction de l’image cible.
 >
 
-Même si le configDrive user data peut être envoyé à l'API en clair directement en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
+Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Voici le configDrive user data en clair avec l'exemple ci-dessus :
+Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 |-|-|-|
 | customizations/hostname | Le hostname | ❌ |
 | customizations/sshKey | La clé publique SSH | ❌ |
-| customizations/imageURL | L'URL de votre image Linux | ✅ |
-| customizations/imageCheckSum | Checksum de votre image | ❌ |
-| customizations/imageCheckSumType | Type de checksum de votre image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
-| customizations/configDriveUserData | Contenu de votre fichier configDrive¹ | ❌ |
-| customizations/configDriveMetadata | Métadonnées Cloud-Init personnalisées | ❌ |
+| customizations/imageURL | L'URL de l'image Linux | ✅ |
+| customizations/imageCheckSum | Checksum de l'image | ❌ |
+| customizations/imageCheckSumType | Type de checksum de l'image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
+| customizations/configDriveUserData | Données utilisateur (user-data) cloud-init¹ | ❌ |
+| customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
 | userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
 
-¹ Il peut s'agir d'un `#cloud-config` ou d'un script. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
+¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script (voir les [exemples officiels de cloud-init](https://docs.cloud-init.io/en/latest/reference/examples.html)). Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
 ² À utiliser uniquement si vous avez besoin d'en-têtes HTTP, tels que `Basic Auth`<br />
 ³ Le chemin du bootloader EFI est utilisé par iPXE pour démarrer votre système d'exploitation. Pour plus d'informations, consultez notre guide « [Comprendre le processus de démarrage des serveurs dédiés](/pages/bare_metal_cloud/dedicated_servers/boot-process) ». Exemples :
 
@@ -178,9 +181,11 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property clé=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
+
 > [!primary]
 >
-> La partition ConfigDrive est utilisée par cloud-init lors du premier démarrage du serveur afin d'appliquer vos configurations. Vous pouvez choisir d'utiliser la partition par défaut ou une partition personnalisée (en utilisant `configDriveUserData`).
+> Lors de l'installation, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) sur votre serveur. Cloud-init la lit au premier démarrage pour appliquer la configuration de base d'OVHcloud. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-fr.md
@@ -22,6 +22,11 @@ En plus des prérequis et limitations mentionnés ci-dessous, vous devez vous as
 - Votre image doit être inférieure à la RAM du serveur moins 3 Gio
 - Un script `/root/.ovh/make_image_bootable.sh` exécutable, qui installera ou configurera le bootloader, [par exemple GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). Ce script ne doit pas modifier l'ordre de boot NVRAM (par exemple, utilisez `grub-install --no-nvram`). Pour plus d'informations, consultez notre guide « [Comprendre le processus de démarrage des serveurs dédiés](/pages/bare_metal_cloud/dedicated_servers/boot-process) ».
 
+> [!primary]
+>
+> Pour appliquer les personnalisations OVHcloud au premier démarrage, votre image doit inclure [cloud-init](https://cloud-init.io/) ou une alternative compatible (par exemple [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/) sur FreeBSD).
+>
+
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
 
@@ -68,8 +73,6 @@ Vous allez être redirigé vers la page de configuration. Assurez-vous que l'URL
 
 Vous trouverez plus de détails sur les options dans la section « [options de déploiement](#options) » ci-dessous.
 
-Pour plus d'informations et des exemples sur ConfigDrive de Cloud-Init, consultez la documentation officielle sur [cette page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
 ![Page de configuration Bring Your Own Linux dans l'espace client](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Déploiement de votre image via l'API <a name="viaapi"></a>
@@ -110,13 +113,13 @@ Le contenu de la requête API de Bring Your Own Linux (BYOLinux) doit être simi
 > Dans l'exemple ci-dessus, la valeur de `imageCheckSum` a été masquée, car elle change régulièrement à chaque reconstruction de l’image cible.
 >
 
-Même si le configDrive user data peut être envoyé à l'API en clair directement en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
+Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Voici le configDrive user data en clair avec l'exemple ci-dessus :
+Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
 
 ```yaml
 #cloud-config
@@ -159,7 +162,7 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
 | userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
 
-¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script. Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
+¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script (voir les [exemples officiels de cloud-init](https://docs.cloud-init.io/en/latest/reference/examples.html)). Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
 ² À utiliser uniquement si vous avez besoin d'en-têtes HTTP, tels que `Basic Auth`<br />
 ³ Le chemin du bootloader EFI est utilisé par iPXE pour démarrer votre système d'exploitation. Pour plus d'informations, consultez notre guide « [Comprendre le processus de démarrage des serveurs dédiés](/pages/bare_metal_cloud/dedicated_servers/boot-process) ». Exemples :
 
@@ -182,7 +185,7 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 
 > [!primary]
 >
-> La partition ConfigDrive est utilisée par cloud-init lors du premier démarrage du serveur afin d'appliquer vos configurations. Vous pouvez choisir d'utiliser la partition par défaut ou une partition personnalisée (en utilisant `configDriveUserData`).
+> Lors de l'installation, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) sur votre serveur. Cloud-init la lit au premier démarrage pour appliquer la configuration de base d'OVHcloud. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init par-dessus.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-fr.md
@@ -154,7 +154,7 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | customizations/imageCheckSum | Checksum de votre image | ❌ |
 | customizations/imageCheckSumType | Type de checksum de votre image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
 | customizations/configDriveUserData | Contenu de votre fichier configDrive¹ | ❌ |
-| customizations/configDriveMetadata | Métadonnées Cloud-Init personnalisées | ❌ |
+| customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
 | userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
@@ -177,6 +177,8 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | Alma | `\\efi\\almalinux\\shimx64.efi` |
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
+
+⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property cle=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
 
 > [!primary]
 >

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Déployer des images Linux personnalisées via Bring Your Own Linux (BYOLinux) sur un serveur dédié"
 excerpt: "Déployez vos propres images Linux personnalisées sur un serveur dédié OVHcloud grâce à la fonctionnalité Bring Your Own Linux (BYOLinux)"
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objectif
@@ -113,13 +113,13 @@ Le contenu de la requête API de Bring Your Own Linux (BYOLinux) doit être simi
 > Dans l'exemple ci-dessus, la valeur de `imageCheckSum` a été masquée, car elle change régulièrement à chaque reconstruction de l’image cible.
 >
 
-Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
+Même si `configDriveUserData` peut être envoyé à l'API directement en clair en échappant les bons caractères, il est recommandé d'envoyer à l'API le script encodé en base64 en utilisant par exemple la commande UNIX/Linux suivante :
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
+Voici la version en clair de `configDriveUserData` de l'exemple ci-dessus :
 
 ```yaml
 #cloud-config
@@ -181,11 +181,11 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
-⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property cle=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
+⁴ Objet JSON de couples clé/valeur arbitraires, équivalent à `server create --property clé=valeur` chez OpenStack. Les couples sont écrits dans le `meta_data.json` du config drive sous la clé `meta`, où cloud-init peut les lire. Exemple : `"configDriveMetadata": {"role": "webserver", "env": "prod"}` devient `"meta": {"role": "webserver", "env": "prod"}` dans `meta_data.json`. Voir la [documentation du service de métadonnées OpenStack](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) pour le schéma complet.
 
 > [!primary]
 >
-> Lors de l'installation, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) sur votre serveur. Cloud-init la lit au premier démarrage pour appliquer la configuration de base d'OVHcloud. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init par-dessus.
+> Lors de l'installation, OVHcloud ajoute une petite partition de [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) sur votre serveur. Cloud-init la lit au premier démarrage pour appliquer la configuration de base d'OVHcloud. Renseignez `configDriveUserData` pour ajouter vos propres données utilisateur (user-data) cloud-init.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-fr.md
@@ -153,13 +153,13 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 | customizations/imageURL | L'URL de votre image Linux | ✅ |
 | customizations/imageCheckSum | Checksum de votre image | ❌ |
 | customizations/imageCheckSumType | Type de checksum de votre image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
-| customizations/configDriveUserData | Contenu de votre fichier configDrive¹ | ❌ |
+| customizations/configDriveUserData | Vos données utilisateur (user-data) cloud-init¹ | ❌ |
 | customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |
 | userMetadata/efiBootloaderPath | Le chemin du bootloader EFI | ✅³ |
 
-¹ Il peut s'agir d'un `#cloud-config` ou d'un script. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
+¹ [Données utilisateur](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) cloud-init standard — généralement un document `#cloud-config` ou un script. Équivalent à `server create --user-data <fichier>` chez OpenStack. Sa représentation JSON doit être sur une seule ligne avec `\n` pour les retours à la ligne, car les chaînes JSON ne peuvent pas contenir de retours à la ligne littéraux.<br />
 ² À utiliser uniquement si vous avez besoin d'en-têtes HTTP, tels que `Basic Auth`<br />
 ³ Le chemin du bootloader EFI est utilisé par iPXE pour démarrer votre système d'exploitation. Pour plus d'informations, consultez notre guide « [Comprendre le processus de démarrage des serveurs dédiés](/pages/bare_metal_cloud/dedicated_servers/boot-process) ». Exemples :
 

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-fr.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.fr-fr.md
@@ -150,10 +150,10 @@ Une fois les champs complétés, démarrez le déploiement en cliquant sur `Exec
 |-|-|-|
 | customizations/hostname | Le hostname | ❌ |
 | customizations/sshKey | La clé publique SSH | ❌ |
-| customizations/imageURL | L'URL de votre image Linux | ✅ |
-| customizations/imageCheckSum | Checksum de votre image | ❌ |
-| customizations/imageCheckSumType | Type de checksum de votre image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
-| customizations/configDriveUserData | Vos données utilisateur (user-data) cloud-init¹ | ❌ |
+| customizations/imageURL | L'URL de l'image Linux | ✅ |
+| customizations/imageCheckSum | Checksum de l'image | ❌ |
+| customizations/imageCheckSumType | Type de checksum de l'image (md5, sha1, sha256, sha512) | ❌ (sauf si checksum fourni) |
+| customizations/configDriveUserData | Données utilisateur (user-data) cloud-init¹ | ❌ |
 | customizations/configDriveMetadata | Métadonnées cloud-init personnalisées, exposées sous la clé `meta` de `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | Clé des en-têtes HTTP | ❌² |
 | customizations/httpHeaders?Value | Valeur des en-têtes HTTP | ❌² |

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.it-it.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.it-it.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
+title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -58,19 +63,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnLinux Control Panel 01](images/byolinux-controlpanel01.png){.thumbnail}
+![Bring Your Own Linux Control Panel install button](images/byolinux-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Linux - byolinux`, and click `Next`{.action}.
 
-![BringYourOwnLinux Control Panel 03](images/byolinux-controlpanel03.png){.thumbnail}
+![Bring Your Own Linux Control Panel custom image selection](images/byolinux-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnLinux Control Panel 04](images/byolinux-controlpanel04.png){.thumbnail}
+![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.pl-pl.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.pl-pl.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
+title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -58,19 +63,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnLinux Control Panel 01](images/byolinux-controlpanel01.png){.thumbnail}
+![Bring Your Own Linux Control Panel install button](images/byolinux-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Linux - byolinux`, and click `Next`{.action}.
 
-![BringYourOwnLinux Control Panel 03](images/byolinux-controlpanel03.png){.thumbnail}
+![Bring Your Own Linux Control Panel custom image selection](images/byolinux-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnLinux Control Panel 04](images/byolinux-controlpanel04.png){.thumbnail}
+![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]

--- a/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.pt-pt.md
+++ b/pages/bare_metal_cloud/dedicated_servers/bring-your-own-linux/guide.pt-pt.md
@@ -1,7 +1,7 @@
 ---
-title: "Deploying custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
+title: "Deploy custom Linux images using Bring Your Own Linux (BYOLinux) on Dedicated Servers"
 excerpt: "Deploy your own custom Linux images on OVHcloud dedicated servers using the Bring Your Own Linux (BYOLinux) feature."
-updated: 2026-03-16
+updated: 2026-05-11
 ---
 
 ## Objective
@@ -21,6 +21,11 @@ In addition to the requirements and limitations mentioned below, you must ensure
 - Access to the [OVHcloud API](/pages/manage_and_operate/api/first-steps) (for the "[Deployment via API](#viaapi)" section of this guide)
 - Your image must be smaller than the server RAM minus 3GiB
 - An executable script `/root/.ovh/make_image_bootable.sh`, which will install and configure the bootloader, [for example GRUB](https://github.com/ovh/bringyourownlinux/blob/e20c9474e1a0/example_build/files/make_image_bootable.sh). This script must not alter the NVRAM boot order (e.g. use `grub-install --no-nvram`). For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process).
+
+> [!primary]
+>
+> To apply OVHcloud customizations at first boot, your image must include [cloud-init](https://cloud-init.io/) or a compatible alternative (such as FreeBSD's [`nuageinit`](https://cgit.freebsd.org/src/tree/libexec/nuageinit/)).
+>
 
 <!-- CP-NAV-START:baremetal-dedicated-servers -->
 ---
@@ -58,19 +63,17 @@ There are some technical limitations linked to the use of physical products such
 
 In the `General information`{.action} tab, click the `...`{.action} button next to "System (OS)" then click `Install`{.action}.
 
-![BringYourOwnLinux Control Panel 01](images/byolinux-controlpanel01.png){.thumbnail}
+![Bring Your Own Linux Control Panel install button](images/byolinux-controlpanel01.png){.thumbnail}
 
 In the window that appears, select `Custom` in the menu, then `Bring Your Own Linux - byolinux`, and click `Next`{.action}.
 
-![BringYourOwnLinux Control Panel 03](images/byolinux-controlpanel03.png){.thumbnail}
+![Bring Your Own Linux Control Panel custom image selection](images/byolinux-controlpanel03.png){.thumbnail}
 
 You will be redirected to the configuration page. Make sure your image URL is in the correct format. Fill in the rest of the required fields on this page. Once you have confirmed that the information is correct, click `Confirm`{.action}.
 
 You can find more details on the options in the [deployment options](#options) section below.
 
-For more information and examples about Cloud-Init's ConfigDrive, please read the official documentation on [this page](https://cloudinit.readthedocs.io/en/22.1_a/topics/examples.html).
-
-![BringYourOwnLinux Control Panel 04](images/byolinux-controlpanel04.png){.thumbnail}
+![Bring Your Own Linux Control Panel configuration page](images/byolinux-controlpanel04.png){.thumbnail}
 
 ### Deploy your image via the API <a name="viaapi"></a>
 
@@ -110,13 +113,13 @@ The Bring Your Own Linux (BYOLinux) payload should be similar to the following:
 > In the example above, the `imageCheckSum` value has been masked because it changes regularly whenever the target image is rebuilt.
 >
 
-Even though the configDrive user data could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
+Even though `configDriveUserData` could be sent to the API directly in clear text by escaping special characters, it is recommended to send a base64-encoded script to the API. You can use the following UNIX/Linux command to encode your data:
 
 ```bash
 cat my-data.yaml | base64 -w0
 ```
 
-Here is the clear-text configDrive user data from the example above:
+Here is the clear-text version of `configDriveUserData` from the example above:
 
 ```yaml
 #cloud-config
@@ -150,16 +153,16 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 |-|-|-|
 | customizations/hostname | Hostname | ❌ |
 | customizations/sshKey | SSH public key | ❌ |
-| customizations/imageURL | Your Linux image URL | ✅ |
-| customizations/imageCheckSum | Your image's checksum | ❌ |
-| customizations/imageCheckSumType | Your image's checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
-| customizations/configDriveUserData | Your configDrive file content¹ | ❌ |
-| customizations/configDriveMetadata | Custom Cloud-Init metadata | ❌ |
+| customizations/imageURL | Linux image URL | ✅ |
+| customizations/imageCheckSum | Image checksum | ❌ |
+| customizations/imageCheckSumType | Image checksum type (md5, sha1, sha256, sha512) | ❌ (except if checksum provided) |
+| customizations/configDriveUserData | cloud-init user-data¹ | ❌ |
+| customizations/configDriveMetadata | Custom cloud-init metadata, exposed under the `meta` key of `meta_data.json`⁴ | ❌ |
 | customizations/httpHeaders?Key | HTTP Headers key  | ❌² |
 | customizations/httpHeaders?Value | HTTP Headers value | ❌² |
 | userMetadata/efiBootloaderPath | EFI bootloader path | ✅³ |
 
-¹ Can either be a `#cloud-config` or a script. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
+¹ Standard cloud-init [user-data](https://cloudinit.readthedocs.io/en/latest/explanation/format.html) — typically a `#cloud-config` document or a script (see the [official cloud-init examples](https://docs.cloud-init.io/en/latest/reference/examples.html)). Equivalent to OpenStack's `server create --user-data <file>`. Its JSON representation must be on a single line with `\n` for line breaks, as JSON strings cannot contain literal newlines.<br />
 ² Use only if you need HTTP Headers, such as `Basic Auth`<br />
 ³ The EFI bootloader path is used by iPXE to boot your operating system. For more information, see [Understanding the dedicated server boot process](/pages/bare_metal_cloud/dedicated_servers/boot-process). Examples:
 
@@ -178,9 +181,11 @@ Once you have filled in the fields, start the deployment by clicking `Execute`{.
 | Arch Linux | `\\efi\\arch\\grubx64.efi` |
 | Gentoo | `\\efi\\boot\\bootx64.efi` |
 
+⁴ JSON object of arbitrary key/value pairs, equivalent to OpenStack's `server create --property key=value`. The pairs are written to the config drive's `meta_data.json` under the `meta` key, where cloud-init can read them. Example: `"configDriveMetadata": {"role": "webserver", "env": "prod"}` becomes `"meta": {"role": "webserver", "env": "prod"}` in `meta_data.json`. See the [OpenStack metadata service documentation](https://docs.openstack.org/nova/latest/user/metadata.html#openstack-format-metadata) for the full schema.
+
 > [!primary]
 >
-> The ConfigDrive partition is used by cloud-init during the first server boot in order to apply your configurations. You can choose whether you want to use the default one, or a custom one (using `configDriveUserData`).
+> During installation, OVHcloud adds a small [config drive](https://docs.cloud-init.io/en/latest/reference/datasources/configdrive.html) partition to your server. Cloud-init reads it at first boot to apply OVHcloud's baseline configuration. Set `configDriveUserData` to add your own cloud-init user-data.
 >
 
 > [!warning]


### PR DESCRIPTION
## What type of Pull Request is this?                                                                                                      
                                                                                                                                           
- Update of existing guide(s)                                                                                                              
- Fix                                                                                                                                      
                                                                                                                                           
## Description                                                                                                                             
                                                                                                                                           
* fix(bring-your-own-{image,linux}): clarify configDriveMetadata field

    The previous "Custom Cloud-Init metadata" wording did not say where the
    values land or how to use them. Clarify that configDriveMetadata is the
    equivalent of OpenStack's `server create --property k=v` and that the pairs
    appear in the config drive's meta_data.json under the `meta` key, with a
    concrete example and a link to the OpenStack metadata service schema.
    
    Ref: PUBM-52977
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
* fix(bring-your-own-{image,linux}): clarify configDriveUserData field

    The previous "Your configDrive file content" wording was unclear about what
    the field actually is. Rename it to "cloud-init user-data" and extend the
    footnote to say it's standard cloud-init user-data (the equivalent of
    OpenStack's `server create --user-data <file>`), with a link to the
    upstream cloud-init format documentation.
    
    Ref: PUBM-52977
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
* fix(bring-your-own-{image,linux}): drop possessive in deployment-options table

    Only 4 of 9 customizations rows used "Your"/"votre" — the rest were already
    phrased as bare noun labels ("Hostname", "EFI bootloader path",
    "HTTP Headers key", etc). Drop the outliers to align: "Your image URL" →
    "Image URL", "L'URL de votre image" → "L'URL de l'image", and so on.
    Also drops a stray trailing period in BYOI fr-fr's imageCheckSumType row.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    
* fix(bring-your-own-{image,linux}): clarify config drive documentation

    Rewrite the misleading "default vs custom" [!primary] callout near
    the deployment-options table (configDriveUserData is purely
    additive, not a toggle between two pre-built config drives) into a
    factual paragraph on what OVHcloud creates during install and how
    configDriveUserData fits in. BYOL: config drive is always added;
    BYOI: only added when at least one customization on the page is
    set, otherwise no config drive is created.
    
    Add a separate brief prerequisite [!primary] in Requirements
    stating that to apply OVHcloud customizations at first boot, the
    image must include cloud-init or a compatible alternative (such as
    FreeBSD's nuageinit).
    
    Normalize prose to cloud-init upstream conventions ("ConfigDrive"
    -> "config drive", "Cloud-Init" -> "cloud-init"; API field names
    like configDriveUserData are unchanged), update an outdated 22.1_a
    documentation URL, and fold the cloud-init examples link into
    footnote 1 where configDriveUserData is defined.
    
    Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
    


    

## Mandatory information

The translations in this Pull Request have been done using:
- [x] Other tool (specify which tool was used): Claude Code (Opus 4.7)
- This Pull Request can be merged as soon as possible.                                                                                                                                                                                                                                  
- This Pull Request content should be replicated for the US OVHcloud documentation: YES
