### PR TITLE
Remove Premier2026 end of sales date

### DIFF
--- a/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/lifecycle_policy/guide.fr-fr.md
+++ b/pages/hosted_private_cloud/hosted_private_cloud_powered_by_vmware/lifecycle_policy/guide.fr-fr.md
@@ -92,7 +92,7 @@ Pour le produit Managed VMware vSphere, un cycle de vie matériel spécifique s�
 |              SDDC2018 (Intel Broadwell)               |          2018        |  2018-11-30  |  2026-06-01   | 2027-05-31  |
 |             Essentials (Intel Broadwell)              |          2020        |  2026-06-01  |  2026-06-01   | 2027-05-31  |
 |               Premier (Intel Xeon Gold)               |          2020        |  2026-05-29  |  2027-03-30   | 2027-10-31  |
-|           Premier2026 (Intel Emerald Rapids)          |          2026        |  2027-06-30  |               |             |
+|           Premier2026 (Intel Emerald Rapids)          |          2026        |              |               |             |
 |           Premier2027 (Intel Granite Rapids)          |          2027        |              |               |             |
 
 ## Logiciels intégrés


### PR DESCRIPTION
Updated the lifecycle policy table for Premier2026 to remove the end date.

> [!WARNING]
> ## This repository is no longer accepting contributions
>
> The OVHcloud documentation has moved to a new platform.
> All new guides, fixes, and translations must be submitted to:
>
> 👉 **https://github.com/ovh/ovhcloud-docs**
>
> Pull requests opened here will be closed without review.
> The content in this repository is preserved for archival purposes only —
> live pages on https://docs.ovh.com now redirect to the new platform.

---

### Before you continue

- [ ] I understand this PR will not be merged.
- [ ] I will re-open my contribution against [ovh/ovhcloud-docs](https://github.com/ovh/ovhcloud-docs).

### Why was the documentation moved?

The new platform offers a modern stack (Rspress/MDX), faster builds, better
search, and per-locale file trees. See the README of the new repository for
contribution guidelines.
