### PR TITLE
fix(kubernetes): use a more appropriate payload example for IP allocation management

### DIFF
--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/configuring-pods-services-ip-allocation/guide.en-gb.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/configuring-pods-services-ip-allocation/guide.en-gb.md
@@ -69,13 +69,17 @@ To set a custom IP allocation policy on pods and/or services, you can use the fo
   "nodepool": {
     "desiredNodes": 3,
     "flavorName": "b3-8",
-    "name": "my-nodepool"
+    "name": "my-nodepool-zone-b",
+    "availabilityZones": ["eu-west-par-b"]
   },
-  "region": "GRA11",
+  "region": "EU-WEST-PAR",
   "ipAllocationPolicy": {
     "podsIpv4Cidr": "172.16.0.0/12",
     "servicesIpv4Cidr": "10.100.0.0/16"
-  }
+  },
+  "privateNetworkId": "a60144a6-5ec1-4fe5-af79-31032f37876a",
+  "nodesSubnetId": "ca2809f6-b7ef-40d8-8ef1-4b64c1a1ffae",
+  "plan": "standard"
 }
 ```
 

--- a/pages/public_cloud/containers_orchestration/managed_kubernetes/configuring-pods-services-ip-allocation/guide.fr-fr.md
+++ b/pages/public_cloud/containers_orchestration/managed_kubernetes/configuring-pods-services-ip-allocation/guide.fr-fr.md
@@ -69,13 +69,17 @@ Pour définir une politique d'allocation IP personnalisée sur les pods et/ou se
   "nodepool": {
     "desiredNodes": 3,
     "flavorName": "b3-8",
-    "name": "my-nodepool"
+    "name": "my-nodepool-zone-b",
+    "availabilityZones": ["eu-west-par-b"]
   },
-  "region": "GRA11",
+  "region": "EU-WEST-PAR",
   "ipAllocationPolicy": {
     "podsIpv4Cidr": "172.16.0.0/12",
     "servicesIpv4Cidr": "10.100.0.0/16"
-  }
+  },
+  "privateNetworkId": "a60144a6-5ec1-4fe5-af79-31032f37876a",
+  "nodesSubnetId": "ca2809f6-b7ef-40d8-8ef1-4b64c1a1ffae",
+  "plan": "standard"
 }
 ```
 


### PR DESCRIPTION

## What type of Pull Request is this?

- Fix

## Description

This PR changes the example for the IP allocation management on Standard Managed Kubernetes to use a more relevant payload.

## Mandatory information

The translations in this Pull Request have been done using:
- [ ] OVHcloud integrated translation LLM <!-- If you're interested in this new option, contact the Guides team -->
- [ ] Systran
- [ ] Other tool (specify which tool was used)
- [x] This Pull Request didn't require any translation.

- This Pull Request can be merged as soon as possible.

