### PR TITLE
[SK-2630] fix(migration_control_panel): surface steps 3.1/3.2 in TOC and fix an…

### DIFF
--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.de-de.md
@@ -80,7 +80,9 @@ Bevor Sie mit der Migration beginnen, müssen Sie die Version des MX Plan identi
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Manuelle Migration eines MX Plan-Angebots zu Exchange, E-Mail Pro oder Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Manuelle Migration eines MX Plan-Angebots zu Exchange, E-Mail Pro oder Zimbra
 
 > [!warning]
 >
@@ -132,7 +134,9 @@ Sie können den ursprünglichen Account nach dieser Migration mit dem vorläufig
 
 Wenn Sie ihn löschen möchten, gehen Sie in den Tab `E-Mails`{.action} Ihres MX Plans, klicken Sie auf `...`{.action} und dann auf `Konto löschen`{.action}.
 
-#### 3.2 Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder E-Mail Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Automatische Migration eines MX Plan Roundcube Angebots zu Exchange oder E-Mail Pro
 
 > [!warning]
 >
@@ -163,13 +167,13 @@ Wenn Sie bereit sind, folgen Sie der Anleitung entsprechend dem gewählten Inter
 > Auch wenn Sie nicht mehr auf Ihre aktuelle E-Mail-Adresse zugreifen können, gehen existierende und neue Nachrichten nicht verloren. Sie werden von Ihrem neuen Account aus sofort verfügbar sein.
 >
 
-##### **Migration mit Exchange Konfigurationsassistent**
+#### **Migration mit Exchange Konfigurationsassistent**
 
 Der Assistent sollte erscheinen, um Ihnen bei der Konfiguration Ihres neuen Exchange Dienstes zu helfen. Während dieses Vorgangs können Sie die zu migrierenden MX Plan E-Mail-Accounts auswählen.
 
 Wenn der Konfigurationsassistent nicht startet, werden stattdessen die allgemeinen Informationen zum Exchange Dienst angezeigt. In diesem Fall müssen Sie Ihre Accounts über das MX Plan Interface migrieren.
 
-##### **Migration über das MX Plan Interface**
+#### **Migration über das MX Plan Interface**
 
 Um die Migration über dieses Interface durchzuführen, wählen Sie im Bereich [MX Plan](/links/control-panel/web-mx-plan) Ihres OVHcloud Kundencenters die betreffende Domain aus. Klicken Sie im Tab `E-Mails`{.action} auf `...`{.action} in der Zeile des betreffenden E-Mail-Accounts (auch als Quell-Account bezeichnet) und dann auf `Account überführen`{.action}.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ca.md
@@ -66,7 +66,9 @@ Please refer to the table below.
 |![email](images/mxplan-starter-legacy-step1.png){.thumbnail}<br> Your solution is specified the "Plan" box.|![email](images/mxplan-starter-new-step1.png){.thumbnail}<br>You will find a `Server model` in the “Summary” box, starting with “mxplan-”.|
 |Continue with [Legacy version of the MX Plan solution](#LegacyMxplan)|Continue with [New version of the MX Plan solution](#NewVersionMxplan)|
 
-#### 3.1 Migrating a legacy MX Plan solution <a name="LegacyMxplan"></a>
+<a name="LegacyMxplan"></a>
+
+### 3.1 Migrating a legacy MX Plan solution
 
 > [!primary]
 >
@@ -92,13 +94,13 @@ Once you are ready, follow the steps below, depending on the interface you have 
 > Even if you can no longer access your current email address, messages that have already been received and those that have been received will not be lost. All will be immediately accessible from your new account.
 >
 
-##### **Migration with the Exchange configuration assistant**
+#### **Migration with the Exchange configuration assistant**
 
 A wizard will guide you through configuring your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
 
 If the configuration wizard does not appear, the general information for the Exchange service will appear instead. In this case, you will need to migrate your accounts via the MX Plan interface.
 
-##### **Migration from the MX Plan interface**
+#### **Migration from the MX Plan interface**
 
 To carry out the migration from this interface, go to the [MX Plan](/links/control-panel/web-mx-plan) section of your OVHcloud Control Panel and select the relevant domain. In the `Emails`{.action} tab, click on `...`{.action} next to the relevant email account (also called the source account), then `Migrate account`{.action}.
 
@@ -112,7 +114,9 @@ Finally, confirm the password for the source email address (the one you want to 
 
 ![Exchange](images/account_migration_steps.png){.thumbnail}
 
-#### 3.2 Migrating the new version of MX Plan <a name="NewVersionMxplan"></a>
+<a name="NewVersionMxplan"></a>
+
+### 3.2 Migrating the new version of MX Plan
 
 > [!warning]
 >

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-gb.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-gb.md
@@ -81,7 +81,9 @@ Before starting your migration, you will need to identify the version of the MX 
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 <!-- CP-STEPS-END:identify-mxplan-version -->
 
-#### 3.1 Manual migration of an MX Plan offer to Exchange, Email Pro or Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Manual migration of an MX Plan offer to Exchange, Email Pro or Zimbra
 
 > [!warning]
 >
@@ -137,7 +139,9 @@ You can keep or delete the original account with the temporary name after this m
 If you want to delete it, go to the `Email accounts`{.action} tab in your MX Plan, click on the `...`{.action} button, then `Reset this account`{.action}.
 <!-- CP-STEPS-END:manual-migration-rename-create-migrate -->
 
-#### 3.2 Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro
 
 > [!warning]
 >
@@ -168,13 +172,13 @@ Once you are ready, follow the steps below, depending on the interface you have 
 >
 > Even if you can no longer access your current email account, existing and newly arriving messages will not be lost. All will be immediately accessible from your new account.
 
-##### **Migration with the Exchange configuration assistant**
+#### **Migration with the Exchange configuration assistant**
 
 A wizard will guide you through configuring your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
 
 If the configuration wizard does not appear, the general information for the Exchange service will appear instead. In this case, you will need to migrate your accounts via the MX Plan interface.
 
-##### **Migration from the MX Plan interface**
+#### **Migration from the MX Plan interface**
 
 <!-- CP-STEPS-START:roundcube-migrate-from-mxplan-interface -->
 To migrate from this interface, go to the [MX Plan](/links/control-panel/web-mx-plan) section of your OVHcloud Control Panel and select the relevant domain. In the `Emails`{.action} tab, click on `...`{.action} on the line of the relevant email account (also called the source account), then on `Migrate account`{.action}.

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ie.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.en-ie.md
@@ -79,7 +79,9 @@ Before starting your migration, you will need to identify the version of the MX 
 >
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 
-#### 3.1 Manual migration of an MX Plan offer to Exchange, Email Pro or Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Manual migration of an MX Plan offer to Exchange, Email Pro or Zimbra
 
 > [!warning]
 >
@@ -131,7 +133,9 @@ You can keep or delete the original account with the temporary name after this m
 
 If you want to delete it, go to the `Email accounts`{.action} tab in your MX Plan, click on the `...`{.action} button, then `Reset this account`{.action}.
 
-#### 3.2 Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Automatic migration of an MX Plan Roundcube offer to Exchange or Email Pro
 
 > [!warning]
 >
@@ -160,13 +164,13 @@ Once you are ready, follow the steps below, depending on the interface you have 
 >
 > Even if you can no longer access your current email account, existing and newly arriving messages will not be lost. All will be immediately accessible from your new account.
 
-##### **Migration with the Exchange configuration assistant**
+#### **Migration with the Exchange configuration assistant**
 
 A wizard will guide you through configuring your new Exchange service. During this process, you can select the MX Plan email accounts to migrate.
 
 If the configuration wizard does not appear, the general information for the Exchange service will appear instead. In this case, you will need to migrate your accounts via the MX Plan interface.
 
-##### **Migration from the MX Plan interface**
+#### **Migration from the MX Plan interface**
 
 To carry out the migration from this interface, go to the [MX Plan](/links/control-panel/web-mx-plan) section of your OVHcloud Control Panel and select the relevant domain. In the `Emails`{.action} tab, click on `...`{.action} on the line of the concerned email account (also called the source account), then on `Migrate account`{.action}.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-es.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.es-es.md
@@ -81,7 +81,9 @@ Antes de realizar la migración, deberá identificar la versión del MX Plan des
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Migración manual de una oferta MX Plan a Exchange, Email Pro o Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Migración manual de una oferta MX Plan a Exchange, Email Pro o Zimbra
 
 > [!warning]
 >
@@ -133,7 +135,9 @@ Una vez realizada la migración, puede conservar o eliminar la cuenta original c
 
 Si quiere eliminarlo, abra la pestaña `Cuentas de correo`{.action} de su MX Plan y haga clic en el botón `...`{.action} y luego en `Restaurar la cuenta`{.action}.
 
-#### 3.2 Migración automática de una oferta MX Plan Roundcube a Exchange o Email Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Migración automática de una oferta MX Plan Roundcube a Exchange o Email Pro
 
 > [!warning]
 >
@@ -164,13 +168,13 @@ Continúe leyendo esta guía en la interfaz seleccionada. Le recordamos que el t
 > Aunque ya no podrá acceder a su dirección de correo electrónico actual, tanto los mensajes ya recibidos como los recibidos no se perderán. Podrá acceder a todos ellos inmediatamente desde su nueva cuenta.
 >
 
-##### **Migración desde el asistente de configuración de Exchange**
+#### **Migración desde el asistente de configuración de Exchange**
 
 El asistente aparecerá para ayudarle a configurar su nuevo servicio Exchange. Durante este proceso, podrá seleccionar las cuentas MX Plan que quiera migrar.
 
 Si no aparece el asistente de configuración, la información general del servicio Exchange se mostrará en su lugar. En ese caso, deberá realizar la migración de sus cuentas a través de la interfaz MX Plan.
 
-##### **Migración desde la interfaz MX Plan**
+#### **Migración desde la interfaz MX Plan**
 
 Para realizar la migración desde esta interfaz, acceda a la sección [MX Plan](/links/control-panel/web-mx-plan) de su área de cliente de OVHcloud y seleccione el dominio correspondiente. En la pestaña `Correo electrónico`{.action}, haga clic en `...`{.action} en la línea de la cuenta de correo correspondiente (también llamada cuenta de origen) y seleccione `Migrar la cuenta`{.action}.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-ca.md
@@ -75,7 +75,9 @@ Avant de débuter votre migration, il vous faudra identifier la version du MX Pl
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Migration manuelle d'une offre MX Plan vers Exchange  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Migration manuelle d'une offre MX Plan vers Exchange
 
 > [!warning]
 >

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.fr-fr.md
@@ -83,7 +83,9 @@ Avant de débuter votre migration, il vous faudra identifier la version du MX Pl
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Migration manuelle d'une offre MX Plan vers Exchange, Email Pro ou Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Migration manuelle d'une offre MX Plan vers Exchange, Email Pro ou Zimbra
 
 > [!warning]
 >
@@ -135,7 +137,9 @@ Vous pouvez conserver ou supprimer le compte d'origine avec le nom provisoire ap
 
 Si vous souhaitez le supprimer, dirigez-vous dans l'onglet `Comptes e-mail`{.action} de votre MX Plan, cliquez sur le bouton `...`{.action} puis sur `Réinitialiser ce compte`{.action}.
 
-#### 3.2 Migration automatique d'une offre MX Plan Roundcube vers Exchange ou Email Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Migration automatique d'une offre MX Plan Roundcube vers Exchange ou Email Pro
 
 > [!warning]
 >
@@ -166,13 +170,13 @@ Une fois que vous êtes prêt, poursuivez la lecture de cette documentation selo
 > Même si vous ne pourrez plus accéder à votre adresse e-mail actuelle, les messages déjà réceptionnés ainsi que ceux reçus ne seront pas perdus. Tous seront immédiatement accessibles depuis votre nouveau compte.
 >
 
-##### **Migration depuis l'assistant de configuration Exchange**
+#### **Migration depuis l'assistant de configuration Exchange**
 
 L'assistant s'affiche pour vous aider à configurer votre nouveau service Exchange. Durant ce processus, vous pouvez sélectionner les comptes e-mail MX Plan à migrer.
 
 Si l'assistant de configuration ne s'affiche pas, les informations générales du service Exchange apparaîtront à la place. Dans ce cas, vous devrez réaliser la migration de vos comptes via l'interface MX Plan.
 
-##### **Migration depuis l'interface MX Plan**
+#### **Migration depuis l'interface MX Plan**
 
 Pour réaliser la migration depuis cette interface, rendez-vous dans la section [MX Plan](/links/control-panel/web-mx-plan) de votre espace client OVHcloud et sélectionnez le domaine concerné. Dans l'onglet `Emails`{.action}, cliquez sur `...`{.action} sur la ligne du compte e-mail concerné (également appelé compte source), puis sur `Migrer le compte`{.action}.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.it-it.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.it-it.md
@@ -81,7 +81,9 @@ Prima di avviare la migrazione, dovrai identificare la versione del MX Plan dal 
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Migrazione manuale di un'offerta MX Plan verso Exchange, Email Pro o Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Migrazione manuale di un'offerta MX Plan verso Exchange, Email Pro o Zimbra
 
 > [!warning]
 >
@@ -133,7 +135,9 @@ Dopo la migrazione è possibile conservare o eliminare l'account di origine.
 
 Per eliminarlo, seleziona la scheda `Account email`{.action} del tuo MX Plan, clicca sul pulsante `...`{.action} e poi su `Reimposta questo account`{.action}.
 
-#### 3.2 Migrazione automatica di un'offerta MX Plan Roundcube verso Exchange o Email Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Migrazione automatica di un'offerta MX Plan Roundcube verso Exchange o Email Pro
 
 > [!warning]
 >
@@ -164,13 +168,13 @@ Quando tutto è pronto, prosegui nella lettura di questa guida utilizzando l'int
 > Anche se non sarà più possibile accedere al tuo indirizzo email corrente, i messaggi già ricevuti e quelli ricevuti non saranno persi. Tutti saranno immediatamente accessibili dal tuo nuovo account.
 >
 
-##### **Migrazione dall'assistente di configurazione Exchange**
+#### **Migrazione dall'assistente di configurazione Exchange**
 
 L'assistente dovrebbe apparire per aiutarti a configurare il tuo nuovo servizio Exchange. Durante questo processo, è possibile selezionare gli account email MX Plan da migrare.
 
 Se l'assistente di configurazione non compare, visualizzi le informazioni generali del servizio Exchange. In questo caso, sarà necessario effettuare la migrazione dei tuoi account tramite l'interfaccia MX Plan.
 
-##### **Migrazione dall'interfaccia MX Plan**
+#### **Migrazione dall'interfaccia MX Plan**
 
 Per effettuare la migrazione da questa interfaccia, accedi alla sezione [MX Plan](/links/control-panel/web-mx-plan) del tuo Spazio Cliente OVHcloud e seleziona il dominio interessato. Nella scheda `Email`{.action}, clicca su `...`{.action} sulla riga dell'account email interessato (chiamato anche account sorgente) e poi su `Migra l'account`{.action}.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pl-pl.md
@@ -81,7 +81,9 @@ Przed rozpoczęciem migracji określ wersję programu MX Plan, z której chcesz 
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Ręczna migracja oferty MX Plan do Exchange, E-mail Pro lub Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Ręczna migracja oferty MX Plan do Exchange, E-mail Pro lub Zimbra
 
 > [!warning]
 >
@@ -133,7 +135,9 @@ Po przeprowadzeniu migracji możesz zachować lub usunąć konto źródłowe, u�
 
 Jeśli chcesz go usunąć, przejdź do zakładki `Konta e-mail`{.action} MX Plan, kliknij przycisk `...`{.action}, a następnie  `Zresetuj to konto`{.action}.
 
-#### 3.2 Automatyczna migracja oferty MX Plan Roundcube do Exchange lub E-mail Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Automatyczna migracja oferty MX Plan Roundcube do Exchange lub E-mail Pro
 
 > [!warning]
 >
@@ -164,13 +168,13 @@ Kiedy wszystko jest gotowe, przejdź do opisu operacji w wybranym interfejsie. P
 > Nawet jeśli nie będziesz miał dostępu do Twojego aktualnego adresu e-mail, już odebrane wiadomości i otrzymane wiadomości nie zostaną utracone. Wszystkie konta będą natychmiast dostępne.
 >
 
-##### **Migracja z poziomu asystenta konfiguracji Exchange**
+#### **Migracja z poziomu asystenta konfiguracji Exchange**
 
 Asystent powinien pojawić się, aby pomóc Ci w skonfigurowaniu nowej usługi Exchange. Podczas tego procesu będziesz mógł wybrać konta e-mail MX Plan, które chcesz przenieść.
 
 Jeśli asystent konfiguracji nie wyświetla się, wyświetlą się ogólne informacje o usłudze Exchange. W takim przypadku będziesz musiał przeprowadzić migrację Twoich kont za pomocą interfejsu MX Plan.
 
-##### **Migracja z poziomu interfejsu MX Plan**
+#### **Migracja z poziomu interfejsu MX Plan**
 
 Aby przeprowadzić migrację w tym interfejsie, przejdź do sekcji [MX Plan](/links/control-panel/web-mx-plan) Panelu klienta OVHcloud i wybierz odpowiednią domenę. W karcie `E-maile`{.action} kliknij logo w kształcie koła zębatego na linii odpowiedniego konta e-mail (zwane również kontem źródłowym), a następnie kliknij `Przeprowadź migrację konta`{.action}.
 

--- a/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
+++ b/pages/web_cloud/email_and_collaborative_solutions/migrating/migration_control_panel/guide.pt-pt.md
@@ -81,7 +81,9 @@ Antes de iniciar a migração, terá de identificar a versão do MX Plan a parti
 > ![MX plan](/pages/assets/schemas/emails/technology-email.png){.thumbnail .w-640}
 >
 
-#### 3.1 Migração manual de uma oferta MX Plan para Exchange, E-mail Pro ou Zimbra  <a name="all-mxplan"></a>
+<a name="all-mxplan"></a>
+
+### 3.1 Migração manual de uma oferta MX Plan para Exchange, E-mail Pro ou Zimbra
 
 > [!warning]
 >
@@ -133,7 +135,9 @@ Pode conservar ou eliminar a conta de origem com o nome provisório após esta m
 
 Se pretender eliminá-lo, aceda ao separador `Contas de e-mail`{.action} do MX Plan e clique no botão `...`{.action} e em `Reinicializar esta conta`{.action}.
 
-#### 3.2 Migração automática de uma oferta MX Plan Roundcube para Exchange ou E-mail Pro <a name="roundcube-mxplan"></a>
+<a name="roundcube-mxplan"></a>
+
+### 3.2 Migração automática de uma oferta MX Plan Roundcube para Exchange ou E-mail Pro
 
 > [!warning]
 >
@@ -164,13 +168,13 @@ Quando estiver pronto, continue a ler este manual em função da interface selec
 > Mesmo que já não possa aceder ao seu endereço de e-mail atual, as mensagens já recebidas e as recebidas não serão perdidas. Todos estarão imediatamente acessíveis a partir da sua nova conta.
 >
 
-##### **Migração a partir do assistente de configuração Exchange**
+#### **Migração a partir do assistente de configuração Exchange**
 
 O assistente deverá aparecer para o ajudar a configurar o seu novo serviço Exchange. Durante este processo, poderá selecionar as contas de e-mail MX Plan a migrar.
 
 Se o assistente de configuração não for apresentado, aparecerão as informações gerais do serviço Exchange. Neste caso, deverá realizar a migração das suas contas através da interface MX Plan.
 
-##### **Migração a partir da interface MX Plan**
+#### **Migração a partir da interface MX Plan**
 
 Para realizar a migração a partir desta interface, aceda à secção [MX Plan](/links/control-panel/web-mx-plan) da sua Área de Cliente OVHcloud e selecione o domínio em causa. No separador `E-mails`{.action}, clique no ícone em forma de engrenagem na linha da conta de e-mail em causa (também designada conta de origem) e, a seguir, em `Migrar conta`{.action}.
 


### PR DESCRIPTION
## Context

Support feedback (SK-2630) on the MX Plan → Exchange / Email Pro migration guide (KB0053486).
Two issues, **same root cause**: sub-parts 3.1 and 3.2 were level-4 headings (`####`).

1. **Table of contents** — the OVHcloud TOC only goes down to `###`, so 3.1 and 3.2 never showed up. The "3.2 Automatic migration…" section couldn't be anchored to send directly to a customer: they landed on Step 3 and could miss the Roundcube alert callout.
2. **Off-by-one anchors** — the `<a name>` anchors sat inline at the end of the heading line, so internal links (`#roundcube-mxplan`) landed one line **below** the heading.

## Changes

- Promote 3.1 / 3.2 from `####` to `###` → they now appear in the TOC and become anchorable.
- Move the `<a name>` anchors onto their own line, just **before** the heading (already the majority convention in the repo) → links now land on the heading.
- Demote the two "Migration from…" sub-headings from `#####` to `####` to keep the hierarchy consistent.

Anchor names are unchanged, so existing internal links keep working.

## Scope

| Group | Locales | Treatment |
|---|---|---|
| EU | de-de, en-gb, en-ie, es-es, fr-fr, it-it, pl-pl, pt-pt | 3.1 + 3.2 (`all-mxplan` / `roundcube-mxplan`) |
| CA | en-ca (`LegacyMxplan` / `NewVersionMxplan`), fr-ca (3.1 only) | same, adapted to local anchors |
| US | en-us, es-us | no change — flat Step 3 (no Roundcube/Zimbra) |