### PR TITLE
chore: add PR template redirecting contributors to ovhcloud-docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+> [!WARNING]
+> ## This repository is no longer accepting contributions
+>
+> The OVHcloud documentation has moved to a new platform.
+> All new guides, fixes, and translations must be submitted to:
+>
+> 👉 **https://github.com/ovh/ovhcloud-docs**
+>
+> Pull requests opened here will be closed without review.
+> The content in this repository is preserved for archival purposes only —
+> live pages on https://docs.ovh.com now redirect to the new platform.
+
+---
+
+### Before you continue
+
+- [ ] I understand this PR will not be merged.
+- [ ] I will re-open my contribution against [ovh/ovhcloud-docs](https://github.com/ovh/ovhcloud-docs).
+
+### Why was the documentation moved?
+
+The new platform offers a modern stack (Rspress/MDX), faster builds, better
+search, and per-locale file trees. See the README of the new repository for
+contribution guidelines.


### PR DESCRIPTION
Legacy docs platform has been replaced by ovh/ovhcloud-docs. This template warns contributors opening new PRs that the repository no longer accepts contributions and points them to the new repository.
